### PR TITLE
feat(backend): Verify Consent Endpoint

### DIFF
--- a/packages/backend/src/pkgs/data-model/schema/get-schema.ts
+++ b/packages/backend/src/pkgs/data-model/schema/get-schema.ts
@@ -56,7 +56,7 @@ export function getSchema(config: C15TOptions) {
 			const fieldName = field.fieldName || fieldKey;
 			// Cast field to Field to ensure it has the right type
 			const typedField = field as Field;
-			processedFields[fieldName] = typedField;
+			processedFields[fieldName as keyof typeof processedFields] = typedField;
 
 			// Handle references - first check if the field has a references property
 			if (typedField && 'references' in typedField && typedField.references) {
@@ -64,7 +64,7 @@ export function getSchema(config: C15TOptions) {
 				const referencedEntity = entities[entityName];
 				if (referencedEntity) {
 					// Create a new object for references to avoid modifying the original
-					processedFields[fieldName] = {
+					processedFields[fieldName as keyof typeof processedFields] = {
 						...typedField,
 						references: {
 							model: referencedEntity.entityName,

--- a/packages/backend/src/pkgs/migrations/get-schema/process-fields.ts
+++ b/packages/backend/src/pkgs/migrations/get-schema/process-fields.ts
@@ -30,7 +30,7 @@ export function processFields<T extends EntityName>(
 
 		// Cast field to Field to ensure it has the right type
 		const typedField = field as Field;
-		actualFields[fieldName] = typedField;
+		actualFields[fieldName as keyof typeof actualFields] = typedField;
 
 		// Handle references to other tables - first check if the field has a references property
 		if (typedField && 'references' in typedField && typedField.references) {
@@ -40,7 +40,7 @@ export function processFields<T extends EntityName>(
 			// Only set up the reference if the referenced table exists
 			if (refTable) {
 				// Create a new object for references to avoid modifying the original
-				actualFields[fieldName] = {
+				actualFields[fieldName as keyof typeof actualFields] = {
 					...typedField,
 					references: {
 						model: refTable.entityName,
@@ -56,7 +56,7 @@ export function processFields<T extends EntityName>(
 					`Warning: Referenced table '${EntityName}' not found for field '${fieldName}'. The reference will be removed to prevent inconsistent state.`
 				);
 				const { references, ...fieldWithoutRef } = typedField;
-				actualFields[fieldName] = fieldWithoutRef;
+				actualFields[fieldName as keyof typeof actualFields] = fieldWithoutRef;
 			}
 		}
 	}

--- a/packages/backend/src/pkgs/utils/test-mocks.ts
+++ b/packages/backend/src/pkgs/utils/test-mocks.ts
@@ -15,7 +15,6 @@ export function createMockContext(): C15TContext {
 			getConsent: vi.fn(),
 			withdrawConsent: vi.fn(),
 			verifyConsent: vi.fn(),
-			getConsentHistory: vi.fn(),
 			getConsentPolicy: vi.fn(),
 			generateConsentReceipt: vi.fn(),
 		},

--- a/packages/backend/src/routes/__tests__/consent.test.ts
+++ b/packages/backend/src/routes/__tests__/consent.test.ts
@@ -219,54 +219,54 @@ describe('Consent Endpoints', () => {
 			});
 		});
 
-		// describe('Error cases', () => {
-		// 	it('should create anonymous subject when external subject is not found', async () => {
-		// 		const response = await setConsent({
-		// 			context,
-		// 			params: undefined,
-		// 			query: undefined,
-		// 			body: createConsentData('privacy_policy', {
-		// 				externalSubjectId: 'non-existent',
-		// 			}),
-		// 		});
+		describe('Error cases', () => {
+			it('should create anonymous subject when external subject is not found', async () => {
+				const response = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('privacy_policy', {
+						externalSubjectId: 'non-existent',
+					}),
+				});
 
-		// 		expectValidConsentResponse(response, 'privacy_policy', {
-		// 			externalSubjectId: 'non-existent',
-		// 		});
-		// 	});
+				expectValidConsentResponse(response, 'privacy_policy', {
+					externalSubjectId: 'non-existent',
+				});
+			});
 
-		// 	it('should error if subject ID is not found', async () => {
-		// 		await expect(
-		// 			setConsent({
-		// 				context,
-		// 				params: undefined,
-		// 				query: undefined,
-		// 				body: createConsentData('privacy_policy', {
-		// 					subjectId: 'non-existent',
-		// 				}),
-		// 			})
-		// 		).rejects.toMatchObject({
-		// 			name: 'DoubleTieError',
-		// 			code: ERROR_CODES.NOT_FOUND,
-		// 			status: 404,
-		// 		});
-		// 	});
+			it('should error if subject ID is not found', async () => {
+				await expect(
+					setConsent({
+						context,
+						params: undefined,
+						query: undefined,
+						body: createConsentData('privacy_policy', {
+							subjectId: 'non-existent',
+						}),
+					})
+				).rejects.toMatchObject({
+					name: 'DoubleTieError',
+					code: ERROR_CODES.NOT_FOUND,
+					status: 404,
+				});
+			});
 
-		// 	it('should handle invalid consent data', async () => {
-		// 		await expect(
-		// 			setConsent({
-		// 				context,
-		// 				params: undefined,
-		// 				query: undefined,
-		// 				body: createConsentData('cookie_banner', {
-		// 					preferences: {
-		// 						marketing: 'invalid' as unknown as boolean,
-		// 						analytics: 'invalid' as unknown as boolean,
-		// 					},
-		// 				}),
-		// 			})
-		// 		).rejects.toThrow('Invalid body parameters');
-		// 	});
-		// });
+			it('should handle invalid consent data', async () => {
+				await expect(
+					setConsent({
+						context,
+						params: undefined,
+						query: undefined,
+						body: createConsentData('cookie_banner', {
+							preferences: {
+								marketing: 'invalid' as unknown as boolean,
+								analytics: 'invalid' as unknown as boolean,
+							},
+						}),
+					})
+				).rejects.toThrow('Invalid body parameters');
+			});
+		});
 	});
 });

--- a/packages/backend/src/routes/__tests__/consent.test.ts
+++ b/packages/backend/src/routes/__tests__/consent.test.ts
@@ -108,6 +108,7 @@ describe('Consent Endpoints', () => {
 
 			beforeEach(async () => {
 				policy = await context.registry.createConsentPolicy({
+					type: 'privacy_policy',
 					name: 'Test Privacy Policy',
 					version: '1.0',
 					content: 'Test content',

--- a/packages/backend/src/routes/__tests__/verify-consent.test.ts
+++ b/packages/backend/src/routes/__tests__/verify-consent.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { c15tInstance } from '~/core';
+import { memoryAdapter } from '~/pkgs/db-adapters';
+import type { ConsentPolicy, PolicyType } from '~/schema';
+import type { C15TContext } from '~/types';
+import { setConsent } from '../set-consent';
+import { verifyConsent } from '../verify-consent';
+
+describe('Verify Consent Endpoint', () => {
+	let context: C15TContext;
+
+	beforeEach(async () => {
+		const instance = await c15tInstance({
+			baseURL: 'http://localhost:3000',
+			database: memoryAdapter({}),
+			trustedOrigins: ['http://localhost:3000'],
+			secret: 'test-secret',
+		});
+
+		const contextResult = await instance.$context;
+		if (!contextResult.isOk()) {
+			throw new Error('Failed to initialize context');
+		}
+		context = contextResult.value;
+	});
+
+	// Helper function for creating consent data
+	const createConsentData = (type: PolicyType, overrides = {}) => ({
+		type,
+		domain: 'example.com',
+		preferences: {
+			marketing: true,
+			analytics: true,
+		},
+		...overrides,
+	});
+
+	// Helper function for creating verify data
+	const createVerifyData = (type: PolicyType, overrides = {}) => ({
+		type,
+		domain: 'example.com',
+		preferences: JSON.stringify(['marketing', 'analytics']),
+		...overrides,
+	});
+
+	describe('verifyConsent', () => {
+		describe('Cookie Banner Consent', () => {
+			it('should verify existing cookie banner consent successfully', async () => {
+				// First set consent
+				const consentResponse = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('cookie_banner'),
+				});
+
+				// Then verify it
+				const verifyResponse = await verifyConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createVerifyData('cookie_banner', {
+						subjectId: consentResponse.subjectId,
+					}),
+				});
+
+				expect(verifyResponse.isValid).toBe(true);
+			});
+
+			it('should fail verification when no preferences are provided for cookie banner', async () => {
+				// First set consent
+				const consentResponse = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('cookie_banner'),
+				});
+
+				// Then verify without preferences
+				const verifyResponse = await verifyConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createVerifyData('cookie_banner', {
+						subjectId: consentResponse.subjectId,
+						preferences: '[]',
+					}),
+				});
+
+				expect(verifyResponse.isValid).toBe(false);
+				expect(verifyResponse.reasons).toContain('Preferences are required');
+			});
+		});
+
+		describe('Privacy Policy Consent', () => {
+			let policy: ConsentPolicy;
+
+			beforeEach(async () => {
+				policy = await context.registry.createConsentPolicy({
+					type: 'privacy_policy',
+					name: 'Test Privacy Policy',
+					version: '1.0',
+					content: 'Test content',
+					contentHash: 'test-hash',
+					effectiveDate: new Date(),
+					updatedAt: new Date(),
+					isActive: true,
+				});
+			});
+
+			it('should verify consent with explicit policy ID', async () => {
+				// First set consent with policy ID
+				const consentResponse = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('privacy_policy', { policyId: policy.id }),
+				});
+
+				// Then verify it with same policy ID
+				const verifyResponse = await verifyConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createVerifyData('privacy_policy', {
+						subjectId: consentResponse.subjectId,
+						policyId: policy.id,
+					}),
+				});
+
+				expect(verifyResponse.isValid).toBe(true);
+			});
+
+			it('should verify consent against latest policy when policyId not provided', async () => {
+				// First set consent with policy ID
+				const consentResponse = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('privacy_policy', { policyId: policy.id }),
+				});
+
+				// Then verify it without specifying policy ID (should use latest)
+				const verifyResponse = await verifyConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createVerifyData('privacy_policy', {
+						subjectId: consentResponse.subjectId,
+					}),
+				});
+
+				expect(verifyResponse.isValid).toBe(true);
+			});
+
+			it('should fail verification with invalid policy ID', async () => {
+				// First set consent with policy ID
+				const consentResponse = await setConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createConsentData('privacy_policy', { policyId: policy.id }),
+				});
+
+				// Then verify with wrong policy ID
+				const verifyResponse = await verifyConsent({
+					context,
+					params: undefined,
+					query: undefined,
+					body: createVerifyData('privacy_policy', {
+						subjectId: consentResponse.subjectId,
+						policyId: 'invalid-policy-id',
+					}),
+				});
+
+				expect(verifyResponse.isValid).toBe(false);
+				expect(verifyResponse.reasons).toContain('Policy not found');
+			});
+		});
+	});
+});

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -1,7 +1,7 @@
 import { setConsent } from './set-consent';
 import { showConsentBanner } from './show-consent-banner';
 import { status } from './status';
