### PR TITLE
feat(docs): re-added theme switcher, added color scheme docs

### DIFF
--- a/docs/content/nextjs/meta.json
+++ b/docs/content/nextjs/meta.json
@@ -23,6 +23,7 @@
 		"../hooks/use-focus-trap",
 		"--- Styling the components ---",
 		"../styling/index",
+		"../styling/color-scheme",
 		"../styling/classnames",
 		"../styling/tailwind",
 		"../styling/css-variables",

--- a/docs/content/react/meta.json
+++ b/docs/content/react/meta.json
@@ -22,6 +22,7 @@
 		"../hooks/use-focus-trap",
 		"--- Styles ---",
 		"../styling/index",
+		"../styling/color-scheme",
 		"../styling/classnames",
 		"../styling/tailwind",
 		"../styling/css-variables",

--- a/docs/content/styling/color-scheme.mdx
+++ b/docs/content/styling/color-scheme.mdx
@@ -23,7 +23,7 @@ The color scheme can be set to one of the following values:
 - `'system'`: Automatically matches the system preference
 - `null`: Falls back to default behavior (respects `.dark` class on root element)
 
-By default, if this prop is not set it will default to `null`.
+By default, if this prop is not set, it will default to `null`.
 
 ### Provider Configuration
 

--- a/docs/content/styling/color-scheme.mdx
+++ b/docs/content/styling/color-scheme.mdx
@@ -1,0 +1,79 @@
+---
+title: Color Scheme (Light/Dark Mode)
+description: Learn how to manage light, dark, and system color schemes in your application using c15t's color scheme utilities.
+---
+
+## Overview
+
+@c15t/react provides built-in support for managing color schemes for your components, allowing you to implement light mode, dark mode, or system-based preferences with minimal configuration.
+
+## Usage
+
+You can control the color scheme through two main approaches:
+
+1. Setting the `colorScheme` prop in `ConsentManagerOptions`
+2. Using the `useColorScheme` hook directly
+
+### Available Options
+
+The color scheme can be set to one of the following values:
+
+- `'light'`: Forces light mode
+- `'dark'`: Forces dark mode
+- `'system'`: Automatically matches the system preference
+- `null`: Falls back to default behavior (respects `.dark` class on root element)
+
+By default, if this prop is not set it will default to `null`.
+
+### Provider Configuration
+
+You can also configure the color scheme through the `ConsentManagerProvider`:
+
+```tsx
+import { ConsentManagerProvider } from '@c15t/react';
+
+function App({ children }) {
+  return (
+    <ConsentManagerProvider
+      options={{
+        react: {
+          // Components will only be light mode
+          colorScheme: 'light'
+        }
+      }}
+    >
+      {children}
+    </ConsentManagerProvider>
+  );
+}
+```
+
+### Using the Hook
+
+The `useColorScheme` hook provides a simple way to manage color scheme preferences:
+
+```tsx
+import { useColorScheme } from '@c15t/react';
+
+function App() {
+  useColorScheme('system'); // Options: 'light' | 'dark' | 'system' | null
+  return <div>Your content</div>;
+}
+```
+
+## CSS Classes
+
+The color scheme system manages two CSS classes:
+
+- `.dark`: The default class for dark mode detection
+- `.c15t-dark`: An internal class used by c15t components
+
+When using the system color scheme:
+- The `.c15t-dark` class is automatically added/removed based on system preferences
+- Components will respond to changes in system color scheme preferences
+- The change is immediate and doesn't require a page reload
+
+## Related
+
+- [Theming](/styling/theming) - Learn about c15t's theming system
+- [CSS Variables](/styling/css-variables) - Understanding CSS variable usage

--- a/docs/src/app/docs/layout.config.tsx
+++ b/docs/src/app/docs/layout.config.tsx
@@ -1,11 +1,11 @@
-import type { DocsLayoutProps } from '~/components/layouts/notebook';
+import { GithubInfo } from 'fumadocs-ui/components/github-info';
 import { DiscordIcon } from '~/components/icons/discord';
 import { RedditIcon } from '~/components/icons/reddit';
 import { XIcon } from '~/components/icons/x';
+import { ThemeToggle } from '~/components/layout/theme-toggle';
+import type { DocsLayoutProps } from '~/components/layouts/notebook';
 import { C15TLogo } from '~/components/logo';
 import packageJson from '../../../../packages/core/package.json';
