### PR TITLE
fix: move styled imports into app css entrypoints

### DIFF
--- a/.changeset/shaggy-pots-relax.md
+++ b/.changeset/shaggy-pots-relax.md
@@ -1,0 +1,11 @@
+---
+'@c15t/react': patch
+'@c15t/nextjs': patch
+'@c15t/cli': patch
+---
+
+Align the styled package install path around app-level CSS entrypoints instead of JS-side stylesheet imports.
+
+- `@c15t/react`: update the published README guidance, quickstart docs, and stylesheet usage comments so styled and IAB installs consistently import `@c15t/react/styles.css` or `styles.tw3.css` from a global CSS file, with explicit guidance on why this avoids layer-order debugging problems.
+- `@c15t/nextjs`: update the published README guidance, quickstart docs, and stylesheet usage comments so styled and IAB installs consistently import `@c15t/nextjs/styles.css` or `styles.tw3.css` from `app/globals.css`, with explicit guidance on why this avoids layer-order debugging problems.
+- `@c15t/cli`: move the stylesheet codemod and scaffold behavior to mutate global CSS entrypoints, remove old JS-side stylesheet imports, share the CSS-entrypoint mutation logic between generate and codemod flows, and add regression coverage for Tailwind v3/v4, IAB, dry-run, and missing-CSS cases.

--- a/benchmarks/no-tw-test/app/globals.css
+++ b/benchmarks/no-tw-test/app/globals.css
@@ -1,3 +1,5 @@
+@import "@c15t/nextjs/styles.css";
+
 :root {
 	color-scheme: light;
 	font-family:

--- a/benchmarks/no-tw-test/app/layout.tsx
+++ b/benchmarks/no-tw-test/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import '@c15t/nextjs/styles.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/benchmarks/tw3-test/app/globals.css
+++ b/benchmarks/tw3-test/app/globals.css
@@ -1,5 +1,6 @@
 @tailwind base;
 @tailwind components;
+@import "@c15t/nextjs/styles.tw3.css";
 @tailwind utilities;
 
 :root {

--- a/benchmarks/tw3-test/app/layout.tsx
+++ b/benchmarks/tw3-test/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import '@c15t/nextjs/styles.tw3.css';
 import './globals.css';
 
 export const metadata: Metadata = {

--- a/benchmarks/tw4-test/app/globals.css
+++ b/benchmarks/tw4-test/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "@c15t/nextjs/styles.css";
 @source "../app/**/*.{ts,tsx}";
 @source "../../shared/src/**/*.{ts,tsx}";
 

--- a/benchmarks/tw4-test/app/layout.tsx
+++ b/benchmarks/tw4-test/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import '@c15t/nextjs/styles.css';
 
 export const metadata: Metadata = {
 	title: 'TW4 + c15t CSS Layer Test',

--- a/benchmarks/vite-react-repro/src/main.tsx
+++ b/benchmarks/vite-react-repro/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './app';
 import './styles.css';
-import '@c15t/react/styles.css';
 
 const rootElement = document.getElementById('root');
 

--- a/benchmarks/vite-react-repro/src/styles.css
+++ b/benchmarks/vite-react-repro/src/styles.css
@@ -1,3 +1,5 @@
+@import "@c15t/react/styles.css";
+
 :root {
 	color: #111827;
 	background: #f8fafc;

--- a/docs/frameworks/javascript/building-ui.mdx
+++ b/docs/frameworks/javascript/building-ui.mdx
@@ -254,10 +254,10 @@ const sw = switchVariants({ size: 'medium' });
 toggleEl.className = sw.root();
 ```
 
-These functions return CSS module class name generators. To apply the associated styles, import the stylesheet at the root of your application:
+These functions return CSS module class name generators. To apply the associated styles, import the stylesheet from your app-level CSS entrypoint:
 
-```ts
-import '@c15t/ui/styles.css';
+```css title="src/index.css"
+@import "@c15t/ui/styles.css";
 ```
 
 ## Building a Framework Library

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -30,14 +30,16 @@ availableIn:
   <Step>
     ### Import styles
 
-    Import the prebuilt component stylesheet in your root layout. This is required for styled components to render correctly.
+    Import the prebuilt component stylesheet in your app-level CSS entrypoint. This is required for styled components to render correctly.
 
-    ```tsx title="app/layout.tsx"
-    import '@c15t/nextjs/styles.css';
+    ```css title="app/globals.css"
+    @import "@c15t/nextjs/styles.css";
     ```
 
+    <import src="../../shared/react/styling/stylesheet-entrypoint.mdx#why-global-css" />
+
     <Callout type="info">
-      If you are using the headless API or fully custom styling, you can skip this import.
+      If you are using the headless API or fully custom styling, you can skip this import. Your root layout should continue importing `./globals.css` as usual.
     </Callout>
   </Step>
 

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -30,14 +30,16 @@ availableIn:
   <Step>
     ### Import styles
 
-    Import the prebuilt component stylesheet at the root of your application. This is required for styled components to render correctly.
+    Import the prebuilt component stylesheet in your app-level CSS entrypoint. This is required for styled components to render correctly.
 
-    ```tsx title="src/main.tsx"
-    import '@c15t/react/styles.css';
+    ```css title="src/index.css"
+    @import "@c15t/react/styles.css";
     ```
 
+    <import src="../../shared/react/styling/stylesheet-entrypoint.mdx#why-global-css" />
+
     <Callout type="info">
-      If you are using the headless API or fully custom styling, you can skip this import.
+      If you are using the headless API or fully custom styling, you can skip this import. `src/main.tsx` should keep importing `./index.css` as usual.
     </Callout>
   </Step>
 

--- a/docs/shared/react/styling/stylesheet-entrypoint.mdx
+++ b/docs/shared/react/styling/stylesheet-entrypoint.mdx
@@ -1,0 +1,3 @@
+<section id="why-global-css">
+  Keeping the c15t stylesheet in your global CSS entrypoint makes layer and cascade order explicit. JS/TSX side-effect imports can load in a different order across framework and Tailwind tooling, which makes style regressions harder to debug.
+</section>

--- a/docs/shared/react/styling/tailwind.mdx
+++ b/docs/shared/react/styling/tailwind.mdx
@@ -5,41 +5,47 @@
 
   ## Setup
 
-  Import the standard c15t stylesheet once at the root of your app:
+  Import the standard c15t stylesheet once in your app-level CSS entrypoint:
 
-  ```tsx
-  // React
-  import '@c15t/react/styles.css';
+  ```css
+  /* React: src/index.css */
+  @import "@c15t/react/styles.css";
 
-  // Next.js
-  import '@c15t/nextjs/styles.css';
+  /* Next.js: app/globals.css */
+  @import "@c15t/nextjs/styles.css";
   ```
+
+  <import src="./stylesheet-entrypoint.mdx#why-global-css" />
 
   ### Tailwind v4
 
-  Tailwind v4 automatically scans your source files. Import Tailwind normally. c15t component styles join Tailwind's `components` layer automatically, so no extra c15t-specific layer declaration is needed:
+  Tailwind v4 automatically scans your source files. Import Tailwind normally, then place the c15t stylesheet immediately after it. c15t component styles join Tailwind's `components` layer automatically, so no extra c15t-specific layer declaration is needed:
 
-  ```css
+  ```css title="src/index.css"
   @import "tailwindcss";
+  @import "@c15t/react/styles.css";
+  ```
+
+  ```css title="app/globals.css"
+  @import "tailwindcss";
+  @import "@c15t/nextjs/styles.css";
   ```
 
   ### Tailwind v3
 
-  Import the Tailwind 3-compatible c15t stylesheet before your app Tailwind globals, then keep your standard Tailwind directives in the app stylesheet:
+  Import the Tailwind 3-compatible c15t stylesheet after `@tailwind components;` and before `@tailwind utilities;`:
 
-  ```tsx title="app/layout.tsx"
-  import '@c15t/react/styles.tw3.css';
-  import './globals.css';
-  ```
-
-  ```tsx title="app/layout.tsx"
-  import '@c15t/nextjs/styles.tw3.css';
-  import './globals.css';
+  ```css title="src/index.css"
+  @tailwind base;
+  @tailwind components;
+  @import "@c15t/react/styles.tw3.css";
+  @tailwind utilities;
   ```
 
   ```css title="app/globals.css"
   @tailwind base;
   @tailwind components;
+  @import "@c15t/nextjs/styles.tw3.css";
   @tailwind utilities;
   ```
 </section>

--- a/examples/demo/app/(main)/layout.tsx
+++ b/examples/demo/app/(main)/layout.tsx
@@ -2,9 +2,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
 import type React from 'react';
-import '../globals.css'; // Must be first — declares @layer order for Tailwind 4 + c15t
-import '@c15t/nextjs/styles.css';
-import '@c15t/nextjs/iab/styles.css';
+import '../globals.css';
 import { ConsentManager } from '../../components/consent-manager/provider';
 
 const geist = Geist({

--- a/examples/demo/app/(ssr)/layout.tsx
+++ b/examples/demo/app/(ssr)/layout.tsx
@@ -2,7 +2,6 @@ import { DevTools } from '@c15t/dev-tools/react';
 import { Analytics } from '@vercel/analytics/next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import type React from 'react';
-import '@c15t/nextjs/styles.css';
 import '../globals.css';
 import { ConsentManager } from '../../components/consent-manager-nextjs';
 

--- a/examples/demo/app/globals.css
+++ b/examples/demo/app/globals.css
@@ -1,5 +1,7 @@
 @layer theme, base, components, c15t, utilities;
 @import "tailwindcss";
+@import "@c15t/nextjs/styles.css";
+@import "@c15t/nextjs/iab/styles.css";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/cli/src/commands/codemods/add-stylesheet-imports.test.ts
+++ b/packages/cli/src/commands/codemods/add-stylesheet-imports.test.ts
@@ -21,6 +21,13 @@ async function createProject(
 	return { root };
 }
 
+async function readProjectFile(
+	root: string,
+	relativePath: string
+): Promise<string> {
+	return readFile(join(root, relativePath), 'utf-8');
+}
+
 afterEach(async () => {
 	await Promise.all(
 		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
@@ -28,113 +35,232 @@ afterEach(async () => {
 });
 
 describe('add-stylesheet-imports codemod', () => {
-	it('uses the Tailwind 3 stylesheet entrypoint when tailwindcss v3 is installed', async () => {
+	it('adds the React stylesheet to the imported CSS entrypoint', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'',
+				'export function App() {',
+				'  return <ConsentBanner />;',
+				'}',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+		const indexCss = await readProjectFile(root, 'src/index.css');
+		const mainTsx = await readProjectFile(root, 'src/main.tsx');
+
+		expect(result.errors).toHaveLength(0);
+		expect(result.changedFiles).toHaveLength(1);
+		expect(result.changedFiles[0]?.filePath).toContain('src/index.css');
+		expect(result.changedFiles[0]?.summaries).toContain(
+			'added @import "@c15t/react/styles.css";'
+		);
+		expect(indexCss).toContain('@import "@c15t/react/styles.css";');
+		expect(mainTsx).not.toContain('@c15t/react/styles.css');
+	});
+
+	it('moves Next.js Tailwind 3 imports into app/globals.css and removes the JS import', async () => {
 		const { root } = await createProject({
 			'package.json': JSON.stringify({
 				name: 'tw3-next-app',
-				dependencies: {
-					'@c15t/nextjs': '2.0.0-rc.6',
-					next: '15.3.3',
-					react: '19.2.3',
-					'react-dom': '19.2.3',
-				},
-				devDependencies: {
-					tailwindcss: '3.4.17',
-				},
-			}),
-			'app/layout.tsx': `
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-	return <html><body>{children}</body></html>;
-}
-`,
-			'app/provider.tsx': `
-import { ConsentBanner } from '@c15t/nextjs';
-
-export function Provider() {
-	return <ConsentBanner />;
-}
-`,
-		});
-
-		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: root,
-			dryRun: false,
-		});
-		const layout = await readFile(join(root, 'app/layout.tsx'), 'utf-8');
-
-		expect(result.changedFiles).toHaveLength(1);
-		expect(layout).toContain("import '@c15t/nextjs/styles.tw3.css';");
-		expect(layout).not.toContain("import '@c15t/nextjs/styles.css';");
-	});
-
-	it('keeps the default stylesheet entrypoint for non-Tailwind-3 projects', async () => {
-		const { root } = await createProject({
-			'package.json': JSON.stringify({
-				name: 'react-app',
-				dependencies: {
-					'@c15t/react': '2.0.0-rc.6',
-					react: '19.2.3',
-					'react-dom': '19.2.3',
-				},
-				devDependencies: {
-					tailwindcss: '4.2.2',
-				},
-			}),
-			'src/main.tsx': `
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { ConsentBanner } from '@c15t/react';
-
-createRoot(document.getElementById('root')!).render(
-	<StrictMode>
-		<ConsentBanner />
-	</StrictMode>
-);
-`,
-		});
-
-		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: root,
-			dryRun: false,
-		});
-		const main = await readFile(join(root, 'src/main.tsx'), 'utf-8');
-
-		expect(result.changedFiles).toHaveLength(1);
-		expect(main).toContain("import '@c15t/react/styles.css';");
-		expect(main).not.toContain('styles.tw3.css');
-	});
-
-	it('replaces the default import with the Tailwind 3 import when needed', async () => {
-		const { root } = await createProject({
-			'package.json': JSON.stringify({
-				name: 'tw3-react-app',
-				dependencies: {
-					'@c15t/react': '2.0.0-rc.6',
-					react: '19.2.3',
-					'react-dom': '19.2.3',
-				},
 				devDependencies: {
 					tailwindcss: '^3.4.17',
 				},
 			}),
-			'src/main.tsx': `
-import '@c15t/react/styles.css';
-import { ConsentBanner } from '@c15t/react';
-
-export function App() {
-	return <ConsentBanner />;
-}
-`,
+			'app/layout.tsx': [
+				"import '@c15t/nextjs/styles.css';",
+				"import './globals.css';",
+				'',
+				'export default function RootLayout({ children }: { children: React.ReactNode }) {',
+				'  return <html><body>{children}</body></html>;',
+				'}',
+			].join('\n'),
+			'app/globals.css': [
+				'@tailwind base;',
+				'@tailwind components;',
+				'@tailwind utilities;',
+			].join('\n'),
+			'app/provider.tsx': [
+				"import { ConsentBanner } from '@c15t/nextjs';",
+				'',
+				'export function Provider() {',
+				'  return <ConsentBanner />;',
+				'}',
+			].join('\n'),
 		});
 
 		const result = await runAddStylesheetImportsCodemod({
 			projectRoot: root,
 			dryRun: false,
 		});
-		const main = await readFile(join(root, 'src/main.tsx'), 'utf-8');
+		const globalsCss = await readProjectFile(root, 'app/globals.css');
+		const layout = await readProjectFile(root, 'app/layout.tsx');
 
-		expect(result.changedFiles).toHaveLength(1);
-		expect(main).toContain("import '@c15t/react/styles.tw3.css';");
-		expect(main).not.toContain("import '@c15t/react/styles.css';");
+		expect(result.errors).toHaveLength(0);
+		expect(result.changedFiles).toHaveLength(2);
+		expect(globalsCss).toContain(
+			'@tailwind components;\n@import "@c15t/nextjs/styles.tw3.css";\n@tailwind utilities;'
+		);
+		expect(layout).not.toContain('@c15t/nextjs/styles.css');
+		expect(
+			result.changedFiles.some((file) =>
+				file.summaries.includes("removed JS import '@c15t/nextjs/styles.css'")
+			)
+		).toBe(true);
+	});
+
+	it('adds both base and IAB imports in order to the CSS entrypoint', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				"import { IABConsentBanner } from '@c15t/react/iab';",
+				'',
+				'export function App() {',
+				'  return <>',
+				'    <ConsentBanner />',
+				'    <IABConsentBanner />',
+				'  </>;',
+				'}',
+			].join('\n'),
+		});
+
+		await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+		const indexCss = await readProjectFile(root, 'src/index.css');
+
+		expect(indexCss).toContain(
+			'@import "@c15t/react/styles.css";\n@import "@c15t/react/iab/styles.css";'
+		);
+	});
+
+	it('is idempotent when the correct CSS import already exists', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': [
+				'@import "@c15t/react/styles.css";',
+				'',
+				':root { color: #111827; }',
+			].join('\n'),
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'export function App() { return <ConsentBanner />; }',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+
+		expect(result.changedFiles).toHaveLength(0);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('reports changes during dry runs without writing files', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import '@c15t/react/styles.css';",
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'export function App() { return <ConsentBanner />; }',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: true,
+		});
+		const mainTsx = await readProjectFile(root, 'src/main.tsx');
+		const indexCss = await readProjectFile(root, 'src/index.css');
+
+		expect(result.changedFiles).toHaveLength(2);
+		expect(mainTsx).toContain("import '@c15t/react/styles.css';");
+		expect(indexCss).not.toContain('@c15t/react/styles.css');
+	});
+
+	it('skips headless-only projects', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { useConsentManager } from '@c15t/react/headless';",
+				'',
+				'export function App() {',
+				'  const store = useConsentManager();',
+				'  return <div>{String(Boolean(store))}</div>;',
+				'}',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+
+		expect(result.changedFiles).toHaveLength(0);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('returns an actionable error when no global CSS entrypoint exists', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'export function App() { return <ConsentBanner />; }',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+
+		expect(result.changedFiles).toHaveLength(0);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.error).toContain(
+			'No suitable global CSS entrypoint found.'
+		);
+		expect(result.errors[0]?.error).toContain('src/index.css');
+		expect(result.errors[0]?.error).toContain('src/styles.css');
 	});
 });

--- a/packages/cli/src/commands/codemods/add-stylesheet-imports.ts
+++ b/packages/cli/src/commands/codemods/add-stylesheet-imports.ts
@@ -2,6 +2,10 @@ import { existsSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { extname, join } from 'node:path';
 import { Project } from 'ts-morph';
+import {
+	ensureGlobalCssStylesheetImports,
+	formatSearchedCssPaths,
+} from '../shared/stylesheets';
 
 const SUPPORTED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
 const IGNORED_DIRS = new Set([
@@ -128,10 +132,6 @@ async function detectTailwindVersion(
 	} catch {
 		return null;
 	}
-}
-
-function isTailwindV3(version: string | null): boolean {
-	return version != null && /^(?:\^|~)?3/.test(version);
 }
 
 async function collectSourceFiles(rootDir: string): Promise<string[]> {
@@ -289,86 +289,31 @@ function findEntrypoint(
 	return null;
 }
 
-/**
- * Checks whether a specific CSS import already exists in a source file.
- */
-function hasCssImport(
+const FRAMEWORK_STYLESHEET_IMPORT_RE =
+	/^@c15t\/(?:react|nextjs)(?:\/iab)?\/styles(?:\.tw3)?\.css$/;
+
+function removeFrameworkStylesheetImports(
 	project: Project,
-	filePath: string,
-	cssImportPath: string
-): boolean {
+	filePath: string
+): string[] {
 	const sourceFile = project.addSourceFileAtPathIfExists(filePath);
 	if (!sourceFile) {
-		return false;
+		return [];
 	}
 
-	const importDeclarations = sourceFile.getImportDeclarations();
-	return importDeclarations.some(
-		(importDecl) => importDecl.getModuleSpecifierValue() === cssImportPath
-	);
-}
+	const removedImports: string[] = [];
 
-/**
- * Adds a CSS import statement at the top of the file (after existing imports).
- */
-function addCssImport(
-	project: Project,
-	filePath: string,
-	cssImportPath: string
-): boolean {
-	const sourceFile = project.addSourceFileAtPathIfExists(filePath);
-	if (!sourceFile) {
-		return false;
-	}
-
-	// Check if it already exists
-	const importDeclarations = sourceFile.getImportDeclarations();
-	const alreadyExists = importDeclarations.some(
-		(importDecl) => importDecl.getModuleSpecifierValue() === cssImportPath
-	);
-
-	if (alreadyExists) {
-		return false;
-	}
-
-	// Find the last import declaration to insert after it
-	if (importDeclarations.length > 0) {
-		const lastImport = importDeclarations[importDeclarations.length - 1];
-		if (lastImport) {
-			sourceFile.insertStatements(
-				lastImport.getChildIndex() + 1,
-				`import '${cssImportPath}';`
-			);
+	for (const importDeclaration of sourceFile.getImportDeclarations()) {
+		const moduleSpecifier = importDeclaration.getModuleSpecifierValue();
+		if (!FRAMEWORK_STYLESHEET_IMPORT_RE.test(moduleSpecifier)) {
+			continue;
 		}
-	} else {
-		// No existing imports; add at the top
-		sourceFile.insertStatements(0, `import '${cssImportPath}';`);
+
+		removedImports.push(moduleSpecifier);
+		importDeclaration.remove();
 	}
 
-	return true;
-}
-
-function replaceCssImport(
-	project: Project,
-	filePath: string,
-	fromPath: string,
-	toPath: string
-): boolean {
-	const sourceFile = project.addSourceFileAtPathIfExists(filePath);
-	if (!sourceFile) {
-		return false;
-	}
-
-	const importDeclaration = sourceFile
-		.getImportDeclarations()
-		.find((importDecl) => importDecl.getModuleSpecifierValue() === fromPath);
-
-	if (!importDeclaration) {
-		return false;
-	}
-
-	importDeclaration.setModuleSpecifier(toPath);
-	return true;
+	return removedImports;
 }
 
 /**
@@ -460,91 +405,61 @@ export async function runAddStylesheetImportsCodemod(
 	// Phase 3: Add CSS imports
 	const pkg = detection.framework === 'nextjs' ? '@c15t/nextjs' : '@c15t/react';
 	const tailwindVersion = await detectTailwindVersion(options.projectRoot);
-	const baseStylesheet = isTailwindV3(tailwindVersion)
-		? `${pkg}/styles.tw3.css`
-		: `${pkg}/styles.css`;
-	const iabStylesheet = isTailwindV3(tailwindVersion)
-		? `${pkg}/iab/styles.tw3.css`
-		: `${pkg}/iab/styles.css`;
-	const operations: number[] = [];
-	const summaries: string[] = [];
 
 	try {
-		// Add base stylesheet if styled UI is used (not just IAB)
-		if (detection.usesStyledUi) {
-			const baseCss = baseStylesheet;
-			const fallbackBaseCss = baseCss.endsWith('.tw3.css')
-				? `${pkg}/styles.css`
-				: `${pkg}/styles.tw3.css`;
-			if (
-				!hasCssImport(project, entrypoint, baseCss) &&
-				hasCssImport(project, entrypoint, fallbackBaseCss)
-			) {
-				const replaced = replaceCssImport(
-					project,
-					entrypoint,
-					fallbackBaseCss,
-					baseCss
-				);
-				if (replaced) {
-					operations.push(1);
-					summaries.push(
-						`replaced import '${fallbackBaseCss}' with '${baseCss}'`
-					);
-				}
-			} else if (!hasCssImport(project, entrypoint, baseCss)) {
-				const added = addCssImport(project, entrypoint, baseCss);
-				if (added) {
-					operations.push(1);
-					summaries.push(`added import '${baseCss}'`);
-				}
-			}
-		}
+		const stylesheetResult = await ensureGlobalCssStylesheetImports({
+			projectRoot: options.projectRoot,
+			packageName: pkg,
+			tailwindVersion,
+			entrypointPath: entrypoint,
+			includeBase: detection.usesStyledUi || detection.usesIabUi,
+			includeIab: detection.usesIabUi,
+			dryRun: options.dryRun,
+		});
 
-		// Add IAB stylesheet if IAB UI is used
-		if (detection.usesIabUi) {
-			const iabCss = iabStylesheet;
-			const fallbackIabCss = iabCss.endsWith('.tw3.css')
-				? `${pkg}/iab/styles.css`
-				: `${pkg}/iab/styles.tw3.css`;
-			if (
-				!hasCssImport(project, entrypoint, iabCss) &&
-				hasCssImport(project, entrypoint, fallbackIabCss)
-			) {
-				const replaced = replaceCssImport(
-					project,
-					entrypoint,
-					fallbackIabCss,
-					iabCss
-				);
-				if (replaced) {
-					operations.push(1);
-					summaries.push(
-						`replaced import '${fallbackIabCss}' with '${iabCss}'`
-					);
-				}
-			} else if (!hasCssImport(project, entrypoint, iabCss)) {
-				const added = addCssImport(project, entrypoint, iabCss);
-				if (added) {
-					operations.push(1);
-					summaries.push(`added import '${iabCss}'`);
-				}
-			}
-		}
-
-		if (operations.length > 0) {
-			changedFiles.push({
-				filePath: entrypoint,
-				operations: operations.length,
-				summaries,
+		if (!stylesheetResult.filePath) {
+			errors.push({
+				filePath: options.projectRoot,
+				error: `No suitable global CSS entrypoint found. Checked: ${formatSearchedCssPaths(
+					options.projectRoot,
+					stylesheetResult.searchedPaths
+				)}`,
 			});
+			return {
+				totalFiles: filePaths.length,
+				changedFiles,
+				errors,
+			};
+		}
 
-			if (!options.dryRun) {
-				const sourceFile = project.getSourceFile(entrypoint);
-				if (sourceFile) {
-					await sourceFile.save();
-				}
+		if (stylesheetResult.updated) {
+			changedFiles.push({
+				filePath: stylesheetResult.filePath,
+				operations: stylesheetResult.changes.length,
+				summaries: stylesheetResult.changes,
+			});
+		}
+
+		for (const filePath of filePaths) {
+			const removedImports = removeFrameworkStylesheetImports(
+				project,
+				filePath
+			);
+			if (removedImports.length === 0) {
+				continue;
 			}
+
+			changedFiles.push({
+				filePath,
+				operations: removedImports.length,
+				summaries: removedImports.map(
+					(importPath) => `removed JS import '${importPath}'`
+				),
+			});
+		}
+
+		if (!options.dryRun) {
+			await project.save();
 		}
 	} catch (error) {
 		errors.push({

--- a/packages/cli/src/commands/codemods/index.ts
+++ b/packages/cli/src/commands/codemods/index.ts
@@ -236,8 +236,8 @@ const codemods: CodemodDefinition[] = [
 	},
 	{
 		id: 'add-stylesheet-imports',
-		label: 'add stylesheet imports for prebuilt UI',
-		hint: 'Adds the correct c15t stylesheet import for styled components, including the Tailwind 3 entrypoint when needed.',
+		label: 'configure global CSS for prebuilt UI',
+		hint: 'Moves styled c15t imports into the app CSS entrypoint, including Tailwind 3 and IAB variants when needed.',
 		run: async (context, dryRun) => {
 			const { projectRoot } = context;
 			const result = await runAddStylesheetImportsCodemod({

--- a/packages/cli/src/commands/generate/options/utils/generate-files.ts
+++ b/packages/cli/src/commands/generate/options/utils/generate-files.ts
@@ -5,9 +5,10 @@ import color from 'picocolors';
 import type { AvailablePackages } from '~/context/framework-detection';
 import type { CliContext } from '~/context/types';
 import { formatLogMessage } from '~/utils/logger';
+import { formatSearchedCssPaths } from '../../../shared/stylesheets';
 import type { ExpandedTheme, UIStyle } from '../../prompts';
 import { generateClientConfigContent } from '../../templates/config';
-import { updateTailwindCss } from '../../templates/css';
+import { updateAppStylesheetImports } from '../../templates/css';
 import {
 	generateEnvExampleContent,
 	generateEnvFileContent,
@@ -394,25 +395,36 @@ export async function generateFiles({
 		});
 	}
 
-	// Update Tailwind CSS if needed (v3 detection)
-	if (context.framework.tailwindVersion) {
-		spinner.start('Checking Tailwind CSS compatibility...');
-		const tailwindResult = await updateTailwindCss(
+	if (pkg === '@c15t/react' || pkg === '@c15t/nextjs') {
+		spinner.start('Configuring app stylesheet...');
+		const stylesheetResult = await updateAppStylesheetImports({
 			projectRoot,
-			context.framework.tailwindVersion
-		);
-		if (tailwindResult.updated) {
+			packageName: pkg,
+			tailwindVersion: context.framework.tailwindVersion,
+			entrypointPath: result.layoutPath,
+		});
+		if (stylesheetResult.updated) {
 			result.tailwindCssUpdated = true;
-			result.tailwindCssPath = tailwindResult.filePath;
+			result.tailwindCssPath = stylesheetResult.filePath;
 			spinner.stop(
 				formatLogMessage(
 					'info',
-					`Tailwind CSS updated for v3 compatibility: ${color.cyan(path.relative(context.cwd, tailwindResult.filePath || ''))}`
+					`App stylesheet updated: ${color.cyan(path.relative(context.cwd, stylesheetResult.filePath || ''))}`
+				)
+			);
+		} else if (stylesheetResult.filePath) {
+			spinner.stop(
+				formatLogMessage(
+					'debug',
+					'App stylesheet already had the correct c15t imports.'
 				)
 			);
 		} else {
 			spinner.stop(
-				formatLogMessage('debug', 'Tailwind CSS update not needed.')
+				formatLogMessage(
+					'warn',
+					`Could not find a global CSS entrypoint. Checked: ${formatSearchedCssPaths(projectRoot, stylesheetResult.searchedPaths)}`
+				)
 			);
 		}
 	}

--- a/packages/cli/src/commands/generate/templates/css.test.ts
+++ b/packages/cli/src/commands/generate/templates/css.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { updateTailwindCss } from './css';
+import { updateAppStylesheetImports } from './css';
 
 const tempDirs: string[] = [];
 
@@ -27,74 +27,151 @@ afterEach(async () => {
 	);
 });
 
-describe('updateTailwindCss', () => {
-	it('leaves plain Tailwind v3 directives unchanged', async () => {
-		const initial = [
-			'@tailwind base;',
-			'@tailwind components;',
-			'@tailwind utilities;',
-		].join('\n');
+describe('updateAppStylesheetImports', () => {
+	it('adds the React stylesheet to src/index.css for non-Tailwind apps', async () => {
 		const { root } = await createProject({
-			'app/globals.css': initial,
+			'src/main.tsx': [
+				"import './index.css';",
+				'',
+				'export default function App() {',
+				'  return null;',
+				'}',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
 		});
 
-		const result = await updateTailwindCss(root, '3.4.17');
-		const content = await readFile(join(root, 'app/globals.css'), 'utf-8');
-
-		expect(result).toEqual({
-			updated: false,
-			filePath: join(root, 'app/globals.css'),
+		const result = await updateAppStylesheetImports({
+			projectRoot: root,
+			packageName: '@c15t/react',
+			tailwindVersion: null,
+			entrypointPath: 'src/main.tsx',
 		});
-		expect(content).toBe(initial);
+		const content = await readFile(join(root, 'src/index.css'), 'utf-8');
+
+		expect(result.updated).toBe(true);
+		expect(result.filePath).toBe(join(root, 'src/index.css'));
+		expect(content).toBe(
+			'@import "@c15t/react/styles.css";\n:root { color: #111827; }\n'
+		);
 	});
 
-	it('leaves the layer-prelude variant unchanged', async () => {
-		const initial = [
-			'@layer base, components, utilities;',
-			'',
-			'@layer base {',
-			'  @tailwind base;',
-			'}',
-			'',
-			'@tailwind components;',
-			'@tailwind utilities;',
-		].join('\n');
+	it('inserts the Tailwind v4 stylesheet immediately after tailwindcss', async () => {
 		const { root } = await createProject({
-			'app/globals.css': initial,
+			'app/layout.tsx': [
+				"import './globals.css';",
+				'',
+				'export default function RootLayout({ children }: { children: React.ReactNode }) {',
+				'  return <html><body>{children}</body></html>;',
+				'}',
+			].join('\n'),
+			'app/globals.css': [
+				'@import "tailwindcss";',
+				'@import "tw-animate-css";',
+				'',
+				':root { color: #111827; }',
+			].join('\n'),
 		});
 
-		const result = await updateTailwindCss(root, '3.4.17');
+		const result = await updateAppStylesheetImports({
+			projectRoot: root,
+			packageName: '@c15t/nextjs',
+			tailwindVersion: '^4.2.2',
+			entrypointPath: 'app/layout.tsx',
+		});
 		const content = await readFile(join(root, 'app/globals.css'), 'utf-8');
 
-		expect(result).toEqual({
-			updated: false,
-			filePath: join(root, 'app/globals.css'),
-		});
-		expect(content).toBe(initial);
+		expect(result.updated).toBe(true);
+		expect(content).toContain(
+			'@import "tailwindcss";\n@import "@c15t/nextjs/styles.css";\n@import "tw-animate-css";'
+		);
 	});
 
-	it('leaves the old c15t layer prelude unchanged', async () => {
-		const initial = [
-			'@layer base, components, c15t;',
-			'',
-			'@layer base {',
-			'  @tailwind base;',
-			'}',
-			'',
-			'@tailwind components;',
-			'@tailwind utilities;',
-		].join('\n');
+	it('inserts the Tailwind v3 stylesheet after @tailwind components', async () => {
 		const { root } = await createProject({
-			'app/globals.css': initial,
+			'app/layout.tsx': [
+				"import './globals.css';",
+				'',
+				'export default function RootLayout({ children }: { children: React.ReactNode }) {',
+				'  return <html><body>{children}</body></html>;',
+				'}',
+			].join('\n'),
+			'app/globals.css': [
+				'@tailwind base;',
+				'@tailwind components;',
+				'@tailwind utilities;',
+			].join('\n'),
 		});
 
-		const result = await updateTailwindCss(root, '3.4.17');
+		const result = await updateAppStylesheetImports({
+			projectRoot: root,
+			packageName: '@c15t/nextjs',
+			tailwindVersion: '3.4.17',
+			entrypointPath: 'app/layout.tsx',
+		});
 		const content = await readFile(join(root, 'app/globals.css'), 'utf-8');
 
-		expect(result).toEqual({
-			updated: false,
-			filePath: join(root, 'app/globals.css'),
+		expect(result.updated).toBe(true);
+		expect(content).toBe(
+			[
+				'@tailwind base;',
+				'@tailwind components;',
+				'@import "@c15t/nextjs/styles.tw3.css";',
+				'@tailwind utilities;',
+			].join('\n')
+		);
+	});
+
+	it('adds base and IAB imports in order after a leading comment block', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './styles.css';",
+				'',
+				'export default function App() {',
+				'  return null;',
+				'}',
+			].join('\n'),
+			'src/styles.css': [
+				'/* App styles */',
+				'',
+				':root { color: #111827; }',
+			].join('\n'),
 		});
-		expect(content).toBe(initial);
+
+		const result = await updateAppStylesheetImports({
+			projectRoot: root,
+			packageName: '@c15t/react',
+			tailwindVersion: null,
+			entrypointPath: 'src/main.tsx',
+			includeIab: true,
+		});
+		const content = await readFile(join(root, 'src/styles.css'), 'utf-8');
+
+		expect(result.updated).toBe(true);
+		expect(content).toContain(
+			'/* App styles */\n\n@import "@c15t/react/styles.css";\n@import "@c15t/react/iab/styles.css";'
+		);
+	});
+
+	it('returns searched targets when no CSS entrypoint exists', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				'export default function App() {',
+				'  return null;',
+				'}',
+			].join('\n'),
+		});
+
+		const result = await updateAppStylesheetImports({
+			projectRoot: root,
+			packageName: '@c15t/react',
+			tailwindVersion: null,
+			entrypointPath: 'src/main.tsx',
+		});
+
+		expect(result.updated).toBe(false);
+		expect(result.filePath).toBeNull();
+		expect(
+			result.searchedPaths.map((filePath) => filePath.replace(`${root}/`, ''))
+		).toContain('src/index.css');
 	});
 });

--- a/packages/cli/src/commands/generate/templates/css.ts
+++ b/packages/cli/src/commands/generate/templates/css.ts
@@ -1,49 +1,28 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
+import {
+	type EnsureGlobalCssStylesheetImportsResult,
+	ensureGlobalCssStylesheetImports,
+	type StyledPackageName,
+} from '../../shared/stylesheets';
 
-/**
- * Patterns for common CSS files that might contain Tailwind directives
- */
-const CSS_PATTERNS = [
-	'app/globals.css',
-	'src/app/globals.css',
-	'app/global.css',
-	'src/app/global.css',
-	'styles/globals.css',
-	'src/styles/globals.css',
-	'styles/global.css',
-	'src/styles/global.css',
-	'src/index.css',
-	'src/App.css',
-];
+export interface UpdateAppStylesheetImportsOptions {
+	projectRoot: string;
+	packageName: Exclude<StyledPackageName, '@c15t/ui'>;
+	tailwindVersion: string | null;
+	entrypointPath?: string | null;
+	dryRun?: boolean;
+	includeIab?: boolean;
+}
 
-/**
- * Updates the project's CSS file for Tailwind v3 compatibility if needed
- *
- * @param projectRoot - The root directory of the project
- * @param tailwindVersion - The detected Tailwind version
- * @returns Object indicating if the update was successful and the file path
- */
-export async function updateTailwindCss(
-	projectRoot: string,
-	tailwindVersion: string | null
-): Promise<{ updated: boolean; filePath: string | null }> {
-	// Tailwind v3 no longer needs a CSS rewrite. Styled installs use the
-	// dedicated styles.tw3.css entrypoint, and standard Tailwind directives can
-	// remain unchanged in the app stylesheet.
-	if (!tailwindVersion || !tailwindVersion.match(/^(?:\^|~)?3/)) {
-		return { updated: false, filePath: null };
-	}
-
-	for (const pattern of CSS_PATTERNS) {
-		const filePath = path.join(projectRoot, pattern);
-		try {
-			await fs.access(filePath);
-			return { updated: false, filePath };
-		} catch {
-			// File doesn't exist, try next pattern
-		}
-	}
-
-	return { updated: false, filePath: null };
+export async function updateAppStylesheetImports(
+	options: UpdateAppStylesheetImportsOptions
+): Promise<EnsureGlobalCssStylesheetImportsResult> {
+	return ensureGlobalCssStylesheetImports({
+		projectRoot: options.projectRoot,
+		packageName: options.packageName,
+		tailwindVersion: options.tailwindVersion,
+		entrypointPath: options.entrypointPath,
+		includeBase: true,
+		includeIab: options.includeIab ?? false,
+		dryRun: options.dryRun,
+	});
 }

--- a/packages/cli/src/commands/generate/templates/shared/framework-config.ts
+++ b/packages/cli/src/commands/generate/templates/shared/framework-config.ts
@@ -13,10 +13,6 @@ export interface FrameworkConfig {
 	docsSlug: string;
 	envVarPrefix: string;
 	hasSSRProps: boolean;
-	/** CSS stylesheet import path for prebuilt (styled) components, or null for unstyled. */
-	stylesheetImport: string | null;
-	/** CSS stylesheet import path for IAB components, or null if IAB is not applicable. */
-	iabStylesheetImport: string | null;
 }
 
 export const NEXTJS_CONFIG: FrameworkConfig = {
@@ -28,8 +24,6 @@ export const NEXTJS_CONFIG: FrameworkConfig = {
 	docsSlug: 'nextjs',
 	envVarPrefix: 'NEXT_PUBLIC',
 	hasSSRProps: true,
-	stylesheetImport: '@c15t/nextjs/styles.css',
-	iabStylesheetImport: '@c15t/nextjs/iab/styles.css',
 };
 
 export const REACT_CONFIG: FrameworkConfig = {
@@ -41,6 +35,4 @@ export const REACT_CONFIG: FrameworkConfig = {
 	docsSlug: 'react',
 	envVarPrefix: '',
 	hasSSRProps: false,
-	stylesheetImport: '@c15t/react/styles.css',
-	iabStylesheetImport: '@c15t/react/iab/styles.css',
 };

--- a/packages/cli/src/commands/shared/stylesheets.ts
+++ b/packages/cli/src/commands/shared/stylesheets.ts
@@ -1,0 +1,363 @@
+import { existsSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const CSS_ENTRYPOINT_CANDIDATES = [
+	'app/globals.css',
+	'src/app/globals.css',
+	'app/global.css',
+	'src/app/global.css',
+	'styles/globals.css',
+	'src/styles/globals.css',
+	'styles/global.css',
+	'src/styles/global.css',
+	'src/index.css',
+	'src/styles.css',
+	'src/style.css',
+	'styles.css',
+	'app.css',
+	'src/App.css',
+] as const;
+
+const LOCAL_CSS_IMPORT_RE =
+	/^\s*import(?:\s+[^'"]+\s+from\s+)?['"]([^'"]+\.css)['"];\s*$/gm;
+
+const TAILWIND_V4_IMPORT_RE = /^\s*@import\s+['"]tailwindcss['"];\s*$/;
+const TAILWIND_COMPONENTS_RE = /^\s*@tailwind\s+components\s*;\s*$/;
+const TAILWIND_UTILITIES_RE = /^\s*@tailwind\s+utilities\s*;\s*$/;
+
+export type StyledPackageName = '@c15t/react' | '@c15t/nextjs' | '@c15t/ui';
+
+export interface EnsureGlobalCssStylesheetImportsOptions {
+	projectRoot: string;
+	packageName: StyledPackageName;
+	tailwindVersion: string | null;
+	entrypointPath?: string | null;
+	includeBase: boolean;
+	includeIab: boolean;
+	dryRun?: boolean;
+}
+
+export interface EnsureGlobalCssStylesheetImportsResult {
+	updated: boolean;
+	filePath: string | null;
+	searchedPaths: string[];
+	changes: string[];
+}
+
+type StylesheetKind = 'base' | 'iab';
+
+function normalizePath(projectRoot: string, filePath: string): string {
+	if (filePath.startsWith(projectRoot)) {
+		return filePath;
+	}
+
+	return resolve(projectRoot, filePath);
+}
+
+function dedupePaths(paths: string[]): string[] {
+	return [...new Set(paths)];
+}
+
+function isNonModuleLocalCssImport(moduleSpecifier: string): boolean {
+	return (
+		moduleSpecifier.startsWith('.') &&
+		moduleSpecifier.endsWith('.css') &&
+		!moduleSpecifier.endsWith('.module.css')
+	);
+}
+
+function getManagedPackages(
+	packageName: StyledPackageName
+): StyledPackageName[] {
+	if (packageName === '@c15t/react' || packageName === '@c15t/nextjs') {
+		return ['@c15t/react', '@c15t/nextjs'];
+	}
+
+	return ['@c15t/ui'];
+}
+
+function getImportVariants(
+	packageName: StyledPackageName,
+	kind: StylesheetKind
+): string[] {
+	if (kind === 'base') {
+		return [`${packageName}/styles.css`, `${packageName}/styles.tw3.css`];
+	}
+
+	return [`${packageName}/iab/styles.css`, `${packageName}/iab/styles.tw3.css`];
+}
+
+function getDesiredImportPath(
+	packageName: StyledPackageName,
+	kind: StylesheetKind,
+	tailwindVersion: string | null
+): string {
+	const suffix = isTailwindV3(tailwindVersion)
+		? 'styles.tw3.css'
+		: 'styles.css';
+	return kind === 'base'
+		? `${packageName}/${suffix}`
+		: `${packageName}/iab/${suffix}`;
+}
+
+function getDesiredImports(
+	packageName: StyledPackageName,
+	tailwindVersion: string | null,
+	includeBase: boolean,
+	includeIab: boolean
+): string[] {
+	const imports: string[] = [];
+
+	if (includeBase) {
+		imports.push(getDesiredImportPath(packageName, 'base', tailwindVersion));
+	}
+
+	if (includeIab) {
+		imports.push(getDesiredImportPath(packageName, 'iab', tailwindVersion));
+	}
+
+	return imports;
+}
+
+function getFrameworkImportRegex(packageNames: StyledPackageName[]): RegExp {
+	const escapedPackages = packageNames
+		.map((packageName) => packageName.replace('/', '\\/'))
+		.join('|');
+
+	return new RegExp(
+		`^\\s*@import\\s+['"](?:${escapedPackages})(?:\\/iab)?\\/styles(?:\\.tw3)?\\.css['"];\\s*$`
+	);
+}
+
+function findTopInsertionLineIndex(lines: string[]): number {
+	let index = 0;
+
+	if (lines[index]?.trim().startsWith('/*')) {
+		while (index < lines.length) {
+			const line = lines[index];
+			index += 1;
+			if (line?.includes('*/')) {
+				break;
+			}
+		}
+
+		while (index < lines.length && lines[index]?.trim() === '') {
+			index += 1;
+		}
+	}
+
+	return index;
+}
+
+function insertImportsIntoCssContent(
+	content: string,
+	desiredImports: string[],
+	tailwindVersion: string | null,
+	managedPackages: StyledPackageName[]
+): string {
+	const normalizedContent = content.replace(/\r\n/g, '\n');
+	const hadTrailingNewline = normalizedContent.endsWith('\n');
+	const body = hadTrailingNewline
+		? normalizedContent.slice(0, -1)
+		: normalizedContent;
+	const lines = body.length > 0 ? body.split('\n') : [];
+	const importRegex = getFrameworkImportRegex(managedPackages);
+	const filteredLines = lines.filter((line) => !importRegex.test(line));
+	const importLines = desiredImports.map(
+		(importPath) => `@import "${importPath}";`
+	);
+
+	let insertionIndex = findTopInsertionLineIndex(filteredLines);
+
+	if (isTailwindV3(tailwindVersion)) {
+		const componentsIndex = filteredLines.findIndex((line) =>
+			TAILWIND_COMPONENTS_RE.test(line)
+		);
+		if (componentsIndex >= 0) {
+			insertionIndex = componentsIndex + 1;
+		} else {
+			const utilitiesIndex = filteredLines.findIndex((line) =>
+				TAILWIND_UTILITIES_RE.test(line)
+			);
+			if (utilitiesIndex >= 0) {
+				insertionIndex = utilitiesIndex;
+			}
+		}
+	} else {
+		const tailwindImportIndex = filteredLines.findIndex((line) =>
+			TAILWIND_V4_IMPORT_RE.test(line)
+		);
+		if (tailwindImportIndex >= 0) {
+			insertionIndex = tailwindImportIndex + 1;
+		}
+	}
+
+	const nextLines = [
+		...filteredLines.slice(0, insertionIndex),
+		...importLines,
+		...filteredLines.slice(insertionIndex),
+	];
+	let nextContent = nextLines.join('\n');
+
+	if (hadTrailingNewline) {
+		nextContent += '\n';
+	}
+
+	if (content.includes('\r\n')) {
+		nextContent = nextContent.replace(/\n/g, '\r\n');
+	}
+
+	return nextContent;
+}
+
+function describeImportChange(
+	content: string,
+	packageName: StyledPackageName,
+	desiredImportPath: string
+): string {
+	const kind: StylesheetKind = desiredImportPath.includes('/iab/')
+		? 'iab'
+		: 'base';
+	const variants = getImportVariants(packageName, kind);
+	const alternateVariant = variants.find(
+		(variant) => variant !== desiredImportPath && content.includes(variant)
+	);
+
+	if (alternateVariant) {
+		return `replaced @import "${alternateVariant}"; with @import "${desiredImportPath}";`;
+	}
+
+	if (content.includes(desiredImportPath)) {
+		return `normalized @import "${desiredImportPath}";`;
+	}
+
+	return `added @import "${desiredImportPath}";`;
+}
+
+async function resolveCssEntrypoint({
+	projectRoot,
+	entrypointPath,
+}: Pick<
+	EnsureGlobalCssStylesheetImportsOptions,
+	'projectRoot' | 'entrypointPath'
+>): Promise<{ filePath: string | null; searchedPaths: string[] }> {
+	const searchedPaths: string[] = [];
+
+	if (entrypointPath) {
+		const resolvedEntrypointPath = normalizePath(projectRoot, entrypointPath);
+		if (existsSync(resolvedEntrypointPath)) {
+			const entrypointContent = await readFile(resolvedEntrypointPath, 'utf-8');
+			for (const match of entrypointContent.matchAll(LOCAL_CSS_IMPORT_RE)) {
+				const moduleSpecifier = match[1];
+				if (!moduleSpecifier || !isNonModuleLocalCssImport(moduleSpecifier)) {
+					continue;
+				}
+
+				const candidatePath = resolve(
+					dirname(resolvedEntrypointPath),
+					moduleSpecifier
+				);
+				searchedPaths.push(candidatePath);
+				if (existsSync(candidatePath)) {
+					return {
+						filePath: candidatePath,
+						searchedPaths: dedupePaths(searchedPaths),
+					};
+				}
+			}
+		}
+	}
+
+	for (const candidate of CSS_ENTRYPOINT_CANDIDATES) {
+		const candidatePath = join(projectRoot, candidate);
+		searchedPaths.push(candidatePath);
+		if (existsSync(candidatePath)) {
+			return {
+				filePath: candidatePath,
+				searchedPaths: dedupePaths(searchedPaths),
+			};
+		}
+	}
+
+	return {
+		filePath: null,
+		searchedPaths: dedupePaths(searchedPaths),
+	};
+}
+
+export function formatSearchedCssPaths(
+	projectRoot: string,
+	searchedPaths: string[]
+): string {
+	return searchedPaths
+		.map((filePath) => relative(projectRoot, filePath) || '.')
+		.join(', ');
+}
+
+export function isTailwindV3(version: string | null): boolean {
+	return version != null && /^(?:\^|~)?3/.test(version);
+}
+
+export async function ensureGlobalCssStylesheetImports(
+	options: EnsureGlobalCssStylesheetImportsOptions
+): Promise<EnsureGlobalCssStylesheetImportsResult> {
+	const desiredImports = getDesiredImports(
+		options.packageName,
+		options.tailwindVersion,
+		options.includeBase,
+		options.includeIab
+	);
+
+	if (desiredImports.length === 0) {
+		return {
+			updated: false,
+			filePath: null,
+			searchedPaths: [],
+			changes: [],
+		};
+	}
+
+	const { filePath, searchedPaths } = await resolveCssEntrypoint(options);
+	if (!filePath) {
+		return {
+			updated: false,
+			filePath: null,
+			searchedPaths,
+			changes: [],
+		};
+	}
+
+	const content = await readFile(filePath, 'utf-8');
+	const managedPackages = getManagedPackages(options.packageName);
+	const nextContent = insertImportsIntoCssContent(
+		content,
+		desiredImports,
+		options.tailwindVersion,
+		managedPackages
+	);
+
+	if (nextContent === content) {
+		return {
+			updated: false,
+			filePath,
+			searchedPaths,
+			changes: [],
+		};
+	}
+
+	if (!options.dryRun) {
+		await writeFile(filePath, nextContent, 'utf-8');
+	}
+
+	const changes = desiredImports.map((importPath) =>
+		describeImportChange(content, options.packageName, importPath)
+	);
+
+	return {
+		updated: true,
+		filePath,
+		searchedPaths,
+		changes,
+	};
+}

--- a/packages/cli/test/codemods/add-stylesheet-imports.test.ts
+++ b/packages/cli/test/codemods/add-stylesheet-imports.test.ts
@@ -1,165 +1,179 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { runAddStylesheetImportsCodemod } from '../../src/commands/codemods/add-stylesheet-imports';
 
-let fixtureDir: string;
+const tempDirs: string[] = [];
 
-async function createFixture(files: Record<string, string>): Promise<string> {
-	const dir = await mkdtemp(join(tmpdir(), 'codemod-test-'));
-	for (const [filePath, content] of Object.entries(files)) {
-		const full = join(dir, filePath);
-		await mkdir(dirname(full), { recursive: true });
-		await writeFile(full, content);
+async function createProject(
+	files: Record<string, string>
+): Promise<{ root: string }> {
+	const root = await mkdtemp(join(tmpdir(), 'c15t-add-stylesheet-'));
+	tempDirs.push(root);
+
+	for (const [relativePath, content] of Object.entries(files)) {
+		const filePath = join(root, relativePath);
+		await mkdir(dirname(filePath), { recursive: true });
+		await writeFile(filePath, content, 'utf-8');
 	}
-	return dir;
+
+	return { root };
 }
 
-beforeEach(() => {
-	fixtureDir = '';
-});
+async function readProjectFile(
+	root: string,
+	relativePath: string
+): Promise<string> {
+	return readFile(join(root, relativePath), 'utf-8');
+}
 
 afterEach(async () => {
-	if (fixtureDir) {
-		await rm(fixtureDir, { recursive: true, force: true });
-	}
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+	);
 });
 
 describe('add-stylesheet-imports codemod', () => {
-	it('adds styles.css import for React styled app', async () => {
-		fixtureDir = await createFixture({
+	it('adds the React stylesheet to the imported CSS entrypoint', async () => {
+		const { root } = await createProject({
 			'src/main.tsx': [
-				"import React from 'react';",
+				"import './index.css';",
 				"import { App } from './app';",
 				'',
 				'export default App;',
 			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
 			'src/app.tsx': [
-				"import { ConsentBanner, ConsentManagerProvider } from '@c15t/react';",
+				"import { ConsentBanner } from '@c15t/react';",
 				'',
 				'export function App() {',
-				'  return (',
-				"    <ConsentManagerProvider options={{ mode: 'offline' }}>",
-				'      <ConsentBanner />',
-				'    </ConsentManagerProvider>',
-				'  );',
+				'  return <ConsentBanner />;',
 				'}',
 			].join('\n'),
 		});
 
 		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
+			projectRoot: root,
 			dryRun: false,
 		});
+		const indexCss = await readProjectFile(root, 'src/index.css');
+		const mainTsx = await readProjectFile(root, 'src/main.tsx');
 
-		expect(result.changedFiles).toHaveLength(1);
-		expect(result.changedFiles[0]?.filePath).toContain('main.tsx');
-		expect(result.changedFiles[0]?.summaries).toContain(
-			"added import '@c15t/react/styles.css'"
-		);
 		expect(result.errors).toHaveLength(0);
-
-		const content = await readFile(join(fixtureDir, 'src/main.tsx'), 'utf-8');
-		expect(content).toContain("import '@c15t/react/styles.css';");
+		expect(result.changedFiles).toHaveLength(1);
+		expect(result.changedFiles[0]?.filePath).toContain('src/index.css');
+		expect(result.changedFiles[0]?.summaries).toContain(
+			'added @import "@c15t/react/styles.css";'
+		);
+		expect(indexCss).toContain('@import "@c15t/react/styles.css";');
+		expect(mainTsx).not.toContain('@c15t/react/styles.css');
 	});
 
-	it('adds styles.css import for Next.js app', async () => {
-		fixtureDir = await createFixture({
+	it('moves Next.js Tailwind 3 imports into app/globals.css and removes the JS import', async () => {
+		const { root } = await createProject({
+			'package.json': JSON.stringify({
+				name: 'tw3-next-app',
+				devDependencies: {
+					tailwindcss: '^3.4.17',
+				},
+			}),
 			'app/layout.tsx': [
-				"import { ConsentBanner, ConsentManagerProvider } from '@c15t/nextjs';",
+				"import '@c15t/nextjs/styles.css';",
+				"import './globals.css';",
 				'',
 				'export default function RootLayout({ children }: { children: React.ReactNode }) {',
-				'  return (',
-				'    <html>',
-				'      <body>',
-				"        <ConsentManagerProvider options={{ mode: 'offline' }}>",
-				'          <ConsentBanner />',
-				'          {children}',
-				'        </ConsentManagerProvider>',
-				'      </body>',
-				'    </html>',
-				'  );',
+				'  return <html><body>{children}</body></html>;',
+				'}',
+			].join('\n'),
+			'app/globals.css': [
+				'@tailwind base;',
+				'@tailwind components;',
+				'@tailwind utilities;',
+			].join('\n'),
+			'app/provider.tsx': [
+				"import { ConsentBanner } from '@c15t/nextjs';",
+				'',
+				'export function Provider() {',
+				'  return <ConsentBanner />;',
 				'}',
 			].join('\n'),
 		});
 
 		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
+			projectRoot: root,
 			dryRun: false,
 		});
+		const globalsCss = await readProjectFile(root, 'app/globals.css');
+		const layout = await readProjectFile(root, 'app/layout.tsx');
 
-		expect(result.changedFiles).toHaveLength(1);
-		expect(result.changedFiles[0]?.filePath).toContain('layout.tsx');
-		expect(result.changedFiles[0]?.summaries).toContain(
-			"added import '@c15t/nextjs/styles.css'"
+		expect(result.errors).toHaveLength(0);
+		expect(result.changedFiles).toHaveLength(2);
+		expect(globalsCss).toContain(
+			'@tailwind components;\n@import "@c15t/nextjs/styles.tw3.css";\n@tailwind utilities;'
 		);
-
-		const content = await readFile(join(fixtureDir, 'app/layout.tsx'), 'utf-8');
-		expect(content).toContain("import '@c15t/nextjs/styles.css';");
+		expect(layout).not.toContain('@c15t/nextjs/styles.css');
+		expect(
+			result.changedFiles.some((file) =>
+				file.summaries.includes("removed JS import '@c15t/nextjs/styles.css'")
+			)
+		).toBe(true);
 	});
 
-	it('adds both styles.css and iab/styles.css for IAB usage', async () => {
-		fixtureDir = await createFixture({
+	it('adds both base and IAB imports in order to the CSS entrypoint', async () => {
+		const { root } = await createProject({
 			'src/main.tsx': [
-				"import React from 'react';",
+				"import './index.css';",
 				"import { App } from './app';",
 				'',
 				'export default App;',
 			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
 			'src/app.tsx': [
-				"import { ConsentBanner, ConsentManagerProvider } from '@c15t/react';",
+				"import { ConsentBanner } from '@c15t/react';",
 				"import { IABConsentBanner } from '@c15t/react/iab';",
 				'',
 				'export function App() {',
-				'  return (',
-				"    <ConsentManagerProvider options={{ mode: 'offline' }}>",
-				'      <ConsentBanner />',
-				'      <IABConsentBanner />',
-				'    </ConsentManagerProvider>',
-				'  );',
+				'  return <>',
+				'    <ConsentBanner />',
+				'    <IABConsentBanner />',
+				'  </>;',
 				'}',
 			].join('\n'),
 		});
 
-		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
+		await runAddStylesheetImportsCodemod({
+			projectRoot: root,
 			dryRun: false,
 		});
+		const indexCss = await readProjectFile(root, 'src/index.css');
 
-		expect(result.changedFiles).toHaveLength(1);
-		expect(result.changedFiles[0]?.summaries).toContain(
-			"added import '@c15t/react/styles.css'"
+		expect(indexCss).toContain(
+			'@import "@c15t/react/styles.css";\n@import "@c15t/react/iab/styles.css";'
 		);
-		expect(result.changedFiles[0]?.summaries).toContain(
-			"added import '@c15t/react/iab/styles.css'"
-		);
-
-		const content = await readFile(join(fixtureDir, 'src/main.tsx'), 'utf-8');
-		expect(content).toContain("import '@c15t/react/styles.css';");
-		expect(content).toContain("import '@c15t/react/iab/styles.css';");
 	});
 
-	it('skips headless-only projects', async () => {
-		fixtureDir = await createFixture({
+	it('is idempotent when the correct CSS import already exists', async () => {
+		const { root } = await createProject({
 			'src/main.tsx': [
-				"import React from 'react';",
+				"import './index.css';",
 				"import { App } from './app';",
 				'',
 				'export default App;',
 			].join('\n'),
-			'src/app.tsx': [
-				"import { useConsentManager } from '@c15t/react/headless';",
+			'src/index.css': [
+				'@import "@c15t/react/styles.css";',
 				'',
-				'export function App() {',
-				'  const { hasConsent } = useConsentManager();',
-				'  return <div>{String(hasConsent)}</div>;',
-				'}',
+				':root { color: #111827; }',
+			].join('\n'),
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'export function App() { return <ConsentBanner />; }',
 			].join('\n'),
 		});
 
 		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
+			projectRoot: root,
 			dryRun: false,
 		});
 
@@ -167,11 +181,65 @@ describe('add-stylesheet-imports codemod', () => {
 		expect(result.errors).toHaveLength(0);
 	});
 
-	it('is idempotent when import already exists', async () => {
-		fixtureDir = await createFixture({
+	it('reports changes during dry runs without writing files', async () => {
+		const { root } = await createProject({
 			'src/main.tsx': [
-				"import React from 'react';",
 				"import '@c15t/react/styles.css';",
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { ConsentBanner } from '@c15t/react';",
+				'export function App() { return <ConsentBanner />; }',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: true,
+		});
+		const mainTsx = await readProjectFile(root, 'src/main.tsx');
+		const indexCss = await readProjectFile(root, 'src/index.css');
+
+		expect(result.changedFiles).toHaveLength(2);
+		expect(mainTsx).toContain("import '@c15t/react/styles.css';");
+		expect(indexCss).not.toContain('@c15t/react/styles.css');
+	});
+
+	it('skips headless-only projects', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
+				"import './index.css';",
+				"import { App } from './app';",
+				'',
+				'export default App;',
+			].join('\n'),
+			'src/index.css': ':root { color: #111827; }\n',
+			'src/app.tsx': [
+				"import { useConsentManager } from '@c15t/react/headless';",
+				'',
+				'export function App() {',
+				'  const store = useConsentManager();',
+				'  return <div>{String(Boolean(store))}</div>;',
+				'}',
+			].join('\n'),
+		});
+
+		const result = await runAddStylesheetImportsCodemod({
+			projectRoot: root,
+			dryRun: false,
+		});
+
+		expect(result.changedFiles).toHaveLength(0);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('returns an actionable error when no global CSS entrypoint exists', async () => {
+		const { root } = await createProject({
+			'src/main.tsx': [
 				"import { App } from './app';",
 				'',
 				'export default App;',
@@ -183,62 +251,16 @@ describe('add-stylesheet-imports codemod', () => {
 		});
 
 		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
-			dryRun: false,
-		});
-
-		expect(result.changedFiles).toHaveLength(0);
-		expect(result.errors).toHaveLength(0);
-
-		const content = await readFile(join(fixtureDir, 'src/main.tsx'), 'utf-8');
-		const matches = content.match(/@c15t\/react\/styles\.css/g);
-		expect(matches).toHaveLength(1);
-	});
-
-	it('returns error when no entrypoint found', async () => {
-		fixtureDir = await createFixture({
-			'src/components/banner.tsx': [
-				"import { ConsentBanner } from '@c15t/react';",
-				'export function Banner() { return <ConsentBanner />; }',
-			].join('\n'),
-		});
-
-		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
+			projectRoot: root,
 			dryRun: false,
 		});
 
 		expect(result.changedFiles).toHaveLength(0);
 		expect(result.errors).toHaveLength(1);
-		expect(result.errors[0]?.error).toContain('No root entrypoint found');
-	});
-
-	it('reports changes but does not write in dry run', async () => {
-		fixtureDir = await createFixture({
-			'src/main.tsx': [
-				"import React from 'react';",
-				"import { App } from './app';",
-				'',
-				'export default App;',
-			].join('\n'),
-			'src/app.tsx': [
-				"import { ConsentBanner } from '@c15t/react';",
-				'export function App() { return <ConsentBanner />; }',
-			].join('\n'),
-		});
-
-		const result = await runAddStylesheetImportsCodemod({
-			projectRoot: fixtureDir,
-			dryRun: true,
-		});
-
-		expect(result.changedFiles).toHaveLength(1);
-		expect(result.changedFiles[0]?.summaries).toContain(
-			"added import '@c15t/react/styles.css'"
+		expect(result.errors[0]?.error).toContain(
+			'No suitable global CSS entrypoint found.'
 		);
-
-		// File should NOT have been modified on disk
-		const content = await readFile(join(fixtureDir, 'src/main.tsx'), 'utf-8');
-		expect(content).not.toContain('@c15t/react/styles.css');
+		expect(result.errors[0]?.error).toContain('src/index.css');
+		expect(result.errors[0]?.error).toContain('src/styles.css');
 	});
 });

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -63,6 +63,13 @@ The CLI will:
 pnpm add @c15t/nextjs
 ```
 
+Then add the prebuilt stylesheet to your app-level CSS entrypoint:
+
+```css
+/* app/globals.css */
+@import "@c15t/nextjs/styles.css";
+```
+
 To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/nextjs/quickstart#manual-setup).
 
 ## Usage

--- a/packages/nextjs/readme.json
+++ b/packages/nextjs/readme.json
@@ -21,6 +21,10 @@
 		"",
 		"```bash\npnpm add @c15t/nextjs\n```",
 		"",
+		"Then add the prebuilt stylesheet to your app-level CSS entrypoint:",
+		"",
+		"```css\n/* app/globals.css */\n@import \"@c15t/nextjs/styles.css\";\n```",
+		"",
 		"To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/nextjs/quickstart#manual-setup)."
 	],
 	"usage": [

--- a/packages/nextjs/src/iab/styles.css
+++ b/packages/nextjs/src/iab/styles.css
@@ -1,10 +1,12 @@
 /**
  * @c15t/nextjs — IAB TCF component styles.
  *
- * Import this stylesheet when using IAB consent components in Next.js.
- * Self-contained — includes shared primitives, no need for base styles.
+ * Add this stylesheet to the same global CSS entrypoint as your base c15t styles
+ * when using IAB consent components in Next.js. Do not import either stylesheet
+ * from JS/TSX.
  *
- * Usage:
- *   import '@c15t/nextjs/iab/styles.css';
+ * Usage (app/globals.css):
+ *   @import "@c15t/nextjs/styles.css";
+ *   @import "@c15t/nextjs/iab/styles.css";
  */
 @import "@c15t/react/iab/styles.css";

--- a/packages/nextjs/src/iab/styles.tw3.css
+++ b/packages/nextjs/src/iab/styles.tw3.css
@@ -1,10 +1,14 @@
 /**
  * @c15t/nextjs/iab — Tailwind 3-compatible IAB component styles.
  *
- * Import this stylesheet before your app Tailwind globals so utility classes
- * can come after the c15t base rules.
+ * Add this stylesheet to the same global CSS entrypoint as your base c15t styles.
+ * Do not import either stylesheet from JS/TSX files.
  *
- * Usage:
- *   import '@c15t/nextjs/iab/styles.tw3.css';
+ * Usage (app/globals.css):
+ *   @tailwind base;
+ *   @tailwind components;
+ *   @import "@c15t/nextjs/styles.tw3.css";
+ *   @import "@c15t/nextjs/iab/styles.tw3.css";
+ *   @tailwind utilities;
  */
 @import "@c15t/react/iab/styles.tw3.css";

--- a/packages/nextjs/src/styles.css
+++ b/packages/nextjs/src/styles.css
@@ -1,10 +1,10 @@
 /**
  * @c15t/nextjs — Non-IAB prebuilt component styles.
  *
- * Import this stylesheet once in your root layout when using
+ * Import this stylesheet once from your app-level CSS entrypoint when using
  * prebuilt (styled) consent components.
  *
- * Usage:
- *   import '@c15t/nextjs/styles.css';
+ * Usage (app/globals.css):
+ *   @import "@c15t/nextjs/styles.css";
  */
 @import "@c15t/react/styles.css";

--- a/packages/nextjs/src/styles.tw3.css
+++ b/packages/nextjs/src/styles.tw3.css
@@ -1,10 +1,13 @@
 /**
  * @c15t/nextjs — Tailwind 3-compatible prebuilt component styles.
  *
- * Import this stylesheet before your app Tailwind globals so utility classes
- * can come after the c15t base rules.
+ * Import this stylesheet in the same global CSS entrypoint as Tailwind 3,
+ * after `@tailwind components;` and before `@tailwind utilities;`.
  *
- * Usage:
- *   import '@c15t/nextjs/styles.tw3.css';
+ * Usage (app/globals.css):
+ *   @tailwind base;
+ *   @tailwind components;
+ *   @import "@c15t/nextjs/styles.tw3.css";
+ *   @tailwind utilities;
  */
 @import "@c15t/react/styles.tw3.css";

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,13 @@ The CLI will:
 pnpm add @c15t/react
 ```
 
+Then add the prebuilt stylesheet to your app-level CSS entrypoint:
+
+```css
+/* src/index.css */
+@import "@c15t/react/styles.css";
+```
+
 To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/react/quickstart#manual-setup).
 
 ## Usage

--- a/packages/react/readme.json
+++ b/packages/react/readme.json
@@ -21,6 +21,10 @@
 		"",
 		"```bash\npnpm add @c15t/react\n```",
 		"",
+		"Then add the prebuilt stylesheet to your app-level CSS entrypoint:",
+		"",
+		"```css\n/* src/index.css */\n@import \"@c15t/react/styles.css\";\n```",
+		"",
 		"To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/react/quickstart#manual-setup)."
 	],
 	"usage": [

--- a/packages/react/src/iab/styles.css
+++ b/packages/react/src/iab/styles.css
@@ -1,10 +1,11 @@
 /**
  * @c15t/react — IAB TCF component styles.
  *
- * Import this stylesheet when using IAB consent components.
- * Self-contained — includes shared primitives, no need for base styles.
+ * Add this stylesheet to the same global CSS entrypoint as your base c15t styles
+ * when using IAB consent components. Do not import either stylesheet from JS/TSX.
  *
- * Usage:
- *   import '@c15t/react/iab/styles.css';
+ * Usage (src/index.css):
+ *   @import "@c15t/react/styles.css";
+ *   @import "@c15t/react/iab/styles.css";
  */
 @import "@c15t/ui/iab/styles.css";

--- a/packages/react/src/iab/styles.tw3.css
+++ b/packages/react/src/iab/styles.tw3.css
@@ -1,10 +1,14 @@
 /**
  * @c15t/react/iab — Tailwind 3-compatible IAB component styles.
  *
- * Import this stylesheet before your app Tailwind globals so utility classes
- * can come after the c15t base rules.
+ * Add this stylesheet to the same global CSS entrypoint as your base c15t styles.
+ * Do not import either stylesheet from JS/TSX files.
  *
- * Usage:
- *   import '@c15t/react/iab/styles.tw3.css';
+ * Usage (src/index.css):
+ *   @tailwind base;
+ *   @tailwind components;
+ *   @import "@c15t/react/styles.tw3.css";
+ *   @import "@c15t/react/iab/styles.tw3.css";
+ *   @tailwind utilities;
  */
 @import "@c15t/ui/iab/styles.tw3.css";

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -1,10 +1,10 @@
 /**
  * @c15t/react — Non-IAB prebuilt component styles.
  *
- * Import this stylesheet once at the root of your application
+ * Import this stylesheet once from your app-level CSS entrypoint
  * when using prebuilt (styled) consent components.
  *
- * Usage:
- *   import '@c15t/react/styles.css';
+ * Usage (src/index.css):
+ *   @import "@c15t/react/styles.css";
  */
 @import "@c15t/ui/styles.css";

--- a/packages/react/src/styles.tw3.css
+++ b/packages/react/src/styles.tw3.css
@@ -1,10 +1,13 @@
 /**
  * @c15t/react — Tailwind 3-compatible prebuilt component styles.
  *
- * Import this stylesheet before your app Tailwind globals so utility classes
- * can come after the c15t base rules.
+ * Import this stylesheet in the same global CSS entrypoint as Tailwind 3,
+ * after `@tailwind components;` and before `@tailwind utilities;`.
  *
- * Usage:
- *   import '@c15t/react/styles.tw3.css';
+ * Usage (src/index.css):
+ *   @tailwind base;
+ *   @tailwind components;
+ *   @import "@c15t/react/styles.tw3.css";
+ *   @tailwind utilities;
  */
 @import "@c15t/ui/styles.tw3.css";


### PR DESCRIPTION
## Overview
This fixes the styled install path so prebuilt `@c15t/*/styles*.css` imports live in app-level CSS entrypoints instead of JS or TSX runtime files. It updates the examples, docs, READMEs, and published stylesheet comments to show the correct placement and explain why it avoids layer-order debugging problems. It also moves the CLI generate and codemod flows onto shared CSS-entrypoint mutation logic so they remove old JS-side imports, handle Tailwind v3 and v4 correctly, and fail clearly when no global stylesheet exists.

## Related Issue
Fixes #707

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Moved styled `@c15t/react` and `@c15t/nextjs` stylesheet imports in examples, benchmarks, docs, READMEs, and published CSS comments from runtime files into global CSS entrypoints, and extracted the repeated docs rationale into a shared MDX partial.
2. Refactored the CLI stylesheet mutation path into shared logic used by both generate and codemod flows, removed JS-side stylesheet imports, placed Tailwind v3 and v4 imports in the right spot, and added regression coverage for IAB, dry-run, and missing-CSS cases.

### Technical Notes
The new shared helper centralizes CSS-entrypoint detection and insertion so the generated guidance, codemod behavior, and docs all agree on the same install path.

## Testing

### Test Plan
- [x] Scenario 1: Verify CLI codemod and template coverage

  ```ts
  bun --cwd packages/cli test
  bun --cwd packages/cli check-types
  ```

  ✓ Expected: CLI tests and type checks pass with the new shared stylesheet-entrypoint behavior.

- [x] Scenario 2: Verify example and stylesheet-layer builds

  ```ts
  bun run css-layer:build
  bun --cwd benchmarks/vite-react-repro build
  bun --cwd examples/demo build
  ```

  ✓ Expected: Benchmarks, demo apps, and stylesheet-layer builds succeed with stylesheet imports coming from CSS entrypoints.

### Edge Cases
- [x] Error handling: The CLI now returns an actionable error when no supported global CSS entrypoint exists instead of falling back to JS-side imports.
- [x] Performance: No meaningful runtime performance impact; the change affects install guidance, generated files, and codemod behavior.
- [x] Security: No security-sensitive behavior changed.

## Checklist

### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
