### PR TITLE
test: add noStyle prop tests for ConsentManagerDialog, ConsentManager…

### DIFF
--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -73,7 +73,7 @@ vi.mock('~/hooks/use-translations', () => ({
 	}),
 }));
 
-test('Theme prop applies string classnames to all components', async () => {
+test('should apply string classNames from theme prop to all dialog elements', async () => {
 	const test = (
 		<ConsentManagerDialog
 			open
@@ -97,7 +97,7 @@ test('Theme prop applies string classnames to all components', async () => {
 	});
 });
 
-test('Theme prop supports object format with className and style for all components', async () => {
+test('should apply className and style objects from theme prop to all dialog elements', async () => {
 	const style = {
 		backgroundColor: '#ffffff',
 		padding: '20px',
@@ -140,7 +140,7 @@ test('Theme prop supports object format with className and style for all compone
 	});
 });
 
-test('No style prop removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when top-level noStyle prop is true', async () => {
 	const test = (
 		<ConsentManagerDialog
 			scrollLock
@@ -166,7 +166,7 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
-test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when theme object provides noStyle: true', async () => {
 	const testCases = ALL_COMPONENTS.reduce(
 		(acc, { themeKey, styles }) => {
 			acc[themeKey] = { className: styles, noStyle: true };
@@ -186,7 +186,7 @@ test('No style being passed in to each component style removes default styles bu
 	});
 });
 
-test('Theme prop handles mixed format (string and object) correctly', async () => {
+test('should correctly apply styles when theme prop uses mixed string and object formats', async () => {
 	const mixedTheme: ConsentManagerDialogTheme = {
 		'dialog.root': {
 			className: 'custom-dialog-root',
@@ -221,7 +221,7 @@ test('Theme prop handles mixed format (string and object) correctly', async () =
 	});
 });
 
-test('Theme prop handles edge cases gracefully', async () => {
+test('should handle empty strings and empty style objects in theme prop gracefully', async () => {
 	const edgeCaseTheme: ConsentManagerDialogTheme = {
 		'dialog.root': '',
 		'dialog.overlay': '',

--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -166,6 +166,26 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
+test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+	const testCases = ALL_COMPONENTS.reduce(
+		(acc, { themeKey, styles }) => {
+			acc[themeKey] = { className: styles, noStyle: true };
+			return acc;
+		},
+		{} as Record<string, ThemeValue>
+	);
+
+	const test = <ConsentManagerDialog scrollLock open theme={testCases} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: ALL_COMPONENTS.map(({ testId, styles }) => ({
+			testId,
+			styles: { className: styles },
+		})),
+	});
+});
+
 test('Theme prop handles mixed format (string and object) correctly', async () => {
 	const mixedTheme: ConsentManagerDialogTheme = {
 		'dialog.root': {

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -93,7 +93,7 @@ const ALL_COMPONENTS: ComponentTestCase[] = [
 	},
 ];
 
-test('Theme prop applies string classnames to all components', async () => {
+test('should apply string classNames from theme prop to all widget elements', async () => {
 	const test = (
 		<ConsentManagerWidget
 			theme={ALL_COMPONENTS.reduce(
@@ -115,7 +115,7 @@ test('Theme prop applies string classnames to all components', async () => {
 	});
 });
 
-test('Theme prop supports object format with className and style for all components', async () => {
+test('should apply className and style objects from theme prop to all widget elements', async () => {
 	const style = {
 		backgroundColor: '#ffffff',
 		padding: '20px',
@@ -156,7 +156,7 @@ test('Theme prop supports object format with className and style for all compone
 	});
 });
 
-test('No style prop removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when top-level noStyle prop is true', async () => {
 	const test = (
 		<ConsentManagerWidget
 			noStyle
@@ -180,7 +180,7 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
-test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when theme object provides noStyle: true', async () => {
 	const testCases = ALL_COMPONENTS.reduce(
 		(acc, { themeKey, styles }) => {
 			acc[themeKey] = { className: styles, noStyle: true };
@@ -200,7 +200,7 @@ test('No style being passed in to each component style removes default styles bu
 	});
 });
 
-test('Theme prop handles mixed format (string and object) correctly', async () => {
+test('should correctly apply styles when theme prop uses mixed string and object formats', async () => {
 	const mixedTheme: ConsentManagerWidgetTheme = {
 		'widget.root': {
 			className: 'custom-root',
@@ -235,7 +235,7 @@ test('Theme prop handles mixed format (string and object) correctly', async () =
 	});
 });
 
-test('Theme prop handles edge cases gracefully', async () => {
+test('should handle empty strings and empty style objects in theme prop gracefully', async () => {
 	const edgeCaseTheme: ConsentManagerWidgetTheme = {
 		'widget.root': '',
 		'widget.accordion': '',

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -180,6 +180,26 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
+test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+	const testCases = ALL_COMPONENTS.reduce(
+		(acc, { themeKey, styles }) => {
+			acc[themeKey] = { className: styles, noStyle: true };
+			return acc;
+		},
+		{} as Record<string, ThemeValue>
+	);
+
+	const test = <ConsentManagerWidget noStyle theme={testCases} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: ALL_COMPONENTS.map(({ testId, styles }) => ({
+			testId,
+			styles: { className: styles },
+		})),
+	});
+});
+
 test('Theme prop handles mixed format (string and object) correctly', async () => {
 	const mixedTheme: ConsentManagerWidgetTheme = {
 		'widget.root': {

--- a/packages/react/src/components/cookie-banner/__tests__/cookie-banner.e2e.test.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/cookie-banner.e2e.test.tsx
@@ -53,7 +53,7 @@ const defaultOptions: ConsentManagerOptions = {
 	mode: 'offline',
 };
 
-describe('CookieBanner E2E Tests', () => {
+describe('CookieBanner End-to-End Behavior', () => {
 	beforeEach(() => {
 		// Clear localStorage before each test
 		window.localStorage.clear();
@@ -227,7 +227,7 @@ describe('CookieBanner E2E Tests', () => {
 		expect(consent.consents.marketing).toBe(true);
 	});
 
-	test('should be keyboard accessible', async () => {
+	test('should allow tabbing through interactive elements', async () => {
 		render(
 			<ConsentManagerProvider options={defaultOptions}>
 				<CookieBanner />
@@ -257,7 +257,7 @@ describe('CookieBanner E2E Tests', () => {
 		expect(document.activeElement).toBe(acceptButton);
 	});
 
-	test('should handle scroll lock properly', async () => {
+	test('should apply and remove overlay correctly when scrollLock is enabled', async () => {
 		render(
 			<ConsentManagerProvider options={defaultOptions}>
 				<CookieBanner scrollLock />

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -89,7 +89,7 @@ const ALL_COMPONENTS: ComponentTestCase[] = [
 	},
 ];
 
-test('Theme prop applies string classnames to all components', async () => {
+test('should apply string classNames from theme prop to all banner elements', async () => {
 	const test = (
 		<CookieBanner
 			scrollLock
@@ -112,7 +112,7 @@ test('Theme prop applies string classnames to all components', async () => {
 	});
 });
 
-test('Theme prop supports object format with className and style for all components', async () => {
+test('should apply className and style objects from theme prop to all banner elements', async () => {
 	const style = {
 		backgroundColor: '#ffffff',
 		padding: '20px',
@@ -154,7 +154,7 @@ test('Theme prop supports object format with className and style for all compone
 	});
 });
 
-test('No style prop removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when top-level noStyle prop is true', async () => {
 	const test = (
 		<CookieBanner
 			scrollLock
@@ -179,7 +179,7 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
-test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+test('should remove default styles but keep custom classNames when theme object provides noStyle: true', async () => {
 	const testCases = ALL_COMPONENTS.reduce(
 		(acc, { themeKey, styles }) => {
 			acc[themeKey] = { className: styles, noStyle: true };
@@ -199,7 +199,7 @@ test('No style being passed in to each component style removes default styles bu
 	});
 });
 
-test('Theme prop handles mixed format (string and object) correctly', async () => {
+test('should correctly apply styles when theme prop uses mixed string and object formats', async () => {
 	const mixedTheme: CookieBannerTheme = {
 		'banner.root': {
 			className: 'custom-root',
@@ -234,7 +234,7 @@ test('Theme prop handles mixed format (string and object) correctly', async () =
 	});
 });
 
-test('Theme prop handles edge cases gracefully', async () => {
+test('should handle empty strings and empty style objects in theme prop gracefully', async () => {
 	const edgeCaseTheme: CookieBannerTheme = {
 		'banner.root': '',
 		'banner.card': '',

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -179,6 +179,26 @@ test('No style prop removes default styles but keeps custom classNames', async (
 	});
 });
 
+test('No style being passed in to each component style removes default styles but keeps custom classNames', async () => {
+	const testCases = ALL_COMPONENTS.reduce(
+		(acc, { themeKey, styles }) => {
+			acc[themeKey] = { className: styles, noStyle: true };
+			return acc;
+		},
+		{} as Record<string, ThemeValue>
+	);
+
+	const test = <CookieBanner scrollLock noStyle theme={testCases} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: ALL_COMPONENTS.map(({ testId, styles }) => ({
+			testId,
+			styles: { className: styles },
+		})),
+	});
+});
+
 test('Theme prop handles mixed format (string and object) correctly', async () => {
 	const mixedTheme: CookieBannerTheme = {
 		'banner.root': {


### PR DESCRIPTION
…Widget, and CookieBanner

- Introduced a new test case to verify that when no style is passed, default styles are removed while custom classNames are retained for ConsentManagerDialog, ConsentManagerWidget, and CookieBanner components.
- Updated the useStyles hook to ensure consistent handling of the noStyle flag, returning appropriate styles based on its value.
- Enhanced mergeStyles utility to normalize ThemeValue inputs and ensure proper merging of classNames and styles.

## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

*Please describe the change here*

## Related Issue
<!-- Always link to the issue. Create one first if it doesn't exist. -->
Fixes # (issue)

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
<!-- Help reviewers understand your changes -->

### Key Changes
<!-- List the important changes you made -->
1. 
2. 

### Technical Notes
<!-- Any important technical details? Design decisions? -->

## Testing
<!-- Help others verify your changes -->

### Test Plan
<!-- List specific test scenarios -->

- [ ] Scenario 1: *What to test*

  ```ts
  // Example code or steps
  ```

  ✓ Expected: *What should happen*

- [ ] Scenario 2: *What to test*

  ```ts
  // Example code or steps
  ```
  
  ✓ Expected: *What should happen*

### Edge Cases
<!-- Important scenarios to verify -->
- [ ] Error handling: *Describe how errors are handled*
- [ ] Performance: *Any performance implications?*
- [ ] Security: *Any security considerations?*

### Visual Changes
<!-- Delete if no UI changes -->

| Before | After |
|--------|-------|
| <!-- Before Screenshot --> | <!-- After Screenshot --> |

## Checklist

### Required

- [ ] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested locally
- [ ] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
<!-- Delete if no breaking changes -->

**Changes:**
- *List breaking changes*

**Migration:**
```ts
// Before
oldMethod()

// After
newMethod()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify that custom class names are retained and default styles are removed when using the noStyle flag within theme objects for ConsentManagerDialog, ConsentManagerWidget, and CookieBanner components.
  - Improved test descriptions for clarity and consistency across ConsentManagerDialog, ConsentManagerWidget, CookieBanner, and CookieBanner end-to-end tests.

- **Refactor**
  - Simplified and clarified style merging logic in the style hook and utility functions for more consistent and predictable merging of class names and styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->