### PR TITLE
fix(core): hasConsentFor should return true when no consent is needed

### DIFF
--- a/.changeset/tasty-toys-film.md
+++ b/.changeset/tasty-toys-film.md
@@ -1,0 +1,5 @@
+---
+"c15t": patch
+---
+
+fix(core): hasConsentFor should return true when no consent is needed

--- a/packages/core/src/libs/fetch-consent-banner.ts
+++ b/packages/core/src/libs/fetch-consent-banner.ts
@@ -102,6 +102,18 @@ async function updateStore(
 						(showConsentBanner && hasLocalStorageAccess) || ignoreGeoLocation,
 				}
 			: {}),
+
+		// If the banner is not shown and has no requirement consent to all
+		...(data.jurisdiction.code === 'NONE' &&
+			!data.showConsentBanner && {
+				consents: {
+					necessary: true,
+					functionality: true,
+					experience: true,
+					marketing: true,
+					measurement: true,
+				},
+			}),
 	});
 }
 

--- a/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
@@ -17,6 +17,9 @@ vi.mock('c15t', async () => {
 				ok: true,
 				data: {
 					showConsentBanner: true,
+					jurisdiction: {
+						code: 'GDPR',
+					},
 					translations: {
 						language: 'en',
 						translations: defaultTranslationConfig.translations.en,

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -17,6 +17,9 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 			new Response(
 				JSON.stringify({
 					showConsentBanner: true,
+					jurisdiction: {
+						code: 'GDPR',
+					},
 					translations: {
 						language: 'en',
 						translations: defaultTranslationConfig.translations.en,

--- a/packages/react/src/providers/__tests__/provider-context.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-context.test.tsx
@@ -26,6 +26,9 @@ vi.mock('c15t', async () => {
 					ok: true,
 					data: {
 						showConsentBanner: true,
+						jurisdiction: {
+							code: 'GDPR',
+						},
 						translations: {
 							language: 'en',
 							translations: defaultTranslationConfig.translations.en,


### PR DESCRIPTION
## Overview
hasConsentFor should return true when no consent is needed e.g. for US

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue to ensure full consent is automatically granted when no consent is required, improving consistency in consent handling.

* **Documentation**
  * Added a changeset file documenting the correction in consent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->