### PR TITLE
fix(nextjs): removed trailing slash from normalizedURL

### DIFF
--- a/.changeset/fresh-bugs-relate.md
+++ b/.changeset/fresh-bugs-relate.md
@@ -1,0 +1,5 @@
+---
+"@c15t/nextjs": patch
+---
+
+fix(nextjs): removed trailing slash from normalizedURL

--- a/packages/nextjs/src/components/consent-manager-provider/utils/normalize-url.test.ts
+++ b/packages/nextjs/src/components/consent-manager-provider/utils/normalize-url.test.ts
@@ -17,6 +17,27 @@ describe('validateBackendURL', () => {
 		}
 	});
 
+	it('should trim trailing slashes from absolute URLs', () => {
+		const testCases = [
+			{
+				input: 'https://my-instance.c15t.dev/',
+				expected: 'https://my-instance.c15t.dev',
+			},
+			{ input: 'https://example.com/', expected: 'https://example.com' },
+			{ input: 'http://localhost:3000/', expected: 'http://localhost:3000' },
+			{
+				input: 'https://api.example.com/path/',
+				expected: 'https://api.example.com/path',
+			},
+		];
+
+		for (const { input, expected } of testCases) {
+			const result = validateBackendURL(input);
+			expect(result.isAbsolute).toBe(true);
+			expect(result.normalizedURL).toBe(expected);
+		}
+	});
+
 	it('should throw error for invalid absolute URLs', () => {
 		const invalidAbsoluteURLs = [
 			'ftp://example.com',
@@ -34,6 +55,20 @@ describe('validateBackendURL', () => {
 		const testCases = [
 			{ input: '/api/c15t', expected: '/api/c15t' },
 			{ input: '/path/to/api', expected: '/path/to/api' },
+		];
+
+		for (const { input, expected } of testCases) {
+			const result = validateBackendURL(input);
+			expect(result.isAbsolute).toBe(false);
+			expect(result.normalizedURL).toBe(expected);
+		}
+	});
+
+	it('should trim trailing slashes from relative URLs', () => {
+		const testCases = [
+			{ input: '/api/c15t/', expected: '/api/c15t' },
+			{ input: '/path/to/api/', expected: '/path/to/api' },
+			{ input: '/', expected: '/' }, // Root path should be preserved
 		];
 
 		for (const { input, expected } of testCases) {
@@ -72,6 +107,26 @@ describe('normalizeBackendURL', () => {
 		expect(result).toBe(absoluteURL);
 	});
 
+	it('should trim trailing slashes from absolute URLs', () => {
+		const testCases = [
+			{
+				input: 'https://my-instance.c15t.dev/',
+				expected: 'https://my-instance.c15t.dev',
+			},
+			{
+				input: 'https://example.com/api/',
+				expected: 'https://example.com/api',
+			},
+		];
+
+		const headers = createMockHeaders({});
+
+		for (const { input, expected } of testCases) {
+			const result = normalizeBackendURL(input, headers);
+			expect(result).toBe(expected);
+		}
+	});
+
 	it('should construct URL from x-forwarded headers', () => {
 		const headers = createMockHeaders({
 			'x-forwarded-proto': 'https',
@@ -80,6 +135,33 @@ describe('normalizeBackendURL', () => {
 
 		const result = normalizeBackendURL('/api/c15t', headers);
 		expect(result).toBe('https://example.com/api/c15t');
+	});
+
+	it('should construct URL from x-forwarded headers and trim trailing slashes', () => {
+		const testCases = [
+			{
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'my-instance.c15t.dev',
+				},
+				input: '/api/c15t/',
+				expected: 'https://my-instance.c15t.dev/api/c15t',
+			},
+			{
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'example.com',
+				},
+				input: '/api/',
+				expected: 'https://example.com/api',
+			},
+		];
+
+		for (const { headers: headerData, input, expected } of testCases) {
+			const headers = createMockHeaders(headerData);
+			const result = normalizeBackendURL(input, headers);
+			expect(result).toBe(expected);
+		}
 	});
 
 	it('should use host header when x-forwarded-host is not available', () => {
@@ -98,6 +180,15 @@ describe('normalizeBackendURL', () => {
 
 		const result = normalizeBackendURL('/api/c15t', headers);
 		expect(result).toBe('https://example.com/api/c15t');
+	});
+
+	it('should use referer and trim trailing slashes', () => {
+		const headers = createMockHeaders({
+			referer: 'https://my-instance.c15t.dev/some/path',
+		});
+
+		const result = normalizeBackendURL('/api/c15t/', headers);
+		expect(result).toBe('https://my-instance.c15t.dev/api/c15t');
 	});
 
 	it('should return null when no headers are available to determine base URL', () => {

--- a/packages/nextjs/src/components/consent-manager-provider/utils/normalize-url.ts
+++ b/packages/nextjs/src/components/consent-manager-provider/utils/normalize-url.ts
@@ -1,5 +1,15 @@
 const ABSOLUTE_URL_REGEX = /^https?:\/\//;
 
+function trimTrailingSlash(url: string): string {
+	// Don't trim if it's just the root path "/"
+	if (url === '/') {
+		return url;
+	}
+
+	// Remove trailing slash if present
+	return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
 export function validateBackendURL(backendURL: string): {
 	isAbsolute: boolean;
 	normalizedURL: string;
@@ -13,14 +23,14 @@ export function validateBackendURL(backendURL: string): {
 
 		return {
 			isAbsolute: true,
-			normalizedURL: backendURL,
+			normalizedURL: trimTrailingSlash(backendURL),
 		};
 	}
 
 	if (backendURL.startsWith('/')) {
 		return {
 			isAbsolute: false,
-			normalizedURL: backendURL,
+			normalizedURL: trimTrailingSlash(backendURL),
 		};
 	}
 
@@ -46,12 +56,14 @@ export function normalizeBackendURL(
 		const host = headersList.get('x-forwarded-host') || headersList.get('host');
 
 		if (host) {
-			return `${protocol}://${host}${validated}`;
+			return trimTrailingSlash(`${protocol}://${host}${validated}`);
 		}
 
 		if (referer) {
 			const refererUrl = new URL(referer);
-			return `${refererUrl.protocol}//${refererUrl.host}${validated}`;
+			return trimTrailingSlash(
+				`${refererUrl.protocol}//${refererUrl.host}${validated}`
+			);
 		}
 
 		if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Overview
remove double slash from normalizedURL so instead of //show-consent-banner it's /show-consent-banner

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where normalized URLs incorrectly ended with a trailing slash, ensuring consistent URL formatting across the application.

* **Tests**
  * Added comprehensive test cases to verify that trailing slashes are correctly removed from both absolute and relative URLs, except for the root path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->