### PR TITLE
refactor(core): deprecate duplicate & unused methods from the store

### DIFF
--- a/.changeset/tired-heads-attack.md
+++ b/.changeset/tired-heads-attack.md
@@ -3,4 +3,4 @@
 "c15t": patch
 ---
 
-refactor(core): depricate duplicate & unused methods from the store
+refactor(core): deprecate duplicate & unused methods from the store

--- a/.changeset/tired-heads-attack.md
+++ b/.changeset/tired-heads-attack.md
@@ -1,0 +1,6 @@
+---
+"@c15t/react": patch
+"c15t": patch
+---
+
+refactor(core): depricate duplicate & unused methods from the store

--- a/packages/core/src/libs/__tests__/save-consents.test.ts
+++ b/packages/core/src/libs/__tests__/save-consents.test.ts
@@ -145,6 +145,13 @@ describe('saveConsents', () => {
 					experience: true,
 					marketing: true,
 				},
+				selectedConsents: {
+					necessary: true,
+					functionality: true,
+					measurement: true,
+					experience: true,
+					marketing: true,
+				},
 				showPopup: false,
 				consentInfo: expect.objectContaining({
 					type: 'all',
@@ -162,20 +169,22 @@ describe('saveConsents', () => {
 				trackingBlocker: mockTrackingBlocker,
 			});
 
-			expect(mockSet).toHaveBeenCalledWith({
-				consents: {
-					necessary: true,
-					functionality: false,
-					measurement: false,
-					experience: false,
-					marketing: false,
-				},
-				showPopup: false,
-				consentInfo: expect.objectContaining({
-					type: 'necessary',
-					time: expect.any(Number),
-				}),
-			});
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					consents: {
+						necessary: true,
+						functionality: false,
+						measurement: false,
+						experience: false,
+						marketing: false,
+					},
+					showPopup: false,
+					consentInfo: expect.objectContaining({
+						type: 'necessary',
+						time: expect.any(Number),
+					}),
+				})
+			);
 		});
 
 		it('should preserve existing consents when type is "custom"', async () => {
@@ -193,6 +202,7 @@ describe('saveConsents', () => {
 					onError: vi.fn(),
 				},
 				consents: customConsents,
+				selectedConsents: customConsents,
 				consentTypes: [
 					{
 						name: 'necessary',
@@ -247,6 +257,7 @@ describe('saveConsents', () => {
 
 			expect(mockSet).toHaveBeenCalledWith({
 				consents: customConsents,
+				selectedConsents: customConsents,
 				showPopup: false,
 				consentInfo: expect.objectContaining({
 					type: 'custom',
@@ -329,20 +340,22 @@ describe('saveConsents', () => {
 				trackingBlocker: null,
 			});
 
-			expect(mockSet).toHaveBeenCalledWith({
-				consents: {
-					necessary: true,
-					functionality: true,
-					measurement: true,
-					experience: true,
-					marketing: true,
-				},
-				showPopup: false,
-				consentInfo: expect.objectContaining({
-					type: 'all',
-					time: expect.any(Number),
-				}),
-			});
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					consents: {
+						necessary: true,
+						functionality: true,
+						measurement: true,
+						experience: true,
+						marketing: true,
+					},
+					showPopup: false,
+					consentInfo: expect.objectContaining({
+						type: 'all',
+						time: expect.any(Number),
+					}),
+				})
+			);
 			expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
 				STORAGE_KEY,
 				expect.any(String)
@@ -359,6 +372,13 @@ describe('saveConsents', () => {
 					onError: vi.fn(),
 				},
 				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
+				selectedConsents: {
 					necessary: true,
 					functionality: false,
 					measurement: false,
@@ -435,6 +455,13 @@ describe('saveConsents', () => {
 					onError: vi.fn(),
 				},
 				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
+				selectedConsents: {
 					necessary: true,
 					functionality: false,
 					measurement: false,
@@ -556,6 +583,13 @@ describe('saveConsents', () => {
 					experience: false,
 					marketing: false,
 				},
+				selectedConsents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
 				consentTypes: [
 					{
 						name: 'necessary',
@@ -635,6 +669,13 @@ describe('saveConsents', () => {
 					experience: false,
 					marketing: false,
 				},
+				selectedConsents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
 				consentTypes: [
 					{
 						name: 'necessary',
@@ -706,6 +747,13 @@ describe('saveConsents', () => {
 					onError: mockOnError,
 				},
 				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
+				selectedConsents: {
 					necessary: true,
 					functionality: false,
 					measurement: false,
@@ -816,14 +864,16 @@ describe('saveConsents', () => {
 				trackingBlocker: mockTrackingBlocker,
 			});
 
-			expect(mockSet).toHaveBeenCalledWith({
-				consents: {},
-				showPopup: false,
-				consentInfo: expect.objectContaining({
-					type: 'all',
-					time: expect.any(Number),
-				}),
-			});
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					consents: {},
+					showPopup: false,
+					consentInfo: expect.objectContaining({
+						type: 'all',
+						time: expect.any(Number),
+					}),
+				})
+			);
 		});
 
 		it('should handle partial consent types', async () => {
@@ -833,6 +883,10 @@ describe('saveConsents', () => {
 					onError: vi.fn(),
 				},
 				consents: {
+					necessary: true,
+					functionality: false,
+				},
+				selectedConsents: {
 					necessary: true,
 					functionality: false,
 				},
@@ -864,17 +918,19 @@ describe('saveConsents', () => {
 				trackingBlocker: mockTrackingBlocker,
 			});
 
-			expect(mockSet).toHaveBeenCalledWith({
-				consents: {
-					necessary: true,
-					functionality: true,
-				},
-				showPopup: false,
-				consentInfo: expect.objectContaining({
-					type: 'all',
-					time: expect.any(Number),
-				}),
-			});
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					consents: {
+						necessary: true,
+						functionality: true,
+					},
+					showPopup: false,
+					consentInfo: expect.objectContaining({
+						type: 'all',
+						time: expect.any(Number),
+					}),
+				})
+			);
 		});
 	});
 });

--- a/packages/core/src/libs/fetch-consent-banner.ts
+++ b/packages/core/src/libs/fetch-consent-banner.ts
@@ -52,10 +52,10 @@ function updateStore(
 	{ set, get, initialTranslationConfig }: FetchConsentBannerConfig,
 	hasLocalStorageAccess: boolean
 ): void {
-	const { consentInfo, setDetectedCountry, ignoreGeoLocation, callbacks } =
+	const { consentInfo, ignoreGeoLocation, callbacks, setDetectedCountry } =
 		get();
 
-	const { translations, location, jurisdiction, showConsentBanner } = data;
+	const { translations, location, showConsentBanner } = data;
 
 	const updatedStore: Partial<PrivacyConsentState> = {
 		isLoadingConsentInfo: false,
@@ -67,7 +67,7 @@ function updateStore(
 			: {}),
 
 		// If the banner is not shown and has no requirement consent to all
-		...(data.jurisdiction.code === 'NONE' &&
+		...(data.jurisdiction?.code === 'NONE' &&
 			!data.showConsentBanner && {
 				consents: {
 					necessary: true,
@@ -80,13 +80,13 @@ function updateStore(
 		locationInfo: {
 			countryCode: location?.countryCode ?? null,
 			regionCode: location?.regionCode ?? null,
-			jurisdiction: jurisdiction?.code ?? null,
-			jurisdictionMessage: jurisdiction?.message ?? null,
+			jurisdiction: data.jurisdiction?.code ?? null,
+			jurisdictionMessage: data.jurisdiction?.message ?? null,
 		},
-		jurisdictionInfo: jurisdiction,
+		jurisdictionInfo: data.jurisdiction,
 	};
 
-	if (translations) {
+	if (translations?.language && translations?.translations) {
 		const translationConfig = prepareTranslationConfig(
 			{
 				translations: {
@@ -154,7 +154,6 @@ export async function fetchConsentBannerInfo(
 
 		// Ensures the promsie has the expected data
 		if (showConsentBanner) {
-			set({ isLoadingConsentInfo: false });
 			updateStore(showConsentBanner, config, true);
 
 			return showConsentBanner;

--- a/packages/core/src/libs/fetch-consent-banner.ts
+++ b/packages/core/src/libs/fetch-consent-banner.ts
@@ -78,8 +78,10 @@ function updateStore(
 				},
 			}),
 		locationInfo: {
-			countryCode: location?.countryCode ?? '',
-			regionCode: location?.regionCode ?? '',
+			countryCode: location?.countryCode ?? null,
+			regionCode: location?.regionCode ?? null,
+			jurisdiction: jurisdiction?.code ?? null,
+			jurisdictionMessage: jurisdiction?.message ?? null,
 		},
 		jurisdictionInfo: jurisdiction,
 	};

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -20,8 +20,9 @@ export async function saveConsents({
 	set,
 	trackingBlocker,
 }: SaveConsentsProps) {
-	const { callbacks, consents, consentTypes } = get();
-	const newConsents = { ...consents };
+	const { callbacks, selectedConsents, consentTypes } = get();
+	const newConsents = { ...selectedConsents };
+
 	if (type === 'all') {
 		for (const consent of consentTypes) {
 			newConsents[consent.name] = true;
@@ -41,6 +42,7 @@ export async function saveConsents({
 	// This makes the interface feel more responsive
 	set({
 		consents: newConsents,
+		selectedConsents: newConsents,
 		showPopup: false,
 		consentInfo,
 	});

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -20,8 +20,8 @@ export async function saveConsents({
 	set,
 	trackingBlocker,
 }: SaveConsentsProps) {
-	const { callbacks, selectedConsents, consentTypes } = get();
-	const newConsents = { ...selectedConsents };
+	const { callbacks, selectedConsents, consents, consentTypes } = get();
+	const newConsents = selectedConsents ?? consents ?? {};
 
 	if (type === 'all') {
 		for (const consent of consentTypes) {

--- a/packages/core/src/store.initial-state.ts
+++ b/packages/core/src/store.initial-state.ts
@@ -42,7 +42,11 @@ export const STORAGE_KEY = 'privacy-consent-storage';
  */
 export const initialState: Omit<
 	PrivacyConsentState,
-	'has' | 'fetchConsentBannerInfo' | 'getEffectiveConsents' | 'hasConsentFor'
+	| 'has'
+	| 'fetchConsentBannerInfo'
+	| 'getEffectiveConsents'
+	| 'hasConsentFor'
+	| 'setSelectedConsent'
 > = {
 	config: {
 		pkg: 'c15t',
@@ -52,6 +56,11 @@ export const initialState: Omit<
 
 	/** Initial consent states based on default values from consent types */
 	consents: consentTypes.reduce((acc, consent) => {
+		acc[consent.name] = consent.defaultValue;
+		return acc;
+	}, {} as ConsentState),
+
+	selectedConsents: consentTypes.reduce((acc, consent) => {
 		acc[consent.name] = consent.defaultValue;
 		return acc;
 	}, {} as ConsentState),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -344,14 +344,13 @@ export const createConsentManagerStore = (
 					return state;
 				}
 
+				// Other selected consents have not been saved/agreed to only the current one.
 				const newConsents = { ...state.consents, [name]: value };
 
 				return { selectedConsents: newConsents };
 			});
 
-			const state = get();
-
-			state.saveConsents('custom');
+			get().saveConsents('custom');
 		},
 
 		/**

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -26,7 +26,7 @@ import type {
 import { type AllConsentNames, consentTypes } from './types/gdpr';
 
 import type { ContractsOutputs } from '@c15t/backend/contracts';
-import { type GTMConfiguration, setupGTM, updateGTMConsent } from './libs/gtm';
+import { type GTMConfiguration, setupGTM } from './libs/gtm';
 import { type HasCondition, has } from './libs/has';
 import { saveConsents } from './libs/save-consents';
 import type { Callbacks } from './types/callbacks';
@@ -237,6 +237,7 @@ export const createConsentManagerStore = (
 		...(storedConsent
 			? {
 					consents: storedConsent.consents,
+					selectedConsents: storedConsent.consents,
 					consentInfo: storedConsent.consentInfo as {
 						time: number;
 						type: 'necessary' | 'all' | 'custom';
@@ -249,39 +250,6 @@ export const createConsentManagerStore = (
 					showPopup: false,
 					isLoadingConsentInfo: true, // Start in loading state
 				}),
-
-		/**
-		 * Updates the consent state for a specific consent type and persists the change.
-		 *
-		 * @param name - The consent type to update
-		 * @param value - The new consent value
-		 *
-		 * @remarks
-		 * This function:
-		 * 1. Updates the consent state
-		 * 2. Persists changes to localStorage
-		 * 3. Triggers consent mode update
-		 */
-		setConsent: (name, value) => {
-			set((state) => {
-				const consentType = state.consentTypes.find(
-					(type) => type.name === name
-				);
-
-				// Don't allow changes to disabled consent types
-				if (consentType?.disabled) {
-					return state;
-				}
-
-				const newConsents = { ...state.consents, [name]: value };
-
-				// Update tracking blocker with new consents
-				trackingBlocker?.updateConsents(newConsents);
-				updateGTMConsent(newConsents);
-
-				return { consents: newConsents };
-			});
-		},
 
 		/**
 		 * Controls the visibility of the consent popup.
@@ -340,20 +308,22 @@ export const createConsentManagerStore = (
 			}
 		},
 
-		/**
-		 * Saves user consent preferences and triggers related callbacks.
-		 *
-		 * @param type - The type of consent being saved
-		 *
-		 * @remarks
-		 * This function:
-		 * 1. Updates UI state immediately
-		 * 2. Updates consent states based on type
-		 * 3. Records consent timestamp
-		 * 4. Persists to localStorage
-		 * 5. Makes network request in background
-		 * 6. Triggers callbacks
-		 */
+		setSelectedConsent: (name, value) => {
+			set((state) => {
+				const consentType = state.consentTypes.find(
+					(type) => type.name === name
+				);
+
+				if (consentType?.disabled) {
+					return state;
+				}
+
+				return {
+					selectedConsents: { ...state.selectedConsents, [name]: value },
+				};
+			});
+		},
+
 		saveConsents: async (type) =>
 			await saveConsents({
 				manager,
@@ -362,6 +332,27 @@ export const createConsentManagerStore = (
 				set,
 				trackingBlocker,
 			}),
+
+		setConsent: (name, value) => {
+			set((state) => {
+				const consentType = state.consentTypes.find(
+					(type) => type.name === name
+				);
+
+				// Don't allow changes to disabled consent types
+				if (consentType?.disabled) {
+					return state;
+				}
+
+				const newConsents = { ...state.consents, [name]: value };
+
+				return { selectedConsents: newConsents };
+			});
+
+			const state = get();
+
+			state.saveConsents('custom');
+		},
 
 		/**
 		 * Resets all consent preferences to their default values.
@@ -374,11 +365,14 @@ export const createConsentManagerStore = (
 		 */
 		resetConsents: () => {
 			set(() => {
+				const consents = consentTypes.reduce((acc, consent) => {
+					acc[consent.name] = consent.defaultValue;
+					return acc;
+				}, {} as ConsentState);
+
 				const resetState = {
-					consents: consentTypes.reduce((acc, consent) => {
-						acc[consent.name] = consent.defaultValue;
-						return acc;
-					}, {} as ConsentState),
+					consents,
+					selectedConsents: consents,
 					consentInfo: null,
 				};
 				localStorage.removeItem(STORAGE_KEY);

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -60,6 +60,9 @@ export interface PrivacyConsentState {
 	/** Current consent states for all consent types */
 	consents: ConsentState;
 
+	/** Selected consents (Not Saved) - use saveConsents to save */
+	selectedConsents: ConsentState;
+
 	/** Information about when and how consent was given */
 	consentInfo: { time: number; type: 'all' | 'custom' | 'necessary' } | null;
 
@@ -105,12 +108,28 @@ export interface PrivacyConsentState {
 	/** Available consent type configurations */
 	consentTypes: ConsentType[];
 
+	/*
+	 * Updates the selected consent state for a specific consent type.
+	 * @param name - The consent type to update
+	 * @param value - The new consent value
+	 */
+	setSelectedConsent: (name: AllConsentNames, value: boolean) => void;
+
 	/**
-	 * Updates the consent state for a specific consent type.
+	 * Saves the user's consent preferences.
+	 * @param type - The type of consent being saved
+	 */
+	saveConsents: (type: 'all' | 'custom' | 'necessary') => void;
+
+	/**
+	 * Updates the consent state for a specific consent type & automatically save the consent.
 	 * @param name - The consent type to update
 	 * @param value - The new consent value
 	 */
 	setConsent: (name: AllConsentNames, value: boolean) => void;
+
+	/** Resets all consent preferences to their default values */
+	resetConsents: () => void;
 
 	/**
 	 * Controls the visibility of the consent popup.
@@ -128,15 +147,6 @@ export interface PrivacyConsentState {
 	 * @param isOpen - Whether the dialog should be open
 	 */
 	setIsPrivacyDialogOpen: (isOpen: boolean) => void;
-
-	/**
-	 * Saves the user's consent preferences.
-	 * @param type - The type of consent being saved
-	 */
-	saveConsents: (type: 'all' | 'custom' | 'necessary') => void;
-
-	/** Resets all consent preferences to their default values */
-	resetConsents: () => void;
 
 	/**
 	 * Updates the active GDPR consent types.

--- a/packages/core/src/store.type.ts
+++ b/packages/core/src/store.type.ts
@@ -81,29 +81,14 @@ export interface PrivacyConsentState {
 	/** Whether the privacy dialog is currently open */
 	isPrivacyDialogOpen: boolean;
 
-	/** Region-specific compliance settings */
-	complianceSettings: Record<ComplianceRegion, ComplianceSettings>;
-
 	/** Event callbacks for consent actions */
 	callbacks: Callbacks;
-
-	/** Subject's detected country code */
-	detectedCountry: string | null;
 
 	/** Subject's location information */
 	locationInfo: LocationInfo | null;
 
-	/** Applicable jurisdiction information */
-	jurisdictionInfo: JurisdictionInfo | null;
-
-	/** Privacy Related Settings @deprecated will be removed in a future version */
-	privacySettings: PrivacySettings;
-
 	/** Translation configuration */
 	translationConfig: TranslationConfig;
-
-	/** Whether the provider is using c15t.dev domain */
-	isConsentDomain: boolean;
 
 	/** Whether to ignore geo location. Will always show the consent banner. */
 	ignoreGeoLocation: boolean;
@@ -160,19 +145,6 @@ export interface PrivacyConsentState {
 	setGdprTypes: (types: AllConsentNames[]) => void;
 
 	/**
-	 * Updates compliance settings for a specific region.
-	 * @param region - The region to update
-	 * @param settings - New compliance settings
-	 */
-	setComplianceSetting: (
-		region: ComplianceRegion,
-		settings: Partial<ComplianceSettings>
-	) => void;
-
-	/** Resets compliance settings to their default values */
-	resetComplianceSettings: () => void;
-
-	/**
 	 * Sets a callback for a specific consent event.
 	 * @param name - The callback event name
 	 * @param callback - The callback function
@@ -181,12 +153,6 @@ export interface PrivacyConsentState {
 		name: keyof Callbacks,
 		callback: Callbacks[keyof Callbacks] | undefined
 	) => void;
-
-	/**
-	 * Updates the user's detected country.
-	 * @param country - The country code
-	 */
-	setDetectedCountry: (country: string) => void;
 
 	/**
 	 * Updates the user's location information.
@@ -206,9 +172,6 @@ export interface PrivacyConsentState {
 	/** Checks if the user has provided any form of consent */
 	hasConsented: () => boolean;
 
-	/** Gets the effective consent states after applying privacy settings @deprecated will be removed in a future version */
-	getEffectiveConsents: () => ConsentState;
-
 	/**
 	 * Checks if consent has been given for a specific type.
 	 * @param consentType - The consent type to check
@@ -223,4 +186,47 @@ export interface PrivacyConsentState {
 	has: <CategoryType extends AllConsentNames>(
 		condition: HasCondition<CategoryType>
 	) => boolean;
+
+	/**
+	 * Deprecated variables and methods thatwill be removed in a future version
+	 */
+
+	/** Whether the provider is using c15t.dev domain  @deprecated will be removed in a future version */
+	isConsentDomain: boolean;
+
+	/** Subject's detected country code @deprecated will be removed in a future version - use locationInfo instead */
+	detectedCountry: string | null;
+
+	/** Privacy Related Settings @deprecated will be removed in a future version */
+	privacySettings: PrivacySettings;
+
+	/** Region-specific compliance settings @deprecated will be removed in a future version due to unused functionality */
+	complianceSettings: Record<ComplianceRegion, ComplianceSettings>;
+
+	/** Applicable jurisdiction information @deprecated will be removed in a future version use locationInfo instead */
+	jurisdictionInfo: JurisdictionInfo | null;
+
+	/** Gets the effective consent states after applying privacy settings @deprecated will be removed in a future version */
+	getEffectiveConsents: () => ConsentState;
+
+	/**
+	 * Updates the user's detected country.
+	 * @param country - The country code
+	 * @deprecated will be removed in a future version - use setLocationInfo instead
+	 */
+	setDetectedCountry: (country: string) => void;
+
+	/** Resets compliance settings to their default values @deprecated will be removed in a future version due to unused functionality */
+	resetComplianceSettings: () => void;
+
+	/**
+	 * Updates compliance settings for a specific region.
+	 * @param region - The region to update
+	 * @param settings - New compliance settings
+	 * @deprecated will be removed in a future version due to unused functionality
+	 */
+	setComplianceSetting: (
+		region: ComplianceRegion,
+		settings: Partial<ComplianceSettings>
+	) => void;
 }

--- a/packages/core/src/types/compliance.ts
+++ b/packages/core/src/types/compliance.ts
@@ -228,6 +228,14 @@ export type LocationInfo = {
 
 	/** Region or state code within the country (e.g., 'CA', 'ENG') */
 	regionCode: string | null;
+
+	/** Jurisdiction code (e.g. 'GDPR') */
+	jurisdiction:
+		| ContractsOutputs['consent']['showBanner']['jurisdiction']['code']
+		| null;
+
+	/** Jurisdiction message (e.g. 'GDPR or equivalent regulations require a cookie banner.') */
+	jurisdictionMessage: string | null;
 };
 
 /**

--- a/packages/react/src/components/consent-manager-widget/atoms/accordion.tsx
+++ b/packages/react/src/components/consent-manager-widget/atoms/accordion.tsx
@@ -62,12 +62,13 @@ const ConsentManagerWidgetSwitch = RadixSwitch.Root;
  * ```
  */
 const ConsentManagerWidgetAccordionItems = () => {
-	const { consents, setConsent, getDisplayedConsents } = useConsentManager();
+	const { selectedConsents, setSelectedConsent, getDisplayedConsents } =
+		useConsentManager();
 	const handleConsentChange = useCallback(
 		(name: AllConsentNames, checked: boolean) => {
-			setConsent(name, checked);
+			setSelectedConsent(name, checked);
 		},
-		[setConsent]
+		[setSelectedConsent]
 	);
 
 	function formatConsentName(name: AllConsentNames) {
@@ -101,7 +102,7 @@ const ConsentManagerWidgetAccordionItems = () => {
 				</ConsentManagerWidgetAccordionTriggerInner>
 
 				<ConsentManagerWidgetSwitch
-					checked={consents[consent.name]}
+					checked={selectedConsents[consent.name]}
 					onClick={(e) => e.stopPropagation()}
 					onKeyUp={(e) => e.stopPropagation()}
 					onKeyDown={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Overview
deprecate duplicate & unused values &  methods from the store.

## Type of Change
- [x] 🏗️ Refactor (no functional changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Separate “selected” consent choices from saved consents; add Save (all/custom/necessary), Reset, and per-switch selection APIs.
  - Consent widget switches now update selections without immediately persisting.

- Improvements
  - Safer consent banner loading (tighter translation checks, null defaults) and automatic country detection.
  - Location info now includes jurisdiction code and human-readable message.
  - Selected choices initialize from persisted consents for consistent UI.

- Bug Fixes
  - Correct handling of “NONE” jurisdiction sets all consents to true.

- Chores
  - Patch bumps for @c15t/react and c15t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->