### PR TITLE
fix: conditional pnpm setup in bundle analysis CI

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -38,10 +38,21 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref || github.ref }}
           fetch-depth: 0 # Full history needed for base branch comparison
 
+      - name: 🔍 Detect package manager
+        id: detect-pm
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          else
+            echo "pm=bun" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: 🅿️ Setup pnpm
+        if: steps.detect-pm.outputs.pm == 'pnpm'
         uses: pnpm/action-setup@v4
 
       - name: 🟢 Setup Node.js
+        if: steps.detect-pm.outputs.pm == 'pnpm'
         uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -50,7 +61,7 @@ jobs:
       - name: 🟢 Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.6
+          bun-version: 1.3.11
 
       # Step 2: Build base branch (using trusted code)
       - name: 🏗️ Build base branch


### PR DESCRIPTION
## Summary
- `pull_request_target` always loads the workflow YAML from the default branch (`main`), not the PR's base branch
- When PRs target `2.0.0` (which uses bun), `pnpm/action-setup@v4` crashes because `package.json` has `"packageManager": "bun@1.3.11"`
- Added a lockfile detection step after checkout — pnpm/node setup now only runs when `pnpm-lock.yaml` exists
- Also bumped bun version from 1.3.6 to 1.3.11

## Test plan
- [ ] Verify this PR's own bundle analysis CI passes (base is `main` with pnpm, so pnpm setup should still run)
- [ ] After merge, verify PRs into `2.0.0` no longer fail on pnpm setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)