### PR TITLE
fix(backend): handle multiple sub domains

### DIFF
--- a/.changeset/smooth-mails-work.md
+++ b/.changeset/smooth-mails-work.md
@@ -1,0 +1,5 @@
+---
+"@c15t/backend": patch
+---
+
+fix(backend): handle multiple sub domains

--- a/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
@@ -100,5 +100,65 @@ describe('CORS utilities', () => {
 				false
 			);
 		});
+
+		describe('multiple subdomain levels', () => {
+			it('should match base domain when explicitly listed', () => {
+				const trustedDomains = ['my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					true
+				);
+			});
+
+			it('should match single-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://foobar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should match multi-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://foo.bar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should match three-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://a.b.c.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should not match base domain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					false
+				);
+			});
+
+			it('should not match similar domain that is not a subdomain', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(isOriginTrusted('https://notmy-site.com', trustedDomains)).toBe(
+					false
+				);
+				expect(
+					isOriginTrusted('https://foobar-my-site.com', trustedDomains)
+				).toBe(false);
+			});
+
+			it('should match both base domain and subdomains when both are configured', () => {
+				const trustedDomains = ['my-site.com', '*.my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					true
+				);
+				expect(
+					isOriginTrusted('https://foobar.my-site.com', trustedDomains)
+				).toBe(true);
+				expect(
+					isOriginTrusted('https://foo.bar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+		});
 	});
 });

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -34,11 +34,14 @@ function matchesWildcard(
 	logger?: Logger
 ): boolean {
 	const wildcardDomain = wildcardPattern.slice(2); // Remove *. prefix
-	const parts = hostname.split('.');
-	const isValid = parts.length > 2 && hostname.endsWith(wildcardDomain);
+
+	// Ensure the hostname is not the base domain and ends with .wildcardDomain
+	// This prevents matching domains like 'foobar-my-site.com' against '*.my-site.com'
+	const isValid =
+		hostname !== wildcardDomain && hostname.endsWith(`.${wildcardDomain}`);
 
 	logger?.debug(
-		`Wildcard match result: ${isValid} ${hostname} ends with ${wildcardDomain} ${parts.length > 2} ${hostname.endsWith(wildcardDomain)}`
+		`Wildcard match result: ${isValid} ${hostname} ends with .${wildcardDomain}`
 	);
 
 	return isValid;

--- a/packages/backend/src/v2/middleware/cors/is-origin-trusted.test.ts
+++ b/packages/backend/src/v2/middleware/cors/is-origin-trusted.test.ts
@@ -100,5 +100,65 @@ describe('CORS utilities', () => {
 				false
 			);
 		});
+
+		describe('multiple subdomain levels', () => {
+			it('should match base domain when explicitly listed', () => {
+				const trustedDomains = ['my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					true
+				);
+			});
+
+			it('should match single-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://foobar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should match multi-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://foo.bar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should match three-level subdomain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(
+					isOriginTrusted('https://a.b.c.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+
+			it('should not match base domain with wildcard pattern', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					false
+				);
+			});
+
+			it('should not match similar domain that is not a subdomain', () => {
+				const trustedDomains = ['*.my-site.com'];
+				expect(isOriginTrusted('https://notmy-site.com', trustedDomains)).toBe(
+					false
+				);
+				expect(
+					isOriginTrusted('https://foobar-my-site.com', trustedDomains)
+				).toBe(false);
+			});
+
+			it('should match both base domain and subdomains when both are configured', () => {
+				const trustedDomains = ['my-site.com', '*.my-site.com'];
+				expect(isOriginTrusted('https://my-site.com', trustedDomains)).toBe(
+					true
+				);
+				expect(
+					isOriginTrusted('https://foobar.my-site.com', trustedDomains)
+				).toBe(true);
+				expect(
+					isOriginTrusted('https://foo.bar.my-site.com', trustedDomains)
+				).toBe(true);
+			});
+		});
 	});
 });

--- a/packages/backend/src/v2/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/v2/middleware/cors/is-origin-trusted.ts
@@ -34,11 +34,14 @@ function matchesWildcard(
 	logger?: Logger
 ): boolean {
 	const wildcardDomain = wildcardPattern.slice(2); // Remove *. prefix
-	const parts = hostname.split('.');
-	const isValid = parts.length > 2 && hostname.endsWith(wildcardDomain);
+
+	// Ensure the hostname is not the base domain and ends with .wildcardDomain
+	// This prevents matching domains like 'foobar-my-site.com' against '*.my-site.com'
+	const isValid =
+		hostname !== wildcardDomain && hostname.endsWith(`.${wildcardDomain}`);
 
 	logger?.debug(
-		`Wildcard match result: ${isValid} ${hostname} ends with ${wildcardDomain} ${parts.length > 2} ${hostname.endsWith(wildcardDomain)}`
+		`Wildcard match result: ${isValid} ${hostname} ends with .${wildcardDomain}`
 	);
 
 	return isValid;


### PR DESCRIPTION
## Overview
When using wildcard domains like *.example.com domains like foo.bar.example.com would error

## Related Issue
Fixes #441 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CORS origin trust to properly handle multiple subdomain levels. Wildcard domains no longer match the base domain, preventing unintended trust and improving security and reliability.

* **Tests**
  * Expanded test coverage for exact domains, single/multi-level wildcard subdomains, negative cases, and combined configurations to ensure robust behavior.

* **Chores**
  * Added release metadata for a patch update of the backend package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->