### PR TITLE
docs: update self hosting docs for latest package compatibility

### DIFF
--- a/docs/frameworks/javascript/storing-consent/self-hosting.mdx
+++ b/docs/frameworks/javascript/storing-consent/self-hosting.mdx
@@ -131,19 +131,17 @@ This guide shows you how to set up a self-hosted c15t instance, giving you compl
     Then, create a catch-all API route that imports and uses this instance:
 
     ```tsx title="app/api/c15t/[...all]/route.ts"
-    import { toNextHandler } from '@c15t/backend/integrations/next';
     import { instance } from '../c15t';
 
-    export const { GET, POST, OPTIONS } = toNextHandler(instance);
+    export const { GET, POST, OPTIONS } = instance;
     ```
 
     <Tabs items={['Next.js', 'Cloudflare']}>
       <Tab value="Next.js">
         ```tsx title="app/api/c15t/[...all]/route.ts"
-        import { toNextHandler } from '@c15t/backend/integrations/next';
         import { instance } from '../c15t';
 
-        export const { GET, POST, OPTIONS } = toNextHandler(instance);
+        export const { GET, POST, OPTIONS } = instance;
         ```
       </Tab>
 

--- a/docs/frameworks/react/storing-consent/self-hosting.mdx
+++ b/docs/frameworks/react/storing-consent/self-hosting.mdx
@@ -136,10 +136,9 @@ This guide shows you how to set up a self-hosted c15t instance using Next.js API
     Then, create a catch-all API route that imports and uses this instance:
 
     ```tsx title="app/api/c15t/[...all]/route.ts"
-    import { toNextHandler } from '@c15t/backend/integrations/next';
     import { instance } from '../c15t';
 
-    export const { GET, POST, OPTIONS } = toNextHandler(instance);
+    export const { GET, POST, OPTIONS } = instance;
     ```
 
     This approach separates your instance configuration from the route handler, making it easier for CLI tools and migration utilities to locate and work with your c15t instance.

--- a/docs/self-host/adapters/drizzle.mdx
+++ b/docs/self-host/adapters/drizzle.mdx
@@ -25,13 +25,105 @@ npm install drizzle-orm better-sqlite3 @types/better-sqlite3
 
 ```typescript
 // schema.ts
-import { pgTable, uuid, text, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, json, boolean } from 'drizzle-orm/pg-core';
 
-export const users = pgTable('users', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  name: text('name').notNull(),
-  email: text('email').notNull().unique(),
-  createdAt: timestamp('created_at').defaultNow()
+export const subject = pgTable("subject", {
+	id: text("id").primaryKey(),
+	isIdentified: boolean("is_identified").notNull(),
+	externalId: text("external_id"),
+	identityProvider: text("identity_provider"),
+	lastIpAddress: text("last_ip_address"),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+	subjectTimezone: text("subject_timezone"),
+});
+
+export const consentPurpose = pgTable("consent_purpose", {
+	id: text("id").primaryKey(),
+	code: text("code").notNull(),
+	name: text("name").notNull(),
+	description: text("description").notNull(),
+	isEssential: boolean("is_essential").notNull(),
+	dataCategory: text("data_category"),
+	legalBasis: text("legal_basis"),
+	isActive: boolean("is_active").notNull(),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at").notNull(),
+});
+
+export const consentPolicy = pgTable("consent_policy", {
+	id: text("id").primaryKey(),
+	version: text("version").notNull(),
+	type: text("type").notNull(),
+	name: text("name").notNull(),
+	effectiveDate: timestamp("effective_date").notNull(),
+	expirationDate: timestamp("expiration_date"),
+	content: text("content").notNull(),
+	contentHash: text("content_hash").notNull(),
+	isActive: boolean("is_active").notNull(),
+	createdAt: timestamp("created_at").notNull(),
+});
+
+export const domain = pgTable("domain", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull().unique(),
+	description: text("description"),
+	allowedOrigins: json("allowed_origins"),
+	isVerified: boolean("is_verified").notNull(),
+	isActive: boolean("is_active").notNull(),
+	createdAt: timestamp("created_at").notNull(),
+	updatedAt: timestamp("updated_at"),
+});
+
+export const consent = pgTable("consent", {
+	id: text("id").primaryKey(),
+	subjectId: text("subject_id")
+		.notNull()
+		.references(() => subject.id, { onDelete: "cascade" }),
+	domainId: text("domain_id")
+		.notNull()
+		.references(() => domain.id, { onDelete: "cascade" }),
+	purposeIds: json("purpose_ids"),
+	metadata: json("metadata"),
+	policyId: text("policy_id").references(() => consentPolicy.id, {
+		onDelete: "cascade",
+	}),
+	ipAddress: text("ip_address"),
+	userAgent: text("user_agent"),
+	status: text("status").notNull(),
+	withdrawalReason: text("withdrawal_reason"),
+	givenAt: timestamp("given_at").notNull(),
+	validUntil: timestamp("valid_until"),
+	isActive: boolean("is_active").notNull(),
+});
+
+export const consentRecord = pgTable("consent_record", {
+	id: text("id").primaryKey(),
+	subjectId: text("subject_id")
+		.notNull()
+		.references(() => subject.id, { onDelete: "cascade" }),
+	consentId: text("consent_id").references(() => consent.id, {
+		onDelete: "cascade",
+	}),
+	actionType: text("action_type").notNull(),
+	details: json("details"),
+	createdAt: timestamp("created_at").notNull(),
+});
+
+export const auditLog = pgTable("audit_log", {
+	id: text("id").primaryKey(),
+	entityType: text("entity_type").notNull(),
+	entityId: text("entity_id").notNull(),
+	actionType: text("action_type").notNull(),
+	subjectId: text("subject_id").references(() => subject.id, {
+		onDelete: "cascade",
+	}),
+	ipAddress: text("ip_address"),
+	userAgent: text("user_agent"),
+	changes: json("changes"),
+	metadata: json("metadata"),
+	createdAt: timestamp("created_at").notNull(),
+	eventTimezone: text("event_timezone").notNull(),
 });
 ```
 
