### PR TITLE
feat(core): specify script loader target e.g. head or body

### DIFF
--- a/.changeset/small-shoes-attack.md
+++ b/.changeset/small-shoes-attack.md
@@ -1,0 +1,5 @@
+---
+"c15t": minor
+---
+
+feat(core): scripts can now be in head and body

--- a/changelog/2025-10-27-v1.8.0.mdx
+++ b/changelog/2025-10-27-v1.8.0.mdx
@@ -117,6 +117,22 @@ Current languages include:
 | Indonesian (id) | Italian (it) | Lithuanian (lt) | Latvian (lv) | Maltese (mt) | Dutch (nl) | Polish (pl) |
 | Portuguese (pt) | Romanian (ro) | Slovak (sk) | Slovenian (sl) | Swedish (sv) | Chinese (zh) | |
 
+### Script Loader Target Location
+
+The script loader now supports specifying the target location of the script in the DOM. This is useful for scripts that need to be loaded in the body of the document.
+
+This can be done with the `target` option.
+
+```tsx
+{
+  id: 'example',
+  src: 'https://analytics.example.com/script.js',
+  category: 'analytics',
+  target: 'body',
+}
+```
+
+The default target is `head`.
 
 ## 🐛 Bug Fixes & Improvements
 

--- a/packages/core/src/libs/script-loader/__tests__/test-setup.ts
+++ b/packages/core/src/libs/script-loader/__tests__/test-setup.ts
@@ -7,6 +7,11 @@ export const mockHead = {
 	appendChild: vi.fn(),
 };
 
+// Mock document.body for testing
+export const mockBody = {
+	appendChild: vi.fn(),
+};
+
 // Registry to track created elements for proper getElementById mocking
 const createdElements: Map<string, HTMLElement> = new Map();
 
@@ -78,6 +83,12 @@ export function setupDomMocks() {
 	// Mock document.head
 	Object.defineProperty(document, 'head', {
 		value: mockHead,
+		writable: true,
+	});
+
+	// Mock document.body
+	Object.defineProperty(document, 'body', {
+		value: mockBody,
 		writable: true,
 	});
 

--- a/packages/core/src/libs/script-loader/core.ts
+++ b/packages/core/src/libs/script-loader/core.ts
@@ -242,8 +242,19 @@ export function loadScripts(
 			script.onBeforeLoad(callbackInfo);
 		}
 
+		// Determine target location (default to 'head')
+		const target = script.target ?? 'head';
+		const targetElement = target === 'body' ? document.body : document.head;
+
+		// Validate target element exists
+		if (!targetElement) {
+			throw new Error(
+				`Document ${target} is not available for script injection`
+			);
+		}
+
 		// Add to document and track
-		document.head.appendChild(scriptElement);
+		targetElement.appendChild(scriptElement);
 		setLoadedScript(script.id, scriptElement);
 		loadedScriptIds.push(script.id);
 	});

--- a/packages/core/src/libs/script-loader/types.ts
+++ b/packages/core/src/libs/script-loader/types.ts
@@ -124,6 +124,35 @@ export interface Script {
 	anonymizeId?: boolean;
 
 	/**
+	 * Where to inject the script element in the DOM.
+	 * - `'head'`: Scripts are appended to `<head>` (default)
+	 * - `'body'`: Scripts are appended to `<body>`
+	 *
+	 * Use `'body'` for scripts that:
+	 * - Need to manipulate DOM elements that don't exist until body loads
+	 * - Should load after page content for performance reasons
+	 * - Are required by third-party services to be in the body
+	 *
+	 * Use `'head'` (default) for scripts that:
+	 * - Need to track early page events (analytics)
+	 * - Should be available before page render
+	 * - Most tracking/analytics scripts
+	 *
+	 * @default 'head'
+	 *
+	 * @example
+	 * ```ts
+	 * const script: Script = {
+	 *   id: 'my-script',
+	 *   src: 'https://example.com/script.js',
+	 *   category: 'analytics',
+	 *   target: 'body', // Load in body instead of head
+	 * };
+	 * ```
+	 */
+	target?: 'head' | 'body';
+
+	/**
 	 * Callback executed before the script is loaded
 	 * @param info - Information about the script and current consent state
 	 */


### PR DESCRIPTION
## Overview
Adds the ability to specify script loader target e.g. head or body. Useful for non essential scripts.

This can be done with the new script `target` option.

## Type of Change
- [x] ✨ Enhancement (improves existing functionality)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script loader now supports a target location option, allowing scripts to be injected into either the page head or body (head is the default).

* **Tests**
  * Expanded test coverage for script injection targeting, lifecycle callbacks, unload behavior, and error handling across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->