### PR TITLE
refactor: remove localStorageKey

### DIFF
--- a/docs/content/storing-consent/offline-mode.mdx
+++ b/docs/content/storing-consent/offline-mode.mdx
@@ -35,8 +35,6 @@ import { createClient } from '@c15t/react'
 
 export const c15tClient = createClient({
   mode: 'offline',
-  // Optional: Custom localStorage key
-  localStorageKey: 'my-app-consent'
 })
 ```
 </Step>
@@ -84,10 +82,6 @@ The offline mode accepts the following configuration options:
 ```jsx
 const options = {
   mode: 'offline',
-  
-  // Optional: Custom localStorage key (default: 'c15t-consent')
-  localStorageKey: 'my-app-consent',
-  
   // Optional: Add callback functions for various events
   callbacks: {
     onConsentBannerFetched: (response) => {
@@ -187,7 +181,6 @@ For static sites without backend integration, offline mode provides a simple sol
 ```jsx
 const options = {
   mode: 'offline',
-  localStorageKey: 'my-static-site-consent'
 };
 ```
 

--- a/packages/cli/src/onboarding/storage-modes/c15t-mode.ts
+++ b/packages/cli/src/onboarding/storage-modes/c15t-mode.ts
@@ -132,7 +132,6 @@ export async function setupC15tMode(
 	const clientConfigContent = generateClientConfigContent(
 		'c15t',
 		backendURL,
-		undefined,
 		useEnvFile
 	);
 

--- a/packages/cli/src/onboarding/storage-modes/offline-mode.ts
+++ b/packages/cli/src/onboarding/storage-modes/offline-mode.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import * as p from '@clack/prompts';
+import type * as p from '@clack/prompts';
 import color from 'picocolors';
 import type { CliContext } from '../../context/types';
 import { formatLogMessage } from '../../utils/logger';
@@ -11,7 +11,6 @@ import { generateClientConfigContent } from '../templates';
  */
 export interface OfflineModeResult {
 	clientConfigContent: string;
-	localStorageKey: string;
 }
 
 /**
@@ -32,27 +31,10 @@ export async function setupOfflineMode(
 	const { logger, cwd } = context;
 	let spinnerActive = false;
 
-	// Ask for localStorage key
-	const localStorageKeySelection = await p.text({
-		message: 'Enter a key for localStorage (optional):',
-		placeholder: 'c15t-consent',
-	});
-
-	if (handleCancel?.(localStorageKeySelection)) {
-		throw new Error('Setup cancelled');
-	}
-
-	// Use default value if empty string is provided
-	const localStorageKey =
-		(localStorageKeySelection as string) || 'c15t-consent';
-
-	logger.debug(`Using localStorage key: ${localStorageKey}`);
-
 	// Generate client config
 	const clientConfigContent = generateClientConfigContent(
 		'offline',
 		undefined,
-		localStorageKey,
 		false
 	);
 
@@ -83,6 +65,5 @@ export async function setupOfflineMode(
 
 	return {
 		clientConfigContent,
-		localStorageKey,
 	};
 }

--- a/packages/cli/src/onboarding/storage-modes/self-hosted-mode.ts
+++ b/packages/cli/src/onboarding/storage-modes/self-hosted-mode.ts
@@ -150,7 +150,6 @@ export async function setupSelfHostedMode(
 	const clientConfigContent = generateClientConfigContent(
 		'c15t',
 		'/api/c15t',
-		undefined,
 		false
 	);
 

--- a/packages/cli/src/onboarding/templates.ts
+++ b/packages/cli/src/onboarding/templates.ts
@@ -8,14 +8,12 @@
  *
  * @param mode - The storage mode ('c15t', 'offline', or 'custom')
  * @param backendURL - URL for the c15t backend/API (for 'c15t' mode)
- * @param localStorageKey - Key to use for localStorage (for 'offline' mode)
  * @param useEnvFile - Whether to use environment variable for backendURL
  * @returns The generated configuration file content
  */
 export function generateClientConfigContent(
 	mode: string,
 	backendURL?: string,
-	localStorageKey?: string,
 	useEnvFile?: boolean
 ): string {
 	let configContent = '';
@@ -62,7 +60,6 @@ import type { ConsentManagerOptions } from '@c15t/react';
 export const c15tConfig = {
   // Using offline mode for browser-based storage
   mode: 'offline',
-  localStorageKey: '${localStorageKey || 'c15t-consent'}',
   
   // Optional: Add callback functions for various events
   callbacks: {

--- a/packages/core/src/client/__tests__/client-offline.test.ts
+++ b/packages/core/src/client/__tests__/client-offline.test.ts
@@ -74,6 +74,7 @@ describe('Offline Client Tests', () => {
 		// The second call should be with our data
 		expect(mockLocalStorage.setItem).toHaveBeenNthCalledWith(
 			2,
+			'c15t-consent',
 			expect.stringContaining(JSON.stringify(consentData.preferences))
 		);
 	});

--- a/packages/core/src/client/__tests__/client-offline.test.ts
+++ b/packages/core/src/client/__tests__/client-offline.test.ts
@@ -54,10 +54,8 @@ describe('Offline Client Tests', () => {
 		// Reset the mock
 		mockLocalStorage.setItem.mockClear();
 
-		const customKey = 'my-custom-consent-key';
-
 		// Create an instance of OfflineClient
-		const client = new OfflineClient({ localStorageKey: customKey });
+		const client = new OfflineClient();
 
 		// Call setConsent with properly typed data
 		const consentData = {
@@ -76,7 +74,6 @@ describe('Offline Client Tests', () => {
 		// The second call should be with our data
 		expect(mockLocalStorage.setItem).toHaveBeenNthCalledWith(
 			2,
-			customKey,
 			expect.stringContaining(JSON.stringify(consentData.preferences))
 		);
 	});

--- a/packages/core/src/client/__tests__/client.browser.test.ts
+++ b/packages/core/src/client/__tests__/client.browser.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { C15tClient } from '../client-c15t';
 import { CustomClient } from '../client-custom';
 import { configureConsentManager } from '../client-factory';
-import { OfflineClient } from '../client-offline';
+import type { OfflineClient } from '../client-offline';
 
 // Note: For Vitest browser mode, we don't need to mock localStorage or fetch
 // as they're available in the browser environment
@@ -215,31 +215,6 @@ describe('Offline Client Browser Tests', () => {
 		// Second call with localStorage data
 		response = await client.showConsentBanner();
 		expect(response.data?.showConsentBanner).toBe(false);
-	});
-
-	it('should use custom localStorage key', async () => {
-		const customKey = 'custom-consent-key';
-
-		// Configure the client with custom key
-		const client = new OfflineClient({
-			localStorageKey: customKey,
-		});
-
-		// Set consent data
-		await client.setConsent({
-			body: {
-				type: 'cookie_banner',
-				domain: 'example.com',
-				preferences: {
-					analytics: true,
-				},
-			},
-		});
-
-		// Verify localStorage has data with custom key
-		expect(localStorage.getItem(customKey)).not.toBeNull();
-		// And default key doesn't have data
-		expect(localStorage.getItem('c15t-consent')).toBeNull();
 	});
 });
 

--- a/packages/core/src/client/client-c15t.ts
+++ b/packages/core/src/client/client-c15t.ts
@@ -650,7 +650,6 @@ export class C15tClient implements ConsentManagerInterface {
 		// Check localStorage to see if the banner has been shown
 		let shouldShow = true;
 		let hasLocalStorageAccess = false;
-		const localStorageKey = 'c15t-consent';
 
 		try {
 			if (typeof window !== 'undefined' && window.localStorage) {
@@ -659,7 +658,7 @@ export class C15tClient implements ConsentManagerInterface {
 				window.localStorage.removeItem('c15t-storage-test-key');
 				hasLocalStorageAccess = true;
 
-				const storedConsent = window.localStorage.getItem(localStorageKey);
+				const storedConsent = window.localStorage.getItem('c15t-consent');
 				shouldShow = storedConsent === null;
 			}
 		} catch (error) {
@@ -763,7 +762,6 @@ export class C15tClient implements ConsentManagerInterface {
 	private async offlineFallbackForSetConsent(
 		options?: FetchOptions<SetConsentResponse, SetConsentRequestBody>
 	): Promise<ResponseContext<SetConsentResponse>> {
-		const localStorageKey = 'c15t-consent';
 		const pendingSubmissionsKey = 'c15t-pending-consent-submissions';
 
 		try {
@@ -774,7 +772,7 @@ export class C15tClient implements ConsentManagerInterface {
 
 				// Store the consent preferences locally
 				window.localStorage.setItem(
-					localStorageKey,
+					'c15t-consent',
 					JSON.stringify({
 						timestamp: new Date().toISOString(),
 						preferences: options?.body?.preferences || {},

--- a/packages/core/src/client/client-offline.ts
+++ b/packages/core/src/client/client-offline.ts
@@ -26,12 +26,6 @@ export interface OfflineClientOptions {
 	 * Global callbacks for handling API responses
 	 */
 	callbacks?: ConsentManagerCallbacks;
-
-	/**
-	 * Custom localStorage key to check for consent banner visibility
-	 * @default 'c15t-consent'
-	 */
-	localStorageKey?: string;
 }
 
 /**
@@ -46,19 +40,12 @@ export class OfflineClient implements ConsentManagerInterface {
 	private callbacks?: ConsentManagerCallbacks;
 
 	/**
-	 * LocalStorage key for consent banner visibility
-	 * @internal
-	 */
-	private localStorageKey: string;
-
-	/**
 	 * Creates a new Offline client instance.
 	 *
 	 * @param options - Configuration options for the client
 	 */
 	constructor(options: OfflineClientOptions = {}) {
 		this.callbacks = options.callbacks;
-		this.localStorageKey = options.localStorageKey || 'c15t-consent';
 	}
 
 	/**
@@ -133,7 +120,7 @@ export class OfflineClient implements ConsentManagerInterface {
 				window.localStorage.setItem('c15t-storage-test-key', 'test');
 				window.localStorage.removeItem('c15t-storage-test-key');
 
-				const storedConsent = window.localStorage.getItem(this.localStorageKey);
+				const storedConsent = window.localStorage.getItem('c15t-consent');
 				shouldShow = storedConsent === null;
 			}
 		} catch (error) {
@@ -183,7 +170,7 @@ export class OfflineClient implements ConsentManagerInterface {
 				window.localStorage.removeItem('c15t-storage-test-key');
 
 				window.localStorage.setItem(
-					this.localStorageKey,
+					'c15t-consent',
 					JSON.stringify({
 						timestamp: new Date().toISOString(),
 						preferences: options?.body?.preferences || {},


### PR DESCRIPTION
## Overview
Remove localStorageKey as it's un-unused  

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated offline mode documentation to remove references to the `localStorageKey` configuration option.
- **Bug Fixes**
  - Removed the ability to customize the localStorage key for storing consent data; a fixed key is now always used.
- **Refactor**
  - Streamlined internal handling of localStorage keys by removing related configuration options and parameters.
- **Tests**
  - Updated and removed tests related to custom localStorage key usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->