### PR TITLE
fix(docs): run component broken

### DIFF
--- a/docs/src/mdx/run-command.tsx
+++ b/docs/src/mdx/run-command.tsx
@@ -7,7 +7,7 @@ export function RunCommand({ command }: { command: string }) {
 		yarn: `yarn dlx ${command}`,
 		bun: `bunx --bun ${command}`,
 	} as const;
-}
+
 	return (
 		<Tabs items={Object.keys(packageManagers)}>
 			{Object.entries(packageManagers).map(([name, cmd]) => (


### PR DESCRIPTION
## Overview
Fix error from merging PR too early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a syntax issue that prevented the proper display of content in the Run Command documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->