### PR TITLE
fix: allow trapFocus={false} in CookieBanner

### DIFF
--- a/packages/react/src/components/cookie-banner/cookie-banner.tsx
+++ b/packages/react/src/components/cookie-banner/cookie-banner.tsx
@@ -95,7 +95,7 @@ export interface CookieBannerProps {
 	 * @remarks Useful for implementing a cookie banner that traps focus
 	 * @default true
 	 */
-	trapFocus?: true;
+	trapFocus?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

Allow setting `trapFocus={false}` in CookieBanner.

## Related Issue

Fixes #290 

## Type of Change
<!-- Select ALL that apply -->

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
<!-- Help reviewers understand your changes -->

### Key Changes
<!-- List the important changes you made -->
1. Fixed types
2. 

### Technical Notes
<!-- Any important technical details? Design decisions? -->

## Testing
<!-- Help others verify your changes -->

### Test Plan
<!-- List specific test scenarios -->

- [ ] Scenario 1: *Types*

```
<CookieBanner trapFocus={false} />
```

  ✓ Expected: *No type error*


### Edge Cases
<!-- Important scenarios to verify -->
- [ ] Error handling: *Describe how errors are handled*
- [ ] Performance: *Any performance implications?*
- [ ] Security: *Any security considerations?*

## Checklist

### Required

- [X] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [X] Tested locally
- [X] Code follows style guide
- [X] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The cookie banner now allows more flexible focus trapping behavior, letting users enable or disable focus trapping as needed. The default remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->