### PR TITLE
fix(nextjs): return null instead of undefined when pages fetch errors

### DIFF
--- a/packages/nextjs/src/components/consent-manager-provider/initial-data-hoc.tsx
+++ b/packages/nextjs/src/components/consent-manager-provider/initial-data-hoc.tsx
@@ -39,7 +39,6 @@ export function withInitialC15TData<
 			// Silently handle consent data fetch errors
 			console.warn('Failed to fetch initial c15t data:', error);
 		}
-
 		// If there's an existing getServerSideProps, call it
 		if (getServerSideProps) {
 			const result = await getServerSideProps(context);
@@ -49,7 +48,7 @@ export function withInitialC15TData<
 					...result,
 					props: {
 						...(await result.props),
-						initialC15TData: initialData,
+						initialC15TData: initialData ?? null,
 					},
 				};
 			}
@@ -60,7 +59,7 @@ export function withInitialC15TData<
 		// Return just the consent data if no existing props
 		return {
 			props: {
-				initialC15TData: initialData,
+				initialC15TData: initialData ?? null,
 			} as Props & WithInitialC15TDataProps,
 		};
 	};


### PR DESCRIPTION
## Overview
returns null instead of undefined if the fetch errors to prevent a hard error as undefined cant be serialized.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of initial consent data to ensure consistent assignment of null values when data is undefined.
  * Minor code cleanup for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->