### PR TITLE
fix: exclude tabindex=-1 elements from focus trap boundary

### DIFF
--- a/apps/storybook-react/src/tabs.stories.tsx
+++ b/apps/storybook-react/src/tabs.stories.tsx
@@ -1,6 +1,9 @@
 import { Tabs } from '@c15t/react/primitives';
 import {
+	arrowLeftNavigation,
+	homeAndEndKeys,
 	keyboardNavigation,
+	tabKeySkipsInactiveTabs,
 	tabSwitching,
 } from '@c15t/storybook-tests/play/tabs';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -61,6 +64,72 @@ export const Default: Story = {
 
 export const KeyboardNavigation: Story = {
 	play: keyboardNavigation,
+	render: () => (
+		<Tabs.Root defaultValue="overview">
+			<Tabs.List>
+				<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+				<Tabs.Trigger value="vendors">Vendors</Tabs.Trigger>
+				<Tabs.Trigger value="storage">Storage</Tabs.Trigger>
+			</Tabs.List>
+			<Tabs.Content style={panelStyle} value="overview">
+				<strong>Overview</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="vendors">
+				<strong>Vendors</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="storage">
+				<strong>Storage</strong>
+			</Tabs.Content>
+		</Tabs.Root>
+	),
+};
+
+export const ArrowLeftNavigation: Story = {
+	play: arrowLeftNavigation,
+	render: () => (
+		<Tabs.Root defaultValue="overview">
+			<Tabs.List>
+				<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+				<Tabs.Trigger value="vendors">Vendors</Tabs.Trigger>
+				<Tabs.Trigger value="storage">Storage</Tabs.Trigger>
+			</Tabs.List>
+			<Tabs.Content style={panelStyle} value="overview">
+				<strong>Overview</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="vendors">
+				<strong>Vendors</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="storage">
+				<strong>Storage</strong>
+			</Tabs.Content>
+		</Tabs.Root>
+	),
+};
+
+export const HomeAndEndKeys: Story = {
+	play: homeAndEndKeys,
+	render: () => (
+		<Tabs.Root defaultValue="overview">
+			<Tabs.List>
+				<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
+				<Tabs.Trigger value="vendors">Vendors</Tabs.Trigger>
+				<Tabs.Trigger value="storage">Storage</Tabs.Trigger>
+			</Tabs.List>
+			<Tabs.Content style={panelStyle} value="overview">
+				<strong>Overview</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="vendors">
+				<strong>Vendors</strong>
+			</Tabs.Content>
+			<Tabs.Content style={panelStyle} value="storage">
+				<strong>Storage</strong>
+			</Tabs.Content>
+		</Tabs.Root>
+	),
+};
+
+export const TabKeySkipsInactiveTabs: Story = {
+	play: tabKeySkipsInactiveTabs,
 	render: () => (
 		<Tabs.Root defaultValue="overview">
 			<Tabs.List>

--- a/internals/storybook-tests/src/play/tabs.ts
+++ b/internals/storybook-tests/src/play/tabs.ts
@@ -49,3 +49,69 @@ export const keyboardNavigation: PlayFunction = async ({ canvasElement }) => {
 	await userEvent.keyboard('{ArrowRight}');
 	await expect(tabs[0]).toHaveFocus();
 };
+
+/**
+ * Verifies ArrowLeft navigation moves backward and wraps.
+ */
+export const arrowLeftNavigation: PlayFunction = async ({ canvasElement }) => {
+	const canvas = within(canvasElement);
+	const tabs = canvas.getAllByRole('tab');
+
+	// Focus first tab
+	await userEvent.click(tabs[0]!);
+	await expect(tabs[0]).toHaveFocus();
+
+	// Arrow left wraps → last tab
+	await userEvent.keyboard('{ArrowLeft}');
+	await expect(tabs[2]).toHaveFocus();
+
+	// Arrow left → second tab
+	await userEvent.keyboard('{ArrowLeft}');
+	await expect(tabs[1]).toHaveFocus();
+
+	// Arrow left → first tab
+	await userEvent.keyboard('{ArrowLeft}');
+	await expect(tabs[0]).toHaveFocus();
+};
+
+/**
+ * Verifies Home and End keys jump to first/last tab.
+ */
+export const homeAndEndKeys: PlayFunction = async ({ canvasElement }) => {
+	const canvas = within(canvasElement);
+	const tabs = canvas.getAllByRole('tab');
+
+	// Focus first tab
+	await userEvent.click(tabs[0]!);
+	await expect(tabs[0]).toHaveFocus();
+
+	// End → last tab
+	await userEvent.keyboard('{End}');
+	await expect(tabs[2]).toHaveFocus();
+	await expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
+
+	// Home → first tab
+	await userEvent.keyboard('{Home}');
+	await expect(tabs[0]).toHaveFocus();
+	await expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+};
+
+/**
+ * Verifies Tab key moves focus out of the tablist to the panel (roving tabindex).
+ * Inactive tabs should NOT receive focus via Tab key.
+ */
+export const tabKeySkipsInactiveTabs: PlayFunction = async ({
+	canvasElement,
+}) => {
+	const canvas = within(canvasElement);
+	const tabs = canvas.getAllByRole('tab');
+
+	// Focus first tab (which is selected)
+	await userEvent.click(tabs[0]!);
+	await expect(tabs[0]).toHaveFocus();
+
+	// Tab should move focus to the tabpanel, NOT the next tab trigger
+	await userEvent.keyboard('{Tab}');
+	const panel = canvas.getByRole('tabpanel');
+	await expect(panel).toHaveFocus();
+};

--- a/packages/ui/src/primitives/__tests__/primitives.test.ts
+++ b/packages/ui/src/primitives/__tests__/primitives.test.ts
@@ -63,22 +63,219 @@ describe('primitives helpers', () => {
 
 	test('tabs helpers derive state and keyboard navigation', () => {
 		expect(getTabState(true)).toBe('active');
+		expect(getTabState(false)).toBe('inactive');
+		expect(getTabPanelState(true)).toBe('active');
 		expect(getTabPanelState(false)).toBe('inactive');
-		expect(
-			getNextTabValue({
-				currentValue: 'one',
-				key: 'ArrowRight',
-				orientation: 'horizontal',
-				triggerValues: ['one', 'two', 'three'],
-			})
-		).toBe('two');
-		expect(
-			getNextTabValue({
-				currentValue: 'three',
-				key: 'ArrowDown',
-				orientation: 'vertical',
-				triggerValues: ['one', 'two', 'three'],
-			})
-		).toBe('one');
+	});
+
+	describe('getNextTabValue', () => {
+		const triggerValues = ['one', 'two', 'three'];
+
+		test('ArrowRight moves forward in horizontal mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowRight',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('two');
+		});
+
+		test('ArrowLeft moves backward in horizontal mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'two',
+					key: 'ArrowLeft',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('ArrowDown moves forward in vertical mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowDown',
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('two');
+		});
+
+		test('ArrowUp moves backward in vertical mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'two',
+					key: 'ArrowUp',
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('Home returns first tab', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'three',
+					key: 'Home',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('End returns last tab', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'End',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('three');
+		});
+
+		test('loop enabled: ArrowRight on last wraps to first', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'three',
+					key: 'ArrowRight',
+					loop: true,
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('loop enabled: ArrowLeft on first wraps to last', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowLeft',
+					loop: true,
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('three');
+		});
+
+		test('loop disabled: ArrowRight on last stays', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'three',
+					key: 'ArrowRight',
+					loop: false,
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('three');
+		});
+
+		test('loop disabled: ArrowLeft on first stays', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowLeft',
+					loop: false,
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('wrong-axis keys are ignored in horizontal mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowUp',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowDown',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('wrong-axis keys are ignored in vertical mode', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowLeft',
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('one');
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowRight',
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('unrecognized key returns current value', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'Enter',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('one');
+		});
+
+		test('currentValue not in list returns current value', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'missing',
+					key: 'ArrowRight',
+					orientation: 'horizontal',
+					triggerValues,
+				})
+			).toBe('missing');
+		});
+
+		test('single tab: navigation returns same value', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'only',
+					key: 'ArrowRight',
+					loop: true,
+					orientation: 'horizontal',
+					triggerValues: ['only'],
+				})
+			).toBe('only');
+		});
+
+		test('vertical loop wraps correctly', () => {
+			expect(
+				getNextTabValue({
+					currentValue: 'three',
+					key: 'ArrowDown',
+					loop: true,
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('one');
+			expect(
+				getNextTabValue({
+					currentValue: 'one',
+					key: 'ArrowUp',
+					loop: true,
+					orientation: 'vertical',
+					triggerValues,
+				})
+			).toBe('three');
+		});
 	});
 });

