### PR TITLE
fix(docs): 500 error instead of 404 on not found pages

### DIFF
--- a/docs/content/callbacks.mdx
+++ b/docs/content/callbacks.mdx
@@ -49,22 +49,22 @@ const c15tConfig: ConsentManagerOptions = {
 
 Callback responses are always of type `ResponseContext<T>`. 
 
-<AutoTypeTable path="node_modules/c15t/src/client/types.ts" name="ResponseContext" />
+<auto-type-table path="../node_modules/c15t/src/client/types.ts" name="ResponseContext" />
 
 ### onConsentSet Data
 
 The `onConsentSet` callback receives consent preference details:
 
-<AutoTypeTable path="node_modules/c15t/src/client/client-interface.ts" name="ConsentSetCallbackPayload" />
+<auto-type-table path="../node_modules/c15t/src/client/client-interface.ts" name="ConsentSetCallbackPayload" />
 
 ### onConsentVerified Data
 
 The `onConsentVerified` callback receives verification results:
 
-<AutoTypeTable path="node_modules/c15t/src/client/client-interface.ts" name="ConsentVerifiedCallbackPayload" />
+<auto-type-table path="../node_modules/c15t/src/client/client-interface.ts" name="ConsentVerifiedCallbackPayload" />
 
 ### onConsentBannerFetched Data
 
 The `onConsentBannerFetched` callback receives banner information:
 
-<AutoTypeTable path="node_modules/c15t/src/client/client-interface.ts" name="ConsentBannerFetchedCallbackPayload" />
+<auto-type-table path="../node_modules/c15t/src/client/client-interface.ts" name="ConsentBannerFetchedCallbackPayload" />

--- a/docs/content/components/react/cookie-banner.mdx
+++ b/docs/content/components/react/cookie-banner.mdx
@@ -109,8 +109,7 @@ The Cookie Banner is designed to adapt to your application's visual style. Here 
 
 Here are the available theme variables:
 
-<AutoTypeTable path="node_modules/@c15t/react/src/components/cookie-banner/index.tsx" name="CookieBannerTheme" />
-
+<auto-type-table path="../../../node_modules/@c15t/react/src/components/cookie-banner/theme.ts" name="CookieBannerTheme" />
 
 The theme prop provides a straightforward way to customize the banner's appearance:
 
@@ -265,7 +264,7 @@ Follow these guidelines for optimal implementation:
 
 The main component accepts these props:
 
-<AutoTypeTable path="node_modules/@c15t/react/src/components/cookie-banner/cookie-banner.tsx" name="CookieBannerProps" />
+<auto-type-table path="../../../node_modules/@c15t/react/src/components/cookie-banner/cookie-banner.tsx" name="CookieBannerProps" />
 
 ### Compound Components
 

--- a/docs/content/components/react/dev-tool.mdx
+++ b/docs/content/components/react/dev-tool.mdx
@@ -49,7 +49,7 @@ The dev tools will automatically appear in your application during development. 
 
 The main development tools component accepts these props:
 
-<AutoTypeTable path="node_modules/@c15t/dev-tools/src/dev-tool.tsx" name="ConsentManagerProviderProps" />
+<auto-type-table path="../../../node_modules/@c15t/dev-tools/src/dev-tool.tsx" name="ConsentManagerProviderProps" />
 
 
 ## Development Best Practices

--- a/docs/content/hooks/use-consent-manager.mdx
+++ b/docs/content/hooks/use-consent-manager.mdx
@@ -14,7 +14,7 @@ This example shows the hook being used to re-open the cookie banner once it has 
 
 The hook returns an object containing both state properties and methods for managing consent:
 
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
 
 ## Notes
 

--- a/docs/content/javascript/api-reference.mdx
+++ b/docs/content/javascript/api-reference.mdx
@@ -21,38 +21,38 @@ For detailed implementation examples, refer to the [Getting Started](/docs/javas
 
 The `PrivacyConsentState` type represents the current state of privacy consents in your application. It contains information about user preferences, consent categories, and their respective settings.
 
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="PrivacyConsentState" />
 
 ## Consent Types
 
 The `ConsentType` type defines the structure of individual consent categories and their properties.
 
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ConsentType" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="ConsentType" />
 
  ## Translation Configuration
 
 The `defaultTranslationConfig` provides the default translation settings for the consent management interface.
 
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="TranslationConfig" /> 
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="TranslationConfig" /> 
 
 ## Tracking Blocker Configuration
 
 The `TrackingBlockerConfig` type defines the configuration options for the tracking blocker functionality.
 
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="TrackingBlockerConfig" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="TrackingBlockerConfig" />
 
 ## Additional Types
 
 ### Consent State
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ConsentState" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="ConsentState" />
 
 ### Compliance Settings
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="ComplianceSettings" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="ComplianceSettings" />
 
 ### Privacy Settings
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="PrivacySettings" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="PrivacySettings" />
 
 ### Translation Types
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="TranslationConfig" />
-<AutoTypeTable path="node_modules/c15t/src/index.ts" name="Translations" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="TranslationConfig" />
+<auto-type-table path="../../node_modules/c15t/src/index.ts" name="Translations" />
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
 		"fumadocs-core": "15.2.6",
 		"fumadocs-docgen": "^2.0.0",
 		"fumadocs-mdx": "11.5.8",
-		"fumadocs-typescript": "^4.0.2",
+		"fumadocs-typescript": "^4.0.4",
 		"fumadocs-ui": "15.2.6",
 		"lucide-react": "^0.487.0",
 		"mermaid": "^11.6.0",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,5 +1,8 @@
 import { remarkInstall } from 'fumadocs-docgen';
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
+import { createGenerator, remarkAutoTypeTable } from 'fumadocs-typescript';
+
+const generator = createGenerator();
 
 export const docs = defineDocs({
 	dir: 'content',
@@ -7,6 +10,6 @@ export const docs = defineDocs({
 
 export default defineConfig({
 	mdxOptions: {
-		remarkPlugins: [remarkInstall],
+		remarkPlugins: [remarkInstall, [remarkAutoTypeTable, { generator }]],
 	},
 });

--- a/docs/src/mdx-components.tsx
+++ b/docs/src/mdx-components.tsx
@@ -1,14 +1,11 @@
-import { createGenerator } from 'fumadocs-typescript';
-import { AutoTypeTable } from 'fumadocs-typescript/ui';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { TypeTable } from 'fumadocs-ui/components/type-table';
 import defaultComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
 import { CompactCard } from './mdx/compact-card';
 import { Mermaid } from './mdx/mermaid';
 import { RunCommand } from './mdx/run-command';
-
-const generator = createGenerator();
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
 	return {
@@ -20,9 +17,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
 		Mermaid,
 		CompactCard,
 		RunCommand,
-		AutoTypeTable: (props) => (
-			<AutoTypeTable {...props} generator={generator} />
-		),
+		TypeTable,
 		...components,
 	};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: 11.5.8
         version: 11.5.8(acorn@8.14.1)(fumadocs-core@15.2.6(@types/react@19.1.1)(next@15.3.0(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.3.0(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       fumadocs-typescript:
-        specifier: ^4.0.2
-        version: 4.0.2(typescript@5.8.3)
+        specifier: ^4.0.4
+        version: 4.0.4(typescript@5.8.3)
       fumadocs-ui:
         specifier: 15.2.6
         version: 15.2.6(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(next@15.3.0(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.3)
@@ -3680,11 +3680,17 @@ packages:
   '@shikijs/core@3.2.2':
     resolution: {integrity: sha512-yvlSKVMLjddAGBa2Yu+vUZxuu3sClOWW1AG+UtJkvejYuGM5BVL35s6Ijiwb75O9QdEx6IkMxinHZSi8ZyrBaA==}
 
+  '@shikijs/core@3.4.0':
+    resolution: {integrity: sha512-0YOzTSRDn/IAfQWtK791gs1u8v87HNGToU6IwcA3K7nPoVOrS2Dh6X6A6YfXgPTSkTwR5y6myk0MnI0htjnwrA==}
+
   '@shikijs/engine-javascript@3.2.1':
     resolution: {integrity: sha512-eMdcUzN3FMQYxOmRf2rmU8frikzoSHbQDFH2hIuXsrMO+IBOCI9BeeRkCiBkcLDHeRKbOCtYMJK3D6U32ooU9Q==}
 
   '@shikijs/engine-javascript@3.2.2':
     resolution: {integrity: sha512-tlDKfhWpF4jKLUyVAnmL+ggIC+0VyteNsUpBzh1iwWLZu4i+PelIRr0TNur6pRRo5UZIv3ss/PLMuwahg9S2hg==}
+
+  '@shikijs/engine-javascript@3.4.0':
+    resolution: {integrity: sha512-1ywDoe+z/TPQKj9Jw0eU61B003J9DqUFRfH+DVSzdwPUFhR7yOmfyLzUrFz0yw8JxFg/NgzXoQyyykXgO21n5Q==}
 
   '@shikijs/engine-oniguruma@3.2.1':
     resolution: {integrity: sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==}
@@ -3692,11 +3698,17 @@ packages:
   '@shikijs/engine-oniguruma@3.2.2':
     resolution: {integrity: sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==}
 
+  '@shikijs/engine-oniguruma@3.4.0':
+    resolution: {integrity: sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==}
+
   '@shikijs/langs@3.2.1':
     resolution: {integrity: sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==}
 
   '@shikijs/langs@3.2.2':
     resolution: {integrity: sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==}
+
+  '@shikijs/langs@3.4.0':
+    resolution: {integrity: sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==}
 
   '@shikijs/rehype@3.2.1':
     resolution: {integrity: sha512-wj4TXI1PQ3TNPyXudUzKfdFIMneTxFym3HKKfWRzbOSAS8P4mECR+ttdUPhYU1dxrXrsatWxTJezOcEjiA0z8g==}
@@ -3707,6 +3719,9 @@ packages:
   '@shikijs/themes@3.2.2':
     resolution: {integrity: sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==}
 
+  '@shikijs/themes@3.4.0':
+    resolution: {integrity: sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==}
+
   '@shikijs/transformers@3.2.1':
     resolution: {integrity: sha512-oIT40p8LOPV/6XLnUrVPeRtJtbu0Mpl+BjGFuMXw870eX9zTSQlidg7CsksFDVyUiSAOC/CH1RQm+ldZp0/6eQ==}
 
@@ -3715,6 +3730,9 @@ packages:
 
   '@shikijs/types@3.2.2':
     resolution: {integrity: sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==}
+
+  '@shikijs/types@3.4.0':
+    resolution: {integrity: sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -5541,6 +5559,9 @@ packages:
   estree-util-value-to-estree@3.3.2:
     resolution: {integrity: sha512-hYH1aSvQI63Cvq3T3loaem6LW4u72F187zW4FHpTrReJSm6W66vYTFNO1vH/chmcOulp1HlAj1pxn8Ag0oXI5Q==}
 
+  estree-util-value-to-estree@3.4.0:
+    resolution: {integrity: sha512-Zlp+gxis+gCfK12d3Srl2PdX2ybsEA8ZYy6vQGVQTNNYLEGRQQ56XB64bjemN8kxIKXP1nC9ip4Z+ILy9LGzvQ==}
+
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
@@ -5758,8 +5779,8 @@ packages:
       '@fumadocs/mdx-remote':
         optional: true
 
-  fumadocs-typescript@4.0.2:
-    resolution: {integrity: sha512-R+jLdGHkdecNF6haUsH5iMRr3t+g582t3l5lYyUIiZRDGhwMZSjLP8s/izGrBos76s/ZnMVlxEhhkty+cK3x+w==}
+  fumadocs-typescript@4.0.4:
+    resolution: {integrity: sha512-wb4iW4DTid0Pbzb2Swh+XgW21c0FcKpiCDm/UU8U7PbvYLydCeYH0cc8SVtkkPpZ87PuiqoG07RhTTI4tqQquQ==}
     peerDependencies:
       typescript: '*'
 
@@ -7121,11 +7142,17 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
   oniguruma-parser@0.5.4:
     resolution: {integrity: sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==}
 
   oniguruma-to-es@4.1.0:
     resolution: {integrity: sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==}
+
+  oniguruma-to-es@4.3.3:
+    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
 
   open@10.1.1:
     resolution: {integrity: sha512-zy1wx4+P3PfhXSEPJNtZmJXfhkkIaxU1VauWIrDZw1O7uJRDRJtKr9n3Ic4NgbA16KyOxOXO2ng9gYwCdXuSXA==}
@@ -7851,6 +7878,9 @@ packages:
 
   shiki@3.2.2:
     resolution: {integrity: sha512-0qWBkM2t/0NXPRcVgtLhtHv6Ak3Q5yI4K/ggMqcgLRKm4+pCs3namgZlhlat/7u2CuqNtlShNs9lENOG6n7UaQ==}
+
+  shiki@3.4.0:
+    resolution: {integrity: sha512-Ni80XHcqhOEXv5mmDAvf5p6PAJqbUc/RzFeaOqk+zP5DLvTPS3j0ckvA+MI87qoxTQ5RGJDVTbdl/ENLSyyAnQ==}
 
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
@@ -12173,6 +12203,13 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@3.2.1':
     dependencies:
       '@shikijs/types': 3.2.1
@@ -12185,6 +12222,12 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.1.0
 
+  '@shikijs/engine-javascript@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.3
+
   '@shikijs/engine-oniguruma@3.2.1':
     dependencies:
       '@shikijs/types': 3.2.1
@@ -12195,6 +12238,11 @@ snapshots:
       '@shikijs/types': 3.2.2
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/engine-oniguruma@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@3.2.1':
     dependencies:
       '@shikijs/types': 3.2.1
@@ -12202,6 +12250,10 @@ snapshots:
   '@shikijs/langs@3.2.2':
     dependencies:
       '@shikijs/types': 3.2.2
+
+  '@shikijs/langs@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
 
   '@shikijs/rehype@3.2.1':
     dependencies:
@@ -12220,6 +12272,10 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.2.2
 
+  '@shikijs/themes@3.4.0':
+    dependencies:
+      '@shikijs/types': 3.4.0
+
   '@shikijs/transformers@3.2.1':
     dependencies:
       '@shikijs/core': 3.2.1
@@ -12231,6 +12287,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@3.2.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.4.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -12517,7 +12578,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/aria-query@5.0.4': {}
 
@@ -12690,7 +12751,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/estree@1.0.6': {}
 
@@ -14165,6 +14226,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.6
 
+  estree-util-value-to-estree@3.4.0:
+    dependencies:
+      '@types/estree': 1.0.7
+
   estree-util-visit@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -14378,15 +14443,15 @@ snapshots:
       - acorn
       - supports-color
 
-  fumadocs-typescript@4.0.2(typescript@5.8.3):
+  fumadocs-typescript@4.0.4(typescript@5.8.3):
     dependencies:
-      estree-util-value-to-estree: 3.3.2
+      estree-util-value-to-estree: 3.4.0
       fast-glob: 3.3.3
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
       remark: 15.0.1
       remark-rehype: 11.1.2
-      shiki: 3.2.2
+      shiki: 3.4.0
       ts-morph: 25.0.1
       typescript: 5.8.3
       unist-util-visit: 5.0.0
@@ -15760,7 +15825,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.2
       micromark-factory-space: 2.0.1
@@ -15772,7 +15837,7 @@ snapshots:
   micromark-extension-mdx-jsx@3.0.1:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.2
@@ -15789,7 +15854,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
       micromark-util-character: 2.1.1
@@ -15825,7 +15890,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -15890,7 +15955,7 @@ snapshots:
   micromark-util-events-to-acorn@2.0.2:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -16266,12 +16331,20 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.1: {}
+
   oniguruma-parser@0.5.4: {}
 
   oniguruma-to-es@4.1.0:
     dependencies:
       emoji-regex-xs: 1.0.0
       oniguruma-parser: 0.5.4
+      regex: 6.0.1
+      regex-recursion: 6.0.2
+
+  oniguruma-to-es@4.3.3:
+    dependencies:
+      oniguruma-parser: 0.12.1
       regex: 6.0.1
       regex-recursion: 6.0.2
 
@@ -17172,6 +17245,17 @@ snapshots:
       '@shikijs/langs': 3.2.2
       '@shikijs/themes': 3.2.2
       '@shikijs/types': 3.2.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  shiki@3.4.0:
+    dependencies:
+      '@shikijs/core': 3.4.0
+      '@shikijs/engine-javascript': 3.4.0
+      '@shikijs/engine-oniguruma': 3.4.0
+      '@shikijs/langs': 3.4.0
+      '@shikijs/themes': 3.4.0
+      '@shikijs/types': 3.4.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 


### PR DESCRIPTION
## Overview
Fixed an issue where AutoTypeTable was causing a 500 error in-production, this was due to the current implementation not working in serverless enviroments

## Related Issue
Fixes #174 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to use consistent casing and relative paths for type table components, improving the rendering of TypeScript type information.
  - Integrated a new plugin for automatic TypeScript type table generation in documentation.
  - Upgraded a documentation dependency to the latest version for enhanced compatibility.
  - Simplified MDX component setup for type tables, streamlining documentation maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->