-
+import { verifyConsent } from './verify-consent';
 export * from './error';
 export * from './ok';
 
@@ -9,4 +9,5 @@ export const baseEndpoints = {
 	setConsent,
 	showConsentBanner,
 	status,
+	verifyConsent,
 };

--- a/packages/backend/src/routes/set-consent.ts
+++ b/packages/backend/src/routes/set-consent.ts
@@ -5,25 +5,14 @@ import type { Adapter } from '~/pkgs/db-adapters';
 import { DoubleTieError, ERROR_CODES } from '~/pkgs/results';
 import type { Consent, ConsentRecord } from '~/schema';
 import type { C15TContext } from '~/types';
-
-const ConsentType = z.enum([
-	'cookie_banner',
-	'privacy_policy',
-	'dpa',
-	'terms_of_service',
-	'marketing_communications',
-	'age_verification',
-	'other',
-]);
-
-export type ConsentType = z.infer<typeof ConsentType>;
+import { PolicyTypeSchema } from '~/schema/consent-policy';
 
 // Base schema for all consent types
 const baseConsentSchema = z.object({
 	subjectId: z.string().optional(),
 	externalSubjectId: z.string().optional(),
 	domain: z.string(),
-	type: ConsentType,
+	type: PolicyTypeSchema,
 	metadata: z.record(z.unknown()).optional(),
 });
 