--- a/packages/ui/src/utils/__tests__/dom.test.ts
+++ b/packages/ui/src/utils/__tests__/dom.test.ts
@@ -175,15 +175,41 @@ describe('getFocusableElements', () => {
 	test('excludes elements with tabindex=-1', () => {
 		container.innerHTML = `
 			<button id="focusable">Focusable</button>
-			<button tabindex="-1">Not focusable</button>
+			<button id="not-focusable" tabindex="-1">Not focusable</button>
 		`;
 		const focusableButton = container.querySelector(
 			'#focusable'
 		) as HTMLElement;
+		const notFocusableButton = container.querySelector(
+			'#not-focusable'
+		) as HTMLElement;
 		makeVisible(focusableButton);
+		makeVisible(notFocusableButton);
 		const elements = getFocusableElements(container);
 		expect(elements).toHaveLength(1);
 		expect(elements[0]?.id).toBe('focusable');
+	});
+
+	test('excludes tabindex=-1 buttons in roving tabindex pattern (tabs)', () => {
+		container.innerHTML = `
+			<button id="active-tab" tabindex="0" role="tab">Tab 1</button>
+			<button id="inactive-tab-1" tabindex="-1" role="tab">Tab 2</button>
+			<button id="inactive-tab-2" tabindex="-1" role="tab">Tab 3</button>
+			<div id="panel" tabindex="0" role="tabpanel">Content</div>
+		`;
+		const activeTab = container.querySelector('#active-tab') as HTMLElement;
+		const inactiveTab1 = container.querySelector(
+			'#inactive-tab-1'
+		) as HTMLElement;
+		const inactiveTab2 = container.querySelector(
+			'#inactive-tab-2'
+		) as HTMLElement;
+		const panel = container.querySelector('#panel') as HTMLElement;
+		[activeTab, inactiveTab1, inactiveTab2, panel].forEach(makeVisible);
+		const elements = getFocusableElements(container);
+		expect(elements).toHaveLength(2);
+		expect(elements[0]?.id).toBe('active-tab');
+		expect(elements[1]?.id).toBe('panel');
 	});
 
 	test('includes elements with positive tabindex when visible', () => {

--- a/packages/ui/src/utils/dom.ts
+++ b/packages/ui/src/utils/dom.ts
@@ -99,12 +99,12 @@ export function setupTextDirection(language?: string) {
  */
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
 	const selector = [
-		'a[href]:not([disabled])',
-		'button:not([disabled])',
-		'textarea:not([disabled])',
-		'input:not([disabled])',
-		'select:not([disabled])',
-		'[contenteditable]',
+		'a[href]:not([disabled]):not([tabindex="-1"])',
+		'button:not([disabled]):not([tabindex="-1"])',
+		'textarea:not([disabled]):not([tabindex="-1"])',
+		'input:not([disabled]):not([tabindex="-1"])',
+		'select:not([disabled]):not([tabindex="-1"])',
+		'[contenteditable]:not([tabindex="-1"])',
 		'[tabindex]:not([tabindex="-1"])',
 	].join(',');
 


### PR DESCRIPTION
## Overview

The `getFocusableElements` utility used by the focus trap included inactive tab triggers (`tabindex="-1"`) in its boundary calculation because `button:not([disabled])` matched all non-disabled buttons regardless of tabindex. This broke Tab-key cycling in dialogs containing tabs — the focus trap's wrap-around logic could fire on elements the browser's native Tab key skips.

## Related Issue
Fixes focus trap interaction with WAI-ARIA roving tabindex tabs pattern.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Implementation Details

### Key Changes
1. Added `:not([tabindex="-1"])` to all element-type selectors in `getFocusableElements` so only Tab-reachable elements are included in focus trap boundaries
2. Fixed a false-pass test that only excluded the `tabindex="-1"` button via the visibility filter, not the selector
3. Added a roving tabindex scenario test modeling tabs inside a focus-trapped dialog
4. Expanded `getNextTabValue` unit tests from 2 assertions to 15 test cases covering arrow keys, Home/End, loop, wrong-axis keys, and edge cases
5. Added storybook play tests for ArrowLeft navigation, Home/End keys, and Tab-key roving tabindex contract

### Technical Notes
The tabs primitive correctly implements WAI-ARIA roving tabindex — only the active tab has `tabIndex={0}`, inactive tabs have `tabIndex={-1}`. Arrow keys navigate between tabs; Tab key moves focus out of the tablist. The bug was in the focus trap's element selector, not in the tabs component itself.

## Testing

### Test Plan

- [x] Scenario 1: Focus trap excludes tabindex=-1 buttons

  ```ts
  // Container with active tab (tabindex=0), two inactive tabs (tabindex=-1), and a panel (tabindex=0)
  // All elements visible
  getFocusableElements(container) // returns only active tab + panel
  ```

  ✓ Expected: Only 2 elements returned (active tab and panel)

- [x] Scenario 2: getNextTabValue keyboard navigation

  ```ts
  getNextTabValue({ currentValue: 'one', key: 'ArrowRight', orientation: 'horizontal', triggerValues: ['one', 'two', 'three'] })
  ```

  ✓ Expected: Returns 'two', with wrapping, Home/End, loop disable, and wrong-axis rejection all covered

### Edge Cases
- [x] Error handling: `currentValue` not in list returns current value unchanged
- [x] Performance: No performance impact — selector change is purely additive
- [x] Security: No security implications

## Checklist

### Required

- [x] Tests added/updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)