### PR TITLE
fix(react): theme overrides & color scheme improvements

### DIFF
--- a/.changeset/dirty-kids-refuse.md
+++ b/.changeset/dirty-kids-refuse.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+fix(react): theme overrides & color scheme improvements

--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test, vi, expect } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { ConsentManagerDialog } from '~/components/consent-manager-dialog/consent-manager-dialog';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';

--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -299,18 +299,18 @@ test('Base layer styles are applied when no custom classes are provided', async 
 		testCases: [],
 	});
 
-	const card = document.querySelector(
-		'[data-testid="consent-manager-dialog-card"]'
+	const root = document.querySelector(
+		'[data-testid="consent-manager-dialog-root"]'
 	);
 	const title = document.querySelector(
 		'[data-testid="consent-manager-dialog-title"]'
 	);
 
-	if (!card || !title) {
+	if (!root || !title) {
 		throw new Error('Required elements not found in the document');
 	}
 
-	expect(getComputedStyle(card).backgroundColor).toBe('rgb(255, 255, 255)');
+	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 255, 255)');
 	expect(getComputedStyle(title).color).toBe('rgb(23, 23, 23)');
 });
 

--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test, vi } from 'vitest';
+import { test, vi, expect } from 'vitest';
 import { ConsentManagerDialog } from '~/components/consent-manager-dialog/consent-manager-dialog';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
@@ -239,4 +239,119 @@ test('Theme prop handles edge cases gracefully', async () => {
 			},
 		],
 	});
+});
+
+test('Custom classes override base layer styles', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-dialog-background {
+			background-color: rgb(255, 0, 0) !important;
+		}
+		.custom-dialog-text {
+			color: rgb(0, 255, 0) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: ConsentManagerDialogTheme = {
+		'dialog.root': 'custom-dialog-background',
+		'dialog.title': 'custom-dialog-text',
+	};
+
+	const test = <ConsentManagerDialog theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-dialog-root',
+				styles: 'custom-dialog-background',
+			},
+			{
+				testId: 'consent-manager-dialog-title',
+				styles: 'custom-dialog-text',
+			},
+		],
+	});
+
+	const root = document.querySelector(
+		'[data-testid="consent-manager-dialog-root"]'
+	);
+	const title = document.querySelector(
+		'[data-testid="consent-manager-dialog-title"]'
+	);
+
+	if (!root || !title) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 0, 0)');
+	expect(getComputedStyle(title).color).toBe('rgb(0, 255, 0)');
+
+	document.head.removeChild(styleElement);
+});
+
+test('Base layer styles are applied when no custom classes are provided', async () => {
+	const test = <ConsentManagerDialog />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [],
+	});
+
+	const card = document.querySelector(
+		'[data-testid="consent-manager-dialog-card"]'
+	);
+	const title = document.querySelector(
+		'[data-testid="consent-manager-dialog-title"]'
+	);
+
+	if (!card || !title) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(card).backgroundColor).toBe('rgb(255, 255, 255)');
+	expect(getComputedStyle(title).color).toBe('rgb(23, 23, 23)');
+});
+
+test('Multiple custom classes can be applied and override base layer', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-padding {
+			padding: 32px !important;
+		}
+		.custom-border {
+			border: 2px solid rgb(0, 0, 255) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: ConsentManagerDialogTheme = {
+		'dialog.root': 'custom-padding custom-border',
+	};
+
+	const test = <ConsentManagerDialog theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-dialog-root',
+				styles: 'custom-padding custom-border',
+			},
+		],
+	});
+
+	const root = document.querySelector(
+		'[data-testid="consent-manager-dialog-root"]'
+	);
+
+	if (!root) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(root).padding).toBe('32px');
+	expect(getComputedStyle(root).border).toBe('2px solid rgb(0, 0, 255)');
+
+	document.head.removeChild(styleElement);
 });

--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
@@ -1,283 +1,291 @@
-:root {
-  /* Typography */
-  --dialog-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial,
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
-  --dialog-line-height: 1.15;
-  --dialog-title-font-size: .875rem;
-  --dialog-title-font-weight: 600;
-  --dialog-title-letter-spacing: -0.025em;
-  --dialog-description-font-size: 1rem;
-  --dialog-description-font-weight: 400;
-  --dialog-description-line-height: 1.15;
-  --dialog-footer-font-size: 14px;
-  --dialog-branding-font-size: 1rem;
-  --dialog-branding-font-weight: 500;
-  --dialog-branding-line-height: 1.5;
-  --dialog-branding-letter-spacing: -0.01em;
+@layer base {
+	:root {
+		/* Typography */
+		--dialog-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial,
+			sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+		--dialog-line-height: 1.15;
+		--dialog-title-font-size: .875rem;
+		--dialog-title-font-weight: 600;
+		--dialog-title-letter-spacing: -0.025em;
+		--dialog-description-font-size: 1rem;
+		--dialog-description-font-weight: 400;
+		--dialog-description-line-height: 1.15;
+		--dialog-footer-font-size: 14px;
+		--dialog-branding-font-size: 1rem;
+		--dialog-branding-font-weight: 500;
+		--dialog-branding-line-height: 1.5;
+		--dialog-branding-letter-spacing: -0.01em;
 
-  /* Colors */
-  --dialog-stroke-color: hsl(0, 0%, 92.16%);
-  --dialog-stroke-color-dark: hsl(0, 0%, 20%);
-  --dialog-branding-focus-color: hsl(227.93, 100%, 63.92%);
-  --dialog-branding-focus-color-dark: hsl(228.07, 69.8%, 48.04%);
-  --dialog-link-text-color: hsl(0, 0%, 9.02%);
-  --dialog-link-text-color-dark: hsl(0, 0%, 90%);
-  --dialog-border-color: hsl(0, 0%, 92.16%);
-  --dialog-border-color-dark: hsl(0, 0%, 20%);
-  --dialog-background-color: white;
-  --dialog-background-color-dark: hsl(0, 0%, 10%);
-  --dialog-foreground-color: hsl(0, 0%, 9.02%);
-  --dialog-foreground-color-dark: hsl(0, 0%, 90%);
-  --dialog-muted-color: hsl(0, 0%, 45.1%);
-  --dialog-muted-color-dark: hsl(0, 0%, 63.9%);
-  --dialog-overlay-background-color: rgb(0 0 0 / 0.5);
-  --dialog-overlay-background-color-dark: rgb(0 0 0 / 0.5);
+		/* Colors */
+		--dialog-stroke-color: hsl(0, 0%, 92.16%);
+		--dialog-stroke-color-dark: hsl(0, 0%, 20%);
+		--dialog-branding-focus-color: hsl(227.93, 100%, 63.92%);
+		--dialog-branding-focus-color-dark: hsl(228.07, 69.8%, 48.04%);
+		--dialog-link-text-color: hsl(0, 0%, 9.02%);
+		--dialog-link-text-color-dark: hsl(0, 0%, 90%);
+		--dialog-border-color: hsl(0, 0%, 92.16%);
+		--dialog-border-color-dark: hsl(0, 0%, 20%);
+		--dialog-background-color: white;
+		--dialog-background-color-dark: hsl(0, 0%, 10%);
+		--dialog-foreground-color: hsl(0, 0%, 9.02%);
+		--dialog-foreground-color-dark: hsl(0, 0%, 90%);
+		--dialog-muted-color: hsl(0, 0%, 45.1%);
+		--dialog-muted-color-dark: hsl(0, 0%, 63.9%);
+		--dialog-overlay-background-color: rgb(0 0 0 / 0.5);
+		--dialog-overlay-background-color-dark: rgb(0 0 0 / 0.5);
 
-  /* Spacing */
-  --dialog-card-padding: 1.5rem;
-  --dialog-card-padding-mobile: 1rem;
-  --dialog-card-gap: 0.375rem;
-  --dialog-header-gap: 0.375rem;
-  --dialog-content-gap: 1rem;
-  --dialog-footer-padding-y: 1rem;
+		/* Spacing */
+		--dialog-card-padding: 1.5rem;
+		--dialog-card-padding-mobile: 1rem;
+		--dialog-card-gap: 0.375rem;
+		--dialog-header-gap: 0.375rem;
+		--dialog-content-gap: 1rem;
+		--dialog-footer-padding-y: 1rem;
 
-  /* Layout */
-  --dialog-card-radius: 1.25rem;
-  --dialog-max-width: 28rem;
-  --dialog-height: 80%;
-  --dialog-z-index: 999999999;
-  --dialog-overlay-z-index: 999999998;
+		/* Layout */
+		--dialog-card-radius: 1.25rem;
+		--dialog-max-width: 28rem;
+		--dialog-height: 80%;
+		--dialog-z-index: 999999999;
+		--dialog-overlay-z-index: 999999998;
 
-  /* Effects */
-  --dialog-card-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --dialog-border-width: 1px;
-  --dialog-border-style: solid;
+		/* Effects */
+		--dialog-card-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+		--dialog-border-width: 1px;
+		--dialog-border-style: solid;
 
-  /* Animation */
-  --dialog-animation-duration: 200ms;
-  --dialog-animation-timing: ease-out;
+		/* Animation */
+		--dialog-animation-duration: 200ms;
+		--dialog-animation-timing: ease-out;
 
-  /* Branding */
-  --dialog-branding-gap: 0.5rem;
-  --dialog-branding-icon-height: 1.25rem;
-  --dialog-branding-icon-width: auto;
-}
+		/* Branding */
+		--dialog-branding-gap: 0.5rem;
+		--dialog-branding-icon-height: 1.25rem;
+		--dialog-branding-icon-width: auto;
+	}
 
-.root {
-  isolation: isolate;
-  font-family: var(--dialog-font-family);
-  line-height: var(--dialog-line-height);
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-  margin: 0;
-  padding: var(--dialog-card-padding-mobile);
-  border: 0;
-  background: none;
-  position: fixed;
-  inset: 0px;
-  z-index: var(--dialog-z-index);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: var(--dialog-card-radius);
-  background-color: transparent;
-  width: 100%;
-  height: var(--dialog-height);
-}
+	.root {
+		isolation: isolate;
+		font-family: var(--dialog-font-family);
+		line-height: var(--dialog-line-height);
+		-webkit-text-size-adjust: 100%;
+		tab-size: 4;
+		margin: 0;
+		padding: var(--dialog-card-padding-mobile);
+		border: 0;
+		background: none;
+		position: fixed;
+		inset: 0px;
+		z-index: var(--dialog-z-index);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		border-radius: var(--dialog-card-radius);
+		background-color: transparent;
+		width: 100%;
+		height: var(--dialog-height);
+	}
 
-/* Animation classes for the dialog */
-.dialogVisible {
-  opacity: 1;
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing);
-}
+	/* Animation classes for the dialog */
+	.dialogVisible {
+		opacity: 1;
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing);
+	}
 
-.dialogHidden {
-  opacity: 0;
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing);
-}
+	.dialogHidden {
+		opacity: 0;
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing);
+	}
 
-/* Animation classes for the content */
-.contentVisible {
-  opacity: 1;
-  transform: scale(1);
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing),
-              transform var(--dialog-animation-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
-}
+	/* Animation classes for the content */
+	.contentVisible {
+		opacity: 1;
+		transform: scale(1);
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing), transform var(--dialog-animation-duration)
+			cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
 
-.contentHidden {
-  opacity: 0;
-  transform: scale(0.95);
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing),
-              transform var(--dialog-animation-duration) var(--dialog-animation-timing);
-}
+	.contentHidden {
+		opacity: 0;
+		transform: scale(0.95);
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing), transform var(--dialog-animation-duration)
+			var(--dialog-animation-timing);
+	}
 
-@media (min-width: 640px) {
-  .root {
-    padding: var(--dialog-card-padding);
-    width: auto;
-  }
-}
+	@media (min-width: 640px) {
+		.root {
+			padding: var(--dialog-card-padding);
+			width: auto;
+		}
+	}
 
-.container {
-  width: 100%;
-  max-width: var(--dialog-max-width);
-  margin: auto;
-}
+	.container {
+		width: 100%;
+		max-width: var(--dialog-max-width);
+		margin: auto;
+	}
 
-.branding {
-  display: flex;
-  margin: auto 0;
-  justify-content: center;
-  align-items: center;
-  gap: var(--dialog-branding-gap);
-  font-size: var(--dialog-branding-font-size);
-  font-weight: var(--dialog-branding-font-weight);
-  line-height: var(--dialog-branding-line-height);
-  letter-spacing: var(--dialog-branding-letter-spacing);
-  color: var(--dialog-foreground-color);
-  text-decoration: none;
-  border-radius: 0.25rem;
-  padding: 0 0.5rem;
-}
+	.branding {
+		display: flex;
+		margin: auto 0;
+		justify-content: center;
+		align-items: center;
+		gap: var(--dialog-branding-gap);
+		font-size: var(--dialog-branding-font-size);
+		font-weight: var(--dialog-branding-font-weight);
+		line-height: var(--dialog-branding-line-height);
+		letter-spacing: var(--dialog-branding-letter-spacing);
+		color: var(--dialog-foreground-color);
+		text-decoration: none;
+		border-radius: 0.25rem;
+		padding: 0 0.5rem;
+	}
 
