### PR TITLE
refactor(react): deprecate options in favor of direct props

### DIFF
--- a/.changeset/soft-walls-smoke.md
+++ b/.changeset/soft-walls-smoke.md
@@ -4,4 +4,18 @@
 "@c15t/cli": patch
 ---
 
-refactor(react): deprecated options prop
+refactor(react): deprecate `options` prop in favor of direct props
+
+The `options` prop on `ConsentManagerProvider` is now deprecated. Instead of passing configuration as a nested object, spread the configuration properties directly as props:
+
+```tsx
+// Before
+<ConsentManagerProvider options={{ mode: 'c15t', backendURL: '/api/c15t' }} />
+
+// After
+<ConsentManagerProvider mode="c15t" backendURL="/api/c15t" />
+// or
+<ConsentManagerProvider {...c15tOptions} />
+```
+
+The old `options` prop is still supported for backward compatibility but will be removed in a future version.

--- a/.changeset/soft-walls-smoke.md
+++ b/.changeset/soft-walls-smoke.md
@@ -1,0 +1,7 @@
+---
+"@c15t/nextjs": patch
+"@c15t/react": patch
+"@c15t/cli": patch
+---
+
+refactor(react): deprecated options prop

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { c15tConfig } from "./c15t.client";
 
 export default function App() {
   return (
-    <ConsentManagerProvider options={c15tConfig}>
+    <ConsentManagerProvider {...c15tConfig}>
       <CookieBanner />
       <ConsentManagerDialog/>
       {/* Your app content */}

--- a/apps/examples/astro-react/src/layouts/consent-manager.tsx
+++ b/apps/examples/astro-react/src/layouts/consent-manager.tsx
@@ -1,8 +1,8 @@
 import {
 	ConsentManagerDialog,
+	type ConsentManagerOptions,
 	ConsentManagerProvider,
 	CookieBanner,
-	type ConsentManagerOptions,
 } from '@c15t/react';
 import type { ReactNode } from 'react';
 
@@ -21,7 +21,7 @@ export const c15tOptions: ConsentManagerOptions = {
 
 export const ConsentManagerLayout = ({ children }: { children: ReactNode }) => {
 	return (
-		<ConsentManagerProvider options={c15tOptions}>
+		<ConsentManagerProvider {...c15tOptions}>
 			{children}
 			<CookieBanner />
 			<ConsentManagerDialog />

--- a/apps/examples/vite-react/src/app.tsx
+++ b/apps/examples/vite-react/src/app.tsx
@@ -11,7 +11,7 @@ function App() {
 	const [count, setCount] = useState(0);
 
 	return (
-		<ConsentManagerProvider options={c15tOptions}>
+		<ConsentManagerProvider {...c15tOptions}>
 			<div>
 				<a href="https://vite.dev" target="_blank" rel="noreferrer">
 					{/* biome-ignore lint/nursery/noImgElement: <explanation> */}

--- a/docs/content/nextjs/google-tag-manager.mdx
+++ b/docs/content/nextjs/google-tag-manager.mdx
@@ -34,12 +34,10 @@ This begins with "GTM-".
 
 ```tsx
 <ConsentManagerProvider
-  options={{
-    mode: 'c15t',
-    backendURL: 'https://your-instance.c15t.dev',
-    unstable_googleTagManager: {
-      id: 'GTM-XXXXXXX',
-    },
+  mode='c15t'
+  backendURL='https://your-instance.c15t.dev'
+  unstable_googleTagManager={{
+    id: 'GTM-XXXXXXX',
   }}
 >
 ```

--- a/docs/content/nextjs/quickstart.mdx
+++ b/docs/content/nextjs/quickstart.mdx
@@ -77,12 +77,10 @@ import {
 export default function Layout ({ children }: { children: ReactNode }) => {
 	return (
       <ConsentManagerProvider
-        options={{
-          mode: 'c15t',
-          backendURL: '/api/c15t',
-          consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner.
-          ignoreGeoLocation: true, // Useful for development to always view the banner.
-        }}
+        mode='c15t'
+        backendURL='/api/c15t'
+        consentCategories={['necessary', 'marketing']} // Optional: Specify which consent categories to show in the banner.
+        ignoreGeoLocation={true} // Useful for development to always view the banner.
       >
         <CookieBanner />
         <ConsentManagerDialog />   

--- a/docs/content/react/google-tag-manager.mdx
+++ b/docs/content/react/google-tag-manager.mdx
@@ -34,12 +34,10 @@ This begins with "GTM-".
 
 ```tsx
 <ConsentManagerProvider
-  options={{
-    mode: 'c15t',
-    backendURL: 'https://your-instance.c15t.dev',
-    unstable_googleTagManager: {
-      id: 'GTM-XXXXXXX',
-    },
+  mode='c15t'
+  backendURL='https://your-instance.c15t.dev'
+  unstable_googleTagManager={{
+    id: 'GTM-XXXXXXX',
   }}
 >
 ```

--- a/docs/content/react/quickstart.mdx
+++ b/docs/content/react/quickstart.mdx
@@ -54,7 +54,7 @@ function App() {
   };
 
   return (
-    <ConsentManagerProvider options={options}>
+    <ConsentManagerProvider {...options}>
       <div className="App">
         {/* Your application content */}
       </div>

--- a/docs/content/storing-consent/custom-client.mdx
+++ b/docs/content/storing-consent/custom-client.mdx
@@ -163,7 +163,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <ConsentManagerProvider options={options}>
+    <ConsentManagerProvider {...options}>
       {children}
       <CookieBanner />
       <ConsentManagerDialog />

--- a/docs/content/storing-consent/hosted-c15t.mdx
+++ b/docs/content/storing-consent/hosted-c15t.mdx
@@ -53,7 +53,7 @@ export default function RootLayout({ children }) {
   };
 
   return (
-    <ConsentManagerProvider options={options}>
+    <ConsentManagerProvider {...options}>
       {children}
       <CookieBanner />
       <ConsentManagerDialog />

--- a/docs/content/storing-consent/offline-mode.mdx
+++ b/docs/content/storing-consent/offline-mode.mdx
@@ -50,7 +50,7 @@ import { c15tClient } from '../lib/c15tClient'
 
 function MyApp({ Component, pageProps }) {
   return (
-    <ConsentManagerProvider options={c15tClient}>
+    <ConsentManagerProvider {...c15tClient}>
       <Component {...pageProps} />
     </ConsentManagerProvider>
   )
@@ -208,7 +208,7 @@ function ConsentProvider({ children }) {
   };
   
   return (
-    <ConsentManagerProvider options={options}>
+    <ConsentManagerProvider {...options}>
       {children}
     </ConsentManagerProvider>
   );

--- a/docs/content/storing-consent/overview.mdx
+++ b/docs/content/storing-consent/overview.mdx
@@ -141,7 +141,7 @@ const options = {
 // Use in a React component
 function App() {
   return (
-    <ConsentManagerProvider options={options}>
+    <ConsentManagerProvider {...options}>
       {/* Your app content */}
     </ConsentManagerProvider>
   );

--- a/docs/content/styling/color-scheme.mdx
+++ b/docs/content/styling/color-scheme.mdx
@@ -35,11 +35,9 @@ import { ConsentManagerProvider } from '@c15t/react';
 function App({ children }) {
   return (
     <ConsentManagerProvider
-      options={{
-        react: {
-          // Components will only be light mode
-          colorScheme: 'light'
-        }
+      react={{
+        // Components will only be light mode
+        colorScheme: 'light'
       }}
     >
       {children}

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -46,12 +46,9 @@ export default function Layout({ children }: { children: ReactNode }) {
 			<body className="flex min-h-screen flex-col">
 				<RootProvider>
 					<ConsentManagerProvider
-						options={{
-							mode: 'c15t',
-							backendURL: '/api/c15t',
-							consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner.
-							ignoreGeoLocation: true, // Useful for development to always view the banner.
-						}}
+						mode="c15t"
+						backendURL="/api/c15t"
+						consentCategories={['necessary', 'marketing']}
 					>
 						<PostHogProvider>{children}</PostHogProvider>
 						<CookieBanner

--- a/docs/src/examples/react/cookie-banner/example-page.tsx
+++ b/docs/src/examples/react/cookie-banner/example-page.tsx
@@ -13,7 +13,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
             <CookieBanner />
             <ConsentManagerDialog />

--- a/docs/src/examples/react/css-variables/example-page.tsx
+++ b/docs/src/examples/react/css-variables/example-page.tsx
@@ -13,7 +13,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
           <CookieBanner 							
 				    theme={{

--- a/docs/src/examples/react/css/example-page.tsx
+++ b/docs/src/examples/react/css/example-page.tsx
@@ -13,7 +13,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-          options={offlineClient}
+          {...offlineClient}
         >
           <CookieBanner 							
             noStyle

--- a/docs/src/examples/react/dialog/example-page.tsx
+++ b/docs/src/examples/react/dialog/example-page.tsx
@@ -12,7 +12,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
             {/* Open the dialog manually */}
             <ConsentManagerDialog open={true} />

--- a/docs/src/examples/react/tailwind/example-page.tsx
+++ b/docs/src/examples/react/tailwind/example-page.tsx
@@ -11,7 +11,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
             <CookieBanner 
               noStyle

--- a/docs/src/examples/react/use-consent-manager/example.tsx
+++ b/docs/src/examples/react/use-consent-manager/example.tsx
@@ -12,7 +12,7 @@ export default function App() {
 
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
             <CookieBanner />
             <ConsentManagerDialog />

--- a/docs/src/examples/react/widget/example-page.tsx
+++ b/docs/src/examples/react/widget/example-page.tsx
@@ -48,7 +48,7 @@ export default function App() {
     clearLocalStorage();
     return (
         <ConsentManagerProvider 
-            options={offlineClient}
+            {...offlineClient}
         >
             <CustomWidget />
             <ExampleContent />

--- a/packages/cli/src/onboarding/templates/config.ts
+++ b/packages/cli/src/onboarding/templates/config.ts
@@ -41,7 +41,7 @@ export const c15tConfig = {
 } satisfies ConsentManagerOptions;
 
 // Use in your app layout:
-// <ConsentManagerProvider options={c15tConfig}>
+// <ConsentManagerProvider {...c15tConfig}>
 //   {children}
 //   <CookieBanner />
 //   <ConsentManagerDialog />
@@ -66,7 +66,7 @@ export const c15tConfig = {
 } satisfies ConsentManagerOptions;
 
 // Use in your app layout:
-// <ConsentManagerProvider options={c15tConfig}>
+// <ConsentManagerProvider {...c15tConfig}>
 //   {children}
 //   <CookieBanner />
 //   <ConsentManagerDialog />
@@ -93,7 +93,7 @@ export const c15tConfig = {
 } satisfies ConsentManagerOptions;
 
 // Use in your app layout:
-// <ConsentManagerProvider options={c15tConfig}>
+// <ConsentManagerProvider {...c15tConfig}>
 //   {children}
 //   <CookieBanner />
 //   <ConsentManagerDialog />

--- a/packages/cli/src/onboarding/templates/layout.ts
+++ b/packages/cli/src/onboarding/templates/layout.ts
@@ -52,40 +52,40 @@ function generateOptionsText(
 	switch (mode) {
 		case 'c15t': {
 			if (proxyNextjs) {
-				return `{
-					mode: 'c15t',
-					backendURL: '/api/c15t',
-					consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
-					ignoreGeoLocation: true, // Useful for development to always view the banner.
-				}`;
+				return `
+					mode='c15t'
+					backendURL='/api/c15t'
+					consentCategories={['necessary', 'marketing']} // Optional: Specify which consent categories to show in the banner. 
+					ignoreGeoLocation={true} // Useful for development to always view the banner.
+				`;
 			}
 
 			if (useEnvFile) {
-				return `{
-					mode: 'c15t',
-					backendURL: process.env.NEXT_PUBLIC_C15T_URL!,
-					consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
-					ignoreGeoLocation: true, // Useful for development to always view the banner.
-				}`;
+				return `
+					mode='c15t'
+					backendURL={process.env.NEXT_PUBLIC_C15T_URL}
+					consentCategories={['necessary', 'marketing']} // Optional: Specify which consent categories to show in the banner. 
+					ignoreGeoLocation={true} // Useful for development to always view the banner.
+				`;
 			}
 
-			return `{
-				mode: 'c15t',
-				backendURL: '${backendURL || 'https://your-instance.c15t.dev'}',
-				consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
-        ignoreGeoLocation: true, // Useful for development to always view the banner.
-			}`;
+			return `
+				mode='c15t'
+				backendURL='${backendURL || 'https://your-instance.c15t.dev'}'
+				consentCategories={['necessary', 'marketing']} // Optional: Specify which consent categories to show in the banner. 
+				ignoreGeoLocation={true} // Useful for development to always view the banner.
+			`;
 		}
 		case 'custom':
-			return `{
-				mode: 'custom',
-				endpointHandlers: createCustomHandlers(),
-			}`;
+			return `
+				mode='custom'
+				endpointHandlers={createCustomHandlers()}
+			`;
 		default:
-			return `{
-				mode: 'offline',
-				consentCategories: ['necessary', 'marketing'], // Optional: Specify which consent categories to show in the banner. 
-			}`;
+			return `
+				mode='offline'
+				consentCategories={['necessary', 'marketing']} // Optional: Specify which consent categories to show in the banner. 
+			`;
 	}
 }
 
@@ -137,7 +137,7 @@ function wrapJsxContent(originalJsx: string, optionsText: string): string {
 		originalJsx.includes('<body') || originalJsx.includes('</body>');
 
 	const providerWrapper = (content: string) => `
-		<ConsentManagerProvider options={${optionsText}}>
+		<ConsentManagerProvider ${optionsText}>
 			<CookieBanner />
 			<ConsentManagerDialog />
 			${content}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -46,7 +46,7 @@ import { c15tConfig } from "./c15t.client";
 
 export default function App() {
   return (
-    <ConsentManagerProvider options={c15tConfig}>
+    <ConsentManagerProvider {...c15tConfig}>
       <CookieBanner />
       <ConsentManagerDialog/>
       {/* Your app content */}

--- a/packages/react/src/components/cookie-banner/__tests__/cookie-banner.e2e.test.tsx
+++ b/packages/react/src/components/cookie-banner/__tests__/cookie-banner.e2e.test.tsx
@@ -65,7 +65,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should show cookie banner on first visit', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>
@@ -98,7 +98,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should accept all cookies when clicking Accept All', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>
@@ -128,7 +128,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should reject non-essential cookies when clicking Reject All', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>
@@ -164,7 +164,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should open consent manager dialog when clicking Customize', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>
@@ -229,7 +229,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should be keyboard accessible', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>
@@ -259,7 +259,7 @@ describe('CookieBanner E2E Tests', () => {
 
 	test('should handle scroll lock properly', async () => {
 		render(
-			<ConsentManagerProvider options={defaultOptions}>
+			<ConsentManagerProvider {...defaultOptions}>
 				<CookieBanner scrollLock />
 				<ConsentManagerDialog />
 			</ConsentManagerProvider>

--- a/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
@@ -46,11 +46,9 @@ describe('useConsentManager', () => {
 		const { result } = renderHook(() => useConsentManager(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
 					}}
 				>
 					{children}
@@ -66,11 +64,9 @@ describe('useConsentManager', () => {
 		const { result } = renderHook(() => useConsentManager(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
 					}}
 				>
 					{children}

--- a/packages/react/src/hooks/__tests__/use-translations.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-translations.test.tsx
@@ -9,11 +9,9 @@ describe('useTranslations', () => {
 		const { result } = renderHook(() => useTranslations(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
 					}}
 				>
 					{children}
@@ -41,34 +39,32 @@ describe('useTranslations', () => {
 		const { result } = renderHook(() => useTranslations(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
+					}}
+					translations={{
+						defaultLanguage: 'de',
+						disableAutoLanguageSwitch: true,
 						translations: {
-							defaultLanguage: 'de',
-							disableAutoLanguageSwitch: true,
-							translations: {
-								de: {
-									common: {
-										acceptAll: 'German Accept All',
-										rejectAll: 'German Reject All',
-										customize: 'German Customize',
-										save: 'German Save',
-									},
-									cookieBanner: {
-										title: 'German Title',
-										description: 'German Description',
-									},
-									consentManagerDialog: {
-										title: 'German Dialog Title',
-									},
-									consentTypes: {
-										necessary: {
-											title: 'German Necessary',
-											description: 'German Necessary Description',
-										},
+							de: {
+								common: {
+									acceptAll: 'German Accept All',
+									rejectAll: 'German Reject All',
+									customize: 'German Customize',
+									save: 'German Save',
+								},
+								cookieBanner: {
+									title: 'German Title',
+									description: 'German Description',
+								},
+								consentManagerDialog: {
+									title: 'German Dialog Title',
+								},
+								consentTypes: {
+									necessary: {
+										title: 'German Necessary',
+										description: 'German Necessary Description',
 									},
 								},
 							},
@@ -111,13 +107,11 @@ describe('useTranslations', () => {
 		const { result } = renderHook(() => useTranslations(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
-						translations: customTranslations,
+					mode="offline"
+					react={{
+						noStyle: false,
 					}}
+					translations={customTranslations}
 				>
 					{children}
 				</ConsentManagerProvider>
@@ -142,14 +136,12 @@ describe('useTranslations', () => {
 		const { result } = renderHook(() => useTranslations(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
-						translations: {
-							defaultLanguage: 'fr', // Language that doesn't exist
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
+					}}
+					translations={{
+						defaultLanguage: 'fr', // Language that doesn't exist
 					}}
 				>
 					{children}
@@ -175,34 +167,32 @@ describe('useTranslations', () => {
 		const { result } = renderHook(() => useTranslations(), {
 			wrapper: ({ children }) => (
 				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-						react: {
-							noStyle: false,
-						},
+					mode="offline"
+					react={{
+						noStyle: false,
+					}}
+					translations={{
+						defaultLanguage: 'en',
+						disableAutoLanguageSwitch: true,
 						translations: {
-							defaultLanguage: 'en',
-							disableAutoLanguageSwitch: true,
-							translations: {
-								en: {
-									common: {
-										acceptAll: 'Custom English Accept All',
-										rejectAll: 'Custom English Reject All',
-										customize: 'Custom English Customize',
-										save: 'Custom English Save',
-									},
-									cookieBanner: {
-										title: 'Custom English Title',
-										description: 'Custom English Description',
-									},
-									consentManagerDialog: {
-										title: 'Custom English Dialog Title',
-									},
-									consentTypes: {
-										necessary: {
-											title: 'Custom English Necessary',
-											description: 'Custom English Necessary Description',
-										},
+							en: {
+								common: {
+									acceptAll: 'Custom English Accept All',
+									rejectAll: 'Custom English Reject All',
+									customize: 'Custom English Customize',
+									save: 'Custom English Save',
+								},
+								cookieBanner: {
+									title: 'Custom English Title',
+									description: 'Custom English Description',
+								},
+								consentManagerDialog: {
+									title: 'Custom English Dialog Title',
+								},
+								consentTypes: {
+									necessary: {
+										title: 'Custom English Necessary',
+										description: 'Custom English Necessary Description',
 									},
 								},
 							},

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -60,7 +60,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 		const { rerender } = render(
 			<ConsentManagerProvider
-				mode="offline"
+				mode="offline" // Use offline mode to prevent additional fetches
 				react={{ theme: { 'banner.root': 'light' } }}
 			>
 				<div>Light theme</div>
@@ -92,7 +92,10 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 	it('should make a new request when core options change', async () => {
 		const { rerender } = render(
-			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t-1">
+			<ConsentManagerProvider
+				mode="c15t"
+				backendURL="/api/c15t-1" // Use unique URLs to distinguish calls
+			>
 				<div>First URL</div>
 			</ConsentManagerProvider>
 		);
@@ -110,7 +113,10 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 		// Change backendURL
 		rerender(
-			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t-2">
+			<ConsentManagerProvider
+				mode="c15t"
+				backendURL="/api/c15t-2" // Different backend URL
+			>
 				<div>Second URL</div>
 			</ConsentManagerProvider>
 		);
@@ -131,7 +137,9 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 		mockFetch.mockClear();
 
 		const { rerender } = render(
-			<ConsentManagerProvider mode="offline">
+			<ConsentManagerProvider
+				mode="offline" // Use offline mode to avoid fetch calls
+			>
 				<div>Counter: 0</div>
 			</ConsentManagerProvider>
 		);

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -38,12 +38,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 	it('should only make one initial request for consent banner status', async () => {
 		render(
-			<ConsentManagerProvider
-				options={{
-					mode: 'c15t',
-					backendURL: '/api/c15t',
-				}}
-			>
+			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t">
 				<div>Test Component</div>
 			</ConsentManagerProvider>
 		);
@@ -65,10 +60,8 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 		const { rerender } = render(
 			<ConsentManagerProvider
-				options={{
-					mode: 'offline', // Use offline mode to prevent additional fetches
-					react: { theme: { 'banner.root': 'light' } },
-				}}
+				mode="offline"
+				react={{ theme: { 'banner.root': 'light' } }}
 			>
 				<div>Light theme</div>
 			</ConsentManagerProvider>
@@ -83,10 +76,8 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 		// Change theme prop
 		rerender(
 			<ConsentManagerProvider
-				options={{
-					mode: 'offline',
-					react: { theme: { 'banner.root': 'dark' } },
-				}}
+				mode="offline"
+				react={{ theme: { 'banner.root': 'dark' } }}
 			>
 				<div>Dark theme</div>
 			</ConsentManagerProvider>
@@ -101,12 +92,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 	it('should make a new request when core options change', async () => {
 		const { rerender } = render(
-			<ConsentManagerProvider
-				options={{
-					mode: 'c15t',
-					backendURL: '/api/c15t-1', // Use unique URLs to distinguish calls
-				}}
-			>
+			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t-1">
 				<div>First URL</div>
 			</ConsentManagerProvider>
 		);
@@ -124,12 +110,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 		// Change backendURL
 		rerender(
-			<ConsentManagerProvider
-				options={{
-					mode: 'c15t',
-					backendURL: '/api/c15t-2', // Different backend URL
-				}}
-			>
+			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t-2">
 				<div>Second URL</div>
 			</ConsentManagerProvider>
 		);
@@ -150,11 +131,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 		mockFetch.mockClear();
 
 		const { rerender } = render(
-			<ConsentManagerProvider
-				options={{
-					mode: 'offline', // Use offline mode to avoid fetch calls
-				}}
-			>
+			<ConsentManagerProvider mode="offline">
 				<div>Counter: 0</div>
 			</ConsentManagerProvider>
 		);
@@ -168,11 +145,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 		// Simulate rapid re-renders
 		for (let i = 1; i <= 5; i++) {
 			rerender(
-				<ConsentManagerProvider
-					options={{
-						mode: 'offline',
-					}}
-				>
+				<ConsentManagerProvider mode="offline">
 					<div>Counter: {i}</div>
 				</ConsentManagerProvider>
 			);

--- a/packages/react/src/providers/__tests__/provider-context.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-context.test.tsx
@@ -108,11 +108,9 @@ describe('ConsentManagerProvider Context Values', () => {
 
 		const { getByTestId } = render(
 			<ConsentManagerProvider
-				options={{
-					mode: 'offline',
-					react: {
-						theme: { 'banner.root': 'dark' },
-					},
+				mode="offline"
+				react={{
+					theme: { 'banner.root': 'dark' },
 				}}
 			>
 				<ConsumerComponent />
@@ -140,11 +138,9 @@ describe('ConsentManagerProvider Context Values', () => {
 
 		render(
 			<ConsentManagerProvider
-				options={{
-					mode: 'offline',
-					callbacks: {
-						onConsentSet,
-					},
+				mode="offline"
+				callbacks={{
+					onConsentSet,
 				}}
 			>
 				<div>Test</div>

--- a/packages/react/src/providers/__tests__/provider-errors.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-errors.test.tsx
@@ -84,12 +84,7 @@ describe('ConsentManagerProvider Error Handling', () => {
 		};
 
 		const { getByTestId } = render(
-			<ConsentManagerProvider
-				options={{
-					mode: 'c15t',
-					backendURL: '/api/c15t',
-				}}
-			>
+			<ConsentManagerProvider mode="c15t" backendURL="/api/c15t">
 				<ErrorDetectingComponent />
 			</ConsentManagerProvider>
 		);

--- a/packages/react/src/types/consent-manager.ts
+++ b/packages/react/src/types/consent-manager.ts
@@ -95,7 +95,7 @@ export type ConsentManagerOptions = CoreOptions & {
  *
  * @public
  */
-export interface ConsentManagerProviderProps {
+export type ConsentManagerProviderProps = {
 	/**
 	 * React children to render within the provider.
 	 */
@@ -104,6 +104,9 @@ export interface ConsentManagerProviderProps {
 	/**
 	 * Configuration options for the consent manager.
 	 * This includes core, React, store, and translation settings.
+	 * @deprecated You can now spread the options object into the provider props.
 	 */
-	options: ConsentManagerOptions;
-}
+	options?: ConsentManagerOptions;
+} & Omit<ConsentManagerOptions, 'mode'> & {
+		mode?: CoreOptions['mode'];
+	};

--- a/packages/react/src/utils/test-helpers.tsx
+++ b/packages/react/src/utils/test-helpers.tsx
@@ -37,14 +37,7 @@ export async function testComponentStyles({
 }: ComponentStyles) {
 	// Render the component with the ConsentManagerProvider
 	const { container } = render(
-		<ConsentManagerProvider
-			options={{
-				mode: 'offline',
-				react: {
-					noStyle,
-				},
-			}}
-		>
+		<ConsentManagerProvider mode="offline" react={{ noStyle }}>
 			{component}
 		</ConsentManagerProvider>
 	);


### PR DESCRIPTION
## Overview
Deprecated  options prop for better devex

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

**Migration:**
```ts
// Before
<ConsentManagerProvider options={{ }} />

// After
<ConsentManagerProvider mode='c15t' backendUrl='' />
// Or
<ConsentManagerProvider {...c15tOptions} />
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the `ConsentManagerProvider` component to accept configuration options as individual props instead of a single `options` prop. Direct props now take precedence, and the `options` prop is deprecated.
  * Simplified and unified prop handling in both React and Next.js integrations for more flexible configuration.
  * Adjusted type definitions to support the new prop structure.

* **Documentation**
  * Updated all documentation and code examples to reflect the new prop passing style, replacing usage of the `options` prop with direct prop spreading.
  * Improved clarity and consistency across guides, quickstarts, and usage snippets.

* **Tests**
  * Refactored tests to use the new direct prop passing approach for `ConsentManagerProvider`, ensuring continued test coverage with the updated API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->