### PR TITLE
fix(react): dialog scroll lock persisting after closure

### DIFF
--- a/.changeset/silly-donkeys-help.md
+++ b/.changeset/silly-donkeys-help.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+fix(react): dialog scroll lock persisting after closure

--- a/packages/react/src/components/consent-manager-dialog/atoms/overlay.tsx
+++ b/packages/react/src/components/consent-manager-dialog/atoms/overlay.tsx
@@ -7,7 +7,6 @@
 import clsx from 'clsx';
 import { type FC, type PropsWithChildren, useEffect, useState } from 'react';
 import { useConsentManager } from '~/hooks/use-consent-manager';
-import { useScrollLock } from '~/hooks/use-scroll-lock';
 import { useStyles } from '~/hooks/use-styles';
 import { useTheme } from '~/hooks/use-theme';
 import type { ThemeValue } from '~/types/theme';
@@ -110,11 +109,7 @@ const ConsentManagerDialogOverlay: FC<OverlayProps> = ({ noStyle, style }) => {
 	// Combine theme className with animation class if needed
 	const finalClassName = clsx(theme.className, animationClass);
 
-	const shouldLockScroll = !!(open || isPrivacyDialogOpen) && scrollLock;
-
-	useScrollLock(shouldLockScroll);
-
-	return shouldLockScroll ? (
+	return (
 		<div
 			style={
 				typeof style === 'object' && 'style' in style
@@ -124,7 +119,7 @@ const ConsentManagerDialogOverlay: FC<OverlayProps> = ({ noStyle, style }) => {
 			className={finalClassName}
 			data-testid="consent-manager-dialog-overlay"
 		/>
-	) : null;
+	);
 };
 
 const Overlay = ConsentManagerDialogOverlay;


### PR DESCRIPTION
## Overview
Fixes dialog scroll lock persisting after closure

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed page remaining scroll-locked after closing the consent dialog.
  - Stabilized overlay behavior to prevent flicker and ensure consistent visibility.
  - Animations now respect theme and “disable animations” settings.

- Refactor
  - Improved overlay rendering for smoother show/hide transitions without changing the public API.

- Chores
  - Added changeset to publish a patch release describing the scroll-lock fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->