### PR TITLE
fix(react): tailwind 3 layer collision error

### DIFF
--- a/.changeset/thirty-readers-jump.md
+++ b/.changeset/thirty-readers-jump.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+fix(react): removed layers to fix collision with Tailwind 3

--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
@@ -1,6 +1,4 @@
-@layer properties, theme, base, c15t, components, utilities;
 
-@layer c15t {
 	:root {
 		/* Typography */
 		--dialog-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial,
@@ -290,4 +288,4 @@
 	:global(.c15t-dark) .footer {
 		border-color: var(--dialog-stroke-color-dark);
 	}
-}
+

--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.module.css
@@ -1,4 +1,6 @@
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		/* Typography */
 		--dialog-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial,

--- a/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
+++ b/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
@@ -1,6 +1,4 @@
-@layer properties, theme, base, c15t, components, utilities;
 
-@layer c15t {
 	:root {
 		/* Widget Colors */
 		--widget-background-color: hsl(0, 0%, 100%);
@@ -367,4 +365,3 @@
 	:global(.c15t-dark) .switch[data-state="checked"] {
 		background-color: var(--widget-accordion-focus-ring-dark);
 	}
-}

--- a/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
+++ b/packages/react/src/components/consent-manager-widget/consent-manager-widget.module.css
@@ -1,4 +1,6 @@
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		/* Widget Colors */
 		--widget-background-color: hsl(0, 0%, 100%);

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -33,8 +33,8 @@
 		--banner-footer-background-color-dark: hsla(0 0% 10.98% / 1);
 		--banner-text-color: hsla(0 0% 9.02% / 1);
 		--banner-text-color-dark: hsla(0 0% 90% / 1);
-		--banner-border-color: hsl(0 0% 92.16%);
-		--banner-border-color-dark: hsl(0 0% 20%);
+		--banner-border-color: hsla(0 0% 92.16% / 1);
+		--banner-border-color-dark: hsla(0 0% 20% / 1);
 		--banner-title-color: hsla(0 0% 9.02% / 1);
 		--banner-title-color-dark: hsla(0 0% 90% / 1);
 		--banner-description-color: hsla(0 0% 36.08% / 1);

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -1,7 +1,3 @@
-/* Base cookie banner variables */
-@layer properties, theme, base, c15t, components, utilities;
-
-@layer c15t {
 	:root {
 		isolation: isolate;
 
@@ -292,5 +288,5 @@
 	/* biome-ignore lint/nursery/noUnknownPseudoClass: Allow global `.dark` class for theme overrides */
 	:global(.c15t-dark) .overlay {
 		background-color: var(--banner-overlay-background-color-dark);
-	}
+	
 }

--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -1,5 +1,7 @@
 /* Base cookie banner variables */
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		isolation: isolate;
 
@@ -35,8 +37,8 @@
 		--banner-footer-background-color-dark: hsla(0 0% 10.98% / 1);
 		--banner-text-color: hsla(0 0% 9.02% / 1);
 		--banner-text-color-dark: hsla(0 0% 90% / 1);
-		--banner-border-color: hsla(0 0% 92.16% / 1);
-		--banner-border-color-dark: hsla(0 0% 20% / 1);
+		--banner-border-color: hsl(0 0% 92.16%);
+		--banner-border-color-dark: hsl(0 0% 20%);
 		--banner-title-color: hsla(0 0% 9.02% / 1);
 		--banner-title-color-dark: hsla(0 0% 90% / 1);
 		--banner-description-color: hsla(0 0% 36.08% / 1);

--- a/packages/react/src/components/shared/ui/accordion/accordion.module.css
+++ b/packages/react/src/components/shared/ui/accordion/accordion.module.css
@@ -1,6 +1,4 @@
-@layer properties, theme, base, c15t, components, utilities;
 
-@layer c15t {
 	:root {
 		/* Layout variables */
 		--accordion-padding: 0.875rem;
@@ -232,4 +230,4 @@
 	:global(.c15t-dark) .contentInner {
 		color: var(--accordion-content-color-dark);
 	}
-}
+

--- a/packages/react/src/components/shared/ui/accordion/accordion.module.css
+++ b/packages/react/src/components/shared/ui/accordion/accordion.module.css
@@ -1,4 +1,6 @@
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		/* Layout variables */
 		--accordion-padding: 0.875rem;

--- a/packages/react/src/components/shared/ui/button/button.module.css
+++ b/packages/react/src/components/shared/ui/button/button.module.css
@@ -1,7 +1,4 @@
-/* Button Base Variables */
-@layer properties, theme, base, c15t, components, utilities;
 
-@layer c15t {
 	:root {
 		/* Primary Colors */
 		--button-primary: hsl(228, 100%, 60%);
@@ -332,4 +329,4 @@
 		align-items: center;
 		justify-content: center;
 	}
-}
+

--- a/packages/react/src/components/shared/ui/button/button.module.css
+++ b/packages/react/src/components/shared/ui/button/button.module.css
@@ -1,5 +1,7 @@
 /* Button Base Variables */
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		/* Primary Colors */
 		--button-primary: hsl(228, 100%, 60%);

--- a/packages/react/src/components/shared/ui/switch/switch.module.css
+++ b/packages/react/src/components/shared/ui/switch/switch.module.css
@@ -1,6 +1,4 @@
-@layer properties, theme, base, c15t, components, utilities;
 
-@layer c15t {
 	:root {
 		/* Layout variables */
 		--switch-height: 1.25rem;
@@ -228,4 +226,4 @@
 	:global(.c15t-dark) .root:focus-visible {
 		box-shadow: var(--switch-focus-shadow-dark);
 	}
-}
+

--- a/packages/react/src/components/shared/ui/switch/switch.module.css
+++ b/packages/react/src/components/shared/ui/switch/switch.module.css
@@ -1,4 +1,6 @@
-@layer base {
+@layer properties, theme, base, c15t, components, utilities;
+
+@layer c15t {
 	:root {
 		/* Layout variables */
 		--switch-height: 1.25rem;


### PR DESCRIPTION
## Overview
Removed layers to prevent collision with Tailwind 3 

## Related Issue
Fixes #217 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance


### Breaking Changes
- Might need to add !important to custom classes. E.g. border-red-500 -> !bg-red-500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a styling conflict with Tailwind CSS v3 by removing CSS layering wrappers in multiple components.
  - No changes to user-facing features or functionality beyond fixing the style collision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->