### PR TITLE
feat(translations): add support for more European languages

### DIFF
--- a/packages/translations/i18n.json
+++ b/packages/translations/i18n.json
@@ -29,7 +29,13 @@
 			"sk",
 			"sl",
 			"sv",
-			"zh"
+			"zh",
+			"is",
+			"nb",
+			"nn",
+			"lb",
+			"rm",
+			"cy"
 		]
 	},
 	"buckets": {

--- a/packages/translations/src/translations/cy.ts
+++ b/packages/translations/src/translations/cy.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'Derbyn pob un',
+		rejectAll: 'Gwrthod pob un',
+		customize: 'Addasu',
+		save: 'Cadw gosodiadau',
+	},
+	cookieBanner: {
+		title: 'Rydym yn gwerthfawrogi eich preifatrwydd',
+		description:
+			"Mae'r wefan hon yn defnyddio cwcis i wella eich profiad pori, dadansoddi traffig y wefan, a dangos cynnwys wedi'i bersonoli.",
+	},
+	consentManagerDialog: {
+		title: 'Gosodiadau preifatrwydd',
+		description:
+			'Addaswch eich gosodiadau preifatrwydd yma. Gallwch ddewis pa fathau o gwcis a thechnolegau tracio rydych yn eu caniatáu.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Cwbl angenrheidiol',
+			description:
+				"Mae'r cwcis hyn yn hanfodol i'r wefan weithredu'n iawn ac ni ellir eu hanalluogi.",
+		},
+		functionality: {
+			title: 'Swyddogaeth',
+			description:
+				"Mae'r cwcis hyn yn galluogi swyddogaeth a phersonoli gwell o'r wefan.",
+		},
+		marketing: {
+			title: 'Marchnata',
+			description:
+				'Defnyddir y cwcis hyn i ddarparu hysbysebion perthnasol a thracio eu heffeithiolrwydd.',
+		},
+		measurement: {
+			title: 'Dadansoddeg',
+			description:
+				"Mae'r cwcis hyn yn ein helpu i ddeall sut mae ymwelwyr yn rhyngweithio â'r wefan a gwella ei pherfformiad.",
+		},
+		experience: {
+			title: 'Profiad',
+			description:
+				"Mae'r cwcis hyn yn ein helpu i ddarparu profiad defnyddiwr gwell a phrofi nodweddion newydd.",
+		},
+	},
+	frame: {
+		title: 'Derbyn caniatâd {category} i weld y cynnwys hwn.',
+		actionButton: 'Galluogi caniatâd {category}',
+	},
+	legalLinks: {
+		privacyPolicy: 'Polisi preifatrwydd',
+		cookiePolicy: 'Polisi cwcis',
+		termsOfService: 'Telerau gwasanaeth',
+	},
+};
+export default translations;

--- a/packages/translations/src/translations/index.ts
+++ b/packages/translations/src/translations/index.ts
@@ -1,5 +1,6 @@
 import { translations as bg } from './bg';
 import { translations as cs } from './cs';
+import { translations as cy } from './cy';
 import { translations as da } from './da';
 import { translations as de } from './de';
 import { translations as el } from './el';
@@ -13,13 +14,18 @@ import { translations as he } from './he';
 import { translations as hr } from './hr';
 import { translations as hu } from './hu';
 import { translations as id } from './id';
+import { translations as is } from './is';
 import { translations as it } from './it';
+import { translations as lb } from './lb';
 import { translations as lt } from './lt';
 import { translations as lv } from './lv';
 import { translations as mt } from './mt';
+import { translations as nb } from './nb';
 import { translations as nl } from './nl';
+import { translations as nn } from './nn';
 import { translations as pl } from './pl';
 import { translations as pt } from './pt';
+import { translations as rm } from './rm';
 import { translations as ro } from './ro';
 import { translations as sk } from './sk';
 import { translations as sl } from './sl';
