### PR TITLE
fix(docs): update PackageCommandTabs to include mode for installation…

### DIFF
--- a/docs/frameworks/javascript/quickstart.mdx
+++ b/docs/frameworks/javascript/quickstart.mdx
@@ -38,7 +38,7 @@ availableIn:
   <Step>
     ### Install `c15t` Package
 
-    <PackageCommandTabs command="c15t" />
+    <PackageCommandTabs mode="install" command="c15t" />
   </Step>
 
   <Step>

--- a/docs/frameworks/next/quickstart-pages.mdx
+++ b/docs/frameworks/next/quickstart-pages.mdx
@@ -26,7 +26,7 @@ You can get started with the `@c15t/cli` which will generate the code for you!
   <Step>
     ### Install `@c15t/nextjs` Package
 
-    <PackageCommandTabs command="@c15t/nextjs" />
+    <PackageCommandTabs mode="install" command="@c15t/nextjs" />
   </Step>
 
   <Step>

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -26,7 +26,7 @@ You can get started with the `@c15t/cli` which will generate the code for you!
   <Step>
     ### Install `@c15t/nextjs` Package
 
-    <PackageCommandTabs command="@c15t/nextjs" />
+    <PackageCommandTabs mode="install" command="@c15t/nextjs" />
   </Step>
 
   <Step>

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -26,7 +26,7 @@ You can get started with the `@c15t/cli` which will generate the code for you!
   <Step>
     ### Install `@c15t/react` Package
 
-    <PackageCommandTabs command="@c15t/react" />
+    <PackageCommandTabs mode="install" command="@c15t/react" />
   </Step>
 
   <Step>

--- a/docs/self-host/v2/index.mdx
+++ b/docs/self-host/v2/index.mdx
@@ -21,7 +21,7 @@ canary: true
   <Step>
     ### Install `@c15t/backend` Package
 
-    <PackageCommandTabs command="@c15t/backend" />
+    <PackageCommandTabs mode="install" command="@c15t/backend" />
   </Step>
 
   <Step>


### PR DESCRIPTION
## Overview
<!-- 
Provide a clear and concise description of your changes:
1. What problem does this solve?
2. How does it solve it?
3. Why is this approach better?
-->

Fixed guides displaying the npx commands instead of npm install commands on the install guides

## Type of Change
<!-- Select ALL that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Quickstart guides for JavaScript, Next.js (including Pages Router), and React to explicitly present install commands with consistent command tabs.
  - Refreshed Self-Host v2 manual setup to align install command presentation with other guides.
  - Improves clarity and consistency of installation steps across docs, reducing ambiguity and aiding copy-paste accuracy for package manager commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->