### PR TITLE
refactor: rename baseURL to backendURL in client config

### DIFF
--- a/apps/docs/src/c15t-client.ts
+++ b/apps/docs/src/c15t-client.ts
@@ -10,7 +10,7 @@ import { env } from './env';
  * and exposes hooks and utilities for consent management.
  */
 export const c15tClient = createConsentClient({
-	baseURL: env.NEXT_PUBLIC_C15T_URL as string,
+	backendURL: env.NEXT_PUBLIC_C15T_URL as string,
 	// defaultPreferences: {
 	// 	analytics: true,
 	// 	marketing: true,

--- a/apps/docs/src/examples/c15t-client-example.ts
+++ b/apps/docs/src/examples/c15t-client-example.ts
@@ -4,7 +4,7 @@ export const c15tClientExample = `import { createConsentClient } from '@c15t/rea
  * Create a client for React components to use
  */
 export const c15tClient = createConsentClient({
-    baseURL: '/api/c15t-demo',
+    backendURL: '/api/c15t-demo',
     defaultPreferences: {
         analytics: true,
         marketing: true,

--- a/apps/docs/src/examples/core/example.ts
+++ b/apps/docs/src/examples/core/example.ts
@@ -179,7 +179,7 @@ import { createConsentManagerStore, createConsentClient } from 'https://cdn.skyp
 // Configuration for the consent manager
 const config = {
     client: {
-        baseURL: '/api/c15t-demo',
+        backendURL: '/api/c15t-demo',
         defaultPreferences: {
             analytics: true,
             marketing: true,

--- a/apps/examples/vite-react/src/c15t-client.ts
+++ b/apps/examples/vite-react/src/c15t-client.ts
@@ -9,7 +9,7 @@ import { type c15tClientOptions, createConsentClient } from '@c15t/react';
  * and exposes hooks and utilities for consent management.
  */
 export const c15tClient = createConsentClient({
-	baseURL: 'http://localhost:8787/api/c15t',
+	backendURL: 'http://localhost:8787/api/c15t',
 	// defaultGdprTypes: ['necessary', 'marketing'],
 	// defaultPreferences: {
 	// 	analytics: true,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -136,7 +136,10 @@ export class c15tClient {
 		if (ABSOLUTE_URL_REGEX.test(backendURL)) {
 			const backendURLObj = new URL(backendURL);
 			// Remove trailing slashes from base path and leading slashes from the path to join
-			const basePath = backendURLObj.pathname.replace(TRAILING_SLASHES_REGEX, '');
+			const basePath = backendURLObj.pathname.replace(
+				TRAILING_SLASHES_REGEX,
+				''
+			);
 			const cleanPath = path.replace(LEADING_SLASHES_REGEX, '');
 			// Combine the paths with a single slash
 			const newPath = `${basePath}/${cleanPath}`;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -11,7 +11,7 @@ import type {
 /**
  * Default consent banner API URL
  */
-const DEFAULT_API_BASE_URL = '/api/c15t';
+const DEFAULT_BACKEND_URL = '/api/c15t';
 
 /**
  * Regex pattern to detect absolute URLs (with protocol)
@@ -517,7 +517,7 @@ export function createConsentClient(options: c15tClientOptions): c15tClient {
 	// If no backendURL provided, use the default
 	const clientOptions = {
 		...options,
-		backendURL: options.backendURL || DEFAULT_API_BASE_URL,
+		backendURL: options.backendURL || DEFAULT_BACKEND_URL,
 	};
 
 	return new c15tClient(clientOptions);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -70,8 +70,7 @@ const API_ENDPOINTS = {
  * import { createConsentClient } from '@c15t/core';
  *
  * const client = createConsentClient({
- *   baseURL: 'https://example.com/api',
- *   headers: { 'X-API-Key': 'your-api-key' }
+ *   backendURL: 'https://example.com/api',
  * });
  *
  * // Get current consent
@@ -90,7 +89,7 @@ export class c15tClient {
 	 *
 	 * @internal
 	 */
-	private baseURL: string;
+	private backendURL: string;
 
 	/**
 	 * Default headers to include with all requests
@@ -110,12 +109,12 @@ export class c15tClient {
 	 * Creates a new c15t client instance.
 	 *
 	 * @param options - Configuration options for the client
-	 * @throws Will throw an error if the baseURL is invalid or if required options are missing
+	 * @throws Will throw an error if the backendURL is invalid or if required options are missing
 	 */
 	constructor(options: c15tClientOptions) {
-		this.baseURL = options.baseURL.endsWith('/')
-			? options.baseURL.slice(0, -1)
-			: options.baseURL;
+		this.backendURL = options.backendURL.endsWith('/')
+			? options.backendURL.slice(0, -1)
+			: options.backendURL;
 
 		this.headers = {
 			'Content-Type': 'application/json',
@@ -126,29 +125,29 @@ export class c15tClient {
 	}
 
 	/**
-	 * Resolves a URL path against a base URL, handling both absolute and relative base URLs.
+	 * Resolves a URL path against the backend URL, handling both absolute and relative URLs.
 	 *
-	 * @param baseURL - The base URL (can be absolute or relative)
+	 * @param backendURL - The backend URL (can be absolute or relative)
 	 * @param path - The path to append
 	 * @returns The resolved URL string
 	 */
-	private resolveUrl(baseURL: string, path: string): string {
-		// Case 1: baseURL is already an absolute URL (includes protocol)
-		if (ABSOLUTE_URL_REGEX.test(baseURL)) {
-			const baseUrlObj = new URL(baseURL);
+	private resolveUrl(backendURL: string, path: string): string {
+		// Case 1: backendURL is already an absolute URL (includes protocol)
+		if (ABSOLUTE_URL_REGEX.test(backendURL)) {
+			const backendURLObj = new URL(backendURL);
 			// Remove trailing slashes from base path and leading slashes from the path to join
-			const basePath = baseUrlObj.pathname.replace(TRAILING_SLASHES_REGEX, '');
+			const basePath = backendURLObj.pathname.replace(TRAILING_SLASHES_REGEX, '');
 			const cleanPath = path.replace(LEADING_SLASHES_REGEX, '');
 			// Combine the paths with a single slash
 			const newPath = `${basePath}/${cleanPath}`;
 			// Set the new path on the URL object
-			baseUrlObj.pathname = newPath;
-			return baseUrlObj.toString();
+			backendURLObj.pathname = newPath;
+			return backendURLObj.toString();
 		}
 
-		// Case 2: baseURL is relative (like '/api/c15t')
+		// Case 2: backendURL is relative (like '/api/c15t')
 		// For relative URLs, we use string concatenation with proper slash handling
-		const cleanBase = baseURL.replace(TRAILING_SLASHES_REGEX, '');
+		const cleanBase = backendURL.replace(TRAILING_SLASHES_REGEX, '');
 		const cleanPath = path.replace(LEADING_SLASHES_REGEX, '');
 		return `${cleanBase}/${cleanPath}`;
 	}
@@ -161,7 +160,7 @@ export class c15tClient {
 	 * error handling and response formatting.
 	 *
 	 * @typeParam ResponseType - The expected type of the response data
-	 * @param path - API endpoint path (will be appended to the baseURL)
+	 * @param path - API endpoint path (will be appended to the backendURL)
 	 * @param options - Request configuration options
 	 * @returns A response context object containing the data, response metadata, and any errors
 	 * @throws Will throw an error if options.throw is true and the request fails
@@ -173,7 +172,7 @@ export class c15tClient {
 	): Promise<ResponseContext<ResponseType>> {
 		try {
 			// Use the resolveUrl method instead of direct URL construction
-			const urlString = this.resolveUrl(this.baseURL, path);
+			const urlString = this.resolveUrl(this.backendURL, path);
 
 			// Create URL object for search params (this should work even with relative URLs
 			// since we're creating it in the browser context)
@@ -492,7 +491,7 @@ export class c15tClient {
  * It provides a convenient factory function that instantiates a properly configured
  * client based on the provided options.
  *
- * @throws Will throw an error if the baseURL is invalid or if required options are missing
+ * @throws Will throw an error if the backendURL is invalid or if required options are missing
  *
  * @example
  * ```typescript
@@ -500,11 +499,7 @@ export class c15tClient {
  *
  * // Create a client for your application
  * const client = createConsentClient({
- *   baseURL: 'https://api.example.com/consent',
- *   headers: {
- *     'X-API-Key': process.env.API_KEY,
- *     'user-agent': 'MyConsentApp/1.0'
- *   },
+ *   backendURL: 'https://api.example.com/consent',
  *   fetchOptions: {
  *     // Optional custom fetch implementation
  *     customFetchImpl: customFetch
@@ -516,10 +511,10 @@ export class c15tClient {
  * @returns A new c15tClient instance
  */
 export function createConsentClient(options: c15tClientOptions): c15tClient {
-	// If no baseURL provided, use the default
+	// If no backendURL provided, use the default
 	const clientOptions = {
 		...options,
-		baseURL: options.baseURL || DEFAULT_API_BASE_URL,
+		backendURL: options.backendURL || DEFAULT_API_BASE_URL,
 	};
 
 	return new c15tClient(clientOptions);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -20,10 +20,8 @@ import type { c15tClientOptions } from './types/client';
  * // Creating a complete c15t configuration
  * const config: c15tConfig = {
  *   client: {
- *     baseURL: 'https://api.example.com/consent',
- *     headers: {
- *       'X-API-Key': process.env.API_KEY,
- *     }
+ *     backendURL: 'https://api.example.com/consent',
+ *
  *   },
  *   store: {
  *     namespace: 'myApp',
@@ -101,8 +99,7 @@ export interface ConsentManagerInstance {
  * // Create a unified consent management system
  * const { store, client } = createConsentManager({
  *   client: {
- *     baseURL: 'https://api.example.com/consent',
- *     headers: { 'X-API-Key': 'your-api-key' }
+ *     backendURL: 'https://api.example.com/consent',
  *   },
  *   store: {
  *     namespace: 'myConsentManager',

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -38,7 +38,6 @@ interface StoredConsent {
 	} | null;
 }
 
-const DEFAULT_API_BASE_URL = '/api/c15t';
 /**
  * Retrieves stored consent data from localStorage.
  *

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -8,20 +8,12 @@
  * ```typescript
  * // Basic client configuration
  * const options: c15tClientOptions = {
- *   baseURL: 'https://api.example.com/consent',
- *   headers: {
- *     'X-API-Key': 'your-api-key',
- *     'Authorization': 'Bearer token'
- *   }
+ *   backendURL: 'https://api.example.com/consent',
  * };
  *
  * // Advanced configuration with plugins and custom fetch
  * const advancedOptions: c15tClientOptions = {
- *   baseURL: 'https://api.example.com/consent',
- *   headers: {
- *     'X-API-Key': 'your-api-key',
- *     'Authorization': 'Bearer token'
- *   },
+ *   backendURL: 'https://api.example.com/consent',
  *   fetchOptions: {
  *     customFetchImpl: nodeFetch // Use node-fetch in Node.js environments
  *   },
@@ -34,23 +26,14 @@
  */
 export interface c15tClientOptions {
 	/**
-	 * Base URL for API endpoints.
+	 * Backend URL for API endpoints. Can be absolute or relative.
+	 * If absolute (starts with http:// or https://), the full URL will be used.
+	 * If relative (starts with /), it will be appended to the origin.
 	 *
-	 * The URL should point to the root of the c15t API without a trailing slash.
-	 * All endpoint paths will be appended to this base URL.
-	 *
-	 * @example 'https://api.example.com/consent'
+	 * @example 'https://api.example.com/consent' or '/api/c15t'
+	 * @default '/api/c15t'
 	 */
-	baseURL: string;
-
-	/**
-	 * Base path for API endpoints.
-	 *
-	 * The path will be appended to the base URL without a leading slash.
-	 *
-	 * @example 'consent'
-	 */
-	basePath?: string;
+	backendURL: string;
 
 	/**
 	 * Default request headers to include with all API requests.
@@ -396,7 +379,7 @@ export interface ResponseContext<ResponseType = unknown> {
  *
  * // Using the plugin
  * const client = createConsentClient({
- *   baseURL: 'https://api.example.com',
+ *   backendURL: 'https://api.example.com',
  *   plugins: [analyticsPlugin({ trackPageviews: true })]
  * });
  *

--- a/packages/react/src/components/consent-manager-dialog/__tests__/utils.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/utils.tsx
@@ -20,7 +20,7 @@ async function testComponentStyles({
 	noStyle = false,
 }: ComponentStyles) {
 	const c15tClient = createConsentClient({
-		baseURL: '/api/c15t',
+		backendURL: '/api/c15t',
 	});
 
 	const { getByTestId } = render(

--- a/packages/react/src/components/consent-manager-widget/__tests__/utils.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/utils.tsx
@@ -20,7 +20,7 @@ async function testComponentStyles({
 	noStyle = false,
 }: ComponentStyles) {
 	const c15tClient = createConsentClient({
-		baseURL: '/api/c15t',
+		backendURL: '/api/c15t',
 	});
 
 	const { getByTestId } = render(

--- a/packages/react/src/components/cookie-banner/__tests__/utils.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/utils.tsx
@@ -14,7 +14,7 @@ interface ComponentStyles {
 	noStyle?: boolean;
 }
 const c15tClient = createConsentClient({
-	baseURL: '/api/c15t',
+	backendURL: '/api/c15t',
 });
 
 async function testComponentStyles({


### PR DESCRIPTION
# Simplify URL Configuration with Unified backendURL Parameter

## Overview

This change simplifies and unifies URL handling in the client packages by introducing a new `backendURL` parameter that combines the functionality of `baseURL` and `basePath`. This solves several problems:

1. Current configuration is split between `baseURL` and `basePath`, making it unclear how they interact
2. URL resolution logic is complex and scattered across different utilities
3. Developers need to understand both parameters to configure API endpoints correctly

The new approach uses a single `backendURL` parameter that can be either absolute or relative, making the configuration more intuitive and reducing complexity.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [x] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes

1. Introduced new `backendURL` parameter in client packages that accepts both absolute and relative URLs
2. Updated URL resolution logic to handle both URL formats consistently
3. Simplified client configuration by removing separate `baseURL` and `basePath` parameters
4. Updated documentation and types to reflect the new parameter
5. Maintained backward compatibility in backend package by keeping `baseURL` for server-side configuration

### Technical Notes

- Backend package continues to use `baseURL` for server configuration to maintain separation of concerns
- URL resolution now handles both absolute URLs (e.g., 'http://localhost:3000/api/c15t') and relative URLs (e.g., '/api/c15t')
- Environment variable support is maintained for backward compatibility

## Checklist

### Required

- [ ] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow conventional commits

### Breaking Changes

**Changes:**
- Client configuration no longer accepts separate `baseURL` and `basePath`
- URL resolution behavior is slightly modified for consistency

**Migration:**
```ts
// Before
const client = createConsentClient({
  baseURL: 'http://localhost:8787',
  basePath: '/api/c15t'
});

// After
const client = createConsentClient({
  backendURL: 'http://localhost:8787'
  // Or relative URL
  backendURL: '/api/c15t'
});
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized the naming of the API endpoint configuration from `baseURL` to `backendURL` across the consent management system.
  - Simplified client settings by removing the `headers` property and the `basePath` property, ensuring a streamlined configuration without altering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->