@@ -67,6 +73,12 @@ const baseTranslations = {
 	sl,
 	sv,
 	zh,
+	is,
+	nb,
+	nn,
+	lb,
+	rm,
+	cy,
 } as const;
 
 /**

--- a/packages/translations/src/translations/is.ts
+++ b/packages/translations/src/translations/is.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'Samþykkja allt',
+		rejectAll: 'Hafna öllu',
+		customize: 'Sérsníða',
+		save: 'Vista stillingar',
+	},
+	cookieBanner: {
+		title: 'Við metum friðhelgi þína',
+		description:
+			'Þessi vefur notar vafrakökur til að bæta vafraupplifun þína, greina umferð á vefnum og sýna persónumiðað efni.',
+	},
+	consentManagerDialog: {
+		title: 'Persónuverndastillingar',
+		description:
+			'Sérsníðaðu persónuverndastillingar þínar hér. Þú getur valið hvaða tegundir af vafrakökum og rakningartækni þú leyfir.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Nauðsynlegar',
+			description:
+				'Þessar vafrakökur eru nauðsynlegar til að vefsíðan virki rétt og ekki er hægt að slökkva á þeim.',
+		},
+		functionality: {
+			title: 'Virkni',
+			description:
+				'Þessar vafrakökur gera mögulegt að auka virkni og persónumiða vefsíðuna.',
+		},
+		marketing: {
+			title: 'Markaðssetning',
+			description:
+				'Þessar vafrakökur eru notaðar til að birta viðeigandi auglýsingar og fylgjast með árangri þeirra.',
+		},
+		measurement: {
+			title: 'Greining',
+			description:
+				'Þessar vafrakökur hjálpa okkur að skilja hvernig gestir nota vefsíðuna og bæta frammistöðu hennar.',
+		},
+		experience: {
+			title: 'Upplifun',
+			description:
+				'Þessar vafrakökur hjálpa okkur að veita betri notendaupplifun og prófa nýja eiginleika.',
+		},
+	},
+	frame: {
+		title: 'Samþykktu {category} samþykki til að skoða þetta efni.',
+		actionButton: 'Virkja {category} samþykki',
+	},
+	legalLinks: {
+		privacyPolicy: 'Persónuverndarstefna',
+		cookiePolicy: 'Stefna um vafrakökur',
+		termsOfService: 'Þjónustuskilmálar',
+	},
+};
+export default translations;

--- a/packages/translations/src/translations/lb.ts
+++ b/packages/translations/src/translations/lb.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'All akzeptéieren',
+		rejectAll: 'All refuséieren',
+		customize: 'Upassen',
+		save: 'Astellunge späicheren',
+	},
+	cookieBanner: {
+		title: 'Mir schätzen Är Privatsphär',
+		description:
+			'Dës Websäit benotzt Cookien fir Är Surferfahrung ze verbesseren, Websäit-Verkéier ze analyséieren an personaliséierten Inhalt unzebidden.',
+	},
+	consentManagerDialog: {
+		title: 'Privatsphär Astellungen',
+		description:
+			'Passt Är Privatsphär Astellungen hei un. Dir kënnt wielen wéi eng Zorte vu Cookien an Tracking-Technologien Dir erlaabt.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Strikt néideg',
+			description:
+				"Dës Cookien si wesentlech fir datt d'Websäit richteg funktionéiert a kënnen net desaktivéiert ginn.",
+		},
+		functionality: {
+			title: 'Funktionalitéit',
+			description:
+				'Dës Cookien erméiglechen erweidert Funktionalitéit a Personaliséierung vun der Websäit.',
+		},
+		marketing: {
+			title: 'Marketing',
+			description:
+				'Dës Cookien ginn benotzt fir relevant Reklammen ze liwweren an hir Wierksamkeet ze verfolgen.',
+		},
+		measurement: {
+			title: 'Analytik',
+			description:
+				"Dës Cookien hëllefen eis ze verstoen wéi d'Besicher mat der Websäit interagéieren an hir Leeschtung verbesseren.",
+		},
+		experience: {
+			title: 'Erfahrung',
+			description:
+				'Dës Cookien hëllefen eis eng besser Benotzererfabrung ze bidden an nei Funktiounen ze testen.',
+		},
+	},
+	frame: {
+		title: 'Akzeptéiert {category} Zoustëmmung fir dësen Inhalt ze gesinn.',
+		actionButton: '{category} Zoustëmmung aktivéieren',
+	},
+	legalLinks: {
+		privacyPolicy: 'Dateschutzrichtlinn',
+		cookiePolicy: 'Cookie-Politik',
+		termsOfService: 'Notzungsbedingungen',
+	},
+};
+export default translations;

--- a/packages/translations/src/translations/nb.ts
+++ b/packages/translations/src/translations/nb.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'Godta alle',
+		rejectAll: 'Avslå alle',
+		customize: 'Tilpass',
+		save: 'Lagre innstillinger',
+	},
+	cookieBanner: {
+		title: 'Vi verdsetter ditt personvern',
+		description:
+			'Dette nettstedet bruker informasjonskapsler for å forbedre din nettopplevelse, analysere trafikk og vise personlig tilpasset innhold.',
+	},
+	consentManagerDialog: {
+		title: 'Personverninnstillinger',
+		description:
+			'Tilpass personverninnstillingene dine her. Du kan velge hvilke typer informasjonskapsler og sporingsteknologier du vil tillate.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Strengt nødvendige',
+			description:
+				'Disse informasjonskapslene er essensielle for at nettstedet skal fungere riktig og kan ikke deaktiveres.',
+		},
+		functionality: {
+			title: 'Funksjonalitet',
+			description:
+				'Disse informasjonskapslene muliggjør forbedret funksjonalitet og personalisering av nettstedet.',
+		},
+		marketing: {
+			title: 'Markedsføring',
+			description:
+				'Disse informasjonskapslene brukes til å levere relevante annonser og spore deres effektivitet.',
+		},
+		measurement: {
+			title: 'Analyse',
+			description:
+				'Disse informasjonskapslene hjelper oss med å forstå hvordan besøkende samhandler med nettstedet og forbedre ytelsen.',
+		},
+		experience: {
+			title: 'Opplevelse',
+			description:
+				'Disse informasjonskapslene hjelper oss med å gi en bedre brukeropplevelse og teste nye funksjoner.',
+		},
+	},
+	frame: {
+		title: 'Godta {category}-samtykke for å se dette innholdet.',
+		actionButton: 'Aktiver {category}-samtykke',
+	},
+	legalLinks: {
+		privacyPolicy: 'Personvernerklæring',
+		cookiePolicy: 'Retningslinjer for informasjonskapsler',
+		termsOfService: 'Vilkår for bruk',
+	},
+};
+export default translations;

--- a/packages/translations/src/translations/nn.ts
+++ b/packages/translations/src/translations/nn.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'Godta alle',
+		rejectAll: 'Avvis alle',
+		customize: 'Tilpass',
+		save: 'Lagre innstillingar',
+	},
+	cookieBanner: {
+		title: 'Vi verdset personvernet ditt',
+		description:
+			'Denne nettstaden brukar informasjonskapslar for å forbetre nettopplevinga di, analysere nettstadtrafikk og vise personleg tilpassa innhald.',
+	},
+	consentManagerDialog: {
+		title: 'Personverninnstillingar',
+		description:
+			'Tilpass personverninnstillingane dine her. Du kan velje kva typar informasjonskapslar og sporingsteknologiar du tillèt.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Strengt nødvendige',
+			description:
+				'Desse informasjonskapslane er nødvendige for at nettstaden skal fungere riktig og kan ikkje deaktiverast.',
+		},
+		functionality: {
+			title: 'Funksjonalitet',
+			description:
+				'Desse informasjonskapslane gjer det mogleg med forbetra funksjonalitet og personleggjering av nettstaden.',
+		},
+		marketing: {
+			title: 'Marknadsføring',
+			description:
+				'Desse informasjonskapslane blir brukte til å levere relevante annonsar og spore effektiviteten deira.',
+		},
+		measurement: {
+			title: 'Analyse',
+			description:
+				'Desse informasjonskapslane hjelper oss å forstå korleis besøkande samhandlar med nettstaden og forbetre ytinga.',
+		},
+		experience: {
+			title: 'Oppleving',
+			description:
+				'Desse informasjonskapslane hjelper oss å gi ei betre brukaroppleving og teste nye funksjonar.',
+		},
+	},
+	frame: {
+		title: 'Godta {category}-samtykke for å sjå dette innhaldet.',
+		actionButton: 'Aktiver {category}-samtykke',
+	},
+	legalLinks: {
+		privacyPolicy: 'Personvernerklæring',
+		cookiePolicy: 'Retningslinjer for informasjonskapslar',
+		termsOfService: 'Brukarvilkår',
+	},
+};
+export default translations;

--- a/packages/translations/src/translations/rm.ts
+++ b/packages/translations/src/translations/rm.ts
@@ -1,0 +1,56 @@
+import type { CompleteTranslations } from '../types';
+export const translations: CompleteTranslations = {
+	common: {
+		acceptAll: 'Acceptar tut',
+		rejectAll: 'Refusar tut',
+		customize: 'Persunalisar',
+		save: 'Memorisar las configuraziuns',
+	},
+	cookieBanner: {
+		title: 'Nus stimain vossa sfera privata',
+		description:
+			"Questa pagina d'internet dovra cookies per meglierar vossa experientscha da navigaziun, analisar il traffic da la pagina e mussar cuntegns persunalisads.",
+	},
+	consentManagerDialog: {
+		title: 'Configuraziuns da la sfera privata',
+		description:
+			'Persunalisai vossas configuraziuns da la sfera privata qua. Vus pudais tscherner tge tips da cookies e tecnologias da tracking che vus lubis.',
+	},
+	consentTypes: {
+		necessary: {
+			title: 'Absolutamain necessari',
+			description:
+				"Quests cookies èn essenzials per il funcziunament da la pagina d'internet e na pon betg vegnir deactivads.",
+		},
+		functionality: {
+			title: 'Funcziunalitad',
+			description:
+				"Quests cookies permettan funcziunalitads avanzadas e la persunalisaziun da la pagina d'internet.",
+		},
+		marketing: {
+			title: 'Marketing',
+			description:
+				'Quests cookies vegnan duvrads per mussar reclamas relevantas e per evaluar lur efficacitad.',
+		},
+		measurement: {
+			title: 'Analisa',
+			description:
+				"Quests cookies ans gidan a chapir co ils visitaders interageschan cun la pagina d'internet e meglierar sia prestaziun.",
+		},
+		experience: {
+			title: 'Experientscha',
+			description:
+				"Quests cookies ans gidan a porscher ina meglra experientscha d'utilisader e testar novas funcziuns.",
+		},
+	},
+	frame: {
+		title: 'Acceptai il consentiment da {category} per vesair quest cuntegn.',
+		actionButton: 'Activar il consentiment da {category}',
+	},
+	legalLinks: {
+		privacyPolicy: 'Directivas da protecziun da datas',
+		cookiePolicy: 'Directivas da cookies',
+		termsOfService: "Cundiziuns d'utilisaziun",
+	},
+};
+export default translations;


### PR DESCRIPTION
## Overview
Adds support for various other European languages including Norwegian, Welsh, Icelandic

## Type of Change
- [x] ✨ Enhancement (improves existing functionality)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for six new languages: Welsh, Icelandic, Luxembourgish, Norwegian Bokmål, Norwegian Nynorsk, and Romansh. Users can now use the application in these languages with complete translations for all UI elements, including preferences, consent dialogs, cookie notices, and legal links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->