### PR TITLE
feat(core, react): added ignoreGeoLocation, improved provider props

### DIFF
--- a/.changeset/late-rice-swim.md
+++ b/.changeset/late-rice-swim.md
@@ -1,0 +1,7 @@
+---
+"@c15t/react": patch
+"c15t": patch
+"@c15t/cli": patch
+---
+
+feat(core, react): added ignoreGeoLocation, improved provider props

--- a/docs/content/nextjs/quickstart.mdx
+++ b/docs/content/nextjs/quickstart.mdx
@@ -76,11 +76,18 @@ import {
 
 export default function Layout ({ children }: { children: ReactNode }) => {
 	return (
-    <ConsentManagerProvider options={{ mode: 'c15t', backendURL: process.env.NEXT_PUBLIC_C15T_URL }}>
-      {children}
-      <CookieBanner />
-      <ConsentManagerDialog />
-    </ConsentManagerProvider>
+      <ConsentManagerProvider
+        options={{
+          mode: 'c15t',
+          backendURL: '/api/c15t',
+          consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner.
+          ignoreGeoLocation: true, // Useful for development to always view the banner.
+        }}
+      >
+        <CookieBanner />
+        <ConsentManagerDialog />   
+        {children}
+      </ConsentManagerProvider>
   );
 };
 ```

--- a/docs/content/react/quickstart.mdx
+++ b/docs/content/react/quickstart.mdx
@@ -49,6 +49,8 @@ function App() {
   const options = {
     mode: 'c15t', 
     backendURL: process.env.REACT_APP_C15T_URL,
+    consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
+    ignoreGeoLocation: true, // Useful for development to always view the banner.
   };
 
   return (

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -49,9 +49,8 @@ export default function Layout({ children }: { children: ReactNode }) {
 						options={{
 							mode: 'c15t',
 							backendURL: '/api/c15t',
-							store: {
-								initialGdprTypes: ['necessary', 'marketing'],
-							},
+							consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner.
+							ignoreGeoLocation: true, // Useful for development to always view the banner.
 						}}
 					>
 						<PostHogProvider>{children}</PostHogProvider>

--- a/docs/src/examples/c15t-client-example.ts
+++ b/docs/src/examples/c15t-client-example.ts
@@ -9,9 +9,7 @@ export const c15tClientExample = `import { type ConsentManagerOptions } from '@c
 export const standardClient: ConsentManagerOptions = {
     // Required backend URL for c15t mode
     backendURL: '/api/c15t',
-    store: {
-        initialGdprTypes: ['necessary', 'marketing'],
-    },
+    consentCategories: ['necessary', 'marketing'],
 };
 
 /**
@@ -25,9 +23,7 @@ export const standardClient: ConsentManagerOptions = {
  */
 export const offlineClient: ConsentManagerOptions = {
     mode: 'offline',
-    store: {
-        initialGdprTypes: ['necessary', 'marketing'],
-    },
+    consentCategories: ['necessary', 'marketing'],
     callbacks: {
         // All callbacks still work even though no network requests are made
         onConsentSet: (response) => {
@@ -83,7 +79,5 @@ export const customClient: ConsentManagerOptions = {
             response: null
         })
     },
-    store: {
-      initialGdprTypes: ['necessary', 'marketing'],
-    },
+    consentCategories: ['necessary', 'marketing'],
 };`;

--- a/docs/src/examples/react/cookie-banner/example-page.tsx
+++ b/docs/src/examples/react/cookie-banner/example-page.tsx
@@ -14,7 +14,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
             options={offlineClient}
-            initialGdprTypes={['necessary', 'marketing']}
         >
             <CookieBanner />
             <ConsentManagerDialog />

--- a/docs/src/examples/react/css-variables/example-page.tsx
+++ b/docs/src/examples/react/css-variables/example-page.tsx
@@ -13,7 +13,6 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            initialGdprTypes={['necessary', 'marketing']}
             options={offlineClient}
         >
           <CookieBanner 							

--- a/docs/src/examples/react/css/example-page.tsx
+++ b/docs/src/examples/react/css/example-page.tsx
@@ -14,7 +14,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
           options={offlineClient}
-          initialGdprTypes={['necessary', 'marketing']}
         >
           <CookieBanner 							
             noStyle

--- a/docs/src/examples/react/dialog/example-page.tsx
+++ b/docs/src/examples/react/dialog/example-page.tsx
@@ -13,7 +13,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
             options={offlineClient}
-            initialGdprTypes={['necessary', 'marketing']}
         >
             {/* Open the dialog manually */}
             <ConsentManagerDialog open={true} />

--- a/docs/src/examples/react/tailwind/example-page.tsx
+++ b/docs/src/examples/react/tailwind/example-page.tsx
@@ -12,7 +12,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
             options={offlineClient}
-            initialGdprTypes={['necessary', 'marketing']}
         >
             <CookieBanner 
               noStyle

--- a/docs/src/examples/react/use-consent-manager/example.tsx
+++ b/docs/src/examples/react/use-consent-manager/example.tsx
@@ -13,7 +13,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
             options={offlineClient}
-            initialGdprTypes={['necessary', 'marketing']}
         >
             <CookieBanner />
             <ConsentManagerDialog />

--- a/docs/src/examples/react/widget/example-page.tsx
+++ b/docs/src/examples/react/widget/example-page.tsx
@@ -49,7 +49,6 @@ export default function App() {
     return (
         <ConsentManagerProvider 
             options={offlineClient}
-            initialGdprTypes={['necessary', 'marketing']}
         >
             <CustomWidget />
             <ExampleContent />

--- a/packages/cli/src/onboarding/templates/config.ts
+++ b/packages/cli/src/onboarding/templates/config.ts
@@ -29,6 +29,8 @@ export const c15tConfig = {
   // Using hosted c15t (consent.io) or self-hosted instance
   mode: 'c15t',
   backendURL: ${useEnvFile ? 'process.env.NEXT_PUBLIC_C15T_URL' : `'${backendURL || 'https://your-instance.c15t.dev'}'`},
+  consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
+  ignoreGeoLocation: true, // Useful for development to always view the banner.
   
   // Optional: Add callback functions for various events
   callbacks: {

--- a/packages/cli/src/onboarding/templates/layout.ts
+++ b/packages/cli/src/onboarding/templates/layout.ts
@@ -55,6 +55,8 @@ function generateOptionsText(
 				return `{
 					mode: 'c15t',
 					backendURL: '/api/c15t',
+					consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
+					ignoreGeoLocation: true, // Useful for development to always view the banner.
 				}`;
 			}
 
@@ -62,12 +64,16 @@ function generateOptionsText(
 				return `{
 					mode: 'c15t',
 					backendURL: process.env.NEXT_PUBLIC_C15T_URL!,
+					consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
+					ignoreGeoLocation: true, // Useful for development to always view the banner.
 				}`;
 			}
 
 			return `{
 				mode: 'c15t',
 				backendURL: '${backendURL || 'https://your-instance.c15t.dev'}',
+				consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
+        ignoreGeoLocation: true, // Useful for development to always view the banner.
 			}`;
 		}
 		case 'custom':
@@ -78,6 +84,7 @@ function generateOptionsText(
 		default:
 			return `{
 				mode: 'offline',
+				consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
 			}`;
 	}
 }

