### PR TITLE
test(react): base classname tests

### DIFF
--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -2,8 +2,8 @@ import { expect, test, vi } from 'vitest';
 import { ConsentManagerDialog } from '~/components/consent-manager-dialog/consent-manager-dialog';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
-import type { ConsentManagerDialogTheme } from '../theme';
 import styles from '../consent-manager-dialog.module.css';
+import type { ConsentManagerDialogTheme } from '../theme';
 type ComponentTestCase = {
 	testId: string;
 	themeKey: keyof ConsentManagerDialogTheme;

--- a/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-dialog/__tests__/styles.spec.tsx
@@ -3,7 +3,7 @@ import { ConsentManagerDialog } from '~/components/consent-manager-dialog/consen
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
 import type { ConsentManagerDialogTheme } from '../theme';
-
+import styles from '../consent-manager-dialog.module.css';
 type ComponentTestCase = {
 	testId: string;
 	themeKey: keyof ConsentManagerDialogTheme;
@@ -374,4 +374,62 @@ test('Multiple custom classes can be applied and override base layer', async () 
 	expect(getComputedStyle(root).border).toBe('2px solid rgb(0, 0, 255)');
 
 	document.head.removeChild(styleElement);
+});
+
+test('All consent manager dialog components should have their base classes applied', async () => {
+	const test = <ConsentManagerDialog open />;
+
+	const baseClasses = {
+		root: styles.root || '',
+		card: styles.card || '',
+		header: styles.header || '',
+		title: styles.title || '',
+		description: styles.description || '',
+		content: styles.content || '',
+		footer: styles.footer || '',
+		overlay: styles.overlay || '',
+	};
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-dialog-root',
+				styles: `${styles.card} ${styles.card} ${styles.card}`,
+			},
+			{
+				testId: 'consent-manager-dialog-card',
+				styles: baseClasses.card,
+			},
+			{
+				testId: 'consent-manager-dialog-header',
+				styles: baseClasses.header,
+			},
+			{
+				testId: 'consent-manager-dialog-title',
+				styles: baseClasses.title,
+			},
+			{
+				testId: 'consent-manager-dialog-description',
+				styles: baseClasses.description,
+			},
+			{
+				testId: 'consent-manager-dialog-content',
+				styles: baseClasses.content,
+			},
+			{
+				testId: 'consent-manager-dialog-footer',
+				styles: baseClasses.footer,
+			},
+			{
+				testId: 'consent-manager-dialog-overlay',
+				styles: baseClasses.overlay,
+			},
+		],
+	});
+
+	// Also verify that none of the base classes are empty strings
+	for (const [key, value] of Object.entries(baseClasses)) {
+		expect(value, `Base class for ${key} should not be empty`).not.toBe('');
+	}
 });

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -2,8 +2,8 @@ import { expect, test, vi } from 'vitest';
 import { ConsentManagerWidget } from '~/components/consent-manager-widget/consent-manager-widget';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
-import type { ConsentManagerWidgetTheme } from '../theme';
 import styles from '../consent-manager-widget.module.css';
