### PR TITLE
fix(react): dialog overlay not showing by default

### DIFF
--- a/.changeset/eager-paws-stand.md
+++ b/.changeset/eager-paws-stand.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+fix(react): dialog overlay not showing by default

--- a/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.tsx
+++ b/packages/react/src/components/consent-manager-dialog/consent-manager-dialog.tsx
@@ -37,7 +37,7 @@ export const ConsentManagerDialog: FC<ConsentManagerDialogProps> = ({
 	theme: localTheme,
 	noStyle: localNoStyle,
 	disableAnimation: localDisableAnimation,
-	scrollLock: localScrollLock,
+	scrollLock: localScrollLock = true,
 	trapFocus: localTrapFocus = true,
 }) => {
 	// Global default settings from provider


### PR DESCRIPTION
## Overview
Overlay should show by default on dialog

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog overlay now displays by default when the Consent Manager opens.
  * Background scrolling is locked by default while the dialog is open, improving accessibility and preventing unintended page interaction.
  * Explicit prop values continue to be respected; only the default behavior is adjusted.

* **Chores**
  * Added a changeset entry to publish a patch release documenting the overlay visibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->