--- a/packages/core/src/libs/fetch-consent-banner.ts
+++ b/packages/core/src/libs/fetch-consent-banner.ts
@@ -52,7 +52,8 @@ async function updateStore(
 	{ set, get, initialTranslationConfig }: FetchConsentBannerConfig,
 	hasLocalStorageAccess: boolean
 ): Promise<void> {
-	const { consentInfo, setDetectedCountry, callbacks } = get();
+	const { consentInfo, setDetectedCountry, callbacks, ignoreGeoLocation } =
+		get();
 
 	const { translations, location, jurisdiction, showConsentBanner } = data;
 
@@ -96,7 +97,10 @@ async function updateStore(
 	set({
 		isLoadingConsentInfo: false,
 		...(consentInfo === null
-			? { showPopup: showConsentBanner && hasLocalStorageAccess }
+			? {
+					showPopup:
+						(showConsentBanner && hasLocalStorageAccess) || ignoreGeoLocation,
+				}
 			: {}),
 	});
 }

--- a/packages/core/src/store.initial-state.ts
+++ b/packages/core/src/store.initial-state.ts
@@ -121,6 +121,9 @@ export const initialState: Omit<
 	/** Use predefined consent types */
 	consentTypes: consentTypes,
 
+	/** Default to not ignoring geo location */
+	ignoreGeoLocation: false,
+
 	// Initialize all methods as no-ops
 	setConsent: () => {
 		/* no-op */

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -128,6 +128,12 @@ export interface StoreOptions {
 	unstable_googleTagManager?: GTMConfiguration;
 
 	/**
+	 * Whether to ignore geo location. Will always show the consent banner.
+	 * @default false
+	 */
+	ignoreGeoLocation?: boolean;
+
+	/**
 	 * Initial Translation Config
 	 */
 	initialTranslationConfig?: Partial<TranslationConfig>;
@@ -242,6 +248,7 @@ export const createConsentManagerStore = (
 
 	const store = createStore<PrivacyConsentState>((set, get) => ({
 		...initialState,
+		ignoreGeoLocation: options.ignoreGeoLocation ?? false,
 		config: options.config ?? initialState.config,
 		// Set isConsentDomain based on the provider's baseURL
 		isConsentDomain,

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -98,6 +98,9 @@ export interface PrivacyConsentState {
 	/** Whether the provider is using c15t.dev domain */
 	isConsentDomain: boolean;
 
+	/** Whether to ignore geo location. Will always show the consent banner. */
+	ignoreGeoLocation: boolean;
+
 	/**
 	 * Updates the translation configuration.
 	 * @param config - The new translation configuration

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -136,6 +136,8 @@ export function ConsentManagerProvider({
 					version: packageJson.version,
 					mode: mode || 'Unknown',
 				},
+				ignoreGeoLocation: options.ignoreGeoLocation,
+				initialGdprTypes: options.consentCategories,
 				...store,
 				isConsentDomain,
 				initialTranslationConfig: translations,
@@ -148,6 +150,8 @@ export function ConsentManagerProvider({
 		isConsentDomain,
 		translations,
 		options.unstable_googleTagManager,
+		options.ignoreGeoLocation,
+		options.consentCategories,
 		store,
 		backendURL,
 		mode,
@@ -171,8 +175,8 @@ export function ConsentManagerProvider({
 			consentStore.getState();
 
 		// Initialize GDPR types if provided
-		if (initialGdprTypes) {
-			setGdprTypes(initialGdprTypes);
+		if (initialGdprTypes || options.consentCategories) {
+			setGdprTypes(initialGdprTypes || options.consentCategories || []);
 		}
 
 		// Initialize compliance settings if provided
@@ -195,7 +199,12 @@ export function ConsentManagerProvider({
 		const unsubscribe = consentStore.subscribe(setState);
 
 		return unsubscribe;
-	}, [consentStore, initialGdprTypes, initialComplianceSettings]);
+	}, [
+		consentStore,
+		initialGdprTypes,
+		initialComplianceSettings,
+		options.consentCategories,
+	]);
 
 	// Create theme context value
 	const themeContextValue = useMemo(() => {

--- a/packages/react/src/types/consent-manager.ts
+++ b/packages/react/src/types/consent-manager.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+	AllConsentNames,
 	ConsentManagerOptions as CoreOptions,
 	GTMConfiguration,
 	TranslationConfig,
@@ -74,6 +75,19 @@ export type ConsentManagerOptions = CoreOptions & {
 	 * Once you set this, the consent manager will automatically setup Google Tag Manager for you.
 	 */
 	unstable_googleTagManager?: GTMConfiguration;
+
+	/**
+	 * Whether to ignore geo location. Will always show the consent banner.
+	 * It is recommended to disable this option in production.
+	 * @default false
+	 */
+	ignoreGeoLocation?: boolean;
+
+	/**
+	 * Consent Categories to show in the consent banner.
+	 * @default ['necessary', 'marketing']
+	 */
+	consentCategories?: AllConsentNames[];
 };
 
 /**


### PR DESCRIPTION
## Overview
Added a new ignoreGeoLocation to the provider & store. This improves dev-ex as non-eu devs for example can see cookie banner in development when enabled.

Additionally I added a new prop to the provider 'consentCategories' this prop is the same as store.initalGDPRTypes but is a lot nicer to use.

Updated CLI & Docs to use these new props

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [x] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying consent categories in the consent banner.
  - Introduced an option to always show the consent banner by ignoring geolocation checks.

- **Documentation**
  - Updated documentation and code examples to reflect new consent category and geolocation options.

- **Chores**
  - Enhanced configuration templates to include new consent category and geolocation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->