### PR TITLE
fix(core): fall back to API call if initialData promise is empty

### DIFF
--- a/.changeset/shaggy-humans-carry.md
+++ b/.changeset/shaggy-humans-carry.md
@@ -1,0 +1,5 @@
+---
+"c15t": patch
+---
+
+fix(core): fall back to API call if initialData promise is empty

--- a/packages/core/src/libs/fetch-consent-banner.ts
+++ b/packages/core/src/libs/fetch-consent-banner.ts
@@ -125,18 +125,21 @@ export async function fetchConsentBannerInfo(
 		return undefined;
 	}
 
-	if (initialData) {
-		set({ isLoadingConsentInfo: true });
-		const showConsentBanner = await initialData;
-		set({ isLoadingConsentInfo: false });
-
-		updateStore(showConsentBanner, config, true);
-
-		return showConsentBanner;
-	}
-
-	// Fall back to API call
 	set({ isLoadingConsentInfo: true });
+
+	if (initialData) {
+		const showConsentBanner = await initialData;
+
+		// Ensures the promsie has the expected data
+		if (showConsentBanner) {
+			set({ isLoadingConsentInfo: false });
+			updateStore(showConsentBanner, config, true);
+
+			return showConsentBanner;
+		}
+
+		// Fall back to API call
+	}
 
 	try {
 		// Let the client handle offline mode internally


### PR DESCRIPTION
## Overview
Adds a fallback useful for the Next.js package that'll hit the API if for some reason the promise is empty.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of the consent banner loading state, ensuring more accurate display and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->