@@ -177,9 +166,7 @@ export const setConsent = createSDKEndpoint(
 					);
 				}
 			} else {
-				const policy = await registry.findOrCreatePolicy(
-					type.replace('_', ' ')
-				);
+				const policy = await registry.findOrCreatePolicy(type);
 				if (!policy) {
 					throw new DoubleTieError(
 						'Failed to create or find the required policy. Please try again later or contact support if the issue persists.',

--- a/packages/backend/src/routes/set-consent.ts
+++ b/packages/backend/src/routes/set-consent.ts
@@ -4,8 +4,8 @@ import { createSDKEndpoint } from '~/pkgs/api-router';
 import type { Adapter } from '~/pkgs/db-adapters';
 import { DoubleTieError, ERROR_CODES } from '~/pkgs/results';
 import type { Consent, ConsentRecord } from '~/schema';
-import type { C15TContext } from '~/types';
 import { PolicyTypeSchema } from '~/schema/consent-policy';
+import type { C15TContext } from '~/types';
 
 // Base schema for all consent types
 const baseConsentSchema = z.object({

--- a/packages/backend/src/routes/set-consent.ts
+++ b/packages/backend/src/routes/set-consent.ts
@@ -24,7 +24,7 @@ const cookieBannerSchema = baseConsentSchema.extend({
 
 // Policy based consent just needs the policy ID
 const policyBasedSchema = baseConsentSchema.extend({
-	type: z.enum(['privacy_policy', 'dpa', 'terms_of_service']),
+	type: z.enum(['privacy_policy', 'dpa', 'terms_and_conditions']),
 	policyId: z.string().optional(),
 	preferences: z.record(z.boolean()).optional(),
 });
@@ -55,7 +55,7 @@ export interface SetConsentResponse {
  * - cookie_banner: For cookie preferences
  * - privacy_policy: For privacy policy acceptance
  * - dpa: For data processing agreement acceptance
- * - terms_of_service: For terms of service acceptance
+ * - terms_and_conditions: For terms and conditions acceptance
  * - marketing_communications: For marketing preferences
  * - age_verification: For age verification
  * - other: For other types of consent

--- a/packages/backend/src/routes/set-consent.ts
+++ b/packages/backend/src/routes/set-consent.ts
@@ -219,6 +219,8 @@ export const setConsent = createSDKEndpoint(
 							status: 'active',
 							isActive: true,
 							givenAt: now,
+							ipAddress: ctx.context.ipAddress || 'unknown',
+							agent: ctx.context.userAgent || 'unknown',
 							history: [],
 						},
 					})) as unknown as Consent;
@@ -248,6 +250,8 @@ export const setConsent = createSDKEndpoint(
 								type,
 							},
 							timestamp: now,
+							ipAddress: ctx.context.ipAddress || 'unknown',
+							agent: ctx.context.userAgent || 'unknown',
 						},
 					});
 

--- a/packages/backend/src/routes/verify-consent.ts
+++ b/packages/backend/src/routes/verify-consent.ts
@@ -2,36 +2,18 @@ import { z } from 'zod';
 import { C15T_ERROR_CODES } from '~/error-codes';
 import { createSDKEndpoint } from '~/pkgs/api-router';
 import { DoubleTieError, ERROR_CODES } from '~/pkgs/results';
-import type {} from '~/schema';
 import type { C15TContext } from '~/types';
-
-const ConsentType = z.enum([
-	'cookie_banner',
-	'privacy_policy',
-	'dpa',
-	'terms_of_service',
-	'marketing_communications',
-	'age_verification',
-	'other',
-]);
-
-export type ConsentType = z.infer<typeof ConsentType>;
+import { PolicyTypeSchema } from '~/schema/consent-policy';
 
 // Base schema
 const verifyConsentSchema = z.object({
 	subjectId: z.string().optional(),
 	externalSubjectId: z.string().optional(),
 	domain: z.string(),
-	type: ConsentType,
+	type: PolicyTypeSchema,
 	policyId: z.string().optional(),
 	preferences: z.string().optional(), // Needs to be parsed,
 });
-
-export interface SetConsentResponse {
-	success: boolean;
-	consentId: string;
-	timestamp: string;
-}
 
 export interface VerifyConsentResponse {
 	isValid: boolean;

--- a/packages/backend/src/routes/verify-consent.ts
+++ b/packages/backend/src/routes/verify-consent.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import { C15T_ERROR_CODES } from '~/error-codes';
 import { createSDKEndpoint } from '~/pkgs/api-router';
 import { DoubleTieError, ERROR_CODES } from '~/pkgs/results';
-import type { C15TContext } from '~/types';
 import { PolicyTypeSchema } from '~/schema/consent-policy';
+import type { C15TContext } from '~/types';
 
 // Base schema
 const verifyConsentSchema = z.object({

--- a/packages/backend/src/routes/verify-consent.ts
+++ b/packages/backend/src/routes/verify-consent.ts
@@ -1,0 +1,251 @@
+import { z } from 'zod';
+import { C15T_ERROR_CODES } from '~/error-codes';
+import { createSDKEndpoint } from '~/pkgs/api-router';
+import { DoubleTieError, ERROR_CODES } from '~/pkgs/results';
+import type {} from '~/schema';
+import type { C15TContext } from '~/types';
+
+const ConsentType = z.enum([
+	'cookie_banner',
+	'privacy_policy',
+	'dpa',
+	'terms_of_service',
+	'marketing_communications',
+	'age_verification',
+	'other',
+]);
+
+export type ConsentType = z.infer<typeof ConsentType>;
+
+// Base schema
+const verifyConsentSchema = z.object({
+	subjectId: z.string().optional(),
+	externalSubjectId: z.string().optional(),
+	domain: z.string(),
+	type: ConsentType,
+	policyId: z.string().optional(),
+	preferences: z.string().optional(), // Needs to be parsed,
+});
+
+export interface SetConsentResponse {
+	success: boolean;
+	consentId: string;
+	timestamp: string;
+}
+
+export interface VerifyConsentResponse {
+	isValid: boolean;
+	reasons?: string[];
+}
+
+/**
+ * Endpoint for verifying existing consent records.
+ *
+ * This endpoint checks if valid consent exists for a given subject, domain, and consent type.
+ * It can also verify specific purposes for cookie banner consent and policy versions for policy-based consent.
+ *
+ * @endpoint POST /consents/verify
+ * @requestExample
+ * ```json
+ * // Verify Cookie Banner Consent
+ * {
+ *   "type": "cookie_banner",
+ *   "domain": "example.com",
+ *   "subjectId": "sub_x1pftyoufsm7xgo1kv",
+ *   "purposeCodes": ["marketing", "analytics"]
+ * }
+ *
+ * // Verify Privacy Policy Consent
+ * {
+ *   "type": "privacy_policy",
+ *   "domain": "example.com",
+ *   "subjectId": "sub_x1pftyoufsm7xgo1kv",
+ *   "policyId": "pol_xyz789"
+ * }
+ * ```
+ *
+ * @returns {VerifyConsentResponse} Object containing verification result and consent details
+ * @throws {DoubleTieError} When verification fails due to invalid parameters or server error
+ */
+export const verifyConsent = createSDKEndpoint(
+	'/consent/verify',
+	{
+		method: 'POST',
+		body: verifyConsentSchema,
+	},
+	async ({ context, body }) => {
+		try {
+			const { type, subjectId, externalSubjectId, domain, policyId } = body;
+			const { registry, adapter } = context as C15TContext;
+
+			// Find subject
+			const subject = await registry.findOrCreateSubject({
+				subjectId,
+				externalSubjectId,
+				ipAddress: context.ipAddress || 'unknown',
+			});
+
+			if (!subject) {
+				return {
+					isValid: false,
+					reasons: ['Subject not found'],
+				};
+			}
+
+			// Find domain
+			const domainRecord = await registry.findDomain(domain);
+			if (!domainRecord) {
+				return {
+					isValid: false,
+					reasons: ['Domain not found'],
+				};
+			}
+
+			async function policyConsentGiven({
+				policyId,
+				subjectId,
+				domainId,
+				purposeIds,
+			}: {
+				policyId: string;
+				subjectId: string;
+				domainId: string;
+				purposeIds?: string[];
+			}) {
+				const rawConsents = await adapter.findMany({
+					model: 'consent',
+					where: [
+						{ field: 'subjectId', value: subjectId },
+						{ field: 'policyId', value: policyId },
+						{ field: 'domainId', value: domainId },
+					],
+					sortBy: {
+						field: 'givenAt',
+						direction: 'desc',
+					},
+				});
+
+				const consents = rawConsents.filter((consent) => {
+					if (!purposeIds) {
+						return true;
+					}
+
+					return purposeIds.every((id) =>
+						(consent.purposeIds as unknown as string[]).some(
+							(purposeId) => purposeId === id
+						)
+					);
+				});
+
+				if (consents.length === 0) {
+					return {
+						isValid: false,
+						reasons: ['No consent found for the given policy'],
+					};
+				}
+
+				return {
+					isValid: true,
+					consent: consents[0],
+				};
+			}
+
+			// Parse preferences
+			const preferences = JSON.parse(
+				body.preferences?.replace(/'/g, '"') || '[]'
+			) as string[];
+
+			if (type === 'cookie_banner' && preferences.length === 0) {
+				return {
+					isValid: false,
+					reasons: ['Preferences are required'],
+				};
+			}
+
+			const purposePromises = preferences.map((purpose: string) =>
+				registry.findConsentPurposeByCode(purpose)
+			);
+
+			const rawPurposes = await Promise.all(purposePromises);
+
+			// Filter out any undefined purposes and get their IDs
+			const purposeIds = rawPurposes
+				.filter(
+					(purpose): purpose is NonNullable<typeof purpose> => purpose !== null
+				)
+				.map((purpose) => purpose.id);
+
+			if (purposeIds.length !== preferences.length) {
+				return {
+					isValid: false,
+					reasons: ['Could not find all purposes'],
+				};
+			}
+
+			// Check if the user has consented to the specific policy
+			if (policyId) {
+				const policy = await registry.findConsentPolicyById(policyId);
+
+				if (!policy) {
+					return {
+						isValid: false,
+						reasons: ['Policy not found'],
+					};
+				}
+
+				return await policyConsentGiven({
+					policyId: policy.id,
+					subjectId: subject.id,
+					domainId: domainRecord.id,
+				});
+			}
+
+			// Check if the user has consented to the latest policy if no policyId is provided
+			const latestPolicy = await registry.findOrCreatePolicy(type);
+
+			if (!latestPolicy) {
+				return {
+					isValid: false,
+					reasons: ['Failed to find or create latest policy'],
+				};
+			}
+
+			return await policyConsentGiven({
+				policyId: latestPolicy.id,
+				subjectId: subject.id,
+				domainId: domainRecord.id,
+			});
+		} catch (error) {
+			context.logger?.error?.('Error verifying consent:', error);
+			if (error instanceof z.ZodError) {
+				context.logger?.error?.(JSON.stringify(error.errors));
+			}
+			if (error instanceof DoubleTieError) {
+				throw error;
+			}
+			if (error instanceof z.ZodError) {
+				throw new DoubleTieError(
+					'The verification request data is invalid. Please ensure all required fields are correctly filled and formatted.',
+					{
+						code: ERROR_CODES.BAD_REQUEST,
+						status: 400,
+						data: {
+							details: error.errors.map((issue) => issue.message),
+						},
+					}
+				);
+			}
+
+			throw new DoubleTieError(
+				'Failed to verify consent. Please try again later or contact support if the issue persists.',
+				{
+					code: C15T_ERROR_CODES.FAILED_TO_GET_CONSENT,
+					status: 500,
+					data: {
+						error: error instanceof Error ? error.message : String(error),
+					},
+				}
+			);
+		}
+	}
+);

--- a/packages/backend/src/schema/consent-policy/registry.ts
+++ b/packages/backend/src/schema/consent-policy/registry.ts
@@ -259,27 +259,25 @@ export function policyRegistry({ adapter, ...ctx }: RegistryContext) {
 					});
 
 					// Find latest policy with exact name match directly from database
-					const matchingPolicies = await txAdapter.findMany({
+					const rawLatestPolicy = await txAdapter.findOne({
 						model: 'consentPolicy',
 						where: [
 							{ field: 'isActive', value: true },
 							{
 								field: 'type',
 								value: type,
-								operator: 'ilike',
 							},
 						],
 						sortBy: {
 							field: 'effectiveDate',
 							direction: 'desc',
 						},
-						limit: 1,
 					});
 
-					const latestPolicy = matchingPolicies[0]
+					const latestPolicy = rawLatestPolicy
 						? validateEntityOutput(
 								'consentPolicy',
-								matchingPolicies[0],
+								rawLatestPolicy,
 								ctx.options
 							)
 						: null;

--- a/packages/backend/src/schema/consent-policy/registry.ts
+++ b/packages/backend/src/schema/consent-policy/registry.ts
@@ -4,7 +4,7 @@ import { getWithHooks } from '~/pkgs/data-model';
 import type { Where } from '~/pkgs/db-adapters';
 import type { GenericEndpointContext, RegistryContext } from '~/pkgs/types';
 import { validateEntityOutput } from '../definition';
-import type { ConsentPolicy } from './schema';
+import type { ConsentPolicy, PolicyType } from './schema';
 
 export interface FindPolicyParams {
 	domainId?: string;
@@ -240,18 +240,15 @@ export function policyRegistry({ adapter, ...ctx }: RegistryContext) {
 		 * Finds the latest active policy or creates a new one if none exists.
 		 * Uses a database transaction to prevent race conditions in multi-threaded environments.
 		 *
-		 * If multiple active policies with the same name exist, returns the most recent one
+		 * If multiple active policies with the same type exist, returns the most recent one
 		 * based on effectiveDate. When creating a new policy, it assigns version '1.0.0'
 		 * and generates placeholder content with a SHA-256 hash.
 		 *
-		 * @param name - The name of the policy to find/create
+		 * @param type - The type of the policy to find/create
 		 * @returns The policy object
 		 * @throws {Error} If the transaction fails to complete
 		 */
-		findOrCreatePolicy: async (name: string) => {
-			// Normalize name for comparison
-			const normalizedSearchName = name.toLowerCase().trim();
-
+		findOrCreatePolicy: async (type: PolicyType) => {
 			// Use a transaction to prevent race conditions
 			return adapter.transaction({
 				callback: async (txAdapter) => {
@@ -267,8 +264,8 @@ export function policyRegistry({ adapter, ...ctx }: RegistryContext) {
 						where: [
 							{ field: 'isActive', value: true },
 							{
-								field: 'name',
-								value: normalizedSearchName,
+								field: 'type',
+								value: type,
 								operator: 'ilike',
 							},
 						],
@@ -293,11 +290,12 @@ export function policyRegistry({ adapter, ...ctx }: RegistryContext) {
 
 					// Generate policy content and hash
 					const { content: defaultContent, contentHash } =
-						generatePolicyPlaceholder(name, now);
+						generatePolicyPlaceholder(type, now);
 
 					return txRegistry.createConsentPolicy({
 						version: '1.0.0',
-						name: normalizedSearchName,
+						type,
+						name: type,
 						effectiveDate: now,
 						content: defaultContent,
 						contentHash,

--- a/packages/backend/src/schema/consent-policy/schema.ts
+++ b/packages/backend/src/schema/consent-policy/schema.ts
@@ -25,7 +25,7 @@ export type PolicyType = z.infer<typeof PolicyTypeSchema>;
  * ```typescript
  * const policyData = {
  *   id: 'pol_w5qufx2a66m7xkn3ty',
- *   version: '1.0.0',
+ *   version: '1.0.0', 
  *   name: 'Privacy Policy 2023',
  *   effectiveDate: new Date(),
  *   content: 'Full policy text...',

--- a/packages/backend/src/schema/consent-policy/schema.ts
+++ b/packages/backend/src/schema/consent-policy/schema.ts
@@ -4,7 +4,7 @@ export const PolicyTypeSchema = z.enum([
 	'cookie_banner',
 	'privacy_policy',
 	'dpa',
-	'terms_of_service',
+	'terms_and_conditions',
 	'marketing_communications',
 	'age_verification',
 	'other',

--- a/packages/backend/src/schema/consent-policy/schema.ts
+++ b/packages/backend/src/schema/consent-policy/schema.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod';
 
+export const PolicyTypeSchema = z.enum([
+	'cookie_banner',
+	'privacy_policy',
+	'dpa',
+	'terms_of_service',
+	'marketing_communications',
+	'age_verification',
+	'other',
+]);
+
+export type PolicyType = z.infer<typeof PolicyTypeSchema>;
+
 /**
  * Zod schema for validating consent policy entities.
  *
@@ -27,6 +39,7 @@ import { z } from 'zod';
 export const consentPolicySchema = z.object({
 	id: z.string(),
 	version: z.string(),
+	type: PolicyTypeSchema,
 	name: z.string(),
 	effectiveDate: z.date(),
 	expirationDate: z.date().nullable().optional(),

--- a/packages/backend/src/schema/consent-policy/schema.ts
+++ b/packages/backend/src/schema/consent-policy/schema.ts
@@ -25,7 +25,7 @@ export type PolicyType = z.infer<typeof PolicyTypeSchema>;
  * ```typescript
  * const policyData = {
  *   id: 'pol_w5qufx2a66m7xkn3ty',
- *   version: '1.0.0', 
+ *   version: '1.0.0',
  *   name: 'Privacy Policy 2023',
  *   effectiveDate: new Date(),
  *   content: 'Full policy text...',

--- a/packages/backend/src/schema/consent-policy/table.ts
+++ b/packages/backend/src/schema/consent-policy/table.ts
@@ -57,6 +57,15 @@ export function getConsentPolicyTable(
 			},
 
 			/**
+			 * Type of the policy
+			 */
+			type: {
+				type: 'string',
+				required: true,
+				fieldName: consentPolicyConfig?.fields?.type || 'type',
+			},
+
+			/**
 			 * Human-readable name of the policy
 			 */
 			name: {

--- a/packages/backend/src/schema/consent-policy/types.ts
+++ b/packages/backend/src/schema/consent-policy/types.ts
@@ -13,11 +13,11 @@ export interface ConsentPolicyEntityConfig extends BaseEntityConfig {
 		/**
 		 * ISO format date string (e.g., "2024-04-15T00:00:00Z")
 		 */
-		effectiveDate?: string;
+		effectiveDate?: Date;
 		/**
 		 * ISO format date string (e.g., "2024-04-15T00:00:00Z")
 		 */
-		expirationDate?: string;
+		expirationDate?: Date;
 		content?: string;
 		contentHash?: string;
 		isActive?: string;

--- a/packages/backend/src/schema/consent-policy/types.ts
+++ b/packages/backend/src/schema/consent-policy/types.ts
@@ -9,6 +9,7 @@ export interface ConsentPolicyEntityConfig extends BaseEntityConfig {
 		id?: string;
 		version?: string;
 		name?: string;
+		type?: string;
 		/**
 		 * ISO format date string (e.g., "2024-04-15T00:00:00Z")
 		 */

--- a/packages/backend/src/schema/consent/schema.ts
+++ b/packages/backend/src/schema/consent/schema.ts
@@ -29,29 +29,21 @@ import { z } from 'zod';
  * };
  * ```
  */
-export const consentHistorySchema = z.object({
-	actionType: z.enum(['given', 'withdrawn', 'updated', 'expired']),
-	timestamp: z.date(),
-	details: z.record(z.unknown()).optional(),
-	previousState: z.record(z.unknown()).optional(),
-	newState: z.record(z.unknown()).optional(),
-});
 
 export const consentSchema = z.object({
 	id: z.string(),
 	subjectId: z.string(),
 	domainId: z.string(),
 	purposeIds: z.array(z.string()),
-	metadata: z.record(z.unknown()).optional(),
+	metadata: z.record(z.unknown()).nullable().optional(),
 	policyId: z.string().optional(),
-	ipAddress: z.string().optional(),
-	userAgent: z.string().optional(),
+	ipAddress: z.string().nullable().optional(),
+	userAgent: z.string().nullable().optional(),
 	status: z.enum(['active', 'withdrawn', 'expired']).default('active'),
-	withdrawalReason: z.string().optional(),
+	withdrawalReason: z.string().nullable().optional(),
 	givenAt: z.date().default(() => new Date()),
-	validUntil: z.date().optional(),
+	validUntil: z.date().nullable().optional(),
 	isActive: z.boolean().default(true),
-	history: z.array(consentHistorySchema).default([]),
 });
 
 /**
@@ -62,4 +54,3 @@ export const consentSchema = z.object({
  * that are part of the consent entity and its history.
  */
 export type Consent = z.infer<typeof consentSchema>;
-export type ConsentHistory = z.infer<typeof consentHistorySchema>;

--- a/packages/backend/src/schema/consent/schema.ts
+++ b/packages/backend/src/schema/consent/schema.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
  * - Required fields: subjectId, domainId, purposeIds
  * - Default value of 'active' for status
  * - Default current date/time for creation timestamp
- * - Includes audit trail of all changes
+ * - Captures contextual information like IP address and user agent
  *
  * @example
  * ```typescript
@@ -19,13 +19,8 @@ import { z } from 'zod';
  *   status: 'active',
  *   givenAt: new Date(),
  *   isActive: true,
- *   history: [
- *     {
- *       actionType: 'given',
- *       timestamp: new Date(),
- *       details: { ip: '192.168.1.1' }
- *     }
- *   ]
+ *   ipAddress: '192.168.1.1',
+ *   userAgent: 'Mozilla/5.0...',
  * };
  * ```
  */

--- a/packages/backend/src/schema/definition.ts
+++ b/packages/backend/src/schema/definition.ts
@@ -188,6 +188,19 @@ export function validateEntityOutput<TableName extends keyof C15TDBSchema>(
 		throw new Error(`Table ${tableName} not found`);
 	}
 
+	// Pre-process data: Convert date strings to Date objects
+	const processedData = { ...data };
+	for (const [field, def] of Object.entries(table.fields)) {
+		if (def.type === 'date' && typeof processedData[field] === 'string') {
+			processedData[field] = new Date(processedData[field] as string);
+		}
+	}
+
 	// Validate and return data using Zod schema
-	return table.schema.parse(data) as EntityOutputFields<TableName>;
+	try {
+		return table.schema.parse(processedData) as EntityOutputFields<TableName>;
+	} catch (error) {
+		console.error('Validation failed:', table, error);
+		throw error;
+	}
 }

--- a/packages/backend/src/schema/definition.ts
+++ b/packages/backend/src/schema/definition.ts
@@ -1,3 +1,4 @@
+import { ZodError } from 'node_modules/zod/lib/ZodError';
 import type { PluginSchema } from '~/pkgs/data-model';
 import type { C15TOptions } from '~/types';
 import { getAuditLogTable } from './audit-log/table';
@@ -12,7 +13,6 @@ import { getDomainTable } from './domain/table';
 import { getGeoLocationTable } from './geo-location/table';
 import type { InferTableShape } from './schemas';
 import { getSubjectTable } from './subject/table';
-import { ZodError } from 'node_modules/zod/lib/ZodError';
 
 /**
  * Retrieves all consent-related database table definitions

--- a/packages/backend/src/schema/definition.ts
+++ b/packages/backend/src/schema/definition.ts
@@ -12,6 +12,7 @@ import { getDomainTable } from './domain/table';
 import { getGeoLocationTable } from './geo-location/table';
 import type { InferTableShape } from './schemas';
 import { getSubjectTable } from './subject/table';
+import { ZodError } from 'node_modules/zod/lib/ZodError';
 
 /**
  * Retrieves all consent-related database table definitions
@@ -196,11 +197,31 @@ export function validateEntityOutput<TableName extends keyof C15TDBSchema>(
 		}
 	}
 
+	// This is useful for debugging validation issues
+	// console.log('[validateEntityOutput] Debug data:', {
+	// 	fields: Object.fromEntries(
+	// 		Object.entries(table.fields).map(([key, field]) => [
+	// 			key,
+	// 			{
+	// 				type: field.type,
+	// 				required: field.required,
+	// 				value: processedData[field.fieldName as keyof typeof processedData],
+	// 			},
+	// 		])
+	// 	),
+	// });
+
 	// Validate and return data using Zod schema
 	try {
 		return table.schema.parse(processedData) as EntityOutputFields<TableName>;
 	} catch (error) {
-		console.error('Validation failed:', table, error);
+		if (error instanceof ZodError) {
+			console.log(
+				'[validateEntityOutput] Validation failed:',
+				table,
+				error.issues
+			);
+		}
 		throw error;
 	}
 }

--- a/packages/backend/src/schema/subject/registry.ts
+++ b/packages/backend/src/schema/subject/registry.ts
@@ -95,7 +95,7 @@ export function subjectRegistry({ adapter, ...ctx }: RegistryContext) {
 				]);
 
 				if (!subjectById || !subjectByExternalId) {
-					ctx.logger?.info(
+					ctx.logger?.error(
 						'Subject validation failed: One or both subjects not found',
 						{
 							providedSubjectId: subjectId,
@@ -127,6 +127,7 @@ export function subjectRegistry({ adapter, ...ctx }: RegistryContext) {
 							subjectByExternalIdId: subjectByExternalId.id,
 						}
 					);
+
 					throw new DoubleTieError(
 						'The provided subjectId and externalSubjectId do not match the same subject. Please ensure both identifiers refer to the same subject.',
 						{
@@ -151,7 +152,7 @@ export function subjectRegistry({ adapter, ...ctx }: RegistryContext) {
 				if (subject) {
 					return subject;
 				}
-				throw new DoubleTieError('Subject not found', {
+				throw new DoubleTieError('Subject not found by subjectId', {
 					code: ERROR_CODES.NOT_FOUND,
 					status: 404,
 				});
@@ -262,6 +263,7 @@ export function subjectRegistry({ adapter, ...ctx }: RegistryContext) {
 					},
 				],
 			});
+
 			return subject
 				? validateEntityOutput('subject', subject, ctx.options)
 				: null;
@@ -286,6 +288,7 @@ export function subjectRegistry({ adapter, ...ctx }: RegistryContext) {
 					},
 				],
 			});
+
 			return subject
 				? validateEntityOutput('subject', subject, ctx.options)
 				: null;

--- a/packages/cli/test/__snapshots__/drizzle/mysql.txt
+++ b/packages/cli/test/__snapshots__/drizzle/mysql.txt
@@ -27,6 +27,7 @@ export const consentPurpose = mysqlTable("consent_purpose", {
 export const consentPolicy = mysqlTable("consent_policy", {
   id: varchar("id", { length: 36 }).primaryKey(),
   version: text('version').notNull(),
+  type: text('type').notNull(),
   name: text('name').notNull(),
   effectiveDate: timestamp('effective_date').notNull(),
   expirationDate: timestamp('expiration_date'),

--- a/packages/cli/test/__snapshots__/drizzle/pg.txt
+++ b/packages/cli/test/__snapshots__/drizzle/pg.txt
@@ -27,6 +27,7 @@ export const consentPurpose = pgTable("consent_purpose", {
 export const consentPolicy = pgTable("consent_policy", {
   id: text("id").primaryKey(),
   version: text('version').notNull(),
+  type: text('type').notNull(),
   name: text('name').notNull(),
   effectiveDate: timestamp('effective_date').notNull(),
   expirationDate: timestamp('expiration_date'),

--- a/packages/cli/test/__snapshots__/drizzle/sqlite.txt
+++ b/packages/cli/test/__snapshots__/drizzle/sqlite.txt
@@ -27,6 +27,7 @@ export const consentPurpose = sqliteTable("consent_purpose", {
 export const consentPolicy = sqliteTable("consent_policy", {
   id: text("id").primaryKey(),
   version: text('version').notNull(),
+  type: text('type').notNull(),
   name: text('name').notNull(),
   effectiveDate: integer('effective_date', { mode: 'timestamp' }).notNull(),
   expirationDate: integer('expiration_date', { mode: 'timestamp' }),

--- a/packages/cli/test/__snapshots__/kysely/d1.sql
+++ b/packages/cli/test/__snapshots__/kysely/d1.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS "geoLocation" (
 CREATE TABLE IF NOT EXISTS "consentPolicy" (
   "id" text NOT NULL PRIMARY KEY,
   "version" text NOT NULL,
+  "type" text NOT NULL,
   "name" text NOT NULL,
   "effectiveDate" date NOT NULL,
   "expirationDate" date,

--- a/packages/cli/test/__snapshots__/kysely/mysql.sql
+++ b/packages/cli/test/__snapshots__/kysely/mysql.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS "geoLocation" (
 CREATE TABLE IF NOT EXISTS "consentPolicy" (
   "id" VARCHAR(255) NOT NULL PRIMARY KEY,
   "version" text NOT NULL,
+  "type" text NOT NULL,
   "name" VARCHAR(255) NOT NULL,
   "effectiveDate" date NOT NULL,
   "expirationDate" date,

--- a/packages/cli/test/__snapshots__/kysely/postgresql.sql
+++ b/packages/cli/test/__snapshots__/kysely/postgresql.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS "geoLocation" (
 CREATE TABLE IF NOT EXISTS "consentPolicy" (
   "id" varchar(255) NOT NULL PRIMARY KEY,
   "version" text NOT NULL,
+  "type" text NOT NULL,
   "name" varchar(255) NOT NULL,
   "effectiveDate" date NOT NULL,
   "expirationDate" date,

--- a/packages/cli/test/__snapshots__/kysely/sqlite.sql
+++ b/packages/cli/test/__snapshots__/kysely/sqlite.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS "geoLocation" (
 CREATE TABLE IF NOT EXISTS "consentPolicy" (
   "id" text NOT NULL PRIMARY KEY,
   "version" text NOT NULL,
+  "type" text NOT NULL,
   "name" text NOT NULL,
   "effectiveDate" date NOT NULL,
   "expirationDate" date,

--- a/packages/cli/test/__snapshots__/prisma/mysql.prisma
+++ b/packages/cli/test/__snapshots__/prisma/mysql.prisma
@@ -40,6 +40,7 @@ model ConsentPurpose {
 model ConsentPolicy {
   id             String    @id
   version        String    @db.Text
+  type           String    @db.Text
   name           String    @db.Text
   effectiveDate  DateTime
   expirationDate DateTime?

--- a/packages/cli/test/__snapshots__/prisma/pg.prisma
+++ b/packages/cli/test/__snapshots__/prisma/pg.prisma
@@ -40,6 +40,7 @@ model ConsentPurpose {
 model ConsentPolicy {
   id             String    @id
   version        String
+  type           String
   name           String
   effectiveDate  DateTime
   expirationDate DateTime?

--- a/packages/cli/test/__snapshots__/prisma/sqlite.prisma
+++ b/packages/cli/test/__snapshots__/prisma/sqlite.prisma
@@ -40,6 +40,7 @@ model ConsentPurpose {
 model ConsentPolicy {
   id             String    @id
   version        String
+  type           String
   name           String
   effectiveDate  DateTime
   expirationDate DateTime?


### PR DESCRIPTION
## Overview
Adds an endpoint to verify the subject has consented to the latest X policy, or the specified policy if provided with the policy id in the body.  

Also added a 'type' column to the policy table so we can easily fetch the latest policy by type. 

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [x] 🚀 New feature
- [x] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Checklist
- [] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [ ] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
Requires DB migration due to changes to the consent policy table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint to verify consent records with comprehensive validation and feedback.
  - Expanded support for multiple consent policy types for more flexible policy management.

- **Enhancements**
  - Streamlined consent creation and verification processes for improved reliability and clearer error feedback.
  - Upgraded data validation to accurately process date information and ensure robust consent handling.
  - Enhanced error handling for consent data validation.

- **Database Updates**
  - Revised the consent policy data model with a new policy type field to better categorize policies.
  - Added a new `type` field to the consent policy tables across various database schemas.
  - Removed the consent history structure from the consent schema, allowing for more flexible field handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->