### PR TITLE
style(cookie-banner): fix preflight line-height to match Tailwind default

### DIFF
--- a/packages/react/src/components/cookie-banner/cookie-banner.module.css
+++ b/packages/react/src/components/cookie-banner/cookie-banner.module.css
@@ -5,7 +5,7 @@
 	font-family:
 		system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
 		"Apple Color Emoji", "Segoe UI Emoji";
-	line-height: 1.15;
+	line-height: 1.5;
 	-webkit-text-size-adjust: 100%;
 	tab-size: 4;
 


### PR DESCRIPTION
## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

We had a line-height of 1.2 when tailwind's default is 1.5, meaning we would see a shift in line-height

## Type of Change
<!-- Select ALL that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance
