### PR TITLE
docs: fix rc.7 release messaging

### DIFF
--- a/.changeset/tidy-phones-dance.md
+++ b/.changeset/tidy-phones-dance.md
@@ -5,9 +5,10 @@
 '@c15t/cli': patch
 ---
 
-Fix the RC theming regressions across the prebuilt UI and align the Tailwind setup contract with the shipped `@layer components` behavior.
+Fix the RC theming regressions across the prebuilt UI, align the Tailwind setup contract with the shipped `@layer components` behavior, and tighten the customization guidance around when to use tokens, slots, compound components, `noStyle`, or headless mode.
 
 - `@c15t/ui`: add a shared DOM style sanitizer for framework adapters, make switch track tokens apply from the rendered subtree, and add regression coverage for slot/style token behavior.
-- `@c15t/react`: stop slot metadata like `noStyle` leaking to the DOM, wire the `consentWidgetAccordion` slot, and add real render-path regression tests for slot `style` and switch token overrides.
+- `@c15t/react`: stop slot metadata like `noStyle` leaking to the DOM, wire the `consentWidgetAccordion` slot, add real render-path regression tests for slot `style` and switch token overrides, and refresh the compound-component examples to point users toward provider options, theme tokens, and slots before advanced composition.
 - `@c15t/nextjs`: keep the published stylesheet assets aligned with the package entrypoints used by the documented install path.
 - `@c15t/cli`: update the Tailwind CSS template helper to standardize on `@layer base, components, utilities;` and add tests for the new setup contract.
+- Documentation: clarify the customization ladder across the AI agent guidance plus the React and Next.js component/styling docs so headless guidance is treated as the last step, not the default escape hatch.

--- a/changelog/2026-04-08-v2.0.0-rc.7.mdx
+++ b/changelog/2026-04-08-v2.0.0-rc.7.mdx
@@ -1,8 +1,8 @@
 ---
-title: "v2.0.0-rc.7 — Theming Fixes, Simpler Tailwind Setup, and Cross-Environment CSS Review"
+title: "v2.0.0-rc.7 — Theming Fixes, Simpler Tailwind Setup, and Clearer Customization Guidance"
 version: "2.0.0-rc.7"
 date: 2026-04-08
-description: "Release candidate focused on fixing theming regressions in the prebuilt UI, simplifying the Tailwind setup contract, and adding better manual coverage for CSS behavior across Tailwind 3, Tailwind 4, and plain CSS."
+description: "Release candidate focused on fixing theming regressions in the prebuilt UI, simplifying the Tailwind setup contract, clarifying the recommended customization ladder, and adding better manual coverage for CSS behavior across Tailwind 3, Tailwind 4, and plain CSS."
 tags:
   - release
   - rc
@@ -15,12 +15,13 @@ breaking: false
 authors: [KayleeWilliams]
 ---
 
-`v2.0.0-rc.7` is a cleanup release aimed at styling correctness rather than new surface area. The main focus is fixing the theming regressions that showed up in `rc.6`, tightening the contract around how c15t styles interact with Tailwind, and improving the manual review workflow for cross-environment CSS behavior before the final 2.0 release.
+`v2.0.0-rc.7` is a cleanup release aimed at styling correctness and clearer implementation guidance rather than new surface area. The main focus is fixing the theming regressions that showed up in `rc.6`, tightening the contract around how c15t styles interact with Tailwind, clarifying the customization ladder across the docs, and improving the manual review workflow for cross-environment CSS behavior before the final 2.0 release.
 
 ## Highlights
 
 - Fixed slot theming regressions in the React prebuilt UI
 - Simplified the Tailwind setup contract to match the actual shipped `@layer components` behavior
+- Clarified the recommended customization ladder across the AI agent docs plus the React and Next.js component guides
 - Added a manual CSS matrix harness to compare Tailwind 3, Tailwind 4, and plain CSS side by side
 - Strengthened regression coverage for slot styling, switch tokens, and packaging/tooling edge cases
 
@@ -55,6 +56,19 @@ The shipped component CSS already lands in Tailwind's `components` layer, so the
 
 This cleanup affects the public setup guidance in the React and Next.js docs as well as the CLI Tailwind CSS template helper used during setup.
 
+## Clearer Customization Guidance
+
+`rc.7` also tightens the guidance around how teams should customize the shipped UI.
+
+The docs, AI-agent guidance, and React compound-component examples now push the same escalation path:
+
+- start with the stock component and provider options
+- use theme tokens and slots for styling changes
+- reach for compound components only when markup really needs to change
+- use `noStyle` or headless mode only when the stock structure is no longer the right fit
+
+This matters because the `rc.6` theming regressions showed that users were hitting advanced escape hatches too early. `rc.7` fixes the broken slot behavior and also makes the recommended path much harder to misread.
+
 ## Better CSS Review Before Release
 
 To make styling regressions easier to catch, the repo now includes a manual CSS matrix harness under `benchmarks/`.
@@ -72,11 +86,13 @@ The preview shell shows those environments side by side so complex styling cases
 - The demo theme showcase now includes regression-focused previews for the fixed theming contract
 - Added browser/render-path regression tests for slot props and switch token styling
 - Added CLI coverage for the new Tailwind CSS template contract
+- Refreshed the bundled guidance for agents and the React/Next.js docs so customization advice matches the shipped component model
 - Fixed CI issues around preview workflow outputs, benchmark config typing, and CSS test path resolution
 
 ## Learn more
 
 - [#697](https://github.com/c15t/c15t/pull/697) — fix RC theming regressions, clean up Tailwind setup guidance, and add the CSS matrix harness
+- [#699](https://github.com/c15t/c15t/pull/699) — clarify the customization ladder across AI agent docs, React/Next.js guides, and component examples
 
 ## Notes
 


### PR DESCRIPTION
## Overview
Correct the `v2.0.0-rc.7` changeset and release note so they describe the full shipped delta since `@c15t/nextjs@2.0.0-rc.6`, not just the theming and Tailwind fixes.

## Related Issue
Fixes #700

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Expanded `.changeset/tidy-phones-dance.md` so the `rc.7` summary also calls out the customization-guidance/docs work that landed after `rc.6`.
2. Updated `changelog/2026-04-08-v2.0.0-rc.7.mdx` to reflect both shipped commits since the last release point, including the added guidance section and the extra learn-more link.

### Technical Notes
This branch only changes release metadata and changelog copy; no runtime code, package versions, or tests changed.

## Testing
### Test Plan
- [ ] Scenario 1: Review the PR diff

  ```ts
  git diff origin/2.0.0...
  ```

  ✓ Expected: only `.changeset/tidy-phones-dance.md` and `changelog/2026-04-08-v2.0.0-rc.7.mdx` change, and both reflect the full `rc.6 -> rc.7` release delta.

### Edge Cases
- [x] Error handling: n/a for this doc-only change.
- [x] Performance: no runtime impact.
- [x] Security: no security-sensitive behavior changed.

## Checklist
### Required
- [x] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
