### PR TITLE
ci: optimize pipeline with caching, parallelism & path filtering

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,40 @@
+name: "Setup"
+description: "Setup Bun, install dependencies, and optionally install Playwright"
+
+inputs:
+  playwright:
+    description: "Install Playwright browsers (chromium)"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: "1.3.11"
+
+    - name: Cache bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        restore-keys: ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile
+
+    - name: Cache Playwright browsers
+      if: inputs.playwright == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('package.json') }}
+        restore-keys: ${{ runner.os }}-playwright-
+
+    - name: Install Playwright
+      if: inputs.playwright == 'true'
+      shell: bash
+      run: bunx playwright install --with-deps chromium chromium-headless-shell

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🟢 Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: 📦 Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/benchmark-nightly.yml
+++ b/.github/workflows/benchmark-nightly.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.6
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.6
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint, Build & Test
 
 on:
   push:
@@ -6,27 +6,67 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint_and_check:
-    name: 🧹 Lint & Type Check
+  changes:
+    name: 🔍 Detect Changes
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Needed for checkout
-      checks: write # Needed for reviewdog to post results
-      pull-requests: write # Needed for reviewdog github-pr-review reporter (optional)
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      storybook: ${{ steps.filter.outputs.storybook }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'apps/**'
+              - 'internals/**'
+              - 'configs/**'
+              - 'examples/**'
+              - 'turbo.json'
+              - 'package.json'
+              - 'bun.lock'
+              - 'biome.jsonc'
+              - 'tsconfig.json'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/**'
+            storybook:
+              - 'packages/ui/**'
+              - 'packages/react/**'
+              - 'packages/solid/**'
+              - 'packages/svelte/**'
+              - 'packages/vue/**'
+              - 'packages/core/**'
+              - 'packages/translations/**'
+              - 'apps/storybook-*/**'
+              - 'internals/storybook-tests/**'
+
+  lint_and_check:
+    name: 🧹 Lint & Type Check
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: ⬇️ Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: 📦 Install dependencies
-        run: bun install --frozen-lockfile
+      - name: 📦 Setup & Install
+        uses: ./.github/actions/setup
 
       - name: 👀 Type Check
         env:
@@ -38,27 +78,24 @@ jobs:
         uses: mongolyy/reviewdog-action-biome@v2.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check # Report results as checks
-          level: warning               # Report errors
+          reporter: github-pr-check
+          level: warning
 
   build:
     name: 🏗️ Build Packages
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Needed for checkout
+      contents: read
     steps:
       - name: ⬇️ Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: 📦 Install dependencies
-        run: bun install --frozen-lockfile
+      - name: 📦 Setup & Install
+        uses: ./.github/actions/setup
 
       - name: 🏗️ Build
         env:
@@ -71,26 +108,21 @@ jobs:
 
   test:
     name: 🧪 Run Tests & Coverage
-    needs: build # Run only after build succeeds
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Needed for checkout
+      contents: read
     steps:
       - name: ⬇️ Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: 📦 Setup & Install
+        uses: ./.github/actions/setup
         with:
-          bun-version: latest
-
-      - name: 📦 Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: 🎭 Install Playwright browsers
-        run: bunx playwright install --with-deps chromium chromium-headless-shell
+          playwright: "true"
 
       - name: 🧪 Run Tests
         env:
@@ -101,20 +133,19 @@ jobs:
       - name: ⬆️ Upload Individual Coverage Reports
         uses: actions/upload-artifact@v4
         with:
-          name: individual-coverage-data # Artifact containing all raw reports
+          name: individual-coverage-data
           path: |
             packages/*/coverage/coverage-summary.json
             packages/*/coverage/coverage-final.json
             apps/*/coverage/coverage-summary.json
             apps/*/coverage/coverage-final.json
-            # Add other potential locations if necessary
           retention-days: 7
-          # Optional: Handle case where no files are found gracefully
-          if-no-files-found: warn # 'warn', 'error', or 'ignore'
+          if-no-files-found: warn
 
   test_storybook:
     name: 🎭 Storybook Tests
-    needs: build
+    needs: changes
+    if: needs.changes.outputs.storybook == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -132,16 +163,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: 📦 Setup & Install
+        uses: ./.github/actions/setup
         with:
-          bun-version: latest
-
-      - name: 📦 Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: 🎭 Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+          playwright: "true"
 
       - name: 🏗️ Build storybook
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Overview

CI wall-clock time is bottlenecked by sequential job dependencies and repeated uncached setup work. This PR removes the `needs: build` gate from test jobs (turbo remote cache handles deduplication), adds bun install + Playwright browser caching via a reusable composite action, introduces path filtering to skip CI on docs-only changes, and adds concurrency control to cancel stale PR runs. Bun is pinned to `1.3.11` across all workflows to match the `packageManager` field.

## Type of Change

- [x] ⚡ Performance
- [x] 🏗️ Refactor (no functional changes)

## Implementation Details

### Key Changes
1. **Reusable composite action** (`.github/actions/setup/action.yml`) — encapsulates bun setup, dependency caching (`~/.bun/install/cache`), `bun install`, and optional Playwright browser caching (`~/.cache/ms-playwright`)
2. **Removed `needs: build`** from `test` and `test_storybook` jobs — all jobs now run in parallel after a lightweight `changes` gate. Turbo remote cache handles build deduplication across jobs
3. **Path filtering** via `dorny/paths-filter@v3` — CI skips entirely for docs/changelog-only changes; storybook tests only run when UI-related packages change
4. **Concurrency control** — stale PR runs are automatically cancelled when new commits are pushed
5. **Pinned bun to `1.3.11`** in all 6 workflows (was `latest` in 4, `1.3.6` in 2)
6. **Renamed workflow** from "CI" to "Lint, Build & Test"

### Technical Notes
- The composite action does NOT include checkout (since `uses: ./.github/actions/setup` requires the repo to already be checked out)
- Path filtering uses `dorny/paths-filter` instead of `paths-ignore` on the trigger to avoid breaking required status checks
- Storybook tests have a stricter filter (UI packages only) vs the general `code` filter

## Testing

### Test Plan

- [ ] Scenario 1: Push a code change to a PR

  ✓ Expected: All 4 jobs (lint, build, test, storybook) start in parallel after `changes` completes (~10s)

- [ ] Scenario 2: Push a docs-only change

  ✓ Expected: Only `changes` job runs; all other jobs are skipped

- [ ] Scenario 3: Push two commits quickly to same PR

  ✓ Expected: First run is cancelled, second run proceeds

- [ ] Scenario 4: Second push to same PR (cache warm)

  ✓ Expected: `Cache restored` appears in bun install and Playwright steps

### Edge Cases
- [ ] Error handling: If turbo remote cache misses, turbo rebuilds automatically — no job failure
- [ ] Performance: ~4-7 min wall-clock improvement on code PRs; full skip on docs PRs
- [ ] Security: No secrets added/changed; path filter runs on trusted code only

## Checklist

### Required

- [ ] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)