### PR TITLE
fix: CI failures in bundle analysis and core tests

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -51,6 +51,8 @@ jobs:
       - name: 🅿️ Setup pnpm
         if: steps.detect-pm.outputs.pm == 'pnpm'
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: 🟢 Setup Node.js
         if: steps.detect-pm.outputs.pm == 'pnpm'

--- a/packages/core/src/libs/tracking-blocker.ts
+++ b/packages/core/src/libs/tracking-blocker.ts
@@ -210,7 +210,18 @@ export function createTrackingBlocker(
 			};
 			// Preserve properties from original fetch (e.g., preconnect in Bun)
 			Object.setPrototypeOf(newFetch, originalFetch);
-			Object.assign(newFetch, originalFetch);
+			for (const key of Object.getOwnPropertyNames(originalFetch)) {
+				const desc = Object.getOwnPropertyDescriptor(originalFetch, key);
+				if (desc && desc.writable !== false && desc.configurable !== false) {
+					try {
+						(newFetch as Record<string, unknown>)[key] = (
+							originalFetch as Record<string, unknown>
+						)[key];
+					} catch {
+						// Skip non-writable properties (e.g., test mock properties)
+					}
+				}
+			}
 			window.fetch = newFetch as typeof window.fetch;
 		}
 


### PR DESCRIPTION
## Summary

- **Bundle Analysis**: `pnpm/action-setup@v4` crashes with "Invalid packageManager field" because it reads `bun@1.3.10` from `package.json`. Fixed by adding explicit `version: 9` so it doesn't parse the field.
- **Core Tests (19 failures)**: `Object.assign(newFetch, originalFetch)` in `tracking-blocker.ts:213` throws "Cannot assign to read only property 'mock'" because vitest's mocked `fetch` has non-writable properties. Fixed by iterating properties and skipping non-writable ones.

## Test plan
- [x] All 318 tests pass locally (23 test files, 0 failures)
- [ ] CI bundle analysis job passes
- [ ] CI test job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)