+import type { ConsentManagerWidgetTheme } from '../theme';
 vi.mock('~/hooks/use-consent-manager', () => ({
 	useConsentManager: () => ({
 		getConsentCategory: vi.fn(() => ({ isEnabled: true })), // Mock needed functions

--- a/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/consent-manager-widget/__tests__/styles.spec.tsx
@@ -3,7 +3,7 @@ import { ConsentManagerWidget } from '~/components/consent-manager-widget/consen
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
 import type { ConsentManagerWidgetTheme } from '../theme';
-
+import styles from '../consent-manager-widget.module.css';
 vi.mock('~/hooks/use-consent-manager', () => ({
 	useConsentManager: () => ({
 		getConsentCategory: vi.fn(() => ({ isEnabled: true })), // Mock needed functions
@@ -386,4 +386,59 @@ test('Multiple custom classes can be applied and override base layer', async () 
 	expect(getComputedStyle(root).border).toBe('2px solid rgb(0, 0, 255)');
 
 	document.head.removeChild(styleElement);
+});
+
+test('All consent manager widget components should have their base classes applied', async () => {
+	const test = <ConsentManagerWidget />;
+
+	const baseClasses = {
+		card: styles.card || '',
+		header: styles.header || '',
+		title: styles.title || '',
+		description: styles.description || '',
+		content: styles.content || '',
+		footer: styles.footer || '',
+		footerGroup: styles.footerGroup || '',
+		accordionItem: styles.accordionItem || '',
+		accordionTrigger: styles.accordionTrigger || '',
+		accordionTriggerInner: styles.accordionTriggerInner || '',
+		accordionContent: styles.accordionContent || '',
+		accordionArrow: styles.accordionArrow || '',
+		switch: styles.switch || '',
+	};
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'consent-manager-widget-footer',
+				styles: baseClasses.footer,
+			},
+			{
+				testId: 'consent-manager-widget-footer-sub-group',
+				styles: baseClasses.footerGroup,
+			},
+			{
+				testId: 'consent-manager-widget-accordion-trigger-marketing',
+				styles: baseClasses.accordionTrigger,
+			},
+			{
+				testId: 'consent-manager-widget-accordion-trigger-inner-marketing',
+				styles: baseClasses.accordionTriggerInner,
+			},
+			{
+				testId: 'consent-manager-widget-accordion-content-marketing',
+				styles: baseClasses.accordionContent,
+			},
+			{
+				testId: 'consent-manager-widget-switch-marketing',
+				styles: baseClasses.switch,
+			},
+		],
+	});
+
+	// Also verify that none of the base classes are empty strings
+	for (const [key, value] of Object.entries(baseClasses)) {
+		expect(value, `Base class for ${key} should not be empty`).not.toBe('');
+	}
 });

--- a/packages/react/src/components/consent-manager-widget/atoms/root.tsx
+++ b/packages/react/src/components/consent-manager-widget/atoms/root.tsx
@@ -108,7 +108,6 @@ const ConsentManagerWidgetRoot: FC<ConsentManagerWidgetRootProps> = ({
 
 	const content = (
 		<Box
-			baseClassName="c15t-consent-manager-widget"
 			data-testid="consent-manager-widget-root"
 			themeKey="widget.root"
 			{...props}

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -3,9 +3,9 @@ import { vi } from 'vitest';
 import { CookieBanner } from '~/components/cookie-banner/cookie-banner';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
-import type { CookieBannerTheme } from '../theme';
-import styles from '../cookie-banner.module.css';
 import buttonStyles from '../../shared/ui/button/button.module.css';
+import styles from '../cookie-banner.module.css';
+import type { CookieBannerTheme } from '../theme';
 
 vi.mock('~/hooks/use-consent-manager', () => ({
 	useConsentManager: () => ({

--- a/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/styles.spec.tsx
@@ -4,6 +4,8 @@ import { CookieBanner } from '~/components/cookie-banner/cookie-banner';
 import type { ThemeValue } from '~/types/theme';
 import testComponentStyles from '~/utils/test-helpers';
 import type { CookieBannerTheme } from '../theme';
+import styles from '../cookie-banner.module.css';
+import buttonStyles from '../../shared/ui/button/button.module.css';
 
 vi.mock('~/hooks/use-consent-manager', () => ({
 	useConsentManager: () => ({
@@ -380,4 +382,72 @@ test('Multiple custom classes can be applied and override base layer', async () 
 	expect(getComputedStyle(card).border).toBe('2px solid rgb(0, 0, 255)');
 
 	document.head.removeChild(styleElement);
+});
+
+test('All cookie banner components should have their base classes applied', async () => {
+	const test = <CookieBanner />;
+
+	const baseClasses = {
+		root: styles.root || '',
+		card: styles.card || '',
+		header: styles.header || '',
+		title: styles.title || '',
+		description: styles.description || '',
+		footer: styles.footer || '',
+		footerSubGroup: styles.footerSubGroup || '',
+		rejectButton: `${buttonStyles.button} ${buttonStyles['button-small']} ${buttonStyles['button-neutral-stroke']}`,
+		customizeButton: `${buttonStyles.button} ${buttonStyles['button-small']} ${buttonStyles['button-neutral-stroke']}`,
+		acceptButton: `${buttonStyles.button} ${buttonStyles['button-small']} ${buttonStyles['button-primary-stroke']}`,
+	};
+
+	await testComponentStyles({
+		component: test,
+		testCases: [
+			{
+				testId: 'cookie-banner-root',
+				styles: baseClasses.root,
+			},
+			{
+				testId: 'cookie-banner-card',
+				styles: baseClasses.card,
+			},
+			{
+				testId: 'cookie-banner-header',
+				styles: baseClasses.header,
+			},
+			{
+				testId: 'cookie-banner-title',
+				styles: baseClasses.title,
+			},
+			{
+				testId: 'cookie-banner-description',
+				styles: baseClasses.description,
+			},
+			{
+				testId: 'cookie-banner-footer',
+				styles: baseClasses.footer,
+			},
+			{
+				testId: 'cookie-banner-footer-sub-group',
+				styles: baseClasses.footerSubGroup,
+			},
+			{
+				testId: 'cookie-banner-reject-button',
+				styles: baseClasses.rejectButton,
+			},
+			{
+				testId: 'cookie-banner-customize-button',
+				styles: baseClasses.customizeButton,
+			},
+			{
+				testId: 'cookie-banner-accept-button',
+				styles: baseClasses.acceptButton,
+			},
+		],
+	});
+
+	// Also verify that none of the base classes are empty strings
+	for (const [key, value] of Object.entries(baseClasses)) {
+		expect(value, `Base class for ${key} should not be empty`).not.toBe('');
+	}
 });


### PR DESCRIPTION
## Overview
Added test to check the components have the expected base classnames. 
Also removed an unused classname from consent manager widget.

## Related Issue
Fixes #190 

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Checklist
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests to verify that all components in the consent manager dialog, consent manager widget, and cookie banner correctly apply their base CSS classes and that these classes are defined.
- **Refactor**
  - Removed a base class name property from the consent manager widget root component to streamline styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->