### PR TITLE
fix: incorrect link to quickstart

### DIFF
--- a/docs/content/javascript/api-reference.mdx
+++ b/docs/content/javascript/api-reference.mdx
@@ -15,7 +15,7 @@ The core package implements a robust state management system for handling privac
 - Persisting consent data
 - Validating consent configurations
 
-For detailed implementation examples, refer to the [Getting Started](/docs/javascript) guide.
+For detailed implementation examples, refer to the [Getting Started](/docs/javascript/quickstart) guide.
 
 ## Privacy Consent State
 


### PR DESCRIPTION
## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

On [this set of documentation](https://c15t.com/docs/javascript/api-reference#store-api), we incorrectly link to /docs/javascript, which leads to a 404.

This change changes the link to go to the Javascript quickstart instead.

## Related Issue
<!-- Always link to the issue. Create one first if it doesn't exist. -->
Fixes #272 

## Type of Change
<!-- Select ALL that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
<!-- Help reviewers understand your changes -->
Not required

### Key Changes
<!-- List the important changes you made -->
1. Changed the link to the Javascript quickstart

### Technical Notes
<!-- Any important technical details? Design decisions? -->
None

## Testing
<!-- Help others verify your changes -->
Ensure clicking the link goes to the correct page.

### Test Plan
<!-- List specific test scenarios -->
Application testing will be needed to ensure that the link correctly redirects to the correct page

### Edge Cases
<!-- Important scenarios to verify -->
- [ ] Error handling: *Describe how errors are handled*
- [ ] Performance: *Any performance implications?*
- [ ] Security: *Any security considerations?*
No considerations are required for this documentation change

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)