### PR TITLE
fix: resolve npm auth and upgrade issues in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: "1.3.11"
+          bun-version: latest
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -43,12 +43,16 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # Upgrade npm for trusted publishing (OIDC provenance requires npm 11+).
+      # Node.js 22.22.2's bundled npm has a missing promise-retry module that
+      # breaks `npm install -g`, so we install it first as a workaround.
+      - name: Upgrade npm for provenance publishing
+        run: |
+          npm install -g promise-retry 2>/dev/null || true
+          npm install -g npm@latest
+
       - name: Install dependencies
         run: bun install --frozen-lockfile # Use frozen lockfile for reliability in CI
-
-      # Ensure npm 11.5.1+ for trusted publishing (OIDC)
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
 
       # Canary release: Create and publish snapshot release
       - name: Create and publish canary snapshot release
@@ -63,7 +67,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
-          # Enable npm provenance (automatic with trusted publishing, but explicit for compatibility)
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
       # RC release: Publish pre-release versions from 2.0.0 branch
@@ -79,6 +83,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
       # Regular release: Create Release Pull Request or Publish to npm
@@ -96,8 +101,10 @@ jobs:
         env:
           # GITHUB_TOKEN is used by the action to create PRs, releases, comments
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN is used by 'changeset publish' (called via 'bun run release')
-          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }} # MUST be set in repo secrets
+          # NPM_TOKEN is used by changesets action to create ~/.npmrc
+          NPM_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
+          # NODE_AUTH_TOKEN is used by actions/setup-node's .npmrc (takes precedence via NPM_CONFIG_USERCONFIG)
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}
           # Enable npm provenance (automatic with trusted publishing, but explicit for compatibility)
           NPM_CONFIG_PROVENANCE: "true"
 


### PR DESCRIPTION
## Overview

Ports the release workflow fixes from `main` to the `2.0.0` branch. The release workflow was failing due to two issues: Node.js 22.22.2's bundled npm has a corrupted `promise-retry` module that breaks `npm install -g`, and `actions/setup-node`'s `.npmrc` uses `NODE_AUTH_TOKEN` (not `NPM_TOKEN`), causing E404 publish errors.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Implementation Details

### Key Changes
1. **Fixed npm upgrade order** — moved npm upgrade step before `bun install` and added a `promise-retry` workaround for Node.js 22.22.2's broken bundled npm
2. **Added `NODE_AUTH_TOKEN`** to all three release steps (canary, RC, production) — `actions/setup-node`'s `.npmrc` uses this env var via `NPM_CONFIG_USERCONFIG`, taking precedence over `NPM_TOKEN`
3. **Updated bun-version** from pinned `1.3.11` to `latest`

### Technical Notes
- `actions/setup-node@v4` with `registry-url` creates an `.npmrc` referencing `${NODE_AUTH_TOKEN}`. This config takes precedence via `NPM_CONFIG_USERCONFIG`, so setting only `NPM_TOKEN` resulted in an empty auth token.
- The old `npm install -g npm@latest` step was placed after `bun install` and would fail on Node.js 22.22.2 due to a missing `promise-retry` dependency. The fix installs `promise-retry` globally first (with error suppression) before upgrading npm.

## Testing

### Test Plan
- [ ] Trigger an RC release from the `2.0.0` branch and verify packages publish successfully to npm

## Checklist

### Required
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)