### PR TITLE
fix(core): callbacks not working on c155 mode

### DIFF
--- a/packages/core/src/client/__tests__/client-callbacks.test.ts
+++ b/packages/core/src/client/__tests__/client-callbacks.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchMock, mockLocalStorage } from '../../../vitest.setup';
+import { configureConsentManager } from '../client-factory';
+import type { ConsentManagerCallbacks } from '../client-interface';
+
+describe('Client Callbacks Tests', () => {
+	// Common callback mocks
+	const callbacks: ConsentManagerCallbacks = {
+		onConsentBannerFetched: vi.fn(),
+		onConsentSet: vi.fn(),
+		onConsentVerified: vi.fn(),
+		onError: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		fetchMock.mockReset();
+		mockLocalStorage.clear();
+	});
+
+	describe('c15t Client Callbacks', () => {
+		it('should call onConsentBannerFetched with correct payload', async () => {
+			// Mock successful response
+			fetchMock.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						showConsentBanner: true,
+						jurisdiction: { code: 'EU', message: 'European Union' },
+						location: { countryCode: 'GB', regionCode: null },
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			);
+
+			const client = configureConsentManager({
+				mode: 'c15t',
+				backendURL: '/api/c15t',
+				callbacks,
+			});
+
+			await client.showConsentBanner();
+
+			expect(callbacks.onConsentBannerFetched).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					showConsentBanner: true,
+					jurisdiction: { code: 'EU', message: 'European Union' },
+					location: { countryCode: 'GB', regionCode: null },
+				},
+			});
+		});
+
+		it('should call onConsentSet with correct payload', async () => {
+			fetchMock.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						type: 'cookie_banner',
+						preferences: { analytics: true },
+						domain: 'example.com',
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			);
+
+			const client = configureConsentManager({
+				mode: 'c15t',
+				backendURL: '/api/c15t',
+				callbacks,
+			});
+
+			const consentData = {
+				type: 'cookie_banner' as const,
+				domain: 'example.com',
+				preferences: { analytics: true },
+			};
+
+			await client.setConsent({ body: consentData });
+
+			expect(callbacks.onConsentSet).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					type: 'cookie_banner',
+					preferences: { analytics: true },
+					domain: 'example.com',
+				},
+			});
+		});
+
+		it('should call onConsentVerified with correct payload', async () => {
+			fetchMock.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						type: 'cookie_banner',
+						preferences: ['analytics'],
+						isValid: true,
+						domain: 'example.com',
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			);
+
+			const client = configureConsentManager({
+				mode: 'c15t',
+				backendURL: '/api/c15t',
+				callbacks,
+			});
+
+			await client.verifyConsent({
+				body: {
+					type: 'cookie_banner',
+					preferences: ['analytics'],
+					domain: 'example.com',
+				},
+			});
+
+			expect(callbacks.onConsentVerified).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					type: 'cookie_banner',
+					preferences: ['analytics'],
+					valid: true,
+					domain: 'example.com',
+				},
+			});
+		});
+	});
+
+	describe('Offline Client Callbacks', () => {
+		it('should call onConsentBannerFetched with correct payload', async () => {
+			const client = configureConsentManager({
+				mode: 'offline',
+				callbacks,
+			});
+
+			await client.showConsentBanner();
+
+			expect(callbacks.onConsentBannerFetched).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					showConsentBanner: true,
+					jurisdiction: { code: 'EU', message: 'EU' },
+					location: { countryCode: 'GB', regionCode: null },
+				},
+			});
+		});
+
+		it('should call onConsentSet with correct payload', async () => {
+			const client = configureConsentManager({
+				mode: 'offline',
+				callbacks,
+			});
+
+			const consentData = {
+				type: 'cookie_banner' as const,
+				domain: 'example.com',
+				preferences: { analytics: true },
+			};
+
+			await client.setConsent({ body: consentData });
+
+			expect(callbacks.onConsentSet).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					type: 'cookie_banner',
+					preferences: { analytics: true },
+					domain: 'example.com',
+				},
+			});
+		});
+
+		it('should call onConsentVerified with correct payload', async () => {
+			const client = configureConsentManager({
+				mode: 'offline',
+				callbacks,
+			});
+
+			await client.verifyConsent({
+				body: {
+					type: 'cookie_banner',
+					preferences: ['analytics'],
+					domain: 'example.com',
+				},
+			});
+
+			expect(callbacks.onConsentVerified).toHaveBeenCalledWith({
+				ok: true,
+				error: null,
+				response: null,
+				data: {
+					type: 'cookie_banner',
+					preferences: ['analytics'],
+					valid: true,
+					domain: 'example.com',
+				},
+			});
+		});
+	});
+
+
+});

--- a/packages/core/src/client/client-interface.ts
+++ b/packages/core/src/client/client-interface.ts
@@ -79,6 +79,34 @@ export interface ConsentManagerInterface {
 }
 
 /**
+ * Payload for the onConsentSet callback
+ */
+export interface ConsentSetCallbackPayload {
+	type: string;
+	preferences: Record<string, boolean>;
+	domain?: string;
+}
+
+/**
+ * Payload for the onConsentBannerFetched callback
+ */
+export interface ConsentBannerFetchedCallbackPayload {
+	showConsentBanner: boolean;
+	jurisdiction: { code: string; message: string };
+	location?: { countryCode: string; regionCode: string | null };
+}
+
+/**
+ * Payload for the onConsentVerified callback
+ */
+export interface ConsentVerifiedCallbackPayload {
+	type: string;
+	domain?: string;
+	preferences: string[];
+	valid: boolean;
+}
+
+/**
  * Base callback configuration for consent clients
  */
 export interface ConsentManagerCallbacks {
@@ -94,20 +122,20 @@ export interface ConsentManagerCallbacks {
 	 * @param response The response from the showConsentBanner endpoint
 	 */
 	onConsentBannerFetched?: (
-		response: ResponseContext<ShowConsentBannerResponse>
+		response: ResponseContext<ConsentBannerFetchedCallbackPayload>
 	) => void;
 
 	/**
 	 * Called after successfully setting consent preferences
 	 * @param response The response from the setConsent endpoint
 	 */
-	onConsentSet?: (response: ResponseContext<SetConsentResponse>) => void;
+	onConsentSet?: (response: ResponseContext<ConsentSetCallbackPayload>) => void;
 
 	/**
 	 * Called after successfully verifying consent
 	 * @param response The response from the verifyConsent endpoint
 	 */
 	onConsentVerified?: (
-		response: ResponseContext<VerifyConsentResponse>
+		response: ResponseContext<ConsentVerifiedCallbackPayload>
 	) => void;
 }


### PR DESCRIPTION
## Overview
Fixed callbacks not firing on other modes e.g. c15t 
Improved the data returned by callbacks e.g. preferences user has consented to

## Related Issue
#195 

## Type of Change
<!-- Select ALL that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Checklist
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [ ] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
Some data such as ids have been removed from the data object of a callback. E.g. on set consent, this data is still accessible on the response object. 

