### PR TITLE
feat(backend): mark edge exports unstable for 2.0

### DIFF
--- a/.changeset/odd-edges-shift.md
+++ b/.changeset/odd-edges-shift.md
@@ -1,0 +1,9 @@
+---
+"@c15t/backend": patch
+---
+
+Mark the edge runtime callables as unstable in `2.0`.
+
+- rename `c15tEdgeInit()` to `unstable_c15tEdgeInit()`
+- rename `resolveConsent()` to `unstable_resolveConsent()`
+- update the edge docs and source examples to use the `unstable_` exports

--- a/docs/self-host/api/configuration.mdx
+++ b/docs/self-host/api/configuration.mdx
@@ -44,7 +44,7 @@ interface C15TInstance {
 
 ## Edge Init Options
 
-`c15tEdgeInit()` from `@c15t/backend/edge` accepts a subset of `C15TOptions` — only the fields needed for consent policy resolution without a database. See the [Edge Deployment guide](/docs/self-host/guides/edge-deployment) for usage.
+`unstable_c15tEdgeInit()` from `@c15t/backend/edge` accepts a subset of `C15TOptions` — only the fields needed for consent policy resolution without a database. This edge runtime API is unstable in `2.0`. See the [Edge Deployment guide](/docs/self-host/guides/edge-deployment) for usage.
 
 <AutoTypeTable path="./packages/backend/src/edge/types.ts" name="C15TEdgeOptions" />
 

--- a/docs/self-host/guides/edge-deployment.mdx
+++ b/docs/self-host/guides/edge-deployment.mdx
@@ -176,7 +176,7 @@ Edge isolates have short-lived memory. The in-memory GVL cache resets on each co
 - **Bundle GVL translations** using `iab.bundled` to avoid fetch latency entirely
 - **Use an external cache** (Upstash Redis, Cloudflare KV) via the `cache.adapter` option to share cached data across isolates — see the [Caching guide](/docs/self-host/guides/caching) for setup
 
-## Custom consent cookie — unstable_resolveConsent
+## Custom consent cookie — unstable\_resolveConsent
 
 <Callout type="info">
   **Experimental** — this API may change in future versions.

--- a/docs/self-host/guides/edge-deployment.mdx
+++ b/docs/self-host/guides/edge-deployment.mdx
@@ -6,9 +6,13 @@ description: Run consent policy resolution at the edge for faster initial banner
 The `/init` endpoint determines consent policy from geo headers, resolves translations, and optionally fetches the GVL. None of this requires a database. The `@c15t/backend/edge` export lets you run this logic in edge runtimes (Vercel Middleware, Cloudflare Workers, Deno Deploy) so the consent banner resolves from the nearest PoP instead of round-tripping to your origin.
 
 ```
-Standard:  Browser → Origin (single region)  → c15tInstance(/init) → Response
-Edge:      Browser → Edge   (nearest PoP)    → c15tEdgeInit        → Response
+Standard:  Browser → Origin (single region)  → c15tInstance(/init)         → Response
+Edge:      Browser → Edge   (nearest PoP)    → unstable_c15tEdgeInit       → Response
 ```
+
+<Callout type="warn">
+  The edge runtime exports in `@c15t/backend/edge` are unstable in `2.0`. Use the `unstable_`-prefixed callables and expect API changes or removal in a future release.
+</Callout>
 
 ## When to use this
 
@@ -57,10 +61,10 @@ export const consentConfig = {
 <Tabs groupId="runtime" items={['Vercel Middleware', 'Cloudflare Workers', 'Deno Deploy']}>
   <Tab value="Vercel Middleware">
     ```ts title="middleware.ts"
-    import { c15tEdgeInit } from '@c15t/backend/edge';
+    import { unstable_c15tEdgeInit } from '@c15t/backend/edge';
     import { consentConfig } from './lib/consent-config';
 
-    const initHandler = c15tEdgeInit(consentConfig);
+    const initHandler = unstable_c15tEdgeInit(consentConfig);
 
     export async function middleware(request: Request) {
       const url = new URL(request.url);
@@ -77,10 +81,10 @@ export const consentConfig = {
 
   <Tab value="Cloudflare Workers">
     ```ts title="worker.ts"
-    import { c15tEdgeInit } from '@c15t/backend/edge';
+    import { unstable_c15tEdgeInit } from '@c15t/backend/edge';
     import { consentConfig } from './lib/consent-config';
 
-    const initHandler = c15tEdgeInit(consentConfig);
+    const initHandler = unstable_c15tEdgeInit(consentConfig);
 
     export default {
       async fetch(request: Request) {
@@ -97,10 +101,10 @@ export const consentConfig = {
 
   <Tab value="Deno Deploy">
     ```ts title="main.ts"
-    import { c15tEdgeInit } from '@c15t/backend/edge';
+    import { unstable_c15tEdgeInit } from '@c15t/backend/edge';
     import { consentConfig } from './lib/consent-config.ts';
 
-    const initHandler = c15tEdgeInit(consentConfig);
+    const initHandler = unstable_c15tEdgeInit(consentConfig);
 
     Deno.serve(async (request) => {
       const url = new URL(request.url);
@@ -131,7 +135,7 @@ export const { GET, POST } = c15t;
 
 ## Configuration
 
-`c15tEdgeInit` accepts `C15TEdgeOptions` — the same fields as `c15tInstance` minus the database-related options (`adapter`, `tablePrefix`, `basePath`, `openapi`, `ipAddress`, `apiKeys`, `background`).
+`unstable_c15tEdgeInit` accepts `C15TEdgeOptions` — the same fields as `c15tInstance` minus the database-related options (`adapter`, `tablePrefix`, `basePath`, `openapi`, `ipAddress`, `apiKeys`, `background`).
 
 | Option | Required | Description |
 |--------|----------|-------------|
@@ -172,16 +176,16 @@ Edge isolates have short-lived memory. The in-memory GVL cache resets on each co
 - **Bundle GVL translations** using `iab.bundled` to avoid fetch latency entirely
 - **Use an external cache** (Upstash Redis, Cloudflare KV) via the `cache.adapter` option to share cached data across isolates — see the [Caching guide](/docs/self-host/guides/caching) for setup
 
-## Custom consent cookie — resolveConsent
+## Custom consent cookie — unstable_resolveConsent
 
 <Callout type="info">
   **Experimental** — this API may change in future versions.
 </Callout>
 
-If you manage your own consent cookie and just need to know **which categories to load** for a given visitor, use `resolveConsent` instead of `c15tEdgeInit`. It's a lightweight, fully synchronous function that returns the matched policy and default consent state — no translations, GVL, branding, or snapshot tokens.
+If you manage your own consent cookie and just need to know **which categories to load** for a given visitor, use `unstable_resolveConsent` instead of `unstable_c15tEdgeInit`. It's a lightweight, fully synchronous function that returns the matched policy and default consent state — no translations, GVL, branding, or snapshot tokens.
 
 ```ts title="middleware.ts"
-import { resolveConsent } from '@c15t/backend/edge';
+import { unstable_resolveConsent } from '@c15t/backend/edge';
 
 const policyPacks = [
   {
@@ -206,7 +210,7 @@ const policyPacks = [
 ];
 
 export function middleware(request: Request) {
-  const consent = resolveConsent(request, { policyPacks });
+  const consent = unstable_resolveConsent(request, { policyPacks });
 
   // consent.model       → "opt-in" | "opt-out" | "none" | "iab"
   // consent.showBanner  → true
@@ -231,9 +235,9 @@ export function middleware(request: Request) {
 | `opt-out` | granted, required | **granted** | GPC signal can override `marketing`/`measurement` to not granted |
 | `none` | granted, required | **granted** | No banner shown |
 
-### `resolveConsent` vs `c15tEdgeInit`
+### `unstable_resolveConsent` vs `unstable_c15tEdgeInit`
 
-| | `resolveConsent` | `c15tEdgeInit` |
+| | `unstable_resolveConsent` | `unstable_c15tEdgeInit` |
 |---|---|---|
 | **Use case** | Custom consent cookie | Drop-in `/init` replacement |
 | **Sync** | Yes | No (async — signs JWT, fetches GVL) |

--- a/packages/backend/src/edge/index.ts
+++ b/packages/backend/src/edge/index.ts
@@ -1,9 +1,9 @@
 export type { InitPayload } from './init-handler';
-export { c15tEdgeInit } from './init-handler';
+export { unstable_c15tEdgeInit } from './init-handler';
 export type {
 	C15TConsentResolverOptions,
 	CategoryConsent,
 	ResolvedConsent,
 } from './resolve-consent';
-export { resolveConsent } from './resolve-consent';
+export { unstable_resolveConsent } from './resolve-consent';
 export type { C15TEdgeOptions } from './types';

--- a/packages/backend/src/edge/init-handler.test.ts
+++ b/packages/backend/src/edge/init-handler.test.ts
@@ -1,6 +1,6 @@
 import type { GlobalVendorList } from '@c15t/schema/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { c15tEdgeInit } from './init-handler';
+import { unstable_c15tEdgeInit } from './init-handler';
 import type { C15TEdgeOptions } from './types';
 
 const { mockGVLGet, mockResolveInitPayload } = vi.hoisted(() => {
@@ -61,7 +61,7 @@ function makeRequest(path: string, init?: RequestInit): Request {
 	return new Request(`http://localhost${path}`, init);
 }
 
-describe('c15tEdgeInit', () => {
+describe('unstable_c15tEdgeInit', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGVLGet.mockResolvedValue(mockGVL);
@@ -72,7 +72,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('works without a database adapter', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -90,7 +90,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('returns 204 for CORS preflight', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				method: 'OPTIONS',
@@ -110,7 +110,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('sets CORS headers for trusted origin', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -129,7 +129,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('omits CORS headers for untrusted origin', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -145,7 +145,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('omits CORS headers when no origin header is present', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -164,7 +164,7 @@ describe('c15tEdgeInit', () => {
 			throw new Error('Something broke');
 		});
 
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -186,7 +186,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('returns no-banner policy for unmatched regions', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {
@@ -203,7 +203,7 @@ describe('c15tEdgeInit', () => {
 	});
 
 	it('returns content-type application/json', async () => {
-		const handler = c15tEdgeInit(baseOptions);
+		const handler = unstable_c15tEdgeInit(baseOptions);
 		const response = await handler(
 			makeRequest('/', {
 				headers: {

--- a/packages/backend/src/edge/init-handler.ts
+++ b/packages/backend/src/edge/init-handler.ts
@@ -24,12 +24,14 @@ export type { InitPayload };
  * It has no dependency on Hono or any database adapter, making it suitable for
  * edge runtimes such as Vercel Middleware, Cloudflare Workers, or Deno Deploy.
  *
+ * @experimental This API is unstable in 2.0 and may change or be removed.
+ *
  * @example
  * ```ts
  * // middleware.ts (Vercel Edge)
- * import { c15tEdgeInit } from '@c15t/backend/edge';
+ * import { unstable_c15tEdgeInit } from '@c15t/backend/edge';
  *
- * const initHandler = c15tEdgeInit({
+ * const initHandler = unstable_c15tEdgeInit({
  *   trustedOrigins: ['https://myapp.com'],
  *   policyPacks: [
  *     { id: 'eu', match: { countries: ['DE', 'FR'] }, consent: { model: 'opt-in' }, ui: { mode: 'banner' } },
@@ -45,7 +47,7 @@ export type { InitPayload };
  * }
  * ```
  */
-export function c15tEdgeInit(
+export function unstable_c15tEdgeInit(
 	options: C15TEdgeOptions
 ): (request: Request) => Promise<Response> {
 	// Construction-time validation (same checks the full init performs)

--- a/packages/backend/src/edge/resolve-consent.test.ts
+++ b/packages/backend/src/edge/resolve-consent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveConsent } from './resolve-consent';
+import { unstable_resolveConsent } from './resolve-consent';
 
 function makeRequest(headers: Record<string, string>): Request {
 	return new Request('http://localhost/', { headers });
@@ -36,11 +36,14 @@ const policyPacks = [
 	},
 ];
 
-describe('resolveConsent', () => {
+describe('unstable_resolveConsent', () => {
 	it('is synchronous', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'DE' }), {
-			policyPacks,
-		});
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'DE' }),
+			{
+				policyPacks,
+			}
+		);
 
 		// Not a Promise — direct value
 		expect(result).not.toBeInstanceOf(Promise);
@@ -48,9 +51,12 @@ describe('resolveConsent', () => {
 	});
 
 	it('resolves opt-in defaults for EU visitor', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'DE' }), {
-			policyPacks,
-		});
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'DE' }),
+			{
+				policyPacks,
+			}
+		);
 
 		expect(result.jurisdiction).toBe('GDPR');
 		expect(result.model).toBe('opt-in');
@@ -65,7 +71,7 @@ describe('resolveConsent', () => {
 	});
 
 	it('resolves opt-out defaults for US-CA visitor', () => {
-		const result = resolveConsent(
+		const result = unstable_resolveConsent(
 			makeRequest({ 'x-c15t-country': 'US', 'x-c15t-region': 'CA' }),
 			{ policyPacks }
 		);
@@ -82,9 +88,12 @@ describe('resolveConsent', () => {
 	});
 
 	it('resolves no-banner defaults for unmatched visitor with default policy', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'JP' }), {
-			policyPacks,
-		});
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'JP' }),
+			{
+				policyPacks,
+			}
+		);
 
 		expect(result.model).toBe('none');
 		expect(result.policyId).toBe('us_default');
@@ -97,7 +106,7 @@ describe('resolveConsent', () => {
 	});
 
 	it('respects GPC signal for opt-out policies', () => {
-		const result = resolveConsent(
+		const result = unstable_resolveConsent(
 			makeRequest({
 				'x-c15t-country': 'US',
 				'x-c15t-region': 'CA',
@@ -122,7 +131,7 @@ describe('resolveConsent', () => {
 	});
 
 	it('ignores GPC for opt-in policies', () => {
-		const result = resolveConsent(
+		const result = unstable_resolveConsent(
 			makeRequest({
 				'x-c15t-country': 'DE',
 				'sec-gpc': '1',
@@ -139,20 +148,23 @@ describe('resolveConsent', () => {
 	});
 
 	it('handles preselected categories in opt-in mode', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'DE' }), {
-			policyPacks: [
-				{
-					id: 'eu_preselect',
-					match: { countries: ['DE'] },
-					consent: {
-						model: 'opt-in',
-						categories: ['necessary', 'marketing', 'measurement'],
-						preselectedCategories: ['measurement'],
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'DE' }),
+			{
+				policyPacks: [
+					{
+						id: 'eu_preselect',
+						match: { countries: ['DE'] },
+						consent: {
+							model: 'opt-in',
+							categories: ['necessary', 'marketing', 'measurement'],
+							preselectedCategories: ['measurement'],
+						},
+						ui: { mode: 'banner' },
 					},
-					ui: { mode: 'banner' },
-				},
-			],
-		});
+				],
+			}
+		);
 
 		expect(result.defaults).toEqual({
 			necessary: { granted: true, required: true },
@@ -162,7 +174,10 @@ describe('resolveConsent', () => {
 	});
 
 	it('returns no-banner fallback when no policies configured', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'DE' }), {});
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'DE' }),
+			{}
+		);
 
 		expect(result.model).toBe('none');
 		expect(result.showBanner).toBe(false);
@@ -170,16 +185,19 @@ describe('resolveConsent', () => {
 	});
 
 	it('returns no-banner fallback for explicit empty policyPacks', () => {
-		const result = resolveConsent(makeRequest({ 'x-c15t-country': 'DE' }), {
-			policyPacks: [],
-		});
+		const result = unstable_resolveConsent(
+			makeRequest({ 'x-c15t-country': 'DE' }),
+			{
+				policyPacks: [],
+			}
+		);
 
 		expect(result.model).toBe('none');
 		expect(result.showBanner).toBe(false);
 	});
 
 	it('defaults to GDPR when geo-location is disabled', () => {
-		const result = resolveConsent(makeRequest({}), {
+		const result = unstable_resolveConsent(makeRequest({}), {
 			policyPacks,
 			disableGeoLocation: true,
 		});
@@ -192,7 +210,7 @@ describe('resolveConsent', () => {
 	});
 
 	it('reports location data', () => {
-		const result = resolveConsent(
+		const result = unstable_resolveConsent(
 			makeRequest({
 				'x-c15t-country': 'US',
 				'x-c15t-region': 'CA',

--- a/packages/backend/src/edge/resolve-consent.ts
+++ b/packages/backend/src/edge/resolve-consent.ts
@@ -138,19 +138,19 @@ function resolveDefaultConsent(
  *
  * Fully synchronous — no async, no fetch calls, no crypto.
  *
- * This is a lightweight alternative to `c15tEdgeInit` for enterprise
+ * This is a lightweight alternative to `unstable_c15tEdgeInit` for enterprise
  * customers who manage their own consent cookie. It returns the resolved
  * policy and default consent state without translations, GVL, branding,
  * or snapshot tokens.
  *
- * @experimental This API may change in future versions.
+ * @experimental This API is unstable in 2.0 and may change or be removed.
  *
  * @example
  * ```ts
- * import { resolveConsent } from '@c15t/backend/edge';
+ * import { unstable_resolveConsent } from '@c15t/backend/edge';
  *
  * export function middleware(request: Request) {
- *   const consent = resolveConsent(request, {
+ *   const consent = unstable_resolveConsent(request, {
  *     policyPacks: [
  *       { id: 'eu', match: { countries: ['DE', 'FR'] }, consent: { model: 'opt-in', categories: ['necessary', 'marketing', 'measurement'] }, ui: { mode: 'banner' } },
  *       { id: 'us', match: { isDefault: true }, consent: { model: 'opt-out', categories: ['necessary', 'marketing', 'measurement'] }, ui: { mode: 'banner' } },
@@ -165,7 +165,7 @@ function resolveDefaultConsent(
  * }
  * ```
  */
-export function resolveConsent(
+export function unstable_resolveConsent(
 	request: Request,
 	options: C15TConsentResolverOptions,
 	logger?: Logger


### PR DESCRIPTION
## Overview
Mark the `@c15t/backend/edge` runtime callables as unstable for `2.0` by renaming the public exports to `unstable_c15tEdgeInit()` and `unstable_resolveConsent()`, while keeping the related types unchanged. Update the backend edge source examples, tests, docs, and release notes so the unstable naming is consistent across the published surface.

## Related Issue
Fixes #709

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [x] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Rename the edge runtime exports from `c15tEdgeInit` and `resolveConsent` to `unstable_c15tEdgeInit` and `unstable_resolveConsent`.
2. Update edge tests, package docs, self-host docs, and add a backend changeset documenting the unstable API shift.

### Technical Notes
Keep `C15TEdgeOptions`, `InitPayload`, and the resolver/result types unchanged so only the runtime entrypoints carry the unstable marker.

## Testing
### Test Plan
- [x] Scenario 1: backend typecheck

  ```sh
  cd packages/backend
  bun run check-types
  ```

  ✓ Expected: TypeScript completes without errors after the export rename.

- [x] Scenario 2: edge handler and resolver tests

  ```sh
  cd packages/backend
  bun run test -- src/edge/init-handler.test.ts src/edge/resolve-consent.test.ts
  ```

  ✓ Expected: Both edge test files pass using the renamed unstable exports.

### Edge Cases
- [x] Error handling: existing edge handler and resolver behavior is unchanged; only the public callable names and docs changed.
- [ ] Performance: no runtime performance changes expected.
- [x] Security: no new permissions, network behavior, or data handling paths were introduced.

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
**Changes:**
- `@c15t/backend/edge` now exports `unstable_c15tEdgeInit()` instead of `c15tEdgeInit()`
- `@c15t/backend/edge` now exports `unstable_resolveConsent()` instead of `resolveConsent()`

**Migration:**
```ts
// Before
import { c15tEdgeInit, resolveConsent } from '@c15t/backend/edge';

// After
import {
  unstable_c15tEdgeInit,
  unstable_resolveConsent,
} from '@c15t/backend/edge';
```
