### PR TITLE
docs: fix broken example in offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { c15tConfig } from "./c15t.client";
 
 export default function App() {
   return (
-    <ConsentManagerProvider config={c15tConfig}>
+    <ConsentManagerProvider options={c15tConfig}>
       <CookieBanner />
       <ConsentManagerDialog/>
       {/* Your app content */}

--- a/docs/content/storing-consent/offline-mode.mdx
+++ b/docs/content/storing-consent/offline-mode.mdx
@@ -42,18 +42,17 @@ export const c15tClient = createClient({
 <Step>
 ### Add the Provider
 
-Wrap your application with the C15tProvider:
+Wrap your application with the ConsentManagerProvider:
 
 ```jsx
-// pages/_app.js
-import { C15tProvider } from '@c15t/react'
+import { ConsentManagerProvider } from '@c15t/react'
 import { c15tClient } from '../lib/c15tClient'
 
 function MyApp({ Component, pageProps }) {
   return (
-    <C15tProvider client={c15tClient}>
+    <ConsentManagerProvider client={c15tClient}>
       <Component {...pageProps} />
-    </C15tProvider>
+    </ConsentManagerProvider>
   )
 }
 

--- a/docs/content/storing-consent/offline-mode.mdx
+++ b/docs/content/storing-consent/offline-mode.mdx
@@ -50,7 +50,7 @@ import { c15tClient } from '../lib/c15tClient'
 
 function MyApp({ Component, pageProps }) {
   return (
-    <ConsentManagerProvider client={c15tClient}>
+    <ConsentManagerProvider options={c15tClient}>
       <Component {...pageProps} />
     </ConsentManagerProvider>
   )

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -46,7 +46,7 @@ import { c15tConfig } from "./c15t.client";
 
 export default function App() {
   return (
-    <ConsentManagerProvider config={c15tConfig}>
+    <ConsentManagerProvider options={c15tConfig}>
       <CookieBanner />
       <ConsentManagerDialog/>
       {/* Your app content */}


### PR DESCRIPTION
## Overview
Offline docs had a broken example

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated offline mode setup instructions to reference `ConsentManagerProvider` instead of `C15tProvider` in example code and import statements.
  - Revised example code to use the `options` prop instead of `client` or `config` when configuring the `ConsentManagerProvider`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->