### PR TITLE
refactor(backend): remove mentions of C15T_SECRET

### DIFF
--- a/packages/backend/src/core.ts
+++ b/packages/backend/src/core.ts
@@ -117,7 +117,6 @@ export interface C15TInstance<PluginTypes extends C15TPlugin[] = C15TPlugin[]> {
  * import { c15tInstance } from '@c15t/backend';
  *
  * const manager = c15tInstance({
- *   secret: process.env.SECRET_KEY,
  *   storage: memoryAdapter()
  * });
  * ```
@@ -128,7 +127,6 @@ export interface C15TInstance<PluginTypes extends C15TPlugin[] = C15TPlugin[]> {
  * type MyPlugins = [typeof geoPlugin, typeof analyticsPlugin];
  *
  * const c15t = c15tInstance<MyPlugins>({
- *   secret: process.env.SECRET_KEY,
  *   storage: kyselyAdapter(db),
  *   plugins: [geoPlugin(), analyticsPlugin()]
  * });

--- a/packages/backend/src/init.test.ts
+++ b/packages/backend/src/init.test.ts
@@ -142,23 +142,6 @@ describe('init', () => {
 		}
 	});
 
-	it('should handle secret from environment', async () => {
-		vi.stubEnv('C15T_SECRET', 'test-secret');
-
-		const result = await init({
-			baseURL: 'http://localhost:3000',
-			database: memoryAdapter({}),
-		});
-
-		expect(result.isOk()).toBe(true);
-		if (result.isOk()) {
-			const ctx = result.value;
-			expect(ctx.secret).toBe('test-secret');
-		}
-
-		vi.unstubAllEnvs();
-	});
-
 	it('should handle multiple plugins in sequence', async () => {
 		const result = await init({
 			baseURL: 'http://localhost:3000',

--- a/packages/backend/src/pkgs/db-adapters/adapters/drizzle-adapter/drizzle-adapter.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/drizzle-adapter/drizzle-adapter.ts
@@ -490,8 +490,6 @@ function checkMissingFields(
  *     schema, // Pass your Drizzle schema
  *     usePlural: true
  *   }),
- *   // Other C15T options...
- *   secret: process.env.SECRET
  * });
  *
  * // Use in your application
@@ -517,7 +515,6 @@ function checkMissingFields(
  *   storage: drizzleAdapter(db, {
  *     provider: 'mysql'
  *   }),
- *   secret: process.env.SECRET
  * });
  * ```
  */

--- a/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/dialect.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/dialect.ts
@@ -103,7 +103,6 @@ function getDatabaseType(
  *
  * // Use in c15t configuration
  * const c15t = c15tInstance({
- *   secret: process.env.SECRET_KEY,
  *   database: { db, type: 'postgres' } // Pre-configured Kysely instance
  * });
  * ```
@@ -124,7 +123,6 @@ function getDatabaseType(
  *
  * // Pass the pool directly to c15t
  * const c15t = c15tInstance({
- *   secret: process.env.SECRET_KEY,
  *   database: pool // The adapter will detect it's a Postgres pool
  * });
  * ```

--- a/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/kysely-adapter.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/kysely-adapter.ts
@@ -632,7 +632,6 @@ const createEntityTransformer = (
  * const c15t = c15tInstance({
  *   storage: kyselyAdapter(db, { type: 'postgres' }),
  *   // Other c15t options...
- *   secret: process.env.SECRET
  * });
  *
  * // Use in your application

--- a/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/types.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/kysely-adapter/types.ts
@@ -159,7 +159,6 @@ export type SQLiteDatabaseConfig = SQLiteDatabase;
  * // Use in c15t configuration
  * const c15t = c15tInstance({
  *   storage: kyselyAdapter(dialectConfig),
- *   secret: process.env.SECRET_KEY
  * });
  * ```
  */
@@ -232,7 +231,6 @@ export interface DialectConfig {
  * // Pass to c15t configuration
  * const c15t = c15tInstance({
  *   storage: kyselyAdapter(config),
- *   secret: process.env.SECRET_KEY
  * });
  * ```
  */

--- a/packages/backend/src/pkgs/db-adapters/adapters/memory-adapter/memory-adapter.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/memory-adapter/memory-adapter.ts
@@ -330,7 +330,6 @@ const createEntityTransformer = (options: C15TOptions) => {
  * // Create the c15t instance with memory adapter
  * const c15t = c15tInstance({
  *   storage: memoryAdapter(db),
- *   secret: process.env.SECRET_KEY
  * });
  *
  * // The database will be populated as records are created

--- a/packages/backend/src/pkgs/db-adapters/adapters/prisma-adapter/prisma-adapter.ts
+++ b/packages/backend/src/pkgs/db-adapters/adapters/prisma-adapter/prisma-adapter.ts
@@ -319,7 +319,6 @@ const createEntityTransformer = (
  * // Create the c15t instance with Prisma adapter
  * const c15t = c15tInstance({
  *   storage: prismaAdapter(prisma, { provider: 'postgresql' }),
- *   secret: process.env.SECRET_KEY
  * });
  *
  * // Use in your application

--- a/packages/backend/src/pkgs/types/context.ts
+++ b/packages/backend/src/pkgs/types/context.ts
@@ -113,11 +113,6 @@ export interface BaseDoubleTieContext {
 	baseURL: string;
 
 	/**
-	 * Secret key used for signing cookies and tokens
-	 */
-	secret: string;
-
-	/**
 	 * Logger instance for recording events and errors
 	 */
 	logger: ReturnType<typeof createLogger>;

--- a/packages/backend/src/pkgs/types/options.ts
+++ b/packages/backend/src/pkgs/types/options.ts
@@ -22,7 +22,6 @@ import type { DoubleTiePlugin } from './plugins';
  * // Basic configuration
  * const options: DoubleTieOptions = {
  *   appName: "My App",
- *   secret: process.env.SECRET_KEY,
  *   baseURL: "https://example.com",
  *   trustedOrigins: ["https://example.com"]
  * };

--- a/packages/backend/src/types/options.ts
+++ b/packages/backend/src/types/options.ts
@@ -24,7 +24,6 @@ import type { TablesConfig } from '~/schema/types';
  * // Basic consent management configuration
  * const options: C15TOptions = {
  *   appName: "My Consent App",
- *   secret: process.env.SECRET_KEY,
  *   baseURL: "https://example.com",
  *   trustedOrigins: ["https://example.com"]
  * };


### PR DESCRIPTION
## Overview
Removes mentions of secret from the backend as its not used anymore. 

## Related Issue
Fixes #176 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the secret key option from initialization and context handling, simplifying configuration and eliminating related warnings.

- **Documentation**
  - Updated all example code snippets and documentation to remove references to the secret key property.
  - Removed outdated test related to secret key environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->