@@ -42,10 +134,11 @@ import { c15tInstance } from '@c15t/backend';
 import { drizzleAdapter } from '@c15t/backend/db/adapters/drizzle';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
+import * as tables from "@/schema";
 
 // Create a PostgreSQL connection
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL
+	connectionString: process.env.DATABASE_URL,
 });
 
 // Initialize Drizzle with the connection
@@ -53,12 +146,16 @@ const db = drizzle(pool);
 
 // Create the c15t instance
 const instance = c15tInstance({
-  baseURL: 'http://localhost:3000',
-  database: drizzleAdapter({
-    client: db,
-    // Optional: Pass your schema for type checking
-    schema: { users }
-  }),
+	baseURL: 'http://localhost:3000',
+	database: drizzleAdapter(
+		db as unknown as { [p: string]: unknown },
+		{
+			provider: 'pg',
+			schema: {
+				...tables,
+			},
+		},
+	),
 });
 ```
 

--- a/docs/self-host/database-adapters.mdx
+++ b/docs/self-host/database-adapters.mdx
@@ -118,8 +118,13 @@ const pool = new Pool({
 const db = drizzle(pool);
 
 const instance = c15tInstance({
-  baseURL: 'http://localhost:3000',
-  database: drizzleAdapter({ client: db }),
+	baseURL: 'http://localhost:3000',
+	database: drizzleAdapter(
+		db as unknown as { [p: string]: unknown },
+		{
+			provider: 'pg',
+		},
+	),
 });
 ```
 


### PR DESCRIPTION
## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

The nextjs route handler setup in the current docs are outdated, this pr adds an update that work with versions `@c15t/nextjs: 1.5.0` and `@c15t/backend: 1.5.0`.
This pr also updates the docs for c15t instance setup for drizzle-orm and postgres

## Related Issue
<!-- Always link to the issue. Create one first if it doesn't exist. -->
Fixes #197 

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Checklist

### Required

- [ ] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested locally
- [ ] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified Next.js and React self-hosting examples by exporting route handlers directly from the instance.
  * Expanded Drizzle ORM schema examples to cover subjects, domains, policies, consents, records, and audit logs.
  * Updated Drizzle adapter setup to accept a full schema and provider options for PostgreSQL.
  * Clarified database adapter usage and typing guidance to match the new invocation pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->