### PR TITLE
feat(core): yield before running set-consent callbacks

### DIFF
--- a/.changeset/pretty-sites-joke.md
+++ b/.changeset/pretty-sites-joke.md
@@ -1,0 +1,5 @@
+---
+"c15t": patch
+---
+
+feat(core): yield before running set-consent callbacks

--- a/examples/next/app/layout.client.tsx
+++ b/examples/next/app/layout.client.tsx
@@ -9,7 +9,14 @@ export function ClientLayout() {
 					console.log('Consent banner fetched', response);
 				},
 				onConsentSet(response) {
-					console.log('Consent has been saved locally', response);
+					console.log('onConsentSet', response);
+
+					// This simulates a heavy operation that could block the click INP
+					const start = performance.now();
+					const end = start + 500;
+					// biome-ignore lint/suspicious/noEmptyBlockStatements: <explanation>
+					while (performance.now() < end) {}
+					console.log('heavy onConsentSet callback finished');
 				},
 				onError(response) {
 					console.log('Error', response);

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -21,6 +21,7 @@ export async function saveConsents({
 	trackingBlocker,
 }: SaveConsentsProps) {
 	const { callbacks, selectedConsents, consents, consentTypes } = get();
+
 	const newConsents = selectedConsents ?? consents ?? {};
 
 	if (type === 'all') {
@@ -47,12 +48,13 @@ export async function saveConsents({
 		consentInfo,
 	});
 
-	// Update tracking blocker with new consents right away
+	// Yield to the next task so the UI can paint before running heavier work
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+	// Run after yielding to avoid blocking the click INP
 	trackingBlocker?.updateConsents(newConsents);
 	updateGTMConsent(newConsents);
 
-	// Store to localStorage immediately for persistence
-	// Wrap in try/catch to handle potential privacy mode errors
 	try {
 		localStorage.setItem(
 			STORAGE_KEY,


### PR DESCRIPTION
## Overview
Yield after updating the store to improve INP performance. I've also added an example in the next app dir callbacks of a heavy callback to simulate the effectiveness. before/after is in a video below.

## Related Issue
Fixes #369 

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [x] ⚡ Performance

## Implementation Details
https://github.com/user-attachments/assets/2d90e5ac-90da-4744-b388-858eaed2ead3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consent saves now yield briefly before running follow-up actions so UI updates apply immediately while analytics/tracking updates and custom consent callbacks run shortly after.

* **Tests**
  * Added a test ensuring UI updates occur first and side effects (tracking, analytics, callbacks) are deferred.

* **Chores**
  * Added a patch release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->