### PR TITLE
fix(cli): asks for pkg manager twice

### DIFF
--- a/.changeset/lemon-clouds-kneel.md
+++ b/.changeset/lemon-clouds-kneel.md
@@ -1,0 +1,5 @@
+---
+"@c15t/cli": patch
+---
+
+fix(cli): asks for pkg manager twice

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
 		"fs-extra": "^11.3.0",
 		"jiti": "^2.4.2",
 		"open": "^10.1.1",
-		"package-manager-detector": "^1.2.0",
+		"package-manager-detector": "^1.3.0",
 		"picocolors": "^1.1.1",
 		"posthog-node": "^4.11.7",
 		"ts-morph": "^25.0.1",

--- a/packages/cli/src/context/package-manager-detection.ts
+++ b/packages/cli/src/context/package-manager-detection.ts
@@ -1,131 +1,16 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import * as p from '@clack/prompts';
+import { detect } from 'package-manager-detector/detect';
 import type { CliLogger } from '~/utils/logger';
 
 export type PackageManager = 'npm' | 'yarn' | 'pnpm';
-
+export const SUPPORTED_PACKAGE_MANAGERS: PackageManager[] = [
+	'npm',
+	'yarn',
+	'pnpm',
+];
 export interface PackageManagerResult {
 	name: PackageManager;
 	version: string | null;
-}
-
-/**
- * Helper function to check if a directory is a valid project root
- *
- * @param dir - Directory to check
- * @returns Promise<boolean> indicating if directory is a valid project root
- */
-async function isValidProjectRoot(dir: string): Promise<boolean> {
-	try {
-		await fs.access(path.join(dir, 'package.json'));
-
-		// Check for node_modules or a lock file to confirm it's an actual project
-		const files = await fs.readdir(dir);
-		return files.some(
-			(file) =>
-				file === 'node_modules' ||
-				file === 'package-lock.json' ||
-				file === 'yarn.lock' ||
-				file === 'pnpm-lock.yaml'
-		);
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Detects package manager in a specific directory
- */
-async function detectPackageManagerInDirectory(
-	dir: string,
-	files: string[],
-	logger?: CliLogger
-): Promise<PackageManagerResult | null> {
-	if (files.includes('pnpm-workspace.yaml')) {
-		logger?.debug('Found pnpm workspace configuration');
-		return {
-			name: 'pnpm',
-			version: await getPackageManagerVersion('pnpm'),
-		};
-	}
-
-	if (files.includes('yarn.lock') && (await isValidProjectRoot(dir))) {
-		logger?.debug('Found yarn.lock at root level');
-		return {
-			name: 'yarn',
-			version: await getPackageManagerVersion('yarn'),
-		};
-	}
-
-	if (files.includes('package-lock.json') && (await isValidProjectRoot(dir))) {
-		logger?.debug('Found package-lock.json at root level');
-		return {
-			name: 'npm',
-			version: await getPackageManagerVersion('npm'),
-		};
-	}
-
-	return null;
-}
-
-/**
- * Helper function to check if any parent directory has package manager files
- *
- * @param startDir - Starting directory to check from
- * @param logger - Optional logger instance for debug messages
- * @returns The package manager if found at root level, null otherwise
- */
-async function findPackageManager(
-	startDir: string,
-	logger?: CliLogger
-): Promise<PackageManagerResult | null> {
-	logger?.debug(`Checking for package manager starting from ${startDir}`);
-
-	if (!(await isValidProjectRoot(startDir))) {
-		logger?.debug(
-			`${startDir} is not a valid project root, skipping detection`
-		);
-		return null;
-	}
-
-	let currentDir = startDir;
-	let depth = 0;
-	const maxDepth = 4;
-
-	while (depth < maxDepth) {
-		try {
-			logger?.debug(
-				`Checking directory ${currentDir} for package manager files`
-			);
-			const files = await fs.readdir(currentDir);
-
-			const packageManager = await detectPackageManagerInDirectory(
-				currentDir,
-				files,
-				logger
-			);
-			if (packageManager) {
-				return packageManager;
-			}
-
-			const parentDir = path.dirname(currentDir);
-			if (parentDir === currentDir) {
-				break;
-			}
-
-			currentDir = parentDir;
-			depth++;
-		} catch (error) {
-			logger?.debug(
-				`Error checking directory ${currentDir}: ${error instanceof Error ? error.message : String(error)}`
-			);
-			break;
-		}
-	}
-
-	logger?.debug('No package manager found');
-	return null;
 }
 
 /**
@@ -158,15 +43,27 @@ export async function detectPackageManager(
 	logger?: CliLogger
 ): Promise<PackageManagerResult> {
 	try {
-		logger?.debug(`Detecting package manager in ${projectRoot}`);
+		logger?.debug('Detecting package manager');
 
 		// First check for monorepo package manager
-		const packageManager = await findPackageManager(projectRoot, logger);
+		const pm = await detect({
+			cwd: projectRoot,
+		});
 
-		if (packageManager) {
-			logger?.debug(`Detected package manager: ${packageManager.name}`);
-			return packageManager;
+		if (!pm) {
+			throw new Error('No package manager detected');
 		}
+
+		logger?.debug(`Detected package manager: ${pm.name}`);
+
+		if (!SUPPORTED_PACKAGE_MANAGERS.includes(pm.name as PackageManager)) {
+			throw new Error(`Unsupported package manager: ${pm.name}`);
+		}
+
+		return {
+			name: pm.name as PackageManager,
+			version: pm.version ?? null,
+		};
 	} catch (error) {
 		logger?.error(
 			`Error detecting package manager: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/cli/src/onboarding/index.ts
+++ b/packages/cli/src/onboarding/index.ts
@@ -11,10 +11,7 @@ import {
 	detectFramework,
 	detectProjectRoot,
 } from '../context/framework-detection';
-import {
-	type PackageManagerResult,
-	detectPackageManager,
-} from '../context/package-manager-detection';
+import type { PackageManagerResult } from '../context/package-manager-detection';
 import type { CliContext } from '../context/types';
 import { TelemetryEventName } from '../utils/telemetry';
 
@@ -95,11 +92,10 @@ async function performOnboarding(
 	existingConfig: C15TOptions | ConsentManagerOptions | null | undefined,
 	handleCancel: (value: unknown) => value is symbol
 ) {
-	const { telemetry, logger } = context;
+	const { telemetry, logger, packageManager } = context;
 	const isUpdate = !!existingConfig;
 
 	const projectRoot = await detectProjectRoot(context.cwd, logger);
-	const packageManager = await detectPackageManager(projectRoot, logger);
 	const { pkg } = await detectFramework(projectRoot, logger);
 
 	if (!pkg) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,8 +481,8 @@ importers:
         specifier: ^10.1.1
         version: 10.1.1
       package-manager-detector:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -7284,8 +7284,8 @@ packages:
   package-manager-detector@1.1.0:
     resolution: {integrity: sha512-Y8f9qUlBzW8qauJjd/eu6jlpJZsuPJm2ZAV0cDVd420o4EdpH5RPdoCv+60/TdJflGatr4sDfpAL6ArWZbM5tA==}
 
-  package-manager-detector@1.2.0:
-    resolution: {integrity: sha512-PutJepsOtsqVfUsxCzgTTpyXmiAgvKptIgY4th5eq5UXXFhj5PxfQ9hnGkypMeovpAvVshFRItoFHYO18TCOqA==}
+  package-manager-detector@1.3.0:
+    resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -16451,7 +16451,7 @@ snapshots:
 
   package-manager-detector@1.1.0: {}
 
-  package-manager-detector@1.2.0: {}
+  package-manager-detector@1.3.0: {}
 
   parse-entities@4.0.2:
     dependencies:


### PR DESCRIPTION
## Overview
fixes issue where pkg manager is asked twice in cli
also using the detect-package-manager module now

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the CLI prompted users twice to select a package manager.
- **Chores**
	- Updated the package manager detection dependency for improved reliability.
- **Refactor**
	- Simplified package manager detection logic by using an external library, reducing internal complexity.
	- Improved onboarding process by using existing package manager information instead of runtime detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->