### PR TITLE
fix: working links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ c15t is a headless consent engine that transforms privacy management from a comp
 
 Comprehensive guides for different frameworks:
 
-- [Next.js Quickstart](/docs/frameworks/next/quickstart)
-- [React Quickstart](/docs/frameworks/react/quickstart)
-- [JavaScript Quickstart](/docs/frameworks/javascript/quickstart)
+- [Next.js Quickstart](https://c15t.com/docs/frameworks/next/quickstart)
+- [React Quickstart](https://c15t.com/docs/frameworks/react/quickstart)
+- [JavaScript Quickstart](https://c15t.com/docs/frameworks/javascript/quickstart)
 
 ## Support
 


### PR DESCRIPTION
## Overview
Fix broken docs links on the README, currently they 404 


## Related Issue


## Type of Change


- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance



### Key Changes

1. Docs point to the c15t.com docs

## Checklist

### Required

- [ ] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested locally
- [ ] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to use absolute URLs for Next.js, React, and JavaScript quickstart guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->