### PR TITLE
Rewrite rc.5 changelog post

### DIFF
--- a/changelog/2026-03-11-v2.0.0-rc.5.mdx
+++ b/changelog/2026-03-11-v2.0.0-rc.5.mdx
@@ -1,23 +1,21 @@
 ---
-title: "v2.0.0-rc.5 — Policy Packs, GPC Per-Policy, Fallback Policies & CLI Improvements"
+title: "v2.0.0-rc.5 — Policy Packs, Per-Policy GPC, Fallback Policies & Dev-Tools Improvements"
 version: "2.0.0-rc.5"
-date: 2026-03-11
-description: "Release candidate introducing policy packs for regional consent resolution, per-policy GPC support, geo-failure fallback policies, CLI consent.io integration, and improved developer experience across the board."
+date: 2026-03-25
+description: "Release candidate introducing policy packs for regional consent resolution, per-policy GPC support, fallback policies, policy inspection, and developer-experience improvements."
 tags:
   - release
   - rc
   - backend
-  - schema
   - react
   - nextjs
-  - cli
   - dev-tools
 type: release
 breaking: false
 authors: [KayleeWilliams]
 ---
 
-This RC introduces **policy packs** — the biggest addition since the v2 rewrite. Policy packs let you define regional consent rules once and have c15t resolve the right policy automatically based on visitor location. This release also ships per-policy GPC support, a fallback safety net for geo-location failures, CLI improvements, and developer experience polish across every package.
+This RC introduces **policy packs** as the main addition in `v2.0.0-rc.5`. Instead of relying on implicit jurisdiction behavior, you can now define regional consent policies explicitly and let c15t resolve the active policy at runtime based on visitor location. `rc.5` also adds per-policy GPC handling, safer geo-failure fallbacks, policy-aware validation, and better tooling for inspecting how a policy was chosen.
 
 ## Highlights
 
@@ -27,9 +25,9 @@ This RC introduces **policy packs** — the biggest addition since the v2 rewrit
 - [Policy fingerprints & re-prompting](#policy-fingerprints--re-prompting) to automatically resurface consent when policies change
 - [Built-in presets](#built-in-presets) for Europe, California, Quebec, and more
 - [Policy validation](#policy-validation) with `inspectPolicies()` for catching misconfigurations
-- [CLI consent.io integration](#cli-improvements) and new v1→v2 codemods
 - [Dev-tools policy panel](#dev-tools-policy-panel) for inspecting match resolution in real time
-- [Naming & DX improvements](#naming--dx-improvements) across hosted/offline modes, i18n, and legal links
+- [Snapshot tokens](#snapshot-tokens) for binding consent writes to the original policy decision
+- [Naming & DX improvements](#naming--dx-improvements) across hosted/offline modes, `i18n`, and legal links
 
 ## New Features
 
@@ -77,7 +75,7 @@ Each policy can now individually opt in to respecting the [Global Privacy Contro
 }
 ```
 
-When `gpc: true` and the visitor's browser sends a GPC signal, `marketing` and `measurement` categories are automatically denied during auto-granting. This replaces the previous global GPC behavior with per-policy control — GDPR policies can leave it off (consent is already opt-in) while CCPA policies can enable it.
+When `gpc: true` and the visitor's browser sends a GPC signal, `marketing` and `measurement` categories are automatically denied during auto-granting. This moves GPC handling from a global behavior to an explicit per-policy setting, which is especially useful for opt-out regions like California. Opt-in policies can leave it disabled when GPC does not change the effective behavior.
 
 ### Fallback Policies
 
@@ -137,18 +135,12 @@ The dev-tools panel now includes a full **match trace** showing the resolution p
 
 When `policySnapshot.signingKey` is configured, `/init` returns a signed JWT alongside the resolved policy. The token is validated on `POST /subjects` to ensure the consent write matches the original `/init` decision — preventing race conditions when policy packs change between requests.
 
-### CLI Improvements
-
-- **consent.io integration** — connect to hosted backends directly from the CLI
-- **New v1→v2 codemods** — automated migration for renamed APIs and imports
-- **Improved file structure support** — handles `[locale]` directory patterns
-- **Removed redundant preflight checks** for faster setup
-
 ## Improvements
 
 - Renamed `c15t` mode to `hosted` and improved hosted vs offline documentation
 - Renamed translation-facing APIs from `translations` to `i18n` across runtime types
 - Improved legal links and overrides documentation
+- Added v1→v2 codemods for renamed APIs and imports
 - `@c15t/backend` API entrypoints flattened for better TypeScript DX
 - Backend now exposes a base `/` root endpoint for health checks
 - React compiler compatibility fixes


### PR DESCRIPTION
## Summary
- rewrite the `v2.0.0-rc.5` changelog entry to focus on shipped policy pack features
- retime the post to March 25, 2026 and tighten the developer-facing framing
- remove unreleased `consent.io` integration claims from the release notes

## Testing
- not run (content-only change)