### PR TITLE
fix(nextjs): missing InitialDataPromise type export for pages

### DIFF
--- a/.changeset/thick-moose-burn.md
+++ b/.changeset/thick-moose-burn.md
@@ -1,0 +1,6 @@
+---
+"@c15t/nextjs": patch
+"@c15t/cli": patch
+---
+
+fix(nextjs): missing InitialDataPromise type export for pages

--- a/packages/cli/src/commands/generate/templates/next/pages/components.ts
+++ b/packages/cli/src/commands/generate/templates/next/pages/components.ts
@@ -25,6 +25,7 @@ import {
 	ConsentManagerDialog,
 	ConsentManagerProvider,
 	CookieBanner,
+  type InitialDataPromise
 } from '@c15t/nextjs/pages';
 // For client-only apps (non-SSR), you can use:
 // import { ConsentManagerProvider } from '@c15t/nextjs/client';
@@ -68,7 +69,7 @@ export function ConsentManager({
 	initialData,
 }: {
 	children: ReactNode;
-	initialData?: unknown;
+	initialData?: InitialDataPromise;
 }) {
 	return (
 		<ConsentManagerProvider

--- a/packages/nextjs/src/pages.ts
+++ b/packages/nextjs/src/pages.ts
@@ -10,5 +10,5 @@
 
 export { withInitialC15TData } from './components/consent-manager-provider/initial-data-hoc';
 export { ConsentManagerProvider } from './components/consent-manager-provider/pages';
-
 export * from './shared';
+export type { InitialDataPromise } from './types';


### PR DESCRIPTION
## Overview
InitialDataPromise type was missing from pages export

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing `InitialDataPromise` type export in the Next.js pages module, enabling proper TypeScript type support for page components.

* **Chores**
  * Patch release for @c15t/nextjs and @c15t/cli packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->