-import { ThemeToggle } from '~/components/layout/theme-toggle';
-import { GithubInfo } from 'fumadocs-ui/components/github-info';
 
 /**
  * Shared layout configurations

--- a/docs/src/app/docs/layout.config.tsx
+++ b/docs/src/app/docs/layout.config.tsx
@@ -1,11 +1,11 @@
-import { GithubInfo } from 'fumadocs-ui/components/github-info';
 import type { DocsLayoutProps } from '~/components/layouts/notebook';
-
 import { DiscordIcon } from '~/components/icons/discord';
 import { RedditIcon } from '~/components/icons/reddit';
 import { XIcon } from '~/components/icons/x';
 import { C15TLogo } from '~/components/logo';
 import packageJson from '../../../../packages/core/package.json';
+import { ThemeToggle } from '~/components/layout/theme-toggle';
+import { GithubInfo } from 'fumadocs-ui/components/github-info';
 
 /**
  * Shared layout configurations
@@ -29,6 +29,16 @@ export const docsOptions: Omit<DocsLayoutProps, 'tree'> = {
 	},
 	links: [
 		{
+			type: 'custom',
+			secondary: true,
+			children: <GithubInfo owner="c15t" repo="c15t" />,
+		},
+		{
+			type: 'custom',
+			secondary: true,
+			children: <ThemeToggle className="ml-2" />,
+		},
+		{
 			icon: <XIcon />,
 			text: 'X',
 			url: 'https://x.com/consentdotio',
@@ -45,11 +55,6 @@ export const docsOptions: Omit<DocsLayoutProps, 'tree'> = {
 			text: 'Discord',
 			url: 'https://c15t.com/discord',
 			type: 'icon',
-		},
-		{
-			type: 'custom',
-			secondary: true,
-			children: <GithubInfo owner="c15t" repo="c15t" />,
 		},
 	],
 };

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -1,11 +1,11 @@
-import type { BaseLayoutProps } from '~/components/layouts/shared';
-import { C15TLogo } from '~/components/logo';
-import { ThemeToggle } from '~/components/layout/theme-toggle';
 import { GithubInfo } from 'fumadocs-ui/components/github-info';
 import { JSIcon, NextIcon, ReactIcon } from '~/components/icons';
 import { DiscordIcon } from '~/components/icons/discord';
 import { RedditIcon } from '~/components/icons/reddit';
 import { XIcon } from '~/components/icons/x';
+import { ThemeToggle } from '~/components/layout/theme-toggle';
+import type { BaseLayoutProps } from '~/components/layouts/shared';
+import { C15TLogo } from '~/components/logo';
 import packageJson from '../../../packages/core/package.json';
 
 /**

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -1,6 +1,6 @@
 import type { BaseLayoutProps } from '~/components/layouts/shared';
 import { C15TLogo } from '~/components/logo';
-
+import { ThemeToggle } from '~/components/layout/theme-toggle';
 import { GithubInfo } from 'fumadocs-ui/components/github-info';
 import { JSIcon, NextIcon, ReactIcon } from '~/components/icons';
 import { DiscordIcon } from '~/components/icons/discord';
@@ -72,6 +72,11 @@ export const homePageOptions: BaseLayoutProps = {
 			type: 'custom',
 			secondary: true,
 			children: <GithubInfo owner="c15t" repo="c15t" />,
+		},
+		{
+			type: 'custom',
+			secondary: true,
+			children: <ThemeToggle className="ml-2" />,
 		},
 	],
 };


### PR DESCRIPTION
## Overview

Reintroduces the theme switcher functionality to both the documentation and home page layouts. 
Added color scheme docs.

## Fixes

Fixes #201 

## Type of Change

- [x] ✨ Enhancement (improves existing functionality)
- [x] 📚 Documentation

## Implementation Details

### Key Changes
Added ThemeToggle component to both layouts\

## Checklist
- [x] Documentation updated
- [x] Code follows style guide
- [x] Commit messages follow conventional commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a theme toggle control to the navigation links on both the documentation and home pages, allowing users to easily switch between light and dark modes.
  - Introduced new documentation on managing color schemes, including light, dark, and system preferences, with usage examples and explanations.
- **Style**
  - Updated the order and arrangement of navigation links for improved accessibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->