### PR TITLE
chore: update rc.6 changelog date to 2026-04-06

### DIFF
--- a/changelog/2026-04-06-v2.0.0-rc.6.mdx
+++ b/changelog/2026-04-06-v2.0.0-rc.6.mdx
@@ -1,7 +1,7 @@
 ---
 title: "v2.0.0-rc.6 — Smaller Client Bundles, Modular IAB, UI Primitives, and Flexible Policy Actions"
 version: "2.0.0-rc.6"
-date: 2026-04-02
+date: 2026-04-06
 description: "Release candidate focused on smaller client bundles, extracted IAB support, shared UI primitives with framework adapters, flexible policy action layouts, and cleaner package styling/toolchain boundaries."
 tags:
   - release


### PR DESCRIPTION
## Overview

Updates the RC 6 changelog date from 2026-04-02 to 2026-04-06 to reflect the actual release date, since RC 6 hasn't shipped yet and now includes the UI primitives and framework adapters that landed after the original changelog was written.

## Type of Change

- [x] 📚 Documentation

## Implementation Details

### Key Changes
1. Renamed `changelog/2026-04-02-v2.0.0-rc.6.mdx` → `changelog/2026-04-06-v2.0.0-rc.6.mdx`
2. Updated `date` frontmatter from `2026-04-02` to `2026-04-06`

## Checklist

### Required

- [x] Tested locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)