### PR TITLE
fix(react): removed scroll lock from widget

### DIFF
--- a/.changeset/lovely-ants-hide.md
+++ b/.changeset/lovely-ants-hide.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+fix(react): removed scroll lock from widget

--- a/packages/react/src/components/consent-manager-widget/atoms/root.tsx
+++ b/packages/react/src/components/consent-manager-widget/atoms/root.tsx
@@ -94,7 +94,6 @@ const ConsentManagerWidgetRoot: FC<ConsentManagerWidgetRootProps> = ({
 	disableAnimation = false,
 	theme,
 	useProvider = true,
-	...props
 }) => {
 	/**
 	 * Combine consent manager state with styling configuration
@@ -107,11 +106,7 @@ const ConsentManagerWidgetRoot: FC<ConsentManagerWidgetRootProps> = ({
 	};
 
 	const content = (
-		<Box
-			data-testid="consent-manager-widget-root"
-			themeKey="widget.root"
-			{...props}
-		>
+		<Box data-testid="consent-manager-widget-root" themeKey="widget.root">
 			{children}
 		</Box>
 	);


### PR DESCRIPTION
## Overview
Fixed an error when opening the dialog caused by the widget being passed the scroll lock prop.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the widget component to no longer support scroll lock functionality.
  * Adjusted component prop handling for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->