### PR TITLE
feat(react): color scheme management

### DIFF
--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
@@ -110,7 +110,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .branding {
+:global(.c15t-dark) .branding {
 	color: var(--dialog-foreground-color-dark);
 }
 
@@ -138,7 +138,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .footer {
+:global(.c15t-dark) .footer {
 	border-color: var(--dialog-stroke-color-dark);
 }
 
@@ -151,7 +151,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .overlay {
+:global(.c15t-dark) .overlay {
 	background-color: var(--dialog-overlay-background-color-dark);
 	color: var(--dialog-link-text-color-dark);
 }
@@ -167,7 +167,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .card {
+:global(.c15t-dark) .card {
 	background-color: var(--dialog-background-color-dark);
 	color: var(--dialog-foreground-color-dark);
 	border-color: var(--dialog-border-color-dark);
@@ -199,7 +199,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .description {
+:global(.c15t-dark) .description {
 	color: var(--dialog-muted-color-dark);
 }
 
@@ -221,6 +221,6 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .footer {
+:global(.c15t-dark) .footer {
 	border-color: var(--dialog-stroke-color-dark);
 }

--- a/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
+++ b/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
@@ -83,7 +83,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .card {
+:global(.c15t-dark) .card {
 	background-color: var(--widget-background-color-dark);
 	border-color: var(--widget-border-color-dark);
 }
@@ -113,7 +113,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .title {
+:global(.c15t-dark) .title {
 	color: var(--widget-text-color-dark);
 }
 
@@ -122,7 +122,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .description {
+:global(.c15t-dark) .description {
 	color: var(--widget-text-muted-color-dark);
 }
 
@@ -140,7 +140,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .footer {
+:global(.c15t-dark) .footer {
 	background-color: var(--widget-footer-background-color-dark);
 }
 
@@ -181,7 +181,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .branding {
+:global(.c15t-dark) .branding {
 	border-color: var(--widget-border-color-dark);
 }
 
@@ -198,7 +198,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .brandingLink {
+:global(.c15t-dark) .brandingLink {
 	color: var(--widget-link-text-color-dark);
 }
 
@@ -259,7 +259,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .accordionItem {
+:global(.c15t-dark) .accordionItem {
 	border-color: var(--widget-accordion-border-color-dark);
 	background-color: var(--widget-accordion-background-color-dark);
 }
@@ -281,12 +281,12 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .accordionTrigger {
+:global(.c15t-dark) .accordionTrigger {
 	color: var(--widget-accordion-text-color-dark);
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .accordionTrigger:hover {
+:global(.c15t-dark) .accordionTrigger:hover {
 	background-color: var(--widget-accordion-background-hover-dark);
 }
 
@@ -306,7 +306,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .accordionContent {
+:global(.c15t-dark) .accordionContent {
 	color: var(--widget-accordion-content-color-dark);
 }
 
@@ -319,7 +319,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .accordionArrow {
+:global(.c15t-dark) .accordionArrow {
 	color: var(--widget-accordion-arrow-color-dark);
 }
 
@@ -342,7 +342,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .switch {
+:global(.c15t-dark) .switch {
 	background-color: var(--widget-accordion-background-hover-dark);
 }
 
@@ -351,7 +351,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .switch[data-state="checked"] {
+:global(.c15t-dark) .switch[data-state="checked"] {
 	background-color: var(--widget-accordion-focus-ring-dark);
 }
 

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -91,7 +91,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .card {
+:global(.c15t-dark) .card {
 	background-color: var(--banner-background-color-dark);
 	border-color: var(--banner-border-color-dark);
 	box-shadow: var(--banner-shadow-dark);
@@ -113,7 +113,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .card > :not([hidden]) ~ :not([hidden]) {
+:global(.c15t-dark) .card > :not([hidden]) ~ :not([hidden]) {
 	border-color: var(--banner-border-color-dark);
 }
 
@@ -174,7 +174,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .header {
+:global(.c15t-dark) .header {
 	color: var(--banner-text-color-dark);
 }
 
@@ -203,7 +203,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .footer {
+:global(.c15t-dark) .footer {
 	background-color: var(--banner-footer-background-color-dark);
 }
 
@@ -229,7 +229,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .description {
+:global(.c15t-dark) .description {
 	color: var(--banner-description-color-dark);
 }
 
@@ -242,7 +242,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .title {
+:global(.c15t-dark) .title {
 	color: var(--banner-title-color-dark);
 }
 
@@ -254,6 +254,6 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .overlay {
+:global(.c15t-dark) .overlay {
 	background-color: var(--banner-overlay-background-color-dark);
 }

--- a/packages/react/src/components/shared/ui/accordion/accordion.module.css
+++ b/packages/react/src/components/shared/ui/accordion/accordion.module.css
@@ -45,7 +45,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .item {
+:global(.c15t-dark) .item {
 	background-color: var(--accordion-background-color-dark);
 	box-shadow: inset 0 0 0 1px var(--accordion-border-color-dark);
 }
@@ -56,7 +56,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .item:is(:hover, :focus-within, [data-state="open"]) {
+:global(.c15t-dark) .item:is(:hover, :focus-within, [data-state="open"]) {
 	background-color: var(--accordion-background-hover-dark);
 	box-shadow: inset 0 0 0 1px transparent;
 }
@@ -90,7 +90,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .triggerInner {
+:global(.c15t-dark) .triggerInner {
 	color: var(--accordion-text-color-dark);
 }
 
@@ -101,7 +101,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .trigger:focus-visible {
+:global(.c15t-dark) .trigger:focus-visible {
 	outline: 2px solid var(--accordion-focus-ring-dark);
 }
 
@@ -113,7 +113,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .icon {
+:global(.c15t-dark) .icon {
 	color: var(--accordion-icon-color-dark);
 }
 
@@ -130,7 +130,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .arrowOpen {
+:global(.c15t-dark) .arrowOpen {
 	color: var(--accordion-arrow-color-dark);
 }
 
@@ -139,7 +139,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .item:hover .arrowOpen {
+:global(.c15t-dark) .item:hover .arrowOpen {
 	color: var(--accordion-icon-color-dark);
 }
 
@@ -149,7 +149,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .arrowClose {
+:global(.c15t-dark) .arrowClose {
 	color: var(--accordion-icon-color-dark);
 }
 
@@ -204,6 +204,6 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .contentInner {
+:global(.c15t-dark) .contentInner {
 	color: var(--accordion-content-color-dark);
 }

--- a/packages/react/src/components/shared/ui/button/button.module.css
+++ b/packages/react/src/components/shared/ui/button/button.module.css
@@ -83,7 +83,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button {
+:global(.c15t-dark) .button {
 	color: var(--button-text-dark);
 }
 
@@ -124,7 +124,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-filled {
+:global(.c15t-dark) .button-primary-filled {
 	background-color: var(--button-primary-dark);
 	color: var(--button-background-color-dark);
 }
@@ -134,7 +134,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-filled:hover:not(:disabled) {
+:global(.c15t-dark) .button-primary-filled:hover:not(:disabled) {
 	background-color: var(--button-primary-hover-dark);
 }
 
@@ -145,7 +145,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-stroke {
+:global(.c15t-dark) .button-primary-stroke {
 	background-color: var(--button-background-color-dark);
 	color: var(--button-primary-dark);
 	box-shadow: var(--button-shadow-primary-dark);
@@ -157,7 +157,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-stroke:hover:not(:disabled) {
+:global(.c15t-dark) .button-primary-stroke:hover:not(:disabled) {
 	background-color: var(--button-primary-hover-dark);
 	box-shadow: var(--button-shadow-primary-hover-dark);
 }
@@ -168,7 +168,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-lighter {
+:global(.c15t-dark) .button-primary-lighter {
 	background-color: color-mix(
 		in srgb,
 		var(--button-primary-dark) 10%,
@@ -182,7 +182,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-lighter:hover:not(:disabled) {
+:global(.c15t-dark) .button-primary-lighter:hover:not(:disabled) {
 	background-color: color-mix(
 		in srgb,
 		var(--button-primary-dark) 20%,
@@ -195,7 +195,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-ghost {
+:global(.c15t-dark) .button-primary-ghost {
 	color: var(--button-primary-dark);
 }
 
@@ -204,7 +204,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-primary-ghost:hover:not(:disabled) {
+:global(.c15t-dark) .button-primary-ghost:hover:not(:disabled) {
 	background-color: var(--button-hover-overlay-dark);
 }
 
@@ -215,7 +215,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-filled {
+:global(.c15t-dark) .button-neutral-filled {
 	background-color: var(--button-neutral-dark);
 	color: var(--button-background-color-dark);
 }
@@ -225,7 +225,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-filled:hover:not(:disabled) {
+:global(.c15t-dark) .button-neutral-filled:hover:not(:disabled) {
 	background-color: var(--button-neutral-hover-dark);
 }
 
@@ -235,7 +235,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-stroke {
+:global(.c15t-dark) .button-neutral-stroke {
 	background-color: var(--button-background-color-dark);
 	box-shadow: var(--button-shadow-neutral-dark);
 }
@@ -247,7 +247,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-stroke:hover:not(:disabled) {
+:global(.c15t-dark) .button-neutral-stroke:hover:not(:disabled) {
 	box-shadow: var(--button-shadow-neutral-hover-dark);
 	color: var(--button-text-hover-dark);
 }
@@ -258,7 +258,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-lighter {
+:global(.c15t-dark) .button-neutral-lighter {
 	background-color: color-mix(
 		in srgb,
 		var(--button-neutral-dark) 10%,
@@ -272,7 +272,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-lighter:hover:not(:disabled) {
+:global(.c15t-dark) .button-neutral-lighter:hover:not(:disabled) {
 	background-color: color-mix(
 		in srgb,
 		var(--button-neutral-dark) 20%,
@@ -285,7 +285,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-ghost {
+:global(.c15t-dark) .button-neutral-ghost {
 	color: var(--button-neutral-dark);
 }
 
@@ -294,7 +294,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .button-neutral-ghost:hover:not(:disabled) {
+:global(.c15t-dark) .button-neutral-ghost:hover:not(:disabled) {
 	background-color: var(--button-hover-overlay-dark);
 }
 

--- a/packages/react/src/components/shared/ui/switch/switch.module.css
+++ b/packages/react/src/components/shared/ui/switch/switch.module.css
@@ -60,7 +60,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .track {
+:global(.c15t-dark) .track {
 	background-color: var(--switch-background-color-dark);
 }
 
@@ -70,7 +70,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .track:hover {
+:global(.c15t-dark) .track:hover {
 	background-color: var(--switch-background-color-hover-dark);
 }
 
@@ -79,7 +79,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .track:focus-visible {
+:global(.c15t-dark) .track:focus-visible {
 	background-color: var(--switch-background-color-hover-dark);
 }
 
@@ -88,7 +88,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .track:active {
+:global(.c15t-dark) .track:active {
 	background-color: var(--switch-background-color-dark);
 }
 
@@ -97,7 +97,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .root[data-state="checked"] .track {
+:global(.c15t-dark) .root[data-state="checked"] .track {
 	background-color: var(--switch-background-color-checked-dark);
 }
 
@@ -106,7 +106,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .root[data-state="checked"]:hover .track {
+:global(.c15t-dark) .root[data-state="checked"]:hover .track {
 	background-color: var(--switch-background-color-checked-dark);
 }
 
@@ -119,7 +119,7 @@
 	outline: 2px solid var(--accordion-focus-ring);
 }
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .root:focus {
+:global(.c15t-dark) .root:focus {
 	outline: 2px solid var(--accordion-focus-ring-dark);
 }
 
@@ -130,7 +130,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .track-disabled {
+:global(.c15t-dark) .track-disabled {
 	background-color: var(--switch-background-color-disabled-dark);
 }
 
@@ -141,7 +141,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .root[data-state="checked"] .track-disabled {
+:global(.c15t-dark) .root[data-state="checked"] .track-disabled {
 	background-color: var(--switch-background-color-checked-dark);
 }
 
@@ -174,7 +174,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .thumb::before {
+:global(.c15t-dark) .thumb::before {
 	background-color: var(--switch-thumb-background-color-dark);
 }
 
@@ -189,7 +189,7 @@
 }
 
 /* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.dark) .thumb::after {
+:global(.c15t-dark) .thumb::after {
 	box-shadow: var(--switch-shadow-thumb-dark);
 }
 

--- a/packages/react/src/hooks/use-color-scheme.ts
+++ b/packages/react/src/hooks/use-color-scheme.ts
@@ -3,9 +3,9 @@ import { useEffect } from 'react';
 export type ColorScheme = 'light' | 'dark' | 'system';
 
 /**
- * Hook to manage color scheme preferences for components
+ * Manage color scheme preferences for components
  *
- * @param colorScheme - The desired color scheme ('light', 'dark', or 'system')
+ * @param colorScheme - 'light' | 'dark' | 'system'
  *
  * @example
  * ```tsx

--- a/packages/react/src/hooks/use-color-scheme.ts
+++ b/packages/react/src/hooks/use-color-scheme.ts
@@ -26,12 +26,12 @@ export function useColorScheme(colorScheme: ColorScheme) {
 		// Handle different color scheme settings
 		switch (colorScheme) {
 			case 'light': {
-				localStorage.c15tTheme = 'light';
+				localStorage.setItem('c15tTheme', 'light');
 				document.documentElement.classList.remove('c15t-dark');
 				break;
 			}
 			case 'dark': {
-				localStorage.c15tTheme = 'dark';
+				localStorage.setItem('c15tTheme', 'dark');
 				document.documentElement.classList.add('c15t-dark');
 				break;
 			}

--- a/packages/react/src/hooks/use-color-scheme.ts
+++ b/packages/react/src/hooks/use-color-scheme.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+export type ColorScheme = 'light' | 'dark' | 'system';
+
+/**
+ * Hook to manage color scheme preferences for components
+ *
+ * @param colorScheme - The desired color scheme ('light', 'dark', or 'system')
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   useColorScheme('system');
+ *   return <div>Content</div>;
+ * }
+ * ```
+ */
+export function useColorScheme(colorScheme: ColorScheme) {
+	useEffect(() => {
+		// Function to update the theme based on system preference
+		const updateSystemTheme = () => {
+			const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+			document.documentElement.classList.toggle('c15t-dark', isDark);
+		};
+
+		// Handle different color scheme settings
+		switch (colorScheme) {
+			case 'light': {
+				localStorage.c15tTheme = 'light';
+				document.documentElement.classList.remove('c15t-dark');
+				break;
+			}
+			case 'dark': {
+				localStorage.c15tTheme = 'dark';
+				document.documentElement.classList.add('c15t-dark');
+				break;
+			}
+			default: {
+				localStorage.removeItem('c15tTheme');
+				updateSystemTheme();
+				break;
+			}
+		}
+
+		// Set up system preference listener for 'system' mode
+		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+		const handleChange = () => {
+			if (colorScheme === 'system') {
+				updateSystemTheme();
+			}
+		};
+
+		mediaQuery.addEventListener('change', handleChange);
+		return () => mediaQuery.removeEventListener('change', handleChange);
+	}, [colorScheme]);
+}

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -126,6 +126,7 @@ export function ConsentManagerProvider({
 		};
 	}, [theme, noStyle, disableAnimation, scrollLock, trapFocus]);
 
+	// Set the color scheme
 	useColorScheme(colorScheme);
 
 	return (

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -15,7 +15,7 @@ import {
 } from '../utils/translations';
 
 import { GlobalThemeContext } from '~/context/theme-context';
-
+import { useColorScheme } from '../hooks/use-color-scheme';
 /**
  * Provider component for consent management functionality.
  *
@@ -41,6 +41,7 @@ export function ConsentManagerProvider({
 	disableAnimation = false,
 	scrollLock = false,
 	trapFocus = true,
+	colorScheme = 'system',
 }: ConsentManagerProviderProps) {
 	const preparedTranslationConfig = useMemo(() => {
 		const mergedConfig = mergeTranslationConfigs(
@@ -124,6 +125,8 @@ export function ConsentManagerProvider({
 			trapFocus,
 		};
 	}, [theme, noStyle, disableAnimation, scrollLock, trapFocus]);
+
+	useColorScheme(colorScheme);
 
 	return (
 		<ConsentStateContext.Provider value={contextValue}>

--- a/packages/react/src/types/consent-manager.ts
+++ b/packages/react/src/types/consent-manager.ts
@@ -11,7 +11,7 @@ import type {
 import type { ReactNode } from 'react';
 import type { ConsentManagerDialogTheme } from '../components/consent-manager-dialog/theme';
 import type { CookieBannerTheme } from '../components/cookie-banner/theme';
-
+import type { ColorScheme } from '../hooks/use-color-scheme';
 /**
  * Configuration options for the ConsentManagerProvider component.
  *
@@ -119,6 +119,13 @@ export interface ConsentManagerProviderProps extends NamespaceProps {
 	 * @default true
 	 */
 	trapFocus?: boolean;
+
+	/**
+	 * @remarks
+	 * Color scheme to use for the consent manager, defaults to 'system'
+	 * @default 'system'
+	 */
+	colorScheme?: ColorScheme;
 }
 
 /**


### PR DESCRIPTION
## Overview
Added color scheme handling to the react. 

Replaced use of .dark with .c15t-dark. This allows for overrides e.g. a light mode cookie banner when the rest of the app is in dark mode.

You can set between light, dark & system as a colorScheme prop in the provider. It defaults to system.

Stores in local storage under 'c15tTheme' to avoid any clashes with the app's theme. 

## Related Issue
#108 

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [x] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

### Required

- [x] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic color scheme management, allowing the interface to automatically adjust between light, dark, or system-driven settings.
  
- **Style**
  - Updated dark mode styling across various UI elements—including banners, dialogs, buttons, accordions, and switches—to utilize a new class naming convention for a more consistent and modern appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->