### PR TITLE
Roll forward bundle analysis: transitive impact + lockfile-aware CI

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -47,16 +47,29 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      - name: 🟢 Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.6
+
       # Step 2: Build base branch (using trusted code)
       - name: 🏗️ Build base branch
         id: build-base
         timeout-minutes: 5
         run: |
-          pnpm install --frozen-lockfile
-          WITH_RSDOCTOR=true pnpm turbo run build --filter="./packages/*" || true
+          if [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile || bun install
+            WITH_RSDOCTOR=1 bun turbo run build --filter="./packages/*" || true
+          elif [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+            WITH_RSDOCTOR=1 pnpm exec turbo run build --filter="./packages/*" || true
+          else
+            echo "No supported lockfile found for base branch"
+            exit 1
+          fi
           mkdir -p .bundle-base
           # Copy rsdoctor data files
-          find packages -name "rsdoctor-data.json" -exec cp --parents {} .bundle-base/ \;
+          find packages -name "rsdoctor-data.json" -exec cp --parents {} .bundle-base/ \; || true
 
       # Step 3: Checkout PR code (untrusted) - only for PR events
       # SECURITY: We checkout PR code after setting up environment from trusted base code
@@ -76,8 +89,16 @@ jobs:
         id: build-current
         timeout-minutes: 5
         run: |
-          pnpm install --frozen-lockfile
-          WITH_RSDOCTOR=1 pnpm turbo run build --filter="./packages/*"
+          if [ -f bun.lock ] || [ -f bun.lockb ]; then
+            bun install --frozen-lockfile || bun install
+            WITH_RSDOCTOR=1 bun turbo run build --filter="./packages/*"
+          elif [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+            WITH_RSDOCTOR=1 pnpm exec turbo run build --filter="./packages/*"
+          else
+            echo "No supported lockfile found for current branch"
+            exit 1
+          fi
 
       - name: 📊 Analyze bundle differences
         uses: ./internals/bundle-analysis-action

--- a/internals/bundle-analysis-action/README.md
+++ b/internals/bundle-analysis-action/README.md
@@ -31,6 +31,7 @@ A GitHub Action for analyzing bundle size differences using rsdoctor data.
 | `pr_number` | Pull request number (auto-detected) | - | No |
 | `skip_comment` | Skip posting comment | `false` | No |
 | `fail_on_increase` | Fail if bundle increases >10% | `false` | No |
+| `transitive_roots` | Comma-separated root package names for transitive impact totals | `c15t,@c15t/react` | No |
 
 ## Outputs
 
@@ -55,4 +56,3 @@ pnpm check-types
 # Lint
 pnpm lint
 ```
-

--- a/internals/bundle-analysis-action/action.yml
+++ b/internals/bundle-analysis-action/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Percentage threshold for significant bundle size increase"
     default: "10"
     required: false
+  transitive_roots:
+    description: "Comma-separated package names to report transitive workspace impact for"
+    default: "c15t,@c15t/react"
+    required: false
 
 outputs:
   report_path:
@@ -63,4 +67,4 @@ runs:
         INPUT_FAIL_ON_INCREASE: ${{ inputs.fail_on_increase }}
         INPUT_PACKAGES_DIR: ${{ inputs.packages_dir }}
         INPUT_THRESHOLD: ${{ inputs.threshold }}
-
+        INPUT_TRANSITIVE_ROOTS: ${{ inputs.transitive_roots }}

--- a/internals/bundle-analysis-action/src/analyze/bundle-analysis.test.ts
+++ b/internals/bundle-analysis-action/src/analyze/bundle-analysis.test.ts
@@ -11,6 +11,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	analyzeBundles,
+	analyzeTransitiveImpact,
 	type BundleStats,
 	calculateTotalDiffPercent,
 	compareBundles,
@@ -18,6 +19,7 @@ import {
 	formatBytes,
 	generateMarkdownReport,
 	type PackageBundleData,
+	type TransitiveBundleData,
 	writeReport,
 } from './bundle-analysis';
 
@@ -386,6 +388,38 @@ describe('bundle-analysis', () => {
 			expect(result).toContain('20.00%');
 		});
 
+		it('should include transitive impact section when provided', () => {
+			const packages: PackageBundleData[] = [
+				{
+					packageName: 'core',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 1024,
+					totalCurrentSize: 2048,
+					totalDiff: 1024,
+					totalDiffPercent: 100,
+				},
+			];
+			const transitive: TransitiveBundleData[] = [
+				{
+					rootPackage: 'c15t',
+					includedPackageDirs: ['backend', 'core', 'translations'],
+					totalBaseSize: 3072,
+					totalCurrentSize: 4096,
+					totalDiff: 1024,
+					totalDiffPercent: 33.3333,
+				},
+			];
+
+			const result = generateMarkdownReport(packages, transitive);
+
+			expect(result).toContain('## Effective Transitive Impact');
+			expect(result).toContain('`c15t`');
+			expect(result).toContain('`backend`, `core`, `translations`');
+			expect(result).toContain('33.33%');
+		});
+
 		it('should skip packages with no changes', () => {
 			const packages: PackageBundleData[] = [
 				{
@@ -514,6 +548,230 @@ describe('bundle-analysis', () => {
 
 			const result = await analyzeBundles('/base', '/current', 'packages');
 			expect(result).toEqual([]);
+		});
+	});
+
+	describe('analyzeTransitiveImpact', () => {
+		it('should compute transitive totals for selected roots', () => {
+			vi.mocked(existsSync).mockImplementation((path: PathLike) =>
+				String(path).includes('packages')
+			);
+
+			vi.mocked(readdirSync).mockImplementation((path: PathLike) => {
+				const pathStr = String(path);
+				if (pathStr.endsWith('packages')) {
+					return [
+						'core',
+						'react',
+						'backend',
+						'translations',
+					] as unknown as ReturnType<typeof readdirSync>;
+				}
+				return [] as unknown as ReturnType<typeof readdirSync>;
+			});
+
+			vi.mocked(statSync).mockReturnValue({
+				isDirectory: () => true,
+			} as unknown as ReturnType<typeof statSync>);
+
+			vi.mocked(readFileSync).mockImplementation(
+				(path: PathOrFileDescriptor) => {
+					const pathStr = String(path);
+					if (pathStr.endsWith('/packages/core/package.json')) {
+						return JSON.stringify({
+							name: 'c15t',
+							dependencies: {
+								'@c15t/backend': 'workspace:*',
+								'@c15t/translations': 'workspace:*',
+							},
+						});
+					}
+					if (pathStr.endsWith('/packages/react/package.json')) {
+						return JSON.stringify({
+							name: '@c15t/react',
+							dependencies: {
+								c15t: 'workspace:*',
+							},
+						});
+					}
+					if (pathStr.endsWith('/packages/backend/package.json')) {
+						return JSON.stringify({
+							name: '@c15t/backend',
+						});
+					}
+					if (pathStr.endsWith('/packages/translations/package.json')) {
+						return JSON.stringify({
+							name: '@c15t/translations',
+						});
+					}
+					return JSON.stringify({});
+				}
+			);
+
+			const packages: PackageBundleData[] = [
+				{
+					packageName: 'core',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 100,
+					totalCurrentSize: 140,
+					totalDiff: 40,
+					totalDiffPercent: 40,
+				},
+				{
+					packageName: 'react',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 200,
+					totalCurrentSize: 260,
+					totalDiff: 60,
+					totalDiffPercent: 30,
+				},
+				{
+					packageName: 'backend',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 300,
+					totalCurrentSize: 330,
+					totalDiff: 30,
+					totalDiffPercent: 10,
+				},
+				{
+					packageName: 'translations',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 50,
+					totalCurrentSize: 60,
+					totalDiff: 10,
+					totalDiffPercent: 20,
+				},
+			];
+
+			const result = analyzeTransitiveImpact(packages, '/repo', 'packages', [
+				'@c15t/react',
+				'c15t',
+			]);
+
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({
+				rootPackage: '@c15t/react',
+				includedPackageDirs: ['backend', 'core', 'react', 'translations'],
+				totalBaseSize: 650,
+				totalCurrentSize: 790,
+				totalDiff: 140,
+			});
+			expect(result[1]).toMatchObject({
+				rootPackage: 'c15t',
+				includedPackageDirs: ['backend', 'core', 'translations'],
+				totalBaseSize: 450,
+				totalCurrentSize: 530,
+				totalDiff: 80,
+			});
+		});
+
+		it('should include packages from base graph when dependencies were removed', () => {
+			vi.mocked(existsSync).mockImplementation((path: PathLike) =>
+				String(path).includes('packages')
+			);
+			vi.mocked(readdirSync).mockImplementation((path: PathLike) => {
+				const pathStr = String(path);
+				if (pathStr.endsWith('packages')) {
+					return ['core', 'backend', 'schema'] as unknown as ReturnType<
+						typeof readdirSync
+					>;
+				}
+				return [] as unknown as ReturnType<typeof readdirSync>;
+			});
+			vi.mocked(statSync).mockReturnValue({
+				isDirectory: () => true,
+			} as unknown as ReturnType<typeof statSync>);
+			vi.mocked(readFileSync).mockImplementation(
+				(path: PathOrFileDescriptor) => {
+					const pathStr = String(path);
+					if (pathStr.includes('/base/')) {
+						if (pathStr.endsWith('/packages/core/package.json')) {
+							return JSON.stringify({
+								name: 'c15t',
+								dependencies: {
+									'@c15t/backend': 'workspace:*',
+									'@c15t/schema': 'workspace:*',
+								},
+							});
+						}
+					}
+					if (pathStr.includes('/current/')) {
+						if (pathStr.endsWith('/packages/core/package.json')) {
+							return JSON.stringify({
+								name: 'c15t',
+								dependencies: {
+									'@c15t/backend': 'workspace:*',
+								},
+							});
+						}
+					}
+					if (pathStr.endsWith('/packages/backend/package.json')) {
+						return JSON.stringify({ name: '@c15t/backend' });
+					}
+					if (pathStr.endsWith('/packages/schema/package.json')) {
+						return JSON.stringify({ name: '@c15t/schema' });
+					}
+					return JSON.stringify({});
+				}
+			);
+
+			const packages: PackageBundleData[] = [
+				{
+					packageName: 'core',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 100,
+					totalCurrentSize: 110,
+					totalDiff: 10,
+					totalDiffPercent: 10,
+				},
+				{
+					packageName: 'backend',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 80,
+					totalCurrentSize: 90,
+					totalDiff: 10,
+					totalDiffPercent: 12.5,
+				},
+				{
+					packageName: 'schema',
+					baseBundles: [],
+					currentBundles: [],
+					diffs: { added: [], removed: [], changed: [] },
+					totalBaseSize: 60,
+					totalCurrentSize: 0,
+					totalDiff: -60,
+					totalDiffPercent: -100,
+				},
+			];
+
+			const result = analyzeTransitiveImpact(
+				packages,
+				'/current',
+				'packages',
+				['c15t'],
+				'/base'
+			);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toMatchObject({
+				rootPackage: 'c15t',
+				includedPackageDirs: ['backend', 'core', 'schema'],
+				totalBaseSize: 240,
+				totalCurrentSize: 200,
+				totalDiff: -40,
+			});
 		});
 	});
 

--- a/internals/bundle-analysis-action/src/analyze/bundle-analysis.ts
+++ b/internals/bundle-analysis-action/src/analyze/bundle-analysis.ts
@@ -40,6 +40,20 @@ export interface PackageBundleData {
 	totalDiffPercent: number;
 }
 
+export interface TransitiveBundleData {
+	rootPackage: string;
+	includedPackageDirs: string[];
+	totalBaseSize: number;
+	totalCurrentSize: number;
+	totalDiff: number;
+	totalDiffPercent: number;
+}
+
+interface WorkspacePackageNode {
+	dirName: string;
+	dependencies: string[];
+}
+
 async function findRsdoctorDataFiles(dir: string): Promise<string[]> {
 	const files: string[] = [];
 	if (!existsSync(dir)) {
@@ -263,7 +277,190 @@ function getChangeEmoji(diffPercent: number): string {
 	return '⚪';
 }
 
-export function generateMarkdownReport(packages: PackageBundleData[]): string {
+function parseWorkspaceDependencyName(version: string): string | undefined {
+	if (!version.startsWith('workspace:')) {
+		return undefined;
+	}
+
+	const specifier = version.slice('workspace:'.length).trim();
+	// Ignore wildcard/version/path specifiers (e.g. workspace:*, workspace:^1.0.0, workspace:../pkg)
+	if (
+		specifier === '' ||
+		specifier === '*' ||
+		specifier.startsWith('^') ||
+		specifier.startsWith('~') ||
+		specifier.startsWith('.') ||
+		specifier.startsWith('/') ||
+		specifier.startsWith('>') ||
+		specifier.startsWith('<') ||
+		specifier.startsWith('=')
+	) {
+		return undefined;
+	}
+
+	// Matches `workspace:pkg` and `workspace:pkg@range`
+	const match = specifier.match(/^(@[^/]+\/[^@/]+|[^@/][^@/]*)(?:@.+)?$/);
+	if (!match) {
+		return undefined;
+	}
+
+	return match[1];
+}
+
+function buildWorkspaceGraph(
+	repoDir: string,
+	packagesDir: string
+): Map<string, WorkspacePackageNode> {
+	const graph = new Map<string, WorkspacePackageNode>();
+	const packagesRoot = join(repoDir, packagesDir);
+
+	if (!existsSync(packagesRoot)) {
+		return graph;
+	}
+
+	const packageFolders = readdirSync(packagesRoot).filter((entry) =>
+		statSync(join(packagesRoot, entry)).isDirectory()
+	);
+
+	for (const folder of packageFolders) {
+		const manifestPath = join(packagesRoot, folder, 'package.json');
+		if (!existsSync(manifestPath)) {
+			continue;
+		}
+
+		try {
+			const content = readFileSync(manifestPath, 'utf-8');
+			const manifest = JSON.parse(content) as {
+				name?: string;
+				dependencies?: Record<string, string>;
+				optionalDependencies?: Record<string, string>;
+			};
+			if (!manifest.name) {
+				continue;
+			}
+
+			const allDeps = {
+				...(manifest.dependencies || {}),
+				...(manifest.optionalDependencies || {}),
+			};
+			const workspaceDeps: string[] = [];
+			for (const [depName, depVersion] of Object.entries(allDeps)) {
+				const explicitDep = parseWorkspaceDependencyName(depVersion);
+				if (explicitDep) {
+					workspaceDeps.push(explicitDep);
+				} else if (depVersion.startsWith('workspace:')) {
+					workspaceDeps.push(depName);
+				}
+			}
+
+			graph.set(manifest.name, {
+				dirName: folder,
+				dependencies: workspaceDeps,
+			});
+		} catch (error) {
+			console.error(`Failed to parse ${manifestPath}:`, error);
+		}
+	}
+
+	return graph;
+}
+
+function collectTransitivePackageDirs(
+	graph: Map<string, WorkspacePackageNode>,
+	rootPackage: string
+): string[] {
+	if (!graph.has(rootPackage)) {
+		return [];
+	}
+
+	const queue = [rootPackage];
+	const visited = new Set<string>();
+	const dirNames = new Set<string>();
+
+	while (queue.length > 0) {
+		const pkgName = queue.shift();
+		if (!pkgName || visited.has(pkgName)) {
+			continue;
+		}
+		visited.add(pkgName);
+
+		const node = graph.get(pkgName);
+		if (!node) {
+			continue;
+		}
+
+		dirNames.add(node.dirName);
+		for (const dep of node.dependencies) {
+			if (!visited.has(dep)) {
+				queue.push(dep);
+			}
+		}
+	}
+
+	return Array.from(dirNames).sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Analyze effective bundle impact including transitive workspace dependencies.
+ *
+ * Uses workspace dependency closure for selected roots and sums matching package bundle totals.
+ * If both `baseDir` and `currentDir` are provided, closure is computed from the union of both
+ * graphs so dependency adds/removals are reflected in totals.
+ */
+export function analyzeTransitiveImpact(
+	packages: PackageBundleData[],
+	currentDir: string,
+	packagesDir = 'packages',
+	roots: string[] = ['c15t', '@c15t/react'],
+	baseDir?: string
+): TransitiveBundleData[] {
+	if (roots.length === 0) {
+		return [];
+	}
+
+	const currentGraph = buildWorkspaceGraph(currentDir, packagesDir);
+	const baseGraph =
+		baseDir && baseDir !== currentDir
+			? buildWorkspaceGraph(baseDir, packagesDir)
+			: currentGraph;
+	const packageByDir = new Map(packages.map((pkg) => [pkg.packageName, pkg]));
+	const normalizedRoots = Array.from(
+		new Set(roots.map((root) => root.trim()).filter(Boolean))
+	);
+
+	return normalizedRoots.map((rootPackage) => {
+		const currentDirs = collectTransitivePackageDirs(currentGraph, rootPackage);
+		const baseDirs = collectTransitivePackageDirs(baseGraph, rootPackage);
+		const includedPackageDirs = Array.from(
+			new Set([...currentDirs, ...baseDirs])
+		).sort((a, b) => a.localeCompare(b));
+		const totalBaseSize = includedPackageDirs.reduce(
+			(sum, dir) => sum + (packageByDir.get(dir)?.totalBaseSize || 0),
+			0
+		);
+		const totalCurrentSize = includedPackageDirs.reduce(
+			(sum, dir) => sum + (packageByDir.get(dir)?.totalCurrentSize || 0),
+			0
+		);
+		const totalDiff = totalCurrentSize - totalBaseSize;
+		const totalDiffPercent =
+			totalBaseSize > 0 ? (totalDiff / totalBaseSize) * 100 : 0;
+
+		return {
+			rootPackage,
+			includedPackageDirs,
+			totalBaseSize,
+			totalCurrentSize,
+			totalDiff,
+			totalDiffPercent,
+		};
+	});
+}
+
+export function generateMarkdownReport(
+	packages: PackageBundleData[],
+	transitive: TransitiveBundleData[] = []
+): string {
 	let markdown = '# 📦 Bundle Size Analysis\n\n';
 
 	if (packages.length === 0) {
@@ -280,6 +477,26 @@ export function generateMarkdownReport(packages: PackageBundleData[]): string {
 		const sign = pkg.totalDiff >= 0 ? '+' : '';
 		const emoji = getChangeEmoji(pkg.totalDiffPercent);
 		markdown += `| ${emoji} \`${pkg.packageName}\` | ${formatBytes(pkg.totalBaseSize)} | ${formatBytes(pkg.totalCurrentSize)} | ${sign}${formatBytes(pkg.totalDiff)} | ${sign}${pkg.totalDiffPercent.toFixed(2)}% |\n`;
+	}
+
+	if (transitive.length > 0) {
+		markdown += '\n## Effective Transitive Impact\n\n';
+		markdown +=
+			'Includes workspace dependency closure for selected root packages.\n\n';
+		markdown +=
+			'| Root Package | Included Packages | Base Size | Current Size | Change | % Change |\n';
+		markdown +=
+			'|--------------|-------------------|-----------|--------------|--------|----------|\n';
+
+		for (const entry of transitive) {
+			const sign = entry.totalDiff >= 0 ? '+' : '';
+			const emoji = getChangeEmoji(entry.totalDiffPercent);
+			const included =
+				entry.includedPackageDirs.length > 0
+					? entry.includedPackageDirs.map((pkg) => `\`${pkg}\``).join(', ')
+					: 'not found';
+			markdown += `| ${emoji} \`${entry.rootPackage}\` | ${included} | ${formatBytes(entry.totalBaseSize)} | ${formatBytes(entry.totalCurrentSize)} | ${sign}${formatBytes(entry.totalDiff)} | ${sign}${entry.totalDiffPercent.toFixed(2)}% |\n`;
+		}
 	}
 
 	// Detailed changes per package (collapsible)
@@ -371,10 +588,11 @@ export async function analyzeBundles(
  */
 export function writeReport(
 	packages: PackageBundleData[],
-	outputPath: string
+	outputPath: string,
+	transitive: TransitiveBundleData[] = []
 ): void {
 	try {
-		const report = generateMarkdownReport(packages);
+		const report = generateMarkdownReport(packages, transitive);
 		writeFileSync(outputPath, report, 'utf-8');
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);

--- a/internals/bundle-analysis-action/src/config/inputs.ts
+++ b/internals/bundle-analysis-action/src/config/inputs.ts
@@ -60,9 +60,19 @@ export const packagesDir =
  * Percentage threshold for significant bundle size increase
  */
 const thresholdInput = core.getInput('threshold', { required: false }) || '10';
-const parsedThreshold = parseFloat(thresholdInput);
+const parsedThreshold = Number.parseFloat(thresholdInput);
 export const threshold =
-	isNaN(parsedThreshold) || parsedThreshold < 0 ? 10 : parsedThreshold;
+	Number.isNaN(parsedThreshold) || parsedThreshold < 0 ? 10 : parsedThreshold;
+
+/**
+ * Root packages used to compute effective transitive impact.
+ */
+export const transitiveRoots = (
+	core.getInput('transitive_roots', { required: false }) || 'c15t,@c15t/react'
+)
+	.split(',')
+	.map((value) => value.trim())
+	.filter(Boolean);
 
 /**
  * Repository descriptor where the action will run

--- a/internals/bundle-analysis-action/src/main.test.ts
+++ b/internals/bundle-analysis-action/src/main.test.ts
@@ -5,13 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PackageBundleData } from './analyze/bundle-analysis';
 import {
 	analyzeBundles,
+	analyzeTransitiveImpact,
 	calculateTotalDiffPercent,
 	writeReport,
 } from './analyze/bundle-analysis';
 import {
 	baseDir,
 	currentDir,
-	failOnIncrease,
 	githubToken,
 	header,
 	packagesDir,
@@ -19,6 +19,7 @@ import {
 	repo,
 	skipComment,
 	threshold,
+	transitiveRoots,
 } from './config/inputs';
 import { ensureComment } from './github/pr-comment';
 
@@ -29,6 +30,7 @@ vi.mock('node:fs', () => ({
 	readFileSync: vi.fn(),
 }));
 vi.mock('./analyze/bundle-analysis', () => ({
+	analyzeTransitiveImpact: vi.fn(),
 	analyzeBundles: vi.fn(),
 	calculateTotalDiffPercent: vi.fn(),
 	writeReport: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock('./config/inputs', () => ({
 	skipComment: false,
 	failOnIncrease: false,
 	threshold: 10,
+	transitiveRoots: ['c15t', '@c15t/react'],
 }));
 vi.mock('./github/pr-comment', () => ({
 	ensureComment: vi.fn(),
@@ -89,19 +92,38 @@ describe('main', () => {
 	describe('bundle analysis workflow', () => {
 		it('should analyze bundles and generate report', async () => {
 			vi.mocked(analyzeBundles).mockResolvedValue(mockPackages);
+			vi.mocked(analyzeTransitiveImpact).mockReturnValue([]);
 			vi.mocked(calculateTotalDiffPercent).mockReturnValue(10);
 
 			await analyzeBundles(baseDir, currentDir, packagesDir);
+			analyzeTransitiveImpact(
+				mockPackages,
+				currentDir,
+				packagesDir,
+				transitiveRoots,
+				baseDir
+			);
 			const totalDiffPercent = calculateTotalDiffPercent(mockPackages);
-			writeReport(mockPackages, 'bundle-diff.md');
+			writeReport(mockPackages, 'bundle-diff.md', []);
 
 			expect(analyzeBundles).toHaveBeenCalledWith(
 				baseDir,
 				currentDir,
 				packagesDir
 			);
+			expect(analyzeTransitiveImpact).toHaveBeenCalledWith(
+				mockPackages,
+				currentDir,
+				packagesDir,
+				transitiveRoots,
+				baseDir
+			);
 			expect(calculateTotalDiffPercent).toHaveBeenCalledWith(mockPackages);
-			expect(writeReport).toHaveBeenCalledWith(mockPackages, 'bundle-diff.md');
+			expect(writeReport).toHaveBeenCalledWith(
+				mockPackages,
+				'bundle-diff.md',
+				[]
+			);
 			expect(totalDiffPercent).toBe(10);
 		});
 

--- a/internals/bundle-analysis-action/src/main.ts
+++ b/internals/bundle-analysis-action/src/main.ts
@@ -7,6 +7,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import {
 	analyzeBundles,
+	analyzeTransitiveImpact,
 	calculateTotalDiffPercent,
 	writeReport,
 } from './analyze/bundle-analysis';
@@ -21,6 +22,7 @@ import {
 	repo,
 	skipComment,
 	threshold,
+	transitiveRoots,
 } from './config/inputs';
 import { ensureComment } from './github/pr-comment';
 
@@ -32,12 +34,22 @@ async function run(): Promise<void> {
 		const packages = await analyzeBundles(baseDir, currentDir, packagesDir);
 		core.info(`Analyzed ${packages.length} packages`);
 
+		// Analyze transitive impact for selected root packages
+		const transitive = analyzeTransitiveImpact(
+			packages,
+			currentDir,
+			packagesDir,
+			transitiveRoots,
+			baseDir
+		);
+		core.info(`Computed transitive impact for ${transitive.length} roots`);
+
 		// Calculate total diff
 		const totalDiffPercent = calculateTotalDiffPercent(packages);
 
 		// Generate report
 		const reportPath = 'bundle-diff.md';
-		writeReport(packages, reportPath);
+		writeReport(packages, reportPath, transitive);
 
 		// Set outputs
 		core.setOutput('report_path', reportPath);
@@ -61,10 +73,13 @@ async function run(): Promise<void> {
 		// Fail if significant increase detected
 		if (failOnIncrease) {
 			core.info(`Using threshold: ${threshold}%`);
-			const hasSignificantIncrease = packages.some(
+			const hasSignificantPackageIncrease = packages.some(
 				(p) => p.totalDiffPercent > threshold
 			);
-			if (hasSignificantIncrease) {
+			const hasSignificantTransitiveIncrease = transitive.some(
+				(entry) => entry.totalDiffPercent > threshold
+			);
+			if (hasSignificantPackageIncrease || hasSignificantTransitiveIncrease) {
 				core.setFailed(
 					`Bundle size increased significantly (>${threshold}%). Review the changes above.`
 				);


### PR DESCRIPTION
Rolls forward transitive bundle impact reporting/guard and fixes bundle-analysis workflow installs for pnpm/bun lockfile differences between base/current branches.