-.branding:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--dialog-branding-focus-color);
-}
+	.branding:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px var(--dialog-branding-focus-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .branding:focus-visible {
-  box-shadow: 0 0 0 2px var(--dialog-branding-focus-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .branding:focus-visible {
+		box-shadow: 0 0 0 2px var(--dialog-branding-focus-color-dark);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .branding {
-  color: var(--dialog-foreground-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .branding {
+		color: var(--dialog-foreground-color-dark);
+	}
 
-.brandingC15T {
-  width: var(--dialog-branding-icon-width);
-  height: var(--dialog-branding-icon-height);
-}
+	.brandingC15T {
+		width: var(--dialog-branding-icon-width);
+		height: var(--dialog-branding-icon-height);
+	}
 
-.brandingConsent {
-  width: var(--dialog-branding-icon-width);
-  height: 1rem;
-}
+	.brandingConsent {
+		width: var(--dialog-branding-icon-width);
+		height: 1rem;
+	}
 
-.headerWrapper {
-  position: relative;
-}
+	.headerWrapper {
+		position: relative;
+	}
 
-.closeButton {
-  position: absolute;
-  right: 22px;
-  top: 22px;
-}
+	.closeButton {
+		position: absolute;
+		right: 22px;
+		top: 22px;
+	}
 
-.footer {
-  justify-content: center;
-  font-size: 14px;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-  border-top: solid 1px var(--dialog-stroke-color);
-}
+	.footer {
+		justify-content: center;
+		font-size: 14px;
+		padding-top: 1rem;
+		padding-bottom: 1rem;
+		border-top: solid 1px var(--dialog-stroke-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .footer {
-  border-color: var(--dialog-stroke-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .footer {
+		border-color: var(--dialog-stroke-color-dark);
+	}
 
-.overlay {
-  color: var(--dialog-link-text-color);
-  position: fixed;
-  inset: 0px;
-  background-color: var(--dialog-overlay-background-color);
-  z-index: var(--dialog-overlay-z-index);
-}
+	.overlay {
+		color: var(--dialog-link-text-color);
+		position: fixed;
+		inset: 0px;
+		background-color: var(--dialog-overlay-background-color);
+		z-index: var(--dialog-overlay-z-index);
+	}
 
-/* Overlay animation classes */
-.overlayVisible {
-  opacity: 1;
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing);
-}
+	/* Overlay animation classes */
+	.overlayVisible {
+		opacity: 1;
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing);
+	}
 
-.overlayHidden {
-  opacity: 0;
-  transition: opacity var(--dialog-animation-duration) var(--dialog-animation-timing);
-}
+	.overlayHidden {
+		opacity: 0;
+		transition: opacity var(--dialog-animation-duration)
+			var(--dialog-animation-timing);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .overlay {
-  background-color: var(--dialog-overlay-background-color-dark);
-  color: var(--dialog-link-text-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .overlay {
+		background-color: var(--dialog-overlay-background-color-dark);
+		color: var(--dialog-link-text-color-dark);
+	}
 
-.card {
-  border-radius: var(--dialog-card-radius);
-  border: var(--dialog-border-width) var(--dialog-border-style)
-    var(--dialog-border-color);
-  background-color: var(--dialog-background-color);
-  color: var(--dialog-foreground-color);
-  box-shadow: var(--dialog-card-shadow);
-  overflow: hidden;
-}
+	.card {
+		border-radius: var(--dialog-card-radius);
+		border: var(--dialog-border-width) var(--dialog-border-style)
+			var(--dialog-border-color);
+		background-color: var(--dialog-background-color);
+		color: var(--dialog-foreground-color);
+		box-shadow: var(--dialog-card-shadow);
+		overflow: hidden;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .card {
-  background-color: var(--dialog-background-color-dark);
-  color: var(--dialog-foreground-color-dark);
-  border-color: var(--dialog-border-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .card {
+		background-color: var(--dialog-background-color-dark);
+		color: var(--dialog-foreground-color-dark);
+		border-color: var(--dialog-border-color-dark);
+	}
 
-.header {
-  display: flex;
-  flex-direction: column;
-  padding: var(--dialog-card-padding);
-  gap: var(--dialog-header-gap);
-}
+	.header {
+		display: flex;
+		flex-direction: column;
+		padding: var(--dialog-card-padding);
+		gap: var(--dialog-header-gap);
+	}
 
-.header > * + * {
-  margin-top: var(--dialog-card-gap);
-}
+	.header > * + * {
+		margin-top: var(--dialog-card-gap);
+	}
 
-.title {
-  font-weight: var(--dialog-title-font-weight);
-  font-size: var(--dialog-title-font-size);
-  line-height: 1;
-  letter-spacing: var(--dialog-title-letter-spacing);
-}
+	.title {
+		font-weight: var(--dialog-title-font-weight);
+		font-size: var(--dialog-title-font-size);
+		line-height: 1;
+		letter-spacing: var(--dialog-title-letter-spacing);
+	}
 
-.description {
-  color: var(--dialog-muted-color);
-  font-size: var(--dialog-description-font-size);
-  font-weight: var(--dialog-description-font-weight);
-  line-height: var(--dialog-description-line-height);
-}
+	.description {
+		color: var(--dialog-muted-color);
+		font-size: var(--dialog-description-font-size);
+		font-weight: var(--dialog-description-font-weight);
+		line-height: var(--dialog-description-line-height);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .description {
-  color: var(--dialog-muted-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .description {
+		color: var(--dialog-muted-color-dark);
+	}
 
-.content {
-  padding: var(--dialog-card-padding);
-  padding-top: 0;
-  gap: var(--dialog-content-gap);
-}
+	.content {
+		padding: var(--dialog-card-padding);
+		padding-top: 0;
+		gap: var(--dialog-content-gap);
+	}
 
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--dialog-footer-font-size);
-  padding-top: var(--dialog-footer-padding-y);
-  padding-bottom: var(--dialog-footer-padding-y);
-  border-top: var(--dialog-border-width) var(--dialog-border-style)
-    var(--dialog-stroke-color);
-}
+	.footer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: var(--dialog-footer-font-size);
+		padding-top: var(--dialog-footer-padding-y);
+		padding-bottom: var(--dialog-footer-padding-y);
+		border-top: var(--dialog-border-width) var(--dialog-border-style)
+			var(--dialog-stroke-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .footer {
-  border-color: var(--dialog-stroke-color-dark);
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .footer {
+		border-color: var(--dialog-stroke-color-dark);
+	}
 }

--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
@@ -150,12 +150,12 @@
 		box-shadow: 0 0 0 2px var(--dialog-branding-focus-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .branding:focus-visible {
 		box-shadow: 0 0 0 2px var(--dialog-branding-focus-color-dark);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .branding {
 		color: var(--dialog-foreground-color-dark);
 	}
@@ -188,7 +188,7 @@
 		border-top: solid 1px var(--dialog-stroke-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .footer {
 		border-color: var(--dialog-stroke-color-dark);
 	}
@@ -214,7 +214,7 @@
 			var(--dialog-animation-timing);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .overlay {
 		background-color: var(--dialog-overlay-background-color-dark);
 		color: var(--dialog-link-text-color-dark);
@@ -230,7 +230,7 @@
 		overflow: hidden;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .card {
 		background-color: var(--dialog-background-color-dark);
 		color: var(--dialog-foreground-color-dark);
@@ -262,7 +262,7 @@
 		line-height: var(--dialog-description-line-height);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .description {
 		color: var(--dialog-muted-color-dark);
 	}
@@ -284,7 +284,7 @@
 			var(--dialog-stroke-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .footer {
 		border-color: var(--dialog-stroke-color-dark);
 	}

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -261,7 +261,7 @@ test('Custom classes override base layer styles', async () => {
 		.custom-widget-background {
 			background-color: rgb(255, 0, 0) !important;
 		}
-		.custom-widget-text {
+		.custom-widget-foooter {
 			color: rgb(0, 255, 0) !important;
 		}
 	`;
@@ -269,7 +269,7 @@ test('Custom classes override base layer styles', async () => {
 
 	const customTheme: ConsentManagerWidgetTheme = {
 		'widget.root': 'custom-widget-background',
-		'widget.accordion.trigger': 'custom-widget-text',
+		'widget.footer': 'custom-widget-foooter',
 	};
 
 	const test = <ConsentManagerWidget theme={customTheme} />;
@@ -282,8 +282,8 @@ test('Custom classes override base layer styles', async () => {
 				styles: 'custom-widget-background',
 			},
 			{
-				testId: 'consent-manager-widget-accordion-trigger-marketing',
-				styles: 'custom-widget-text',
+				testId: 'consent-manager-widget-footer',
+				styles: 'custom-widget-foooter',
 			},
 		],
 	});
@@ -291,41 +291,39 @@ test('Custom classes override base layer styles', async () => {
 	const root = document.querySelector(
 		'[data-testid="consent-manager-widget-root"]'
 	);
-	const trigger = document.querySelector(
-		'[data-testid="consent-manager-widget-accordion-trigger-marketing"]'
+	const footer = document.querySelector(
+		'[data-testid="consent-manager-widget-footer"]'
 	);
 
-	if (!root || !trigger) {
+	if (!root || !footer) {
 		throw new Error('Required elements not found in the document');
 	}
 
 	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 0, 0)');
-	expect(getComputedStyle(trigger).color).toBe('rgb(0, 255, 0)');
+	expect(getComputedStyle(footer).color).toBe('rgb(0, 255, 0)');
 
 	document.head.removeChild(styleElement);
 });
 
 test('Base layer styles are applied when no custom classes are provided', async () => {
-	const test = <ConsentManagerWidget />;
-
 	await testComponentStyles({
-		component: test,
+		component: <ConsentManagerWidget />,
 		testCases: [],
 	});
 
 	const root = document.querySelector(
 		'[data-testid="consent-manager-widget-root"]'
 	);
-	const trigger = document.querySelector(
-		'[data-testid="consent-manager-widget-accordion-trigger-marketing"]'
+	const footer = document.querySelector(
+		'[data-testid="consent-manager-widget-footer"]'
 	);
-
-	if (!root || !trigger) {
+	// console.log(root, trigger);
+	if (!root || !footer) {
 		throw new Error('Required elements not found in the document');
 	}
 
-	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 255, 255)');
-	expect(getComputedStyle(trigger).color).toBe('rgb(23, 23, 23)');
+	expect(getComputedStyle(root).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+	expect(getComputedStyle(footer).color).toBe('rgb(0, 0, 0)');
 });
 
 test('Multiple custom classes can be applied and override base layer', async () => {

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test, vi } from 'vitest';
+import { test, vi, expect } from 'vitest';
 import { ConsentManagerWidget } from '~/components/consent-manager-widget/consent-manager-widget';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
@@ -253,4 +253,119 @@ test('Theme prop handles edge cases gracefully', async () => {
 			},
 		],
 	});
+});
+
+test('Custom classes override base layer styles', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-widget-background {
+			background-color: rgb(255, 0, 0) !important;
+		}
+		.custom-widget-text {
+			color: rgb(0, 255, 0) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: ConsentManagerWidgetTheme = {
+		'widget.root': 'custom-widget-background',
+		'widget.accordion.trigger': 'custom-widget-text',
+	};
+
+	const test = <ConsentManagerWidget theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-widget-root',
+				styles: 'custom-widget-background',
+			},
+			{
+				testId: 'consent-manager-widget-accordion-trigger-marketing',
+				styles: 'custom-widget-text',
+			},
+		],
+	});
+
+	const root = document.querySelector(
+		'[data-testid="consent-manager-widget-root"]'
+	);
+	const trigger = document.querySelector(
+		'[data-testid="consent-manager-widget-accordion-trigger-marketing"]'
+	);
+
+	if (!root || !trigger) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 0, 0)');
+	expect(getComputedStyle(trigger).color).toBe('rgb(0, 255, 0)');
+
+	document.head.removeChild(styleElement);
+});
+
+test('Base layer styles are applied when no custom classes are provided', async () => {
+	const test = <ConsentManagerWidget />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [],
+	});
+
+	const root = document.querySelector(
+		'[data-testid="consent-manager-widget-root"]'
+	);
+	const trigger = document.querySelector(
+		'[data-testid="consent-manager-widget-accordion-trigger-marketing"]'
+	);
+
+	if (!root || !trigger) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(root).backgroundColor).toBe('rgb(255, 255, 255)');
+	expect(getComputedStyle(trigger).color).toBe('rgb(23, 23, 23)');
+});
+
+test('Multiple custom classes can be applied and override base layer', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-padding {
+			padding: 32px !important;
+		}
+		.custom-border {
+			border: 2px solid rgb(0, 0, 255) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: ConsentManagerWidgetTheme = {
+		'widget.root': 'custom-padding custom-border',
+	};
+
+	const test = <ConsentManagerWidget theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-widget-root',
+				styles: 'custom-padding custom-border',
+			},
+		],
+	});
+
+	const root = document.querySelector(
+		'[data-testid="consent-manager-widget-root"]'
+	);
+
+	if (!root) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(root).padding).toBe('32px');
+	expect(getComputedStyle(root).border).toBe('2px solid rgb(0, 0, 255)');
+
+	document.head.removeChild(styleElement);
 });

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test, vi, expect } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { ConsentManagerWidget } from '~/components/consent-manager-widget/consent-manager-widget';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';

--- a/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
+++ b/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
@@ -85,7 +85,7 @@
 		background-color: var(--widget-background-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .card {
 		background-color: var(--widget-background-color-dark);
 		border-color: var(--widget-border-color-dark);
@@ -115,7 +115,7 @@
 		color: var(--widget-text-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .title {
 		color: var(--widget-text-color-dark);
 	}
@@ -124,7 +124,7 @@
 		color: var(--widget-text-muted-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .description {
 		color: var(--widget-text-muted-color-dark);
 	}
@@ -142,7 +142,7 @@
 		background-color: var(--widget-footer-background-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .footer {
 		background-color: var(--widget-footer-background-color-dark);
 	}
@@ -183,7 +183,7 @@
 		padding-top: 1rem;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .branding {
 		border-color: var(--widget-border-color-dark);
 	}
@@ -200,7 +200,7 @@
 		justify-content: center;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .brandingLink {
 		color: var(--widget-link-text-color-dark);
 	}
@@ -267,7 +267,7 @@
 		box-shadow: 0 0 0 2px var(--widget-accordion-focus-ring);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .accordionItem {
 		border-color: var(--widget-accordion-border-color-dark);
 		background-color: var(--widget-accordion-background-color-dark);
@@ -289,12 +289,12 @@
 		background-color: var(--widget-accordion-background-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .accordionTrigger {
 		color: var(--widget-accordion-text-color-dark);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .accordionTrigger:hover {
 		background-color: var(--widget-accordion-background-hover-dark);
 	}
@@ -316,7 +316,7 @@
 		line-height: 1.5;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .accordionContent {
 		color: var(--widget-accordion-content-color-dark);
 	}
@@ -329,7 +329,7 @@
 			var(--widget-accordion-ease);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .accordionArrow {
 		color: var(--widget-accordion-arrow-color-dark);
 	}
@@ -352,7 +352,7 @@
 			var(--widget-accordion-ease);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .switch {
 		background-color: var(--widget-accordion-background-hover-dark);
 	}
@@ -361,7 +361,7 @@
 		background-color: var(--widget-accordion-focus-ring);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .switch[data-state="checked"] {
 		background-color: var(--widget-accordion-focus-ring-dark);
 	}

--- a/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
+++ b/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
@@ -1,366 +1,368 @@
-:root {
-  /* Widget Colors */
-  --widget-background-color: hsl(0, 0%, 100%);
-  --widget-background-color-dark: hsl(0, 0%, 10%);
-  --widget-border-color: hsl(0, 0%, 92.16%);
-  --widget-border-color-dark: hsl(0, 0%, 20%);
-  --widget-text-color: hsl(0, 0%, 9.02%);
-  --widget-text-color-dark: hsl(0, 0%, 90%);
-  --widget-text-muted-color: hsl(0, 0%, 36.08%);
-  --widget-text-muted-color-dark: hsl(0, 0%, 60%);
-  --widget-footer-background-color: transparent;
-  --widget-footer-background-color-dark: transparent;
-  --widget-link-text-color: hsl(0, 0%, 9.02%);
-  --widget-link-text-color-dark: hsl(0, 0%, 90%);
-  --widget-branding-link-color: #47c2ff;
+@layer base {
+	:root {
+		/* Widget Colors */
+		--widget-background-color: hsl(0, 0%, 100%);
+		--widget-background-color-dark: hsl(0, 0%, 10%);
+		--widget-border-color: hsl(0, 0%, 92.16%);
+		--widget-border-color-dark: hsl(0, 0%, 20%);
+		--widget-text-color: hsl(0, 0%, 9.02%);
+		--widget-text-color-dark: hsl(0, 0%, 90%);
+		--widget-text-muted-color: hsl(0, 0%, 36.08%);
+		--widget-text-muted-color-dark: hsl(0, 0%, 60%);
+		--widget-footer-background-color: transparent;
+		--widget-footer-background-color-dark: transparent;
+		--widget-link-text-color: hsl(0, 0%, 9.02%);
+		--widget-link-text-color-dark: hsl(0, 0%, 90%);
+		--widget-branding-link-color: #47c2ff;
 
-  /* Widget Layout */
-  --widget-padding: 0;
-  --widget-radius: 0;
-  --widget-gap: 0.375rem;
-  --widget-border-width: 0;
-  --widget-max-width: 32rem;
-  --widget-z-index: 50;
-  --widget-footer-padding: 1.5rem 0 0 0;
+		/* Widget Layout */
+		--widget-padding: 0;
+		--widget-radius: 0;
+		--widget-gap: 0.375rem;
+		--widget-border-width: 0;
+		--widget-max-width: 32rem;
+		--widget-z-index: 50;
+		--widget-footer-padding: 1.5rem 0 0 0;
 
-  /* Typography */
-  --widget-title-size: 0.875rem;
-  --widget-title-line-height: 1.25;
-  --widget-title-tracking: -0.006em;
-  --widget-title-weight: 600;
+		/* Typography */
+		--widget-title-size: 0.875rem;
+		--widget-title-line-height: 1.25;
+		--widget-title-tracking: -0.006em;
+		--widget-title-weight: 600;
 
-  /* Animation */
-  --widget-entry-animation: enter 150ms ease-out;
-  --widget-exit-animation: exit 150ms ease-out;
+		/* Animation */
+		--widget-entry-animation: enter 150ms ease-out;
+		--widget-exit-animation: exit 150ms ease-out;
 
-  /* Accordion */
-  --widget-accordion-padding: 0.875rem;
-  --widget-accordion-radius: 0.625rem;
-  --widget-accordion-duration: 200ms;
-  --widget-accordion-ease: cubic-bezier(0.4, 0, 0.2, 1);
-  --widget-accordion-icon-size: 1.25rem;
-  --widget-accordion-background-color: hsl(0, 0%, 100%);
-  --widget-accordion-background-color-dark: hsl(0, 0%, 9.02%);
-  --widget-accordion-background-hover: hsl(0, 0%, 96.86%);
-  --widget-accordion-background-hover-dark: hsl(0, 0%, 10.98%);
-  --widget-accordion-border-color: hsl(0, 0%, 92.16%);
-  --widget-accordion-border-color-dark: hsl(0, 0%, 20%);
-  --widget-accordion-text-color: hsl(0, 0%, 9.02%);
-  --widget-accordion-text-color-dark: hsl(0, 0%, 90%);
-  --widget-accordion-icon-color: hsl(0, 0%, 36.08%);
-  --widget-accordion-icon-color-dark: hsl(0, 0%, 60%);
-  --widget-accordion-arrow-color: hsl(0, 0%, 63.92%);
-  --widget-accordion-arrow-color-dark: hsl(0, 0%, 80%);
-  --widget-accordion-content-color: hsl(0, 0%, 36.08%);
-  --widget-accordion-content-color-dark: hsl(0, 0%, 60%);
-  --widget-accordion-focus-ring: hsl(227.93, 100%, 63.92%);
-  --widget-accordion-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
-  --widget-accordion-focus-shadow: 0 0 0 2px hsl(227.93, 100%, 63.92%);
-  --widget-accordion-focus-shadow-dark: 0 0 0 2px hsl(228.07, 69.8%, 48.04%);
-}
+		/* Accordion */
+		--widget-accordion-padding: 0.875rem;
+		--widget-accordion-radius: 0.625rem;
+		--widget-accordion-duration: 200ms;
+		--widget-accordion-ease: cubic-bezier(0.4, 0, 0.2, 1);
+		--widget-accordion-icon-size: 1.25rem;
+		--widget-accordion-background-color: hsl(0, 0%, 100%);
+		--widget-accordion-background-color-dark: hsl(0, 0%, 9.02%);
+		--widget-accordion-background-hover: hsl(0, 0%, 96.86%);
+		--widget-accordion-background-hover-dark: hsl(0, 0%, 10.98%);
+		--widget-accordion-border-color: hsl(0, 0%, 92.16%);
+		--widget-accordion-border-color-dark: hsl(0, 0%, 20%);
+		--widget-accordion-text-color: hsl(0, 0%, 9.02%);
+		--widget-accordion-text-color-dark: hsl(0, 0%, 90%);
+		--widget-accordion-icon-color: hsl(0, 0%, 36.08%);
+		--widget-accordion-icon-color-dark: hsl(0, 0%, 60%);
+		--widget-accordion-arrow-color: hsl(0, 0%, 63.92%);
+		--widget-accordion-arrow-color-dark: hsl(0, 0%, 80%);
+		--widget-accordion-content-color: hsl(0, 0%, 36.08%);
+		--widget-accordion-content-color-dark: hsl(0, 0%, 60%);
+		--widget-accordion-focus-ring: hsl(227.93, 100%, 63.92%);
+		--widget-accordion-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
+		--widget-accordion-focus-shadow: 0 0 0 2px hsl(227.93, 100%, 63.92%);
+		--widget-accordion-focus-shadow-dark: 0 0 0 2px hsl(228.07, 69.8%, 48.04%);
+	}
 
-.widget {
-  isolation: isolate;
-  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji";
-  line-height: 1.15;
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-}
+	.widget {
+		isolation: isolate;
+		font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+			"Apple Color Emoji", "Segoe UI Emoji";
+		line-height: 1.15;
+		-webkit-text-size-adjust: 100%;
+		tab-size: 4;
+	}
 
-.widget > :not([hidden]) ~ :not([hidden]) {
-  --space-y-reverse: 0;
-  margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
-  margin-bottom: calc(1.5rem * var(--space-y-reverse));
-}
+	.widget > :not([hidden]) ~ :not([hidden]) {
+		--space-y-reverse: 0;
+		margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
+		margin-bottom: calc(1.5rem * var(--space-y-reverse));
+	}
 
-/* Card styles */
-.card {
-  position: relative;
-  width: 100%;
-  max-width: var(--widget-max-width);
-  border-radius: var(--widget-radius);
-  border: var(--widget-border-width) solid var(--widget-border-color);
-  background-color: var(--widget-background-color);
-}
+	/* Card styles */
+	.card {
+		position: relative;
+		width: 100%;
+		max-width: var(--widget-max-width);
+		border-radius: var(--widget-radius);
+		border: var(--widget-border-width) solid var(--widget-border-color);
+		background-color: var(--widget-background-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .card {
-  background-color: var(--widget-background-color-dark);
-  border-color: var(--widget-border-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .card {
+		background-color: var(--widget-background-color-dark);
+		border-color: var(--widget-border-color-dark);
+	}
 
-/* Animation states */
-.card[data-state="open"] {
-  animation: var(--widget-entry-animation);
-}
+	/* Animation states */
+	.card[data-state="open"] {
+		animation: var(--widget-entry-animation);
+	}
 
-.card[data-state="closed"] {
-  animation: var(--widget-exit-animation);
-}
+	.card[data-state="closed"] {
+		animation: var(--widget-exit-animation);
+	}
 
-.header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--widget-gap);
-  padding: var(--widget-padding);
-}
+	.header {
+		display: flex;
+		flex-direction: column;
+		gap: var(--widget-gap);
+		padding: var(--widget-padding);
+	}
 
-.title {
-  font-size: var(--widget-title-size);
-  line-height: var(--widget-title-line-height);
-  letter-spacing: var(--widget-title-tracking);
-  font-weight: var(--widget-title-weight);
-  color: var(--widget-text-color);
-}
+	.title {
+		font-size: var(--widget-title-size);
+		line-height: var(--widget-title-line-height);
+		letter-spacing: var(--widget-title-tracking);
+		font-weight: var(--widget-title-weight);
+		color: var(--widget-text-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .title {
-  color: var(--widget-text-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .title {
+		color: var(--widget-text-color-dark);
+	}
 
-.description {
-  color: var(--widget-text-muted-color);
-}
+	.description {
+		color: var(--widget-text-muted-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .description {
-  color: var(--widget-text-muted-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .description {
+		color: var(--widget-text-muted-color-dark);
+	}
 
-.content {
-  padding: 0 var(--widget-padding);
-  padding-bottom: var(--widget-padding);
-}
+	.content {
+		padding: 0 var(--widget-padding);
+		padding-bottom: var(--widget-padding);
+	}
 
-.footer {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: var(--widget-footer-padding);
-  background-color: var(--widget-footer-background-color);
-}
+	.footer {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: var(--widget-footer-padding);
+		background-color: var(--widget-footer-background-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .footer {
-  background-color: var(--widget-footer-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .footer {
+		background-color: var(--widget-footer-background-color-dark);
+	}
 
-@media (max-width: 640px) {
-  .footer {
-    flex-direction: column;
-  }
-}
+	@media (max-width: 640px) {
+		.footer {
+			flex-direction: column;
+		}
+	}
 
-@media (min-width: 640px) {
-  .footer {
-    flex-direction: row;
-  }
-}
+	@media (min-width: 640px) {
+		.footer {
+			flex-direction: row;
+		}
+	}
 
-.footerGroup {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  gap: 1rem;
-}
+	.footerGroup {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		gap: 1rem;
+	}
 
-@media (max-width: 640px) {
-  .footerGroup {
-    width: 100%;
-  }
-  .footerGroup button {
-    width: 100%;
-  }
-}
+	@media (max-width: 640px) {
+		.footerGroup {
+			width: 100%;
+		}
+		.footerGroup button {
+			width: 100%;
+		}
+	}
 
-.branding {
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  border-top: var(--widget-border-width) solid var(--widget-border-color);
-  padding-top: 1rem;
-}
+	.branding {
+		display: flex;
+		justify-content: center;
+		width: 100%;
+		border-top: var(--widget-border-width) solid var(--widget-border-color);
+		padding-top: 1rem;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .branding {
-  border-color: var(--widget-border-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .branding {
+		border-color: var(--widget-border-color-dark);
+	}
 
-.brandingLink {
-  color: var(--widget-link-text-color);
-  text-decoration: none;
-  text-align: center;
-  flex-direction: row;
-  display: flex;
-  flex: 1;
-  gap: 0.5rem;
-  align-items: center;
-  justify-content: center;
-}
+	.brandingLink {
+		color: var(--widget-link-text-color);
+		text-decoration: none;
+		text-align: center;
+		flex-direction: row;
+		display: flex;
+		flex: 1;
+		gap: 0.5rem;
+		align-items: center;
+		justify-content: center;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .brandingLink {
-  color: var(--widget-link-text-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .brandingLink {
+		color: var(--widget-link-text-color-dark);
+	}
 
-.brandingLink svg {
-  height: 1.2rem;
-}
+	.brandingLink svg {
+		height: 1.2rem;
+	}
 
-/* Animation keyframes */
-@keyframes enter {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
+	/* Animation keyframes */
+	@keyframes enter {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
 
-@keyframes exit {
-  from {
-    opacity: 1;
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-}
+	@keyframes exit {
+		from {
+			opacity: 1;
+			transform: scale(1);
+		}
+		to {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+	}
 
-/* Position variants */
-.bottomLeft {
-  left: 0px;
-  bottom: 0px;
-}
+	/* Position variants */
+	.bottomLeft {
+		left: 0px;
+		bottom: 0px;
+	}
 
-.bottomRight {
-  right: 0px;
-  bottom: 0px;
-}
+	.bottomRight {
+		right: 0px;
+		bottom: 0px;
+	}
 
-.topLeft {
-  left: 0px;
-  top: 0px;
-}
+	.topLeft {
+		left: 0px;
+		top: 0px;
+	}
 
-.topRight {
-  right: 0px;
-  top: 0px;
-}
+	.topRight {
+		right: 0px;
+		top: 0px;
+	}
 
-/* Accordion styles */
-.accordionItem {
-  border-radius: var(--widget-accordion-radius);
-  border: 1px solid var(--widget-accordion-border-color);
-  background-color: var(--widget-accordion-background-color);
-  position: relative;
-  overflow: visible;
-}
+	/* Accordion styles */
+	.accordionItem {
+		border-radius: var(--widget-accordion-radius);
+		border: 1px solid var(--widget-accordion-border-color);
+		background-color: var(--widget-accordion-background-color);
+		position: relative;
+		overflow: visible;
+	}
 
-/* Add focus styles to accordionItem when accordionTriggerInner is focused */
-.accordionItem:has(.accordionTriggerInner:focus-visible) {
-  box-shadow: 0 0 0 2px var(--widget-accordion-focus-ring);
-}
+	/* Add focus styles to accordionItem when accordionTriggerInner is focused */
+	.accordionItem:has(.accordionTriggerInner:focus-visible) {
+		box-shadow: 0 0 0 2px var(--widget-accordion-focus-ring);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .accordionItem {
-  border-color: var(--widget-accordion-border-color-dark);
-  background-color: var(--widget-accordion-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .accordionItem {
+		border-color: var(--widget-accordion-border-color-dark);
+		background-color: var(--widget-accordion-background-color-dark);
+	}
 
-.accordionTrigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  /* padding: var(--widget-accordion-padding); */
-  color: var(--widget-accordion-text-color);
-  background-color: transparent;
-  transition: background-color var(--widget-accordion-duration)
-    var(--widget-accordion-ease);
-}
+	.accordionTrigger {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		/* padding: var(--widget-accordion-padding); */
+		color: var(--widget-accordion-text-color);
+		background-color: transparent;
+		transition: background-color var(--widget-accordion-duration)
+			var(--widget-accordion-ease);
+	}
 
-.accordionTrigger:hover {
-  background-color: var(--widget-accordion-background-hover);
-}
+	.accordionTrigger:hover {
+		background-color: var(--widget-accordion-background-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .accordionTrigger {
-  color: var(--widget-accordion-text-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .accordionTrigger {
+		color: var(--widget-accordion-text-color-dark);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .accordionTrigger:hover {
-  background-color: var(--widget-accordion-background-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .accordionTrigger:hover {
+		background-color: var(--widget-accordion-background-hover-dark);
+	}
 
-.accordionTriggerInner {
-  display: flex;
-  align-items: center;
-  gap: var(--widget-gap);
-  font-size: var(--widget-title-size);
-  font-weight: var(--widget-title-weight);
-  position: relative;
-  border-radius: var(--widget-accordion-radius);
-}
+	.accordionTriggerInner {
+		display: flex;
+		align-items: center;
+		gap: var(--widget-gap);
+		font-size: var(--widget-title-size);
+		font-weight: var(--widget-title-weight);
+		position: relative;
+		border-radius: var(--widget-accordion-radius);
+	}
 
-.accordionContent {
-  padding: var(--widget-accordion-padding);
-  color: var(--widget-accordion-content-color);
-  font-size: 0.875rem;
-  line-height: 1.5;
-}
+	.accordionContent {
+		padding: var(--widget-accordion-padding);
+		color: var(--widget-accordion-content-color);
+		font-size: 0.875rem;
+		line-height: 1.5;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .accordionContent {
-  color: var(--widget-accordion-content-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .accordionContent {
+		color: var(--widget-accordion-content-color-dark);
+	}
 
-.accordionArrow {
-  color: var(--widget-accordion-arrow-color);
-  width: var(--widget-accordion-icon-size);
-  height: var(--widget-accordion-icon-size);
-  transition: transform var(--widget-accordion-duration)
-    var(--widget-accordion-ease);
-}
+	.accordionArrow {
+		color: var(--widget-accordion-arrow-color);
+		width: var(--widget-accordion-icon-size);
+		height: var(--widget-accordion-icon-size);
+		transition: transform var(--widget-accordion-duration)
+			var(--widget-accordion-ease);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .accordionArrow {
-  color: var(--widget-accordion-arrow-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .accordionArrow {
+		color: var(--widget-accordion-arrow-color-dark);
+	}
 
-.accordionItem[data-state="open"] .accordionArrow {
-  transform: rotate(180deg);
-}
+	.accordionItem[data-state="open"] .accordionArrow {
+		transform: rotate(180deg);
+	}
 
-/* Switch styles */
-.switch {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  width: 2rem;
-  height: 1.25rem;
-  background-color: var(--widget-accordion-background-hover);
-  border-radius: 9999px;
-  transition: background-color var(--widget-accordion-duration)
-    var(--widget-accordion-ease);
-}
+	/* Switch styles */
+	.switch {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		width: 2rem;
+		height: 1.25rem;
+		background-color: var(--widget-accordion-background-hover);
+		border-radius: 9999px;
+		transition: background-color var(--widget-accordion-duration)
+			var(--widget-accordion-ease);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .switch {
-  background-color: var(--widget-accordion-background-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .switch {
+		background-color: var(--widget-accordion-background-hover-dark);
+	}
 
-.switch[data-state="checked"] {
-  background-color: var(--widget-accordion-focus-ring);
-}
+	.switch[data-state="checked"] {
+		background-color: var(--widget-accordion-focus-ring);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .switch[data-state="checked"] {
-  background-color: var(--widget-accordion-focus-ring-dark);
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .switch[data-state="checked"] {
+		background-color: var(--widget-accordion-focus-ring-dark);
+	}
 }

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
 import { vi } from 'vitest';
 import { CookieBanner } from '~/components/cookie-banner/cookie-banner';
 import type { ThemeValue } from '~/types/theme';
@@ -255,4 +255,109 @@ test('Theme prop handles edge cases gracefully', async () => {
 			},
 		],
 	});
+});
+
+test('Custom classes override base layer styles', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-banner-background {
+			background-color: rgb(255, 0, 0) !important;
+		}
+		.custom-banner-text {
+			color: rgb(0, 255, 0) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: CookieBannerTheme = {
+		'banner.card': 'custom-banner-background',
+		'banner.header.title': 'custom-banner-text',
+	};
+
+	const test = <CookieBanner theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'cookie-banner-card',
+				styles: 'custom-banner-background',
+			},
+			{
+				testId: 'cookie-banner-title',
+				styles: 'custom-banner-text',
+			},
+		],
+	});
+
+	const card = document.querySelector('[data-testid="cookie-banner-card"]');
+	const title = document.querySelector('[data-testid="cookie-banner-title"]');
+
+	if (!card || !title) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(card).backgroundColor).toBe('rgb(255, 0, 0)');
+	expect(getComputedStyle(title).color).toBe('rgb(0, 255, 0)');
+
+	document.head.removeChild(styleElement);
+});
+
+test('Base layer styles are applied when no custom classes are provided', async () => {
+	const test = <CookieBanner />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [],
+	});
+
+	const card = document.querySelector('[data-testid="cookie-banner-card"]');
+	const title = document.querySelector('[data-testid="cookie-banner-title"]');
+
+	if (!card || !title) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(card).backgroundColor).toBe('rgb(255, 255, 255)');
+	expect(getComputedStyle(title).color).toBe('rgb(23, 23, 23)');
+});
+
+test('Multiple custom classes can be applied and override base layer', async () => {
+	const styleElement = document.createElement('style');
+	styleElement.textContent = `
+		.custom-padding {
+			padding: 32px !important;
+		}
+		.custom-border {
+			border: 2px solid rgb(0, 0, 255) !important;
+		}
+	`;
+	document.head.appendChild(styleElement);
+
+	const customTheme: CookieBannerTheme = {
+		'banner.card': 'custom-padding custom-border',
+	};
+
+	const test = <CookieBanner theme={customTheme} />;
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'cookie-banner-card',
+				styles: 'custom-padding custom-border',
+			},
+		],
+	});
+
+	const card = document.querySelector('[data-testid="cookie-banner-card"]');
+
+	if (!card) {
+		throw new Error('Required elements not found in the document');
+	}
+
+	expect(getComputedStyle(card).padding).toBe('32px');
+	expect(getComputedStyle(card).border).toBe('2px solid rgb(0, 0, 255)');
+
+	document.head.removeChild(styleElement);
 });

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest';
+import { expect, test } from 'vitest';
 import { vi } from 'vitest';
 import { CookieBanner } from '~/components/cookie-banner/cookie-banner';
 import type { ThemeValue } from '~/types/theme';

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -1,288 +1,294 @@
 /* Base cookie banner variables */
-:root {
-	isolation: isolate;
+@layer base {
+	:root {
+		isolation: isolate;
 
-	/* css reset */
-	font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
-		"Apple Color Emoji", "Segoe UI Emoji";
-	line-height: 1.15;
-	-webkit-text-size-adjust: 100%;
-	tab-size: 4;
+		/* css reset */
+		font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+			"Apple Color Emoji", "Segoe UI Emoji";
+		line-height: 1.15;
+		-webkit-text-size-adjust: 100%;
+		tab-size: 4;
 
-	/* Layout variables */
-	--banner-border-radius-sm: 0.3125rem;
-	--banner-border-radius: 1.25rem;
-	--banner-max-width: 440px;
+		/* Layout variables */
+		--banner-border-radius-sm: 0.3125rem;
+		--banner-border-radius: 1.25rem;
+		--banner-max-width: 440px;
 
-	/* Animation variables */
-	--banner-animation-duration: 200ms;
-	--banner-animation-timing: ease-out;
-	--banner-entry-animation: enter 150ms ease-out;
-	--banner-exit-animation: exit 150ms ease-out;
+		/* Animation variables */
+		--banner-animation-duration: 200ms;
+		--banner-animation-timing: ease-out;
+		--banner-entry-animation: enter 150ms ease-out;
+		--banner-exit-animation: exit 150ms ease-out;
 
-	/* Border */
-	--banner-border-width: 1px;
+		/* Border */
+		--banner-border-width: 1px;
 
-	/* Shadow */
-	--banner-shadow: 0 16px 32px -12px rgba(14, 18, 27, 0.1);
-	--banner-shadow-dark: 0 16px 32px -12px rgba(14, 18, 27, 0.1);
+		/* Shadow */
+		--banner-shadow: 0 16px 32px -12px rgba(14, 18, 27, 0.1);
+		--banner-shadow-dark: 0 16px 32px -12px rgba(14, 18, 27, 0.1);
 
-	/* Colors */
-	--banner-background-color: hsla(0 0% 100% / 1);
-	--banner-background-color-dark: hsla(0 0% 9.02% / 1);
-	--banner-footer-background-color: hsla(0 0% 96.86% / 1);
-	--banner-footer-background-color-dark: hsla(0 0% 10.98% / 1);
-	--banner-text-color: hsla(0 0% 9.02% / 1);
-	--banner-text-color-dark: hsla(0 0% 90% / 1);
-	--banner-border-color: hsla(0 0% 92.16% / 1);
-	--banner-border-color-dark: hsla(0 0% 20% / 1);
-	--banner-title-color: hsla(0 0% 9.02% / 1);
-	--banner-title-color-dark: hsla(0 0% 90% / 1);
-	--banner-description-color: hsla(0 0% 36.08% / 1);
-	--banner-description-color-dark: hsla(0 0% 60% / 1);
-	--banner-overlay-background-color: hsla(0 0% 0% / 0.5);
-	--banner-overlay-background-color-dark: hsla(0 0% 0% / 0.5);
-}
+		/* Colors */
+		--banner-background-color: hsla(0 0% 100% / 1);
+		--banner-background-color-dark: hsla(0 0% 9.02% / 1);
+		--banner-footer-background-color: hsla(0 0% 96.86% / 1);
+		--banner-footer-background-color-dark: hsla(0 0% 10.98% / 1);
+		--banner-text-color: hsla(0 0% 9.02% / 1);
+		--banner-text-color-dark: hsla(0 0% 90% / 1);
+		--banner-border-color: hsla(0 0% 92.16% / 1);
+		--banner-border-color-dark: hsla(0 0% 20% / 1);
+		--banner-title-color: hsla(0 0% 9.02% / 1);
+		--banner-title-color-dark: hsla(0 0% 90% / 1);
+		--banner-description-color: hsla(0 0% 36.08% / 1);
+		--banner-description-color-dark: hsla(0 0% 60% / 1);
+		--banner-overlay-background-color: hsla(0 0% 0% / 0.5);
+		--banner-overlay-background-color-dark: hsla(0 0% 0% / 0.5);
+	}
 
-.root {
-	padding: 1rem;
-	flex-direction: column;
-	width: 100%;
-	display: flex;
-	z-index: 999999998;
-	position: fixed;
-}
-
-/* Banner animation classes */
-.bannerVisible {
-	opacity: 1;
-	transform: translateY(0);
-	transition: opacity var(--banner-animation-duration) var(--banner-animation-timing),
-	           transform var(--banner-animation-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.bannerHidden {
-	opacity: 0;
-	transform: translateY(50px);
-	transition: opacity var(--banner-animation-duration) var(--banner-animation-timing),
-	           transform var(--banner-animation-duration) var(--banner-animation-timing);
-}
-
-@media (min-width: 640px) {
 	.root {
-		padding: 1.5rem;
-		width: auto;
+		padding: 1rem;
+		flex-direction: column;
+		width: 100%;
+		display: flex;
+		z-index: 999999998;
+		position: fixed;
 	}
-}
 
-.bottomLeft {
-	left: 0px;
-	bottom: 0px;
-}
-
-.bottomRight {
-	right: 0px;
-	bottom: 0px;
-}
-
-.topLeft {
-	left: 0px;
-	top: 0px;
-}
-
-.topRight {
-	right: 0px;
-	top: 0px;
-}
-
-/* Card styles */
-.card {
-	position: relative;
-	width: 100%;
-	max-width: var(--banner-max-width);
-	border-radius: var(--banner-border-radius);
-	border-width: var(--banner-border-width);
-	border-color: var(--banner-border-color);
-	background-color: var(--banner-background-color);
-	box-shadow: var(--banner-shadow);
-	overflow: hidden;
-}
-
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .card {
-	background-color: var(--banner-background-color-dark);
-	border-color: var(--banner-border-color-dark);
-	box-shadow: var(--banner-shadow-dark);
-}
-
-/* Animation states */
-.card[data-state="open"] {
-	animation: var(--banner-entry-animation);
-}
-
-.card[data-state="closed"] {
-	animation: var(--banner-exit-animation);
-}
-
-/* Divider between sections */
-.card > :not([hidden]) ~ :not([hidden]) {
-	border-top-width: var(--banner-border-width);
-	border-color: var(--banner-border-color);
-}
-
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .card > :not([hidden]) ~ :not([hidden]) {
-	border-color: var(--banner-border-color-dark);
-}
-
-/* Focus styles */
-.card:focus {
-	outline: none;
-	outline-offset: 2px;
-}
-
-/* Animation keyframes */
-@keyframes enter {
-	from {
-		opacity: 0;
-		transform: scale(0.95);
-	}
-	to {
+	/* Banner animation classes */
+	.bannerVisible {
 		opacity: 1;
-		transform: scale(1);
+		transform: translateY(0);
+		transition: opacity var(--banner-animation-duration)
+			var(--banner-animation-timing), transform var(--banner-animation-duration)
+			cubic-bezier(0.34, 1.56, 0.64, 1);
 	}
-}
 
-@keyframes exit {
-	from {
-		opacity: 1;
-		transform: scale(1);
-	}
-	to {
+	.bannerHidden {
 		opacity: 0;
-		transform: scale(0.95);
+		transform: translateY(50px);
+		transition: opacity var(--banner-animation-duration)
+			var(--banner-animation-timing), transform var(--banner-animation-duration)
+			var(--banner-animation-timing);
 	}
-}
 
-.rejectButton {
-	width: 100%;
-}
+	@media (min-width: 640px) {
+		.root {
+			padding: 1.5rem;
+			width: auto;
+		}
+	}
 
-.acceptButton {
-	width: 100%;
-}
+	.bottomLeft {
+		left: 0px;
+		bottom: 0px;
+	}
 
-.customizeButton {
-	width: 100%;
-}
+	.bottomRight {
+		right: 0px;
+		bottom: 0px;
+	}
 
-@media (min-width: 640px) {
-	.rejectButton,
-	.acceptButton,
+	.topLeft {
+		left: 0px;
+		top: 0px;
+	}
+
+	.topRight {
+		right: 0px;
+		top: 0px;
+	}
+
+	/* Card styles */
+	.card {
+		position: relative;
+		width: 100%;
+		max-width: var(--banner-max-width);
+		border-radius: var(--banner-border-radius);
+		border-width: var(--banner-border-width);
+		border-color: var(--banner-border-color);
+		background-color: var(--banner-background-color);
+		box-shadow: var(--banner-shadow);
+		overflow: hidden;
+	}
+
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .card {
+		background-color: var(--banner-background-color-dark);
+		border-color: var(--banner-border-color-dark);
+		box-shadow: var(--banner-shadow-dark);
+	}
+
+	/* Animation states */
+	.card[data-state="open"] {
+		animation: var(--banner-entry-animation);
+	}
+
+	.card[data-state="closed"] {
+		animation: var(--banner-exit-animation);
+	}
+
+	/* Divider between sections */
+	.card > :not([hidden]) ~ :not([hidden]) {
+		border-top-width: var(--banner-border-width);
+		border-color: var(--banner-border-color);
+	}
+
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .card > :not([hidden]) ~ :not([hidden]) {
+		border-color: var(--banner-border-color-dark);
+	}
+
+	/* Focus styles */
+	.card:focus {
+		outline: none;
+		outline-offset: 2px;
+	}
+
+	/* Animation keyframes */
+	@keyframes enter {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	@keyframes exit {
+		from {
+			opacity: 1;
+			transform: scale(1);
+		}
+		to {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+	}
+
+	.rejectButton {
+		width: 100%;
+	}
+
+	.acceptButton {
+		width: 100%;
+	}
+
 	.customizeButton {
-		width: auto;
+		width: 100%;
 	}
-}
 
-.header {
-	display: flex;
-	flex-direction: column;
-	padding: 1rem;
-	color: var(--banner-text-color);
-}
+	@media (min-width: 640px) {
+		.rejectButton,
+		.acceptButton,
+		.customizeButton {
+			width: auto;
+		}
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .header {
-	color: var(--banner-text-color-dark);
-}
-
-@media (min-width: 640px) {
 	.header {
-		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		padding: 1rem;
+		color: var(--banner-text-color);
 	}
-}
 
-.header > :not([hidden]) ~ :not([hidden]) {
-	--banner-space-y-reverse: 0;
-	margin-top: calc(0.5rem * calc(1 - var(--banner-space-y-reverse)));
-	margin-bottom: calc(0.5rem * var(--banner-space-y-reverse));
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .header {
+		color: var(--banner-text-color-dark);
+	}
 
-.footer {
-	display: flex;
-	flex-direction: column;
-	gap: 0.75rem;
-	justify-content: space-between;
-	padding-left: 1.25rem;
-	padding-right: 1.25rem;
-	padding-top: 1rem;
-	padding-bottom: 1rem;
-	background-color: var(--banner-footer-background-color);
-}
+	@media (min-width: 640px) {
+		.header {
+			padding: 1.5rem;
+		}
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .footer {
-	background-color: var(--banner-footer-background-color-dark);
-}
+	.header > :not([hidden]) ~ :not([hidden]) {
+		--banner-space-y-reverse: 0;
+		margin-top: calc(0.5rem * calc(1 - var(--banner-space-y-reverse)));
+		margin-bottom: calc(0.5rem * var(--banner-space-y-reverse));
+	}
 
-@media (min-width: 640px) {
 	.footer {
-		flex-direction: row;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		justify-content: space-between;
+		padding-left: 1.25rem;
+		padding-right: 1.25rem;
+		padding-top: 1rem;
+		padding-bottom: 1rem;
+		background-color: var(--banner-footer-background-color);
 	}
-}
 
-.footerSubGroup {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	gap: 1rem;
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .footer {
+		background-color: var(--banner-footer-background-color-dark);
+	}
 
-.description {
-	font-size: 0.875rem;
-	line-height: 1.25rem;
-	letter-spacing: -0.006em;
-	font-weight: 400;
-	color: var(--banner-description-color);
-}
+	@media (min-width: 640px) {
+		.footer {
+			flex-direction: row;
+		}
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .description {
-	color: var(--banner-description-color-dark);
-}
+	.footerSubGroup {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		gap: 1rem;
+	}
 
-.title {
-	font-size: 1rem;
-	line-height: 1.5rem;
-	letter-spacing: -0.011em;
-	font-weight: 500;
-	color: var(--banner-title-color);
-}
+	.description {
+		font-size: 0.875rem;
+		line-height: 1.25rem;
+		letter-spacing: -0.006em;
+		font-weight: 400;
+		color: var(--banner-description-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .title {
-	color: var(--banner-title-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .description {
+		color: var(--banner-description-color-dark);
+	}
 
-.overlay {
-	position: fixed;
-	inset: 0px;
-	background-color: var(--banner-overlay-background-color);
-	z-index: 999999997;
-}
+	.title {
+		font-size: 1rem;
+		line-height: 1.5rem;
+		letter-spacing: -0.011em;
+		font-weight: 500;
+		color: var(--banner-title-color);
+	}
 
-/* Animation classes for overlay */
-.overlayVisible {
-	opacity: 1;
-	transition: opacity var(--banner-animation-duration) var(--banner-animation-timing);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .title {
+		color: var(--banner-title-color-dark);
+	}
 
-.overlayHidden {
-	opacity: 0;
-	transition: opacity var(--banner-animation-duration) var(--banner-animation-timing);
-}
+	.overlay {
+		position: fixed;
+		inset: 0px;
+		background-color: var(--banner-overlay-background-color);
+		z-index: 999999997;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .overlay {
-	background-color: var(--banner-overlay-background-color-dark);
+	/* Animation classes for overlay */
+	.overlayVisible {
+		opacity: 1;
+		transition: opacity var(--banner-animation-duration)
+			var(--banner-animation-timing);
+	}
+
+	.overlayHidden {
+		opacity: 0;
+		transition: opacity var(--banner-animation-duration)
+			var(--banner-animation-timing);
+	}
+
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .overlay {
+		background-color: var(--banner-overlay-background-color-dark);
+	}
 }

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -111,7 +111,7 @@
 		overflow: hidden;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .card {
 		background-color: var(--banner-background-color-dark);
 		border-color: var(--banner-border-color-dark);
@@ -133,7 +133,7 @@
 		border-color: var(--banner-border-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .card > :not([hidden]) ~ :not([hidden]) {
 		border-color: var(--banner-border-color-dark);
 	}
@@ -194,7 +194,7 @@
 		color: var(--banner-text-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .header {
 		color: var(--banner-text-color-dark);
 	}
@@ -223,7 +223,7 @@
 		background-color: var(--banner-footer-background-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .footer {
 		background-color: var(--banner-footer-background-color-dark);
 	}
@@ -249,7 +249,7 @@
 		color: var(--banner-description-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .description {
 		color: var(--banner-description-color-dark);
 	}
@@ -262,7 +262,7 @@
 		color: var(--banner-title-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .title {
 		color: var(--banner-title-color-dark);
 	}
@@ -287,7 +287,7 @@
 			var(--banner-animation-timing);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .overlay {
 		background-color: var(--banner-overlay-background-color-dark);
 	}

--- a/packages/react/src/components/shared/ui/accordion/accordion.module.css
+++ b/packages/react/src/components/shared/ui/accordion/accordion.module.css
@@ -48,7 +48,7 @@
 		overflow: visible;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .item {
 		background-color: var(--accordion-background-color-dark);
 		box-shadow: inset 0 0 0 1px var(--accordion-border-color-dark);
@@ -59,7 +59,7 @@
 		box-shadow: inset 0 0 0 1px transparent;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .item:is(:hover, [data-state="open"]) {
 		background-color: var(--accordion-background-hover-dark);
 		box-shadow: inset 0 0 0 1px transparent;
@@ -71,7 +71,7 @@
 		box-shadow: inset 0 0 0 1px transparent;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark)
 		.item:focus-within:not(:has(.triggerInner:focus-visible)) {
 		background-color: var(--accordion-background-hover-dark);
@@ -82,7 +82,7 @@
 		box-shadow: var(--accordion-focus-shadow);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .item:has(.triggerInner:focus-visible) {
 		box-shadow: var(--accordion-focus-shadow-dark);
 	}
@@ -119,7 +119,7 @@
 		z-index: 1;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .triggerInner {
 		color: var(--accordion-text-color-dark);
 	}
@@ -135,7 +135,7 @@
 		flex-shrink: 0;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .icon {
 		color: var(--accordion-icon-color-dark);
 	}
@@ -152,7 +152,7 @@
 		color: var(--accordion-arrow-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .arrowOpen {
 		color: var(--accordion-arrow-color-dark);
 	}
@@ -161,7 +161,7 @@
 		color: var(--accordion-icon-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .item:hover .arrowOpen {
 		color: var(--accordion-icon-color-dark);
 	}
@@ -171,7 +171,7 @@
 		display: none;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .arrowClose {
 		color: var(--accordion-icon-color-dark);
 	}
@@ -226,7 +226,7 @@
 		color: var(--accordion-content-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .contentInner {
 		color: var(--accordion-content-color-dark);
 	}

--- a/packages/react/src/components/shared/ui/accordion/accordion.module.css
+++ b/packages/react/src/components/shared/ui/accordion/accordion.module.css
@@ -1,230 +1,233 @@
-:root {
-  /* Layout variables */
-  --accordion-padding: 0.875rem;
-  --accordion-radius: 0.625rem;
-  --accordion-duration: 200ms;
-  --accordion-ease: cubic-bezier(0.4, 0, 0.2, 1);
+@layer base {
+	:root {
+		/* Layout variables */
+		--accordion-padding: 0.875rem;
+		--accordion-radius: 0.625rem;
+		--accordion-duration: 200ms;
+		--accordion-ease: cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* Icon sizes */
-  --accordion-icon-size: 1.25rem;
+		/* Icon sizes */
+		--accordion-icon-size: 1.25rem;
 
-  /* Colors */
-  --accordion-background-color: hsl(0, 0%, 100%);
-  --accordion-background-color-dark: hsl(0, 0%, 9.02%);
-  --accordion-background-hover: hsl(0, 0%, 96.86%);
-  --accordion-background-hover-dark: hsl(0, 0%, 10.98%);
-  --accordion-border-color: hsl(0, 0%, 92.16%);
-  --accordion-border-color-dark: hsl(0, 0%, 20%);
-  --accordion-text-color: hsl(0, 0%, 9.02%);
-  --accordion-text-color-dark: hsl(0, 0%, 90%);
-  --accordion-icon-color: hsl(0, 0%, 36.08%);
-  --accordion-icon-color-dark: hsl(0, 0%, 60%);
-  --accordion-arrow-color: hsl(0, 0%, 63.92%);
-  --accordion-arrow-color-dark: hsl(0, 0%, 80%);
-  --accordion-content-color: hsl(0, 0%, 36.08%);
-  --accordion-content-color-dark: hsl(0, 0%, 60%);
-  --accordion-focus-ring: hsl(227.93, 100%, 63.92%);
-  --accordion-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
-  --accordion-focus-shadow: 0 0 0 2px var(--accordion-focus-ring);
-  --accordion-focus-shadow-dark: 0 0 0 2px var(--accordion-focus-ring-dark);
-}
+		/* Colors */
+		--accordion-background-color: hsl(0, 0%, 100%);
+		--accordion-background-color-dark: hsl(0, 0%, 9.02%);
+		--accordion-background-hover: hsl(0, 0%, 96.86%);
+		--accordion-background-hover-dark: hsl(0, 0%, 10.98%);
+		--accordion-border-color: hsl(0, 0%, 92.16%);
+		--accordion-border-color-dark: hsl(0, 0%, 20%);
+		--accordion-text-color: hsl(0, 0%, 9.02%);
+		--accordion-text-color-dark: hsl(0, 0%, 90%);
+		--accordion-icon-color: hsl(0, 0%, 36.08%);
+		--accordion-icon-color-dark: hsl(0, 0%, 60%);
+		--accordion-arrow-color: hsl(0, 0%, 63.92%);
+		--accordion-arrow-color-dark: hsl(0, 0%, 80%);
+		--accordion-content-color: hsl(0, 0%, 36.08%);
+		--accordion-content-color-dark: hsl(0, 0%, 60%);
+		--accordion-focus-ring: hsl(227.93, 100%, 63.92%);
+		--accordion-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
+		--accordion-focus-shadow: 0 0 0 2px var(--accordion-focus-ring);
+		--accordion-focus-shadow-dark: 0 0 0 2px var(--accordion-focus-ring-dark);
+	}
 
-.root {
-  & > :not([hidden]) ~ :not([hidden]) {
-    --space-y-reverse: 0;
-    margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
-    margin-bottom: calc(1rem * var(--space-y-reverse));
-  }
-}
+	.root {
+		& > :not([hidden]) ~ :not([hidden]) {
+			--space-y-reverse: 0;
+			margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
+			margin-bottom: calc(1rem * var(--space-y-reverse));
+		}
+	}
 
-.item {
-  position: relative;
-  padding: var(--accordion-padding);
-  background-color: var(--accordion-background-color);
-  box-shadow: inset 0 0 0 1px var(--accordion-border-color);
-  transition: all var(--accordion-duration) var(--accordion-ease);
-  border-radius: var(--accordion-radius);
-  overflow: visible;
-}
+	.item {
+		position: relative;
+		padding: var(--accordion-padding);
+		background-color: var(--accordion-background-color);
+		box-shadow: inset 0 0 0 1px var(--accordion-border-color);
+		transition: all var(--accordion-duration) var(--accordion-ease);
+		border-radius: var(--accordion-radius);
+		overflow: visible;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .item {
-  background-color: var(--accordion-background-color-dark);
-  box-shadow: inset 0 0 0 1px var(--accordion-border-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .item {
+		background-color: var(--accordion-background-color-dark);
+		box-shadow: inset 0 0 0 1px var(--accordion-border-color-dark);
+	}
 
-.item:is(:hover, [data-state="open"]) {
-  background-color: var(--accordion-background-hover);
-  box-shadow: inset 0 0 0 1px transparent;
-}
+	.item:is(:hover, [data-state="open"]) {
+		background-color: var(--accordion-background-hover);
+		box-shadow: inset 0 0 0 1px transparent;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .item:is(:hover, [data-state="open"]) {
-  background-color: var(--accordion-background-hover-dark);
-  box-shadow: inset 0 0 0 1px transparent;
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .item:is(:hover, [data-state="open"]) {
+		background-color: var(--accordion-background-hover-dark);
+		box-shadow: inset 0 0 0 1px transparent;
+	}
 
-/* Focus styles for item */
-.item:focus-within:not(:has(.triggerInner:focus-visible)) {
-  background-color: var(--accordion-background-hover);
-  box-shadow: inset 0 0 0 1px transparent;
-}
+	/* Focus styles for item */
+	.item:focus-within:not(:has(.triggerInner:focus-visible)) {
+		background-color: var(--accordion-background-hover);
+		box-shadow: inset 0 0 0 1px transparent;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .item:focus-within:not(:has(.triggerInner:focus-visible)) {
-  background-color: var(--accordion-background-hover-dark);
-  box-shadow: inset 0 0 0 1px transparent;
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark)
+		.item:focus-within:not(:has(.triggerInner:focus-visible)) {
+		background-color: var(--accordion-background-hover-dark);
+		box-shadow: inset 0 0 0 1px transparent;
+	}
 
-.item:has(.triggerInner:focus-visible) {
-  box-shadow: var(--accordion-focus-shadow);
-}
+	.item:has(.triggerInner:focus-visible) {
+		box-shadow: var(--accordion-focus-shadow);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .item:has(.triggerInner:focus-visible) {
-  box-shadow: var(--accordion-focus-shadow-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .item:has(.triggerInner:focus-visible) {
+		box-shadow: var(--accordion-focus-shadow-dark);
+	}
 
-.trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  position: relative;
-  width: 100%;
-  overflow: visible;
-}
+	.trigger {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		position: relative;
+		width: 100%;
+		overflow: visible;
+	}
 
-.triggerInner {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 0.625rem;
-  width: 90%;
-  margin: calc(-1 * var(--accordion-padding));
-  padding: var(--accordion-padding);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  letter-spacing: -0.006em;
-  font-weight: 500;
-  text-align: left;
-  color: var(--accordion-text-color);
-  border: 0;
-  background: none;
-  cursor: pointer;
-  padding-right: 0;
-  border-radius: var(--accordion-radius);
-  position: relative;
-  z-index: 1;
-}
+	.triggerInner {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		align-items: center;
+		gap: 0.625rem;
+		width: 90%;
+		margin: calc(-1 * var(--accordion-padding));
+		padding: var(--accordion-padding);
+		font-size: 0.875rem;
+		line-height: 1.25rem;
+		letter-spacing: -0.006em;
+		font-weight: 500;
+		text-align: left;
+		color: var(--accordion-text-color);
+		border: 0;
+		background: none;
+		cursor: pointer;
+		padding-right: 0;
+		border-radius: var(--accordion-radius);
+		position: relative;
+		z-index: 1;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .triggerInner {
-  color: var(--accordion-text-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .triggerInner {
+		color: var(--accordion-text-color-dark);
+	}
 
-.triggerInner:focus-visible {
-  outline: none;
-}
+	.triggerInner:focus-visible {
+		outline: none;
+	}
 
-.icon {
-  width: var(--accordion-icon-size);
-  height: var(--accordion-icon-size);
-  color: var(--accordion-icon-color);
-  flex-shrink: 0;
-}
+	.icon {
+		width: var(--accordion-icon-size);
+		height: var(--accordion-icon-size);
+		color: var(--accordion-icon-color);
+		flex-shrink: 0;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .icon {
-  color: var(--accordion-icon-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .icon {
+		color: var(--accordion-icon-color-dark);
+	}
 
-.arrowOpen,
-.arrowClose {
-  width: var(--accordion-icon-size);
-  height: var(--accordion-icon-size);
-  transition: color var(--accordion-duration) var(--accordion-ease);
-  flex-shrink: 0;
-}
+	.arrowOpen,
+	.arrowClose {
+		width: var(--accordion-icon-size);
+		height: var(--accordion-icon-size);
+		transition: color var(--accordion-duration) var(--accordion-ease);
+		flex-shrink: 0;
+	}
 
-.arrowOpen {
-  color: var(--accordion-arrow-color);
-}
+	.arrowOpen {
+		color: var(--accordion-arrow-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .arrowOpen {
-  color: var(--accordion-arrow-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .arrowOpen {
+		color: var(--accordion-arrow-color-dark);
+	}
 
-.item:hover .arrowOpen {
-  color: var(--accordion-icon-color);
-}
+	.item:hover .arrowOpen {
+		color: var(--accordion-icon-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .item:hover .arrowOpen {
-  color: var(--accordion-icon-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .item:hover .arrowOpen {
+		color: var(--accordion-icon-color-dark);
+	}
 
-.arrowClose {
-  color: var(--accordion-icon-color);
-  display: none;
-}
+	.arrowClose {
+		color: var(--accordion-icon-color);
+		display: none;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .arrowClose {
-  color: var(--accordion-icon-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .arrowClose {
+		color: var(--accordion-icon-color-dark);
+	}
 
-.item[data-state="open"] .arrowOpen {
-  display: none;
-}
+	.item[data-state="open"] .arrowOpen {
+		display: none;
+	}
 
-.item[data-state="open"] .arrowClose {
-  display: block;
-}
+	.item[data-state="open"] .arrowClose {
+		display: block;
+	}
 
-.content {
-  overflow: hidden;
-}
+	.content {
+		overflow: hidden;
+	}
 
-@keyframes accordionDown {
-  from {
-    height: 0;
-    opacity: 0;
-  }
-  to {
-    height: var(--radix-accordion-content-height);
-    opacity: 1;
-  }
-}
+	@keyframes accordionDown {
+		from {
+			height: 0;
+			opacity: 0;
+		}
+		to {
+			height: var(--radix-accordion-content-height);
+			opacity: 1;
+		}
+	}
 
-@keyframes accordionUp {
-  from {
-    height: var(--radix-accordion-content-height);
-    opacity: 1;
-  }
-  to {
-    height: 0;
-    opacity: 0;
-  }
-}
+	@keyframes accordionUp {
+		from {
+			height: var(--radix-accordion-content-height);
+			opacity: 1;
+		}
+		to {
+			height: 0;
+			opacity: 0;
+		}
+	}
 
-.content[data-state="open"] {
-  animation: accordionDown var(--accordion-duration) var(--accordion-ease);
-}
+	.content[data-state="open"] {
+		animation: accordionDown var(--accordion-duration) var(--accordion-ease);
+	}
 
-.content[data-state="closed"] {
-  animation: accordionUp var(--accordion-duration) var(--accordion-ease);
-}
+	.content[data-state="closed"] {
+		animation: accordionUp var(--accordion-duration) var(--accordion-ease);
+	}
 
-.contentInner {
-  padding-top: 0.375rem;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  letter-spacing: -0.006em;
-  color: var(--accordion-content-color);
-}
+	.contentInner {
+		padding-top: 0.375rem;
+		font-size: 0.875rem;
+		line-height: 1.25rem;
+		letter-spacing: -0.006em;
+		color: var(--accordion-content-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .contentInner {
-  color: var(--accordion-content-color-dark);
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .contentInner {
+		color: var(--accordion-content-color-dark);
+	}
 }

--- a/packages/react/src/components/shared/ui/button/button.module.css
+++ b/packages/react/src/components/shared/ui/button/button.module.css
@@ -1,331 +1,333 @@
 /* Button Base Variables */
-:root {
-  /* Primary Colors */
-  --button-primary: hsl(228, 100%, 60%);
-  --button-primary-dark: hsl(228, 69.8%, 48.04%);
-  --button-primary-hover: hsl(227, 100%, 63.92%, 10%);
-  --button-primary-hover-dark: hsla(228, 100%, 64%, 0.1);
+@layer base {
+	:root {
+		/* Primary Colors */
+		--button-primary: hsl(228, 100%, 60%);
+		--button-primary-dark: hsl(228, 69.8%, 48.04%);
+		--button-primary-hover: hsl(227, 100%, 63.92%, 10%);
+		--button-primary-hover-dark: hsla(228, 100%, 64%, 0.1);
 
-  /* Neutral Colors */
-  --button-neutral: hsl(0, 0%, 36%);
-  --button-neutral-dark: hsl(220, 15%, 30%);
-  --button-neutral-hover: hsl(220, 15%, 45%);
-  --button-neutral-hover-dark: hsl(220, 15%, 25%);
-  --button-neutral-soft: hsl(0, 0%, 92.16%);
-  --button-neutral-soft-dark: hsl(220, 15%, 30%);
+		/* Neutral Colors */
+		--button-neutral: hsl(0, 0%, 36%);
+		--button-neutral-dark: hsl(220, 15%, 30%);
+		--button-neutral-hover: hsl(220, 15%, 45%);
+		--button-neutral-hover-dark: hsl(220, 15%, 25%);
+		--button-neutral-soft: hsl(0, 0%, 92.16%);
+		--button-neutral-soft-dark: hsl(220, 15%, 30%);
 
-  /* Focus Colors */
-  --button-focus-ring: hsl(227.93, 100%, 63.92%);
-  --button-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
+		/* Focus Colors */
+		--button-focus-ring: hsl(227.93, 100%, 63.92%);
+		--button-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
 
-  /* Theme Colors */
-  --button-text: hsla(0, 0%, 36%, 1);
-  --button-text-dark: hsla(0, 0%, 70%, 1);
-  --button-text-hover: hsla(0, 0%, 9%, 1);
-  --button-text-hover-dark: hsla(0, 0%, 90%, 1);
-  --button-background-color: hsla(0, 0%, 100%, 1);
-  --button-background-color-dark: hsla(0, 0%, 10%, 1);
-  --button-border: hsla(0, 0%, 36%, 1);
-  --button-border-dark: hsla(220, 15%, 30%, 1);
-  --button-hover-overlay: hsla(220, 15%, 20%, 0.05);
-  --button-hover-overlay-dark: hsla(220, 15%, 90%, 0.1);
+		/* Theme Colors */
+		--button-text: hsla(0, 0%, 36%, 1);
+		--button-text-dark: hsla(0, 0%, 70%, 1);
+		--button-text-hover: hsla(0, 0%, 9%, 1);
+		--button-text-hover-dark: hsla(0, 0%, 90%, 1);
+		--button-background-color: hsla(0, 0%, 100%, 1);
+		--button-background-color-dark: hsla(0, 0%, 10%, 1);
+		--button-border: hsla(0, 0%, 36%, 1);
+		--button-border-dark: hsla(220, 15%, 30%, 1);
+		--button-hover-overlay: hsla(220, 15%, 20%, 0.05);
+		--button-hover-overlay-dark: hsla(220, 15%, 90%, 0.1);
 
-  /* Component Variables */
-  --button-font: inherit;
-  --button-border-width: 0px;
-  --button-border-style: solid;
-  --button-border-color: transparent;
-  --button-border-radius: 0.375rem;
-  --button-font-weight: 500;
-  --button-font-size: 0.875rem;
-  --button-line-height: 1.25rem;
-  --button-transition: all 150ms ease-in-out;
-  --button-cursor: pointer;
+		/* Component Variables */
+		--button-font: inherit;
+		--button-border-width: 0px;
+		--button-border-style: solid;
+		--button-border-color: transparent;
+		--button-border-radius: 0.375rem;
+		--button-font-weight: 500;
+		--button-font-size: 0.875rem;
+		--button-line-height: 1.25rem;
+		--button-transition: all 150ms ease-in-out;
+		--button-cursor: pointer;
 
-  /* Shadows */
-  /* Base Shadows */
-  --button-shadow: 0px 1px 2px 0px hsla(222, 32%, 8%, 0.06);
-  --button-shadow-dark: 0px 1px 2px 0px hsla(0, 0%, 50%, 0.06);
+		/* Shadows */
+		/* Base Shadows */
+		--button-shadow: 0px 1px 2px 0px hsla(222, 32%, 8%, 0.06);
+		--button-shadow-dark: 0px 1px 2px 0px hsla(0, 0%, 50%, 0.06);
 
-  /* Focus Shadows */
-  --button-shadow-primary-focus: 0 0 0 2px var(--button-focus-ring);
-  --button-shadow-neutral-focus: 0 0 0 2px var(--button-focus-ring);
-  --button-shadow-primary-focus-dark: 0 0 0 2px var(--button-focus-ring-dark);
-  --button-shadow-neutral-focus-dark: 0 0 0 2px var(--button-focus-ring-dark);
+		/* Focus Shadows */
+		--button-shadow-primary-focus: 0 0 0 2px var(--button-focus-ring);
+		--button-shadow-neutral-focus: 0 0 0 2px var(--button-focus-ring);
+		--button-shadow-primary-focus-dark: 0 0 0 2px var(--button-focus-ring-dark);
+		--button-shadow-neutral-focus-dark: 0 0 0 2px var(--button-focus-ring-dark);
 
-  /* Primary Shadows */
-  --button-shadow-primary: var(--button-shadow), inset 0 0 0 1px
-    var(--button-primary);
-  --button-shadow-primary-dark: var(--button-shadow-dark), inset 0 0 0 1px
-    var(--button-primary-dark);
-  --button-shadow-primary-hover: none;
-  --button-shadow-primary-hover-dark: none;
+		/* Primary Shadows */
+		--button-shadow-primary: var(--button-shadow), inset 0 0 0 1px
+			var(--button-primary);
+		--button-shadow-primary-dark: var(--button-shadow-dark), inset 0 0 0 1px
+			var(--button-primary-dark);
+		--button-shadow-primary-hover: none;
+		--button-shadow-primary-hover-dark: none;
 
-  /* Neutral Shadows */
-  --button-shadow-neutral: var(--button-shadow), inset 0 0 0 1px
-    var(--button-neutral-soft);
-  --button-shadow-neutral-dark: var(--button-shadow-dark), inset 0 0 0 1px
-    var(--button-neutral-soft-dark);
-  --button-shadow-neutral-hover: none;
-  --button-shadow-neutral-hover-dark: none;
-}
+		/* Neutral Shadows */
+		--button-shadow-neutral: var(--button-shadow), inset 0 0 0 1px
+			var(--button-neutral-soft);
+		--button-shadow-neutral-dark: var(--button-shadow-dark), inset 0 0 0 1px
+			var(--button-neutral-soft-dark);
+		--button-shadow-neutral-hover: none;
+		--button-shadow-neutral-hover-dark: none;
+	}
 
-/* Base Button Styles */
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  border-radius: var(--button-border-radius);
-  font-weight: var(--button-font-weight);
-  transition: var(--button-transition);
-  cursor: var(--button-cursor);
-  border: var(--button-border-width) var(--button-border-style)
-    var(--button-border-color);
-  font-size: var(--button-font-size);
-  line-height: var(--button-line-height);
-  color: var(--button-text);
-  font-family: var(--button-font);
-}
+	/* Base Button Styles */
+	.button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		border-radius: var(--button-border-radius);
+		font-weight: var(--button-font-weight);
+		transition: var(--button-transition);
+		cursor: var(--button-cursor);
+		border: var(--button-border-width) var(--button-border-style)
+			var(--button-border-color);
+		font-size: var(--button-font-size);
+		line-height: var(--button-line-height);
+		color: var(--button-text);
+		font-family: var(--button-font);
+	}
 
-/* Focus Styles */
-.button:focus-visible {
-  outline: none;
-  box-shadow: var(--button-shadow-primary-focus);
-}
+	/* Focus Styles */
+	.button:focus-visible {
+		outline: none;
+		box-shadow: var(--button-shadow-primary-focus);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button:focus-visible {
-  box-shadow: var(--button-shadow-primary-focus-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button:focus-visible {
+		box-shadow: var(--button-shadow-primary-focus-dark);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button {
-  color: var(--button-text-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button {
+		color: var(--button-text-dark);
+	}
 
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+	.button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
 
-/* Size Variants */
-.button-medium {
-  padding: 0.625rem 1rem;
-  font-size: var(--button-font-size);
-  line-height: var(--button-line-height);
-}
+	/* Size Variants */
+	.button-medium {
+		padding: 0.625rem 1rem;
+		font-size: var(--button-font-size);
+		line-height: var(--button-line-height);
+	}
 
-.button-small {
-  padding: 0.5rem 0.75rem;
-  font-size: var(--button-font-size);
-  line-height: var(--button-line-height);
-}
+	.button-small {
+		padding: 0.5rem 0.75rem;
+		font-size: var(--button-font-size);
+		line-height: var(--button-line-height);
+	}
 
-.button-xsmall {
-  padding: 0.375rem 0.625rem;
-  font-size: var(--button-font-size);
-  line-height: var(--button-line-height);
-}
+	.button-xsmall {
+		padding: 0.375rem 0.625rem;
+		font-size: var(--button-font-size);
+		line-height: var(--button-line-height);
+	}
 
-.button-xxsmall {
-  padding: 0.25rem 0.5rem;
-  font-size: var(--button-font-size);
-  line-height: var(--button-line-height);
-}
+	.button-xxsmall {
+		padding: 0.25rem 0.5rem;
+		font-size: var(--button-font-size);
+		line-height: var(--button-line-height);
+	}
 
-/* Primary Button Variants */
-.button-primary-filled {
-  background-color: var(--button-primary);
-  color: var(--button-background-color);
-}
+	/* Primary Button Variants */
+	.button-primary-filled {
+		background-color: var(--button-primary);
+		color: var(--button-background-color);
+	}
 
-.button-primary-filled:focus-visible {
-  box-shadow: var(--button-shadow-primary-focus);
-}
+	.button-primary-filled:focus-visible {
+		box-shadow: var(--button-shadow-primary-focus);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-filled {
-  background-color: var(--button-primary-dark);
-  color: var(--button-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-filled {
+		background-color: var(--button-primary-dark);
+		color: var(--button-background-color-dark);
+	}
 
-.button-primary-filled:hover:not(:disabled) {
-  background-color: var(--button-primary-hover);
-}
+	.button-primary-filled:hover:not(:disabled) {
+		background-color: var(--button-primary-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-filled:hover:not(:disabled) {
-  background-color: var(--button-primary-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-filled:hover:not(:disabled) {
+		background-color: var(--button-primary-hover-dark);
+	}
 
-.button-primary-stroke {
-  background-color: var(--button-background-color);
-  color: var(--button-primary);
-  box-shadow: var(--button-shadow-primary);
-}
+	.button-primary-stroke {
+		background-color: var(--button-background-color);
+		color: var(--button-primary);
+		box-shadow: var(--button-shadow-primary);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-stroke {
-  background-color: var(--button-background-color-dark);
-  color: var(--button-primary-dark);
-  box-shadow: var(--button-shadow-primary-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-stroke {
+		background-color: var(--button-background-color-dark);
+		color: var(--button-primary-dark);
+		box-shadow: var(--button-shadow-primary-dark);
+	}
 
-.button-primary-stroke:hover:not(:disabled) {
-  background-color: var(--button-primary-hover);
-  box-shadow: var(--button-shadow-primary-hover);
-}
+	.button-primary-stroke:hover:not(:disabled) {
+		background-color: var(--button-primary-hover);
+		box-shadow: var(--button-shadow-primary-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-stroke:hover:not(:disabled) {
-  background-color: var(--button-primary-hover-dark);
-  box-shadow: var(--button-shadow-primary-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-stroke:hover:not(:disabled) {
+		background-color: var(--button-primary-hover-dark);
+		box-shadow: var(--button-shadow-primary-hover-dark);
+	}
 
-.button-primary-lighter {
-  background-color: color-mix(in srgb, var(--button-primary) 10%, transparent);
-  color: var(--button-primary);
-}
+	.button-primary-lighter {
+		background-color: color-mix(in srgb, var(--button-primary) 10%, transparent);
+		color: var(--button-primary);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-lighter {
-  background-color: color-mix(
-    in srgb,
-    var(--button-primary-dark) 10%,
-    transparent
-  );
-  color: var(--button-primary-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-lighter {
+		background-color: color-mix(
+			in srgb,
+			var(--button-primary-dark) 10%,
+			transparent
+		);
+		color: var(--button-primary-dark);
+	}
 
-.button-primary-lighter:hover:not(:disabled) {
-  background-color: color-mix(in srgb, var(--button-primary) 20%, transparent);
-}
+	.button-primary-lighter:hover:not(:disabled) {
+		background-color: color-mix(in srgb, var(--button-primary) 20%, transparent);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-lighter:hover:not(:disabled) {
-  background-color: color-mix(
-    in srgb,
-    var(--button-primary-dark) 20%,
-    transparent
-  );
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-lighter:hover:not(:disabled) {
+		background-color: color-mix(
+			in srgb,
+			var(--button-primary-dark) 20%,
+			transparent
+		);
+	}
 
-.button-primary-ghost {
-  color: var(--button-primary);
-}
+	.button-primary-ghost {
+		color: var(--button-primary);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-ghost {
-  color: var(--button-primary-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-ghost {
+		color: var(--button-primary-dark);
+	}
 
-.button-primary-ghost:hover:not(:disabled) {
-  background-color: var(--button-hover-overlay);
-}
+	.button-primary-ghost:hover:not(:disabled) {
+		background-color: var(--button-hover-overlay);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-primary-ghost:hover:not(:disabled) {
-  background-color: var(--button-hover-overlay-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-primary-ghost:hover:not(:disabled) {
+		background-color: var(--button-hover-overlay-dark);
+	}
 
-/* Neutral Button Variants */
-.button-neutral-filled {
-  background-color: var(--button-neutral);
-  color: var(--button-background-color);
-}
+	/* Neutral Button Variants */
+	.button-neutral-filled {
+		background-color: var(--button-neutral);
+		color: var(--button-background-color);
+	}
 
-.button-neutral-filled:focus-visible {
-  box-shadow: var(--button-shadow-neutral-focus);
-}
+	.button-neutral-filled:focus-visible {
+		box-shadow: var(--button-shadow-neutral-focus);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-filled {
-  background-color: var(--button-neutral-dark);
-  color: var(--button-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-filled {
+		background-color: var(--button-neutral-dark);
+		color: var(--button-background-color-dark);
+	}
 
-.button-neutral-filled:hover:not(:disabled) {
-  background-color: var(--button-neutral-hover);
-}
+	.button-neutral-filled:hover:not(:disabled) {
+		background-color: var(--button-neutral-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-filled:hover:not(:disabled) {
-  background-color: var(--button-neutral-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-filled:hover:not(:disabled) {
+		background-color: var(--button-neutral-hover-dark);
+	}
 
-.button-neutral-stroke {
-  background-color: var(--button-background-color);
-  box-shadow: var(--button-shadow-neutral);
-}
+	.button-neutral-stroke {
+		background-color: var(--button-background-color);
+		box-shadow: var(--button-shadow-neutral);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-stroke {
-  background-color: var(--button-background-color-dark);
-  box-shadow: var(--button-shadow-neutral-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-stroke {
+		background-color: var(--button-background-color-dark);
+		box-shadow: var(--button-shadow-neutral-dark);
+	}
 
-.button-neutral-stroke:hover:not(:disabled) {
-  background-color: transparent;
-  box-shadow: var(--button-shadow-neutral-hover);
-  color: var(--button-text-hover);
-}
+	.button-neutral-stroke:hover:not(:disabled) {
+		background-color: transparent;
+		box-shadow: var(--button-shadow-neutral-hover);
+		color: var(--button-text-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-stroke:hover:not(:disabled) {
-  box-shadow: var(--button-shadow-neutral-hover-dark);
-  color: var(--button-text-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-stroke:hover:not(:disabled) {
+		box-shadow: var(--button-shadow-neutral-hover-dark);
+		color: var(--button-text-hover-dark);
+	}
 
-.button-neutral-lighter {
-  background-color: color-mix(in srgb, var(--button-neutral) 10%, transparent);
-  color: var(--button-neutral);
-}
+	.button-neutral-lighter {
+		background-color: color-mix(in srgb, var(--button-neutral) 10%, transparent);
+		color: var(--button-neutral);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-lighter {
-  background-color: color-mix(
-    in srgb,
-    var(--button-neutral-dark) 10%,
-    transparent
-  );
-  color: var(--button-neutral-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-lighter {
+		background-color: color-mix(
+			in srgb,
+			var(--button-neutral-dark) 10%,
+			transparent
+		);
+		color: var(--button-neutral-dark);
+	}
 
-.button-neutral-lighter:hover:not(:disabled) {
-  background-color: color-mix(in srgb, var(--button-neutral) 20%, transparent);
-}
+	.button-neutral-lighter:hover:not(:disabled) {
+		background-color: color-mix(in srgb, var(--button-neutral) 20%, transparent);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-lighter:hover:not(:disabled) {
-  background-color: color-mix(
-    in srgb,
-    var(--button-neutral-dark) 20%,
-    transparent
-  );
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-lighter:hover:not(:disabled) {
+		background-color: color-mix(
+			in srgb,
+			var(--button-neutral-dark) 20%,
+			transparent
+		);
+	}
 
-.button-neutral-ghost {
-  color: var(--button-neutral);
-}
+	.button-neutral-ghost {
+		color: var(--button-neutral);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-ghost {
-  color: var(--button-neutral-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-ghost {
+		color: var(--button-neutral-dark);
+	}
 
-.button-neutral-ghost:hover:not(:disabled) {
-  background-color: var(--button-hover-overlay);
-}
+	.button-neutral-ghost:hover:not(:disabled) {
+		background-color: var(--button-hover-overlay);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .button-neutral-ghost:hover:not(:disabled) {
-  background-color: var(--button-hover-overlay-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .button-neutral-ghost:hover:not(:disabled) {
+		background-color: var(--button-hover-overlay-dark);
+	}
 
-/* Icon Styles */
-.button-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+	/* Icon Styles */
+	.button-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
 }

--- a/packages/react/src/components/shared/ui/button/button.module.css
+++ b/packages/react/src/components/shared/ui/button/button.module.css
@@ -95,12 +95,12 @@
 		box-shadow: var(--button-shadow-primary-focus);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button:focus-visible {
 		box-shadow: var(--button-shadow-primary-focus-dark);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button {
 		color: var(--button-text-dark);
 	}
@@ -145,7 +145,7 @@
 		box-shadow: var(--button-shadow-primary-focus);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-filled {
 		background-color: var(--button-primary-dark);
 		color: var(--button-background-color-dark);
@@ -155,7 +155,7 @@
 		background-color: var(--button-primary-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-filled:hover:not(:disabled) {
 		background-color: var(--button-primary-hover-dark);
 	}
@@ -166,7 +166,7 @@
 		box-shadow: var(--button-shadow-primary);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-stroke {
 		background-color: var(--button-background-color-dark);
 		color: var(--button-primary-dark);
@@ -178,7 +178,7 @@
 		box-shadow: var(--button-shadow-primary-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-stroke:hover:not(:disabled) {
 		background-color: var(--button-primary-hover-dark);
 		box-shadow: var(--button-shadow-primary-hover-dark);
@@ -189,7 +189,7 @@
 		color: var(--button-primary);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-lighter {
 		background-color: color-mix(
 			in srgb,
@@ -203,7 +203,7 @@
 		background-color: color-mix(in srgb, var(--button-primary) 20%, transparent);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-lighter:hover:not(:disabled) {
 		background-color: color-mix(
 			in srgb,
@@ -216,7 +216,7 @@
 		color: var(--button-primary);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-ghost {
 		color: var(--button-primary-dark);
 	}
@@ -225,7 +225,7 @@
 		background-color: var(--button-hover-overlay);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-primary-ghost:hover:not(:disabled) {
 		background-color: var(--button-hover-overlay-dark);
 	}
@@ -240,7 +240,7 @@
 		box-shadow: var(--button-shadow-neutral-focus);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-filled {
 		background-color: var(--button-neutral-dark);
 		color: var(--button-background-color-dark);
@@ -250,7 +250,7 @@
 		background-color: var(--button-neutral-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-filled:hover:not(:disabled) {
 		background-color: var(--button-neutral-hover-dark);
 	}
@@ -260,7 +260,7 @@
 		box-shadow: var(--button-shadow-neutral);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-stroke {
 		background-color: var(--button-background-color-dark);
 		box-shadow: var(--button-shadow-neutral-dark);
@@ -272,7 +272,7 @@
 		color: var(--button-text-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-stroke:hover:not(:disabled) {
 		box-shadow: var(--button-shadow-neutral-hover-dark);
 		color: var(--button-text-hover-dark);
@@ -283,7 +283,7 @@
 		color: var(--button-neutral);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-lighter {
 		background-color: color-mix(
 			in srgb,
@@ -297,7 +297,7 @@
 		background-color: color-mix(in srgb, var(--button-neutral) 20%, transparent);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-lighter:hover:not(:disabled) {
 		background-color: color-mix(
 			in srgb,
@@ -310,7 +310,7 @@
 		color: var(--button-neutral);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-ghost {
 		color: var(--button-neutral-dark);
 	}
@@ -319,7 +319,7 @@
 		background-color: var(--button-hover-overlay);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .button-neutral-ghost:hover:not(:disabled) {
 		background-color: var(--button-hover-overlay-dark);
 	}

--- a/packages/react/src/components/shared/ui/switch/switch.module.css
+++ b/packages/react/src/components/shared/ui/switch/switch.module.css
@@ -1,227 +1,229 @@
-:root {
-  /* Layout variables */
-  --switch-height: 1.25rem;
-  --switch-width: 2rem;
-  --switch-padding: 0.125rem;
-  --switch-duration: 200ms;
-  --switch-ease: cubic-bezier(0.4, 0, 0.2, 1);
+@layer base {
+	:root {
+		/* Layout variables */
+		--switch-height: 1.25rem;
+		--switch-width: 2rem;
+		--switch-padding: 0.125rem;
+		--switch-duration: 200ms;
+		--switch-ease: cubic-bezier(0.4, 0, 0.2, 1);
 
-  /* Thumb sizes */
-  --switch-thumb-size: 0.75rem;
-  --switch-thumb-size-disabled: 0.625rem;
-  --switch-thumb-translate: 0.75rem;
+		/* Thumb sizes */
+		--switch-thumb-size: 0.75rem;
+		--switch-thumb-size-disabled: 0.625rem;
+		--switch-thumb-translate: 0.75rem;
 
-  /* Colors */
-  --switch-background-color: hsl(0, 0%, 92%);
-  --switch-background-color-dark: hsl(0, 0%, 20%);
-  --switch-background-color-hover: hsl(0, 0%, 82%);
-  --switch-background-color-hover-dark: hsl(0, 0%, 16.08%);
-  --switch-background-color-checked: hsl(227.94, 100%, 60%);
-  --switch-background-color-checked-dark: hsl(228.07, 69.8%, 48.04%);
-  --switch-background-color-disabled: hsl(0, 0%, 100%);
-  --switch-background-color-disabled-dark: hsl(0, 0%, 9.02%);
-  --switch-thumb-background-color: hsl(0, 0%, 100%);
-  --switch-thumb-background-color-dark: hsl(0, 0%, 96.86%);
-  --switch-thumb-background-color-disabled: hsl(0, 0%, 96.86%);
-  --switch-thumb-background-color-disabled-dark: hsl(0, 0%, 20%);
+		/* Colors */
+		--switch-background-color: hsl(0, 0%, 92%);
+		--switch-background-color-dark: hsl(0, 0%, 20%);
+		--switch-background-color-hover: hsl(0, 0%, 82%);
+		--switch-background-color-hover-dark: hsl(0, 0%, 16.08%);
+		--switch-background-color-checked: hsl(227.94, 100%, 60%);
+		--switch-background-color-checked-dark: hsl(228.07, 69.8%, 48.04%);
+		--switch-background-color-disabled: hsl(0, 0%, 100%);
+		--switch-background-color-disabled-dark: hsl(0, 0%, 9.02%);
+		--switch-thumb-background-color: hsl(0, 0%, 100%);
+		--switch-thumb-background-color-dark: hsl(0, 0%, 96.86%);
+		--switch-thumb-background-color-disabled: hsl(0, 0%, 96.86%);
+		--switch-thumb-background-color-disabled-dark: hsl(0, 0%, 20%);
 
-  /* Shadows */
-  --switch-shadow-thumb: 0 0 0 1px hsl(0, 0%, 92.16%);
-  --switch-shadow-thumb-dark: 0 0 0 1px hsl(0, 0%, 20%);
-  --switch-focus-ring: hsl(228, 100%, 60%);
-  --switch-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
-  --switch-focus-shadow: 0 0 0 2px var(--switch-focus-ring);
-  --switch-focus-shadow-dark: 0 0 0 2px var(--switch-focus-ring-dark);
-}
+		/* Shadows */
+		--switch-shadow-thumb: 0 0 0 1px hsl(0, 0%, 92.16%);
+		--switch-shadow-thumb-dark: 0 0 0 1px hsl(0, 0%, 20%);
+		--switch-focus-ring: hsl(228, 100%, 60%);
+		--switch-focus-ring-dark: hsl(228.07, 69.8%, 48.04%);
+		--switch-focus-shadow: 0 0 0 2px var(--switch-focus-ring);
+		--switch-focus-shadow-dark: 0 0 0 2px var(--switch-focus-ring-dark);
+	}
 
-/* Root switch wrapper */
-.root {
-  display: block;
-  height: var(--switch-height);
-  width: var(--switch-width);
-  flex-shrink: 0;
-  padding: var(--switch-padding);
-  outline: none;
-  font-family: inherit;
-  font-size: 100%;
-  line-height: 1.15;
-  margin: 0;
-  white-space: nowrap;
-  border: 0;
-  background: none;
-  border-radius: 9999px;
-}
+	/* Root switch wrapper */
+	.root {
+		display: block;
+		height: var(--switch-height);
+		width: var(--switch-width);
+		flex-shrink: 0;
+		padding: var(--switch-padding);
+		outline: none;
+		font-family: inherit;
+		font-size: 100%;
+		line-height: 1.15;
+		margin: 0;
+		white-space: nowrap;
+		border: 0;
+		background: none;
+		border-radius: 9999px;
+	}
 
-/* Switch track */
-.track {
-  position: relative;
-  height: calc(var(--switch-height) - 2 * var(--switch-padding));
-  width: calc(var(--switch-width) - 2 * var(--switch-padding));
-  border-radius: 9999px;
-  padding: var(--switch-padding);
-  background-color: var(--switch-background-color);
-  outline: none;
-  transition: all var(--switch-duration) var(--switch-ease);
-}
+	/* Switch track */
+	.track {
+		position: relative;
+		height: calc(var(--switch-height) - 2 * var(--switch-padding));
+		width: calc(var(--switch-width) - 2 * var(--switch-padding));
+		border-radius: 9999px;
+		padding: var(--switch-padding);
+		background-color: var(--switch-background-color);
+		outline: none;
+		transition: all var(--switch-duration) var(--switch-ease);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .track {
-  background-color: var(--switch-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .track {
+		background-color: var(--switch-background-color-dark);
+	}
 
-/* Track states */
-.track:hover {
-  background-color: var(--switch-background-color-hover);
-}
+	/* Track states */
+	.track:hover {
+		background-color: var(--switch-background-color-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .track:hover {
-  background-color: var(--switch-background-color-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .track:hover {
+		background-color: var(--switch-background-color-hover-dark);
+	}
 
-.track:focus-visible {
-  background-color: var(--switch-background-color-hover);
-}
+	.track:focus-visible {
+		background-color: var(--switch-background-color-hover);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .track:focus-visible {
-  background-color: var(--switch-background-color-hover-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .track:focus-visible {
+		background-color: var(--switch-background-color-hover-dark);
+	}
 
-.track:active {
-  background-color: var(--switch-background-color);
-}
+	.track:active {
+		background-color: var(--switch-background-color);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .track:active {
-  background-color: var(--switch-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .track:active {
+		background-color: var(--switch-background-color-dark);
+	}
 
-.root[data-state="checked"] .track {
-  background-color: var(--switch-background-color-checked);
-}
+	.root[data-state="checked"] .track {
+		background-color: var(--switch-background-color-checked);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .root[data-state="checked"] .track {
-  background-color: var(--switch-background-color-checked-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .root[data-state="checked"] .track {
+		background-color: var(--switch-background-color-checked-dark);
+	}
 
-.root[data-state="checked"]:hover .track {
-  background-color: var(--switch-background-color-checked);
-}
+	.root[data-state="checked"]:hover .track {
+		background-color: var(--switch-background-color-checked);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .root[data-state="checked"]:hover .track {
-  background-color: var(--switch-background-color-checked-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .root[data-state="checked"]:hover .track {
+		background-color: var(--switch-background-color-checked-dark);
+	}
 
-/* Disabled states */
-.root[data-disabled] {
-  cursor: not-allowed;
-}
+	/* Disabled states */
+	.root[data-disabled] {
+		cursor: not-allowed;
+	}
 
-.root:focus {
-  outline: none;
-}
+	.root:focus {
+		outline: none;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .root:focus {
-  outline: none;
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .root:focus {
+		outline: none;
+	}
 
-.track-disabled {
-  background-color: var(--switch-background-color-disabled);
-  opacity: 0.4;
-  box-shadow: inset 0 0 0 1px hsl(0, 0%, 92.16%);
-}
+	.track-disabled {
+		background-color: var(--switch-background-color-disabled);
+		opacity: 0.4;
+		box-shadow: inset 0 0 0 1px hsl(0, 0%, 92.16%);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .track-disabled {
-  background-color: var(--switch-background-color-disabled-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .track-disabled {
+		background-color: var(--switch-background-color-disabled-dark);
+	}
 
-.root[data-state="checked"] .track-disabled {
-  background-color: var(--switch-background-color-checked);
-  opacity: 0.4;
-  box-shadow: none;
-}
+	.root[data-state="checked"] .track-disabled {
+		background-color: var(--switch-background-color-checked);
+		opacity: 0.4;
+		box-shadow: none;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .root[data-state="checked"] .track-disabled {
-  background-color: var(--switch-background-color-checked-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .root[data-state="checked"] .track-disabled {
+		background-color: var(--switch-background-color-checked-dark);
+	}
 
-/* Switch thumb */
-.thumb {
-  position: relative;
-  display: block;
-  pointer-events: none;
-  width: var(--switch-thumb-size);
-  height: var(--switch-thumb-size);
-  transition: transform var(--switch-duration) var(--switch-ease);
-  transform: translateX(0);
-}
+	/* Switch thumb */
+	.thumb {
+		position: relative;
+		display: block;
+		pointer-events: none;
+		width: var(--switch-thumb-size);
+		height: var(--switch-thumb-size);
+		transition: transform var(--switch-duration) var(--switch-ease);
+		transform: translateX(0);
+	}
 
-/* Thumb states */
-.thumb::before {
-  content: "";
-  position: absolute;
-  inset-block: 0;
-  left: 0;
-  width: 100%;
-  border-radius: 9999px;
-  background-color: var(--switch-thumb-background-color);
-  mask: radial-gradient(
-      circle farthest-side at 50% 50%,
-      #0000 1.95px,
-      #000 2.05px 100%
-    )
-    50% 50% / 100% 100% no-repeat;
-}
+	/* Thumb states */
+	.thumb::before {
+		content: "";
+		position: absolute;
+		inset-block: 0;
+		left: 0;
+		width: 100%;
+		border-radius: 9999px;
+		background-color: var(--switch-thumb-background-color);
+		mask: radial-gradient(
+				circle farthest-side at 50% 50%,
+				#0000 1.95px,
+				#000 2.05px 100%
+			)
+			50% 50% / 100% 100% no-repeat;
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .thumb::before {
-  background-color: var(--switch-thumb-background-color-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .thumb::before {
+		background-color: var(--switch-thumb-background-color-dark);
+	}
 
-.thumb::after {
-  content: "";
-  position: absolute;
-  inset-block: 0;
-  left: 0;
-  width: 100%;
-  border-radius: 9999px;
-  box-shadow: var(--switch-shadow-thumb);
-}
+	.thumb::after {
+		content: "";
+		position: absolute;
+		inset-block: 0;
+		left: 0;
+		width: 100%;
+		border-radius: 9999px;
+		box-shadow: var(--switch-shadow-thumb);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .thumb::after {
-  box-shadow: var(--switch-shadow-thumb-dark);
-}
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .thumb::after {
+		box-shadow: var(--switch-shadow-thumb-dark);
+	}
 
-.root[data-state="checked"] .thumb {
-  transform: translateX(var(--switch-thumb-translate));
-}
+	.root[data-state="checked"] .thumb {
+		transform: translateX(var(--switch-thumb-translate));
+	}
 
-.track:active .thumb {
-  transform: scale(0.833);
-}
+	.track:active .thumb {
+		transform: scale(0.833);
+	}
 
-/* Disabled thumb */
-.thumb-disabled {
-  box-shadow: none;
-}
+	/* Disabled thumb */
+	.thumb-disabled {
+		box-shadow: none;
+	}
 
-.root[data-state="checked"] .thumb-disabled {
-  transform: translateX(var(--switch-thumb-translate));
-}
+	.root[data-state="checked"] .thumb-disabled {
+		transform: translateX(var(--switch-thumb-translate));
+	}
 
-.root:focus-visible {
-  outline: none;
-  box-shadow: var(--switch-focus-shadow);
-}
+	.root:focus-visible {
+		outline: none;
+		box-shadow: var(--switch-focus-shadow);
+	}
 
-/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
-:global(.c15t-dark) .root:focus-visible {
-  box-shadow: var(--switch-focus-shadow-dark);
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	:global(.c15t-dark) .root:focus-visible {
+		box-shadow: var(--switch-focus-shadow-dark);
+	}
 }

--- a/packages/react/src/components/shared/ui/switch/switch.module.css
+++ b/packages/react/src/components/shared/ui/switch/switch.module.css
@@ -65,7 +65,7 @@
 		transition: all var(--switch-duration) var(--switch-ease);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .track {
 		background-color: var(--switch-background-color-dark);
 	}
@@ -75,7 +75,7 @@
 		background-color: var(--switch-background-color-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .track:hover {
 		background-color: var(--switch-background-color-hover-dark);
 	}
@@ -84,7 +84,7 @@
 		background-color: var(--switch-background-color-hover);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .track:focus-visible {
 		background-color: var(--switch-background-color-hover-dark);
 	}
@@ -93,7 +93,7 @@
 		background-color: var(--switch-background-color);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .track:active {
 		background-color: var(--switch-background-color-dark);
 	}
@@ -102,7 +102,7 @@
 		background-color: var(--switch-background-color-checked);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .root[data-state="checked"] .track {
 		background-color: var(--switch-background-color-checked-dark);
 	}
@@ -111,7 +111,7 @@
 		background-color: var(--switch-background-color-checked);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .root[data-state="checked"]:hover .track {
 		background-color: var(--switch-background-color-checked-dark);
 	}
@@ -125,7 +125,7 @@
 		outline: none;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .root:focus {
 		outline: none;
 	}
@@ -136,7 +136,7 @@
 		box-shadow: inset 0 0 0 1px hsl(0, 0%, 92.16%);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .track-disabled {
 		background-color: var(--switch-background-color-disabled-dark);
 	}
@@ -147,7 +147,7 @@
 		box-shadow: none;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .root[data-state="checked"] .track-disabled {
 		background-color: var(--switch-background-color-checked-dark);
 	}
@@ -180,7 +180,7 @@
 			50% 50% / 100% 100% no-repeat;
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .thumb::before {
 		background-color: var(--switch-thumb-background-color-dark);
 	}
@@ -195,7 +195,7 @@
 		box-shadow: var(--switch-shadow-thumb);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .thumb::after {
 		box-shadow: var(--switch-shadow-thumb-dark);
 	}
@@ -222,7 +222,7 @@
 		box-shadow: var(--switch-focus-shadow);
 	}
 
-	/* biome-ignore lint/nursery/noUnknownPseudoClass: <explanation> */
+	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .root:focus-visible {
 		box-shadow: var(--switch-focus-shadow-dark);
 	}

--- a/packages/react/src/hooks/__tests__/use-color-scheme.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-color-scheme.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { useColorScheme } from '../use-color-scheme';
 

--- a/packages/react/src/hooks/__tests__/use-color-scheme.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-color-scheme.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { useColorScheme } from '../use-color-scheme';
+
+describe('useColorScheme', () => {
+	let mediaQueryList: {
+		matches: boolean;
+		addEventListener: ReturnType<typeof vi.fn>;
+		removeEventListener: ReturnType<typeof vi.fn>;
+		addListener: ReturnType<typeof vi.fn>;
+		removeListener: ReturnType<typeof vi.fn>;
+		dispatchEvent: ReturnType<typeof vi.fn>;
+		onchange: null;
+		media: string;
+	};
+	let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+	let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		// Reset document classes
+		document.documentElement.classList.remove('c15t-dark', 'dark');
+
+		// Mock matchMedia
+		mediaQueryList = {
+			matches: false,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(), // Deprecated but included for completeness
+			removeListener: vi.fn(), // Deprecated but included for completeness
+			dispatchEvent: vi.fn(),
+			onchange: null,
+			media: '(prefers-color-scheme: dark)',
+		};
+
+		vi.spyOn(window, 'matchMedia').mockImplementation(
+			() => mediaQueryList as MediaQueryList
+		);
+
+		// Spy on event listeners
+		addEventListenerSpy = vi.spyOn(mediaQueryList, 'addEventListener');
+		removeEventListenerSpy = vi.spyOn(mediaQueryList, 'removeEventListener');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('sets light theme correctly', () => {
+		renderHook(() => useColorScheme('light'));
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(
+			false
+		);
+	});
+
+	test('sets dark theme correctly', () => {
+		renderHook(() => useColorScheme('dark'));
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(true);
+	});
+
+	test('responds to system preference', () => {
+		mediaQueryList.matches = true;
+		renderHook(() => useColorScheme('system'));
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(true);
+		expect(addEventListenerSpy).toHaveBeenCalledWith(
+			'change',
+			expect.any(Function)
+		);
+	});
+
+	test('cleans up system preference listener on unmount', () => {
+		const { unmount } = renderHook(() => useColorScheme('system'));
+		unmount();
+		expect(removeEventListenerSpy).toHaveBeenCalled();
+	});
+
+	test('updates theme when system preference changes', () => {
+		renderHook(() => useColorScheme('system'));
+
+		const calls = addEventListenerSpy.mock.calls;
+		const callback = calls[0]?.[1];
+		if (!callback) throw new Error('Callback not found');
+
+		(callback as (e: MediaQueryListEvent) => void)({
+			matches: true,
+		} as MediaQueryListEvent);
+
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(true);
+	});
+
+	test('handles default theme based on document class', () => {
+		document.documentElement.classList.add('dark');
+		renderHook(() => useColorScheme(null));
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(true);
+	});
+
+	test('updates theme when default theme changes', async () => {
+		renderHook(() => useColorScheme(null));
+
+		// Simulate class change
+		document.documentElement.classList.add('dark');
+
+		// Wait for MutationObserver to process
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(document.documentElement.classList.contains('c15t-dark')).toBe(true);
+	});
+});

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -58,7 +58,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 			<ConsentManagerProvider
 				options={{
 					mode: 'offline', // Use offline mode to prevent additional fetches
-					react: { theme: 'light' },
+					react: { theme: { 'banner.root': 'light' } },
 				}}
 			>
 				<div>Light theme</div>
@@ -76,7 +76,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 			<ConsentManagerProvider
 				options={{
 					mode: 'offline',
-					react: { theme: 'dark' },
+					react: { theme: { 'banner.root': 'dark' } },
 				}}
 			>
 				<div>Dark theme</div>

--- a/packages/react/src/providers/__tests__/provider-context.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-context.test.tsx
@@ -105,7 +105,7 @@ describe('ConsentManagerProvider Context Values', () => {
 				options={{
 					mode: 'offline',
 					react: {
-						theme: 'dark',
+						theme: { 'banner.root': 'dark' },
 					},
 				}}
 			>

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -68,7 +68,7 @@ export function ConsentManagerProvider({
 		disableAnimation = false,
 		scrollLock = false,
 		trapFocus = true,
-		colorScheme = 'system',
+		colorScheme,
 		noStyle = false,
 	} = react;
 
@@ -222,8 +222,9 @@ export function ConsentManagerProvider({
 			disableAnimation,
 			scrollLock,
 			trapFocus,
+			colorScheme,
 		};
-	}, [theme, noStyle, disableAnimation, scrollLock, trapFocus]);
+	}, [theme, noStyle, disableAnimation, scrollLock, trapFocus, colorScheme]);
 
 	// Set the color scheme
 	useColorScheme(colorScheme);

--- a/packages/react/src/types/consent-manager.ts
+++ b/packages/react/src/types/consent-manager.ts
@@ -8,6 +8,9 @@ import type {
 	TranslationConfig,
 } from 'c15t';
 import type { ReactNode } from 'react';
+import type { CookieBannerTheme } from '~/components/cookie-banner/theme';
+import type { ConsentManagerWidgetTheme } from '~/components/consent-manager-widget/theme';
+import type { ConsentManagerDialogTheme } from '~/components/consent-manager-dialog/theme';
 
 /**
  * React-specific configuration options
@@ -16,8 +19,9 @@ export interface ReactUIOptions {
 	/**
 	 * Visual theme to apply.
 	 */
-	theme?: 'light' | 'dark';
-
+	theme?: CookieBannerTheme &
+		ConsentManagerWidgetTheme &
+		ConsentManagerDialogTheme;
 	/**
 	 * Whether to disable animations.
 	 * @default false
@@ -38,7 +42,8 @@ export interface ReactUIOptions {
 
 	/**
 	 * Color scheme preference.
-	 * @default 'system'
+	 * With this option, you can force the theme to be light, dark or system.
+	 * Otherwise, the theme will be detected if you have '.dark' classname in your document.
 	 */
 	colorScheme?: 'light' | 'dark' | 'system';
 

--- a/packages/react/src/types/consent-manager.ts
+++ b/packages/react/src/types/consent-manager.ts
@@ -8,9 +8,9 @@ import type {
 	TranslationConfig,
 } from 'c15t';
 import type { ReactNode } from 'react';
-import type { CookieBannerTheme } from '~/components/cookie-banner/theme';
-import type { ConsentManagerWidgetTheme } from '~/components/consent-manager-widget/theme';
 import type { ConsentManagerDialogTheme } from '~/components/consent-manager-dialog/theme';
+import type { ConsentManagerWidgetTheme } from '~/components/consent-manager-widget/theme';
+import type { CookieBannerTheme } from '~/components/cookie-banner/theme';
 
 /**
  * React-specific configuration options


### PR DESCRIPTION
## Overview
Fixes theme not being overridable by making the color scheme system more flexible and robust. This allows better integration with existing theme systems while maintaining the default behavior.

## Related Issue

Fixes #202 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Made `colorScheme` parameter optional in `useColorScheme` hook
2. Added support for detecting theme from document class (`.dark`)
3. Improved theme type definitions for better customization
4. Added comprehensive test suite for color scheme functionality
5. Removed local storage dependency for theme persistence
6. Providers theme should now work properly allowing for configuration of themes at the top level

### Technical Notes
- The color scheme now falls back to checking the document's `.dark` class when no explicit scheme is provided
- Added MutationObserver to watch for class changes on the document element
- Improved type safety by extending theme types from component-specific themes
- System preference detection now properly cleans up event listeners

## Testing

### Test Plan

- [ ] Scenario 1: Default Theme Detection

  ```ts
  // Theme should be detected from document class
  document.documentElement.classList.add('dark');
  useColorScheme(null);
  // Should have c15t-dark class
  ```

  ✓ Expected: Theme should automatically sync with document's `.dark` class

- [ ] Scenario 2: System Preference Override

  ```ts
  // Force system dark mode
  useColorScheme('system');
  // Should respond to system preference changes
  ```
  
  ✓ Expected: Theme should follow system dark mode preference

- [ ] Scenario 3: Explicit Theme Override

  ```ts
  // Force light theme
  useColorScheme('light');
  // Should ignore system preference and document class
  ```

  ✓ Expected: Theme should remain light regardless of system or document settings

### Edge Cases
- [ ] Error handling: Gracefully handles missing mediaQuery support
- [ ] Performance: MutationObserver and event listeners are properly cleaned up
- [ ] Security: No security implications as changes are purely presentational

## Checklist

- [x] Issue is linked
- [x] Tests added/updated
- [] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow conventional commits

### Breaking Changes
People with the 'theme' prop misconfigured in the c15t config may need to remove it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive tests for theme and style overrides in consent dialogs, widgets, and banners, ensuring custom CSS classes can override base styles and multiple classes are supported.
  - Introduced a new test suite for color scheme handling, verifying theme switching and system preference detection.

- **Refactor**
  - All component CSS styles are now organized within a `@layer base` for improved encapsulation and maintainability.
  - Updated the theme configuration structure to support granular theme customization for consent UI components.
  - Refined color scheme logic to better handle system preferences and DOM class changes, including removal of localStorage usage.
  - Adjusted theme option format in provider tests to a nested object structure for banner theming.
  - Enhanced cleanup and event handling in color scheme hook for improved reliability.

- **Documentation**
  - Clarified documentation for theme and color scheme options in configuration types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->