### PR TITLE
feat: simplify static prefetch consumption before 2.0 GA

### DIFF
--- a/.changeset/fresh-pumpkins-change.md
+++ b/.changeset/fresh-pumpkins-change.md
@@ -1,0 +1,13 @@
+---
+'c15t': patch
+'@c15t/react': patch
+'@c15t/nextjs': patch
+'@c15t/cli': patch
+---
+
+Simplify the 2.0 static prefetch flow so static routes only need to start `/init` early and matching prefetched data is consumed automatically during first store initialization.
+
+- `c15t`: add canonical request-context metadata for SSR and browser-prefetch payloads, auto-consume matching prefetched data on first runtime/store initialization, and replace blanket SSR skip-on-overrides behavior with exact request-context matching.
+- `@c15t/react`: preserve the dynamic SSR `fetchInitialData()` flow while exposing the new `context_mismatch` SSR status behavior for matching overrides, backend URLs, credentials, and ambient GPC.
+- `@c15t/nextjs`: remove the RC-era public static-prefetch consumer APIs from the package surface and document `C15tPrefetch` as the only static-route setup step.
+- `@c15t/cli`: update generated static-route templates to rely on automatic prefetch consumption instead of wiring manual prefetch lookups.

--- a/benchmarks/nextjs-browser-bench/app/_bench/provider.tsx
+++ b/benchmarks/nextjs-browser-bench/app/_bench/provider.tsx
@@ -4,11 +4,9 @@ import {
 	ConsentBanner,
 	ConsentDialog,
 	ConsentManagerProvider,
-	getPrefetchedInitialData,
 	type InitialDataPromise,
 } from '@c15t/nextjs';
 import type { ReactNode } from 'react';
-import { useMemo } from 'react';
 import { NextjsBenchmarkProbe } from './probe';
 import { getState, type NextjsBenchScenario } from './state';
 
@@ -21,22 +19,12 @@ export function NextjsBenchmarkProvider({
 	scenario: NextjsBenchScenario;
 	ssrData?: InitialDataPromise;
 }) {
-	const resolvedSSRData = useMemo(() => {
-		if (scenario === 'prefetch') {
-			return getPrefetchedInitialData({
-				backendURL: '/api/bench-consent',
-			});
-		}
-
-		return ssrData;
-	}, [scenario, ssrData]);
-
 	return (
 		<ConsentManagerProvider
 			options={{
 				mode: 'c15t',
 				backendURL: '/api/bench-consent',
-				ssrData: resolvedSSRData,
+				ssrData: scenario === 'prefetch' ? undefined : ssrData,
 				callbacks: {
 					onBannerFetched() {
 						const state = getState(scenario);

--- a/docs/frameworks/javascript/optimization.mdx
+++ b/docs/frameworks/javascript/optimization.mdx
@@ -36,25 +36,21 @@ const script = buildPrefetchScript({
 // Inject `script` into a <script> tag in your HTML <head>
 ```
 
-Then retrieve the prefetched data when creating the store:
+Then create the store normally. Matching prefetched data is consumed automatically by the runtime during first store initialization:
 
 ```ts
 import {
   createConsentManagerStore,
-  getPrefetchedInitialData,
 } from 'c15t';
 
 const store = createConsentManagerStore({
   mode: 'hosted',
   backendURL: '/api/c15t',
-  ssrData: getPrefetchedInitialData({
-    backendURL: '/api/c15t',
-  }),
 });
 ```
 
 <Callout type="info">
-  If you use `overrides` or custom `credentials` in `buildPrefetchScript`, pass the same values to `getPrefetchedInitialData(...)` so it resolves the matching prefetched request.
+  If `overrides.gpc` conflicts with the browser's ambient GPC signal, the prefetched entry is not reused and c15t falls back to a normal client `/init`.
 </Callout>
 
 <import src="../../shared/react/guides/optimization.mdx#animation" />

--- a/docs/frameworks/next/optimization.mdx
+++ b/docs/frameworks/next/optimization.mdx
@@ -1,7 +1,7 @@
 ---
 title: Optimization
 description: Improve c15t startup performance in Next.js with rewrites, static prefetching, and rendering tradeoffs.
-lastModified: 2026-03-17
+lastModified: 2026-04-09
 ---
 
 <import src="../../shared/react/guides/optimization.mdx#intro" />
@@ -52,6 +52,71 @@ Then use:
 | Simplest setup | Client-only init (no prefetch) | Banner appears later on slow networks |
 
 <import src="../../shared/react/guides/optimization.mdx#benchmark" />
+
+### Dynamic Routes: Fetch On The Server And Stream
+
+Use `fetchInitialData()` in a Server Component when you want the fastest first banner and can accept the route becoming dynamic.
+
+```tsx title="app/layout.tsx"
+import { fetchInitialData } from '@c15t/nextjs';
+import ConsentManager from '@/components/consent-manager';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const ssrData = fetchInitialData({
+    backendURL: process.env.NEXT_PUBLIC_C15T_URL!,
+  });
+
+  return (
+    <html lang="en">
+      <body>
+        <ConsentManager ssrData={ssrData}>{children}</ConsentManager>
+      </body>
+    </html>
+  );
+}
+```
+
+```tsx title="components/consent-manager/provider.tsx"
+'use client';
+
+import { type ReactNode } from 'react';
+import {
+  ConsentManagerProvider,
+  ConsentBanner,
+  ConsentDialog,
+  type InitialDataPromise,
+} from '@c15t/nextjs';
+
+export default function ConsentManager({
+  children,
+  ssrData,
+}: {
+  children: ReactNode;
+  ssrData?: InitialDataPromise;
+}) {
+  return (
+    <ConsentManagerProvider
+      options={{
+        mode: 'hosted',
+        backendURL: '/api/c15t',
+        store: { ssrData },
+      }}
+    >
+      <ConsentBanner />
+      <ConsentDialog />
+      {children}
+    </ConsentManagerProvider>
+  );
+}
+```
+
+<Callout type="warn">
+  Do not `await` `fetchInitialData()`. Pass the unresolved Promise to the provider so Next.js can stream the route while `/init` runs in parallel.
+</Callout>
+
+<Callout type="info">
+  For `fetchInitialData()`, prefer a direct backend URL such as `https://your-instance.c15t.dev` instead of a rewrite to avoid an extra server-side proxy hop. See [Server-Side Data Fetching](/docs/frameworks/next/server-side) for the full flow.
+</Callout>
 
 ### Static Routes: Start Fetch Early In The Browser
 

--- a/docs/frameworks/next/optimization.mdx
+++ b/docs/frameworks/next/optimization.mdx
@@ -47,7 +47,7 @@ Then use:
 
 | Goal | Strategy | Tradeoff |
 |------|----------|----------|
-| Keep routes fully static | `C15tPrefetch` + `getPrefetchedInitialData()` | Still client-side fetch, but starts earlier |
+| Keep routes fully static | `C15tPrefetch` | Still client-side fetch, but starts earlier |
 | Fastest first banner on dynamic routes | `fetchInitialData()` in a Server Component (do not await) | Route becomes dynamic because of `next/headers` |
 | Simplest setup | Client-only init (no prefetch) | Banner appears later on slow networks |
 
@@ -55,7 +55,7 @@ Then use:
 
 ### Static Routes: Start Fetch Early In The Browser
 
-Use `C15tPrefetch` in your layout and consume the same Promise in the provider.
+Use `C15tPrefetch` in your layout. Matching prefetched data is consumed automatically by the runtime during first store initialization.
 
 ```tsx title="app/layout.tsx"
 import { C15tPrefetch } from '@c15t/nextjs';
@@ -85,7 +85,6 @@ import {
   ConsentManagerProvider,
   ConsentBanner,
   ConsentDialog,
-  getPrefetchedInitialData,
 } from '@c15t/nextjs';
 
 export default function ConsentManagerClient({ children }: { children: React.ReactNode }) {
@@ -94,10 +93,7 @@ export default function ConsentManagerClient({ children }: { children: React.Rea
       options={{
         mode: 'hosted',
         backendURL: '/api/c15t',
-        ssrData: getPrefetchedInitialData({
-          backendURL: '/api/c15t',
-          overrides: { country: 'DE', region: 'BE', language: 'de' },
-        }),
+        overrides: { country: 'DE', region: 'BE', language: 'de' },
       }}
     >
       <ConsentBanner />
@@ -113,7 +109,7 @@ export default function ConsentManagerClient({ children }: { children: React.Rea
 </Callout>
 
 <Callout type="info">
-  If you use `overrides` or custom `credentials` in `C15tPrefetch`, pass the same values to `getPrefetchedInitialData(...)` so it resolves the matching prefetched request.
+  If `overrides.gpc` conflicts with the browser's ambient GPC signal, the prefetched entry is not reused and c15t falls back to a normal client `/init`.
 </Callout>
 
 <import src="../../shared/react/guides/optimization.mdx#keep-mounted" />

--- a/docs/frameworks/next/server-side.mdx
+++ b/docs/frameworks/next/server-side.mdx
@@ -32,7 +32,7 @@ const ssrData = fetchInitialData({
 </Callout>
 
 <Callout type="info">
-  Need fully static routes? Use `C15tPrefetch` in your layout and `getPrefetchedInitialData()` in your client provider instead of `fetchInitialData()`. See [Optimization](/docs/frameworks/next/optimization).
+  Need fully static routes? Use `C15tPrefetch` in your layout. Matching prefetched data is consumed automatically by the runtime instead of using `fetchInitialData()`. See [Optimization](/docs/frameworks/next/optimization).
 </Callout>
 
 ### How Streaming Works

--- a/docs/frameworks/react/optimization.mdx
+++ b/docs/frameworks/react/optimization.mdx
@@ -41,7 +41,7 @@ const prefetchScript = buildPrefetchScript({
 </head>
 ```
 
-Then consume the prefetched data in your provider:
+Then initialize your provider normally. Matching prefetched data is consumed automatically by the runtime during first store initialization:
 
 ```tsx
 import {
@@ -49,7 +49,6 @@ import {
   ConsentBanner,
   ConsentDialog,
 } from '@c15t/react';
-import { getPrefetchedInitialData } from 'c15t';
 
 export default function App({ children }: { children: React.ReactNode }) {
   return (
@@ -57,9 +56,6 @@ export default function App({ children }: { children: React.ReactNode }) {
       options={{
         mode: 'hosted',
         backendURL: '/api/c15t',
-        ssrData: getPrefetchedInitialData({
-          backendURL: '/api/c15t',
-        }),
       }}
     >
       <ConsentBanner />
@@ -71,7 +67,7 @@ export default function App({ children }: { children: React.ReactNode }) {
 ```
 
 <Callout type="info">
-  If you use `overrides` or custom `credentials` in `buildPrefetchScript`, pass the same values to `getPrefetchedInitialData(...)` so it resolves the matching prefetched request.
+  If `overrides.gpc` conflicts with the browser's ambient GPC signal, the prefetched entry is not reused and c15t falls back to a normal client `/init`.
 </Callout>
 
 <import src="../../shared/react/guides/optimization.mdx#keep-mounted" />

--- a/examples/demo/app/(benchmark)/benchmark/_components/consent-provider.tsx
+++ b/examples/demo/app/(benchmark)/benchmark/_components/consent-provider.tsx
@@ -4,7 +4,6 @@ import {
 	type AllConsentNames,
 	ConsentBanner,
 	ConsentManagerProvider,
-	getPrefetchedInitialData,
 	type InitialDataPromise,
 } from '@c15t/nextjs';
 import type { ReactNode } from 'react';
@@ -81,23 +80,11 @@ export function BenchmarkConsentProvider({
 		}
 	}, []);
 
-	const resolvedSSRData = useMemo(() => {
-		if (variant === 'prefetch') {
-			return (
-				getPrefetchedInitialData({
-					backendURL: BENCHMARK_BACKEND_URL,
-				}) ?? ssrData
-			);
-		}
-
-		return ssrData;
-	}, [ssrData, variant]);
-
 	const options = useMemo(
 		() => ({
 			mode: 'c15t' as const,
 			backendURL: BENCHMARK_BACKEND_URL,
-			ssrData: resolvedSSRData,
+			ssrData: variant === 'prefetch' ? undefined : ssrData,
 			theme: getBenchmarkTheme(animationMode),
 			consentCategories: BENCHMARK_CONSENT_CATEGORIES,
 			callbacks: createBenchmarkCallbacks(variant),
@@ -106,7 +93,7 @@ export function BenchmarkConsentProvider({
 				termsOfService: { href: '/benchmark' },
 			},
 		}),
-		[animationMode, resolvedSSRData, variant]
+		[animationMode, ssrData, variant]
 	);
 
 	return (

--- a/examples/demo/app/globals.css
+++ b/examples/demo/app/globals.css
@@ -1,5 +1,6 @@
-@layer theme, base, components, c15t, utilities;
+@layer theme, base, components, utilities;
 @import "tailwindcss";
+@import "@c15t/nextjs/styles.css";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));

--- a/examples/demo/next.config.ts
+++ b/examples/demo/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from 'next';
 
 const config: NextConfig = {
 	allowedDevOrigins: [
+		'pigeon-post.localhost',
+		'*.pigeon-post.localhost',
 		'css-module-strategy.pigeon-post.localhost',
 		'theme-rc-bugs.pigeon-post.localhost',
 	],

--- a/packages/cli/src/commands/generate/templates/shared/components.ts
+++ b/packages/cli/src/commands/generate/templates/shared/components.ts
@@ -24,7 +24,7 @@ interface GenerateConsentComponentOptions {
 	defaultExport?: boolean;
 	/** Whether to add ssrData prop passed inside options object (App Dir client with SSR) */
 	ssrDataOption?: boolean;
-	/** Whether to add geo override for development (shows banner in non-EU countries) */
+	/** Whether to add geo override for development */
 	includeOverrides?: boolean;
 	/** Whether to add c15t DevTools component */
 	enableDevTools?: boolean;
@@ -95,9 +95,7 @@ export function generateConsentComponent({
 	// Build the full options object
 	const ssrDataLine = ssrDataOption ? '\n\t\t\t\tssrData,' : '';
 	const themeLine = includeTheme ? '\n\t\t\t\ttheme,' : '';
-	const overridesLine = includeOverrides
-		? `\n\t\t\t\t// Shows banner during development. Remove for production.\n\t\t\t\toverrides: { country: 'DE' },`
-		: '';
+	const overridesLine = '';
 
 	const fullOptionsText = `{
 			${optionsText}${ssrDataLine}${themeLine}

--- a/packages/cli/src/commands/generate/templates/shared/server-components.ts
+++ b/packages/cli/src/commands/generate/templates/shared/server-components.ts
@@ -45,8 +45,6 @@ import ConsentManagerProvider from './provider';
 export function ConsentManager({ children }: { children: ReactNode }) {
 	const ssrData = fetchInitialData({
 		backendURL: ${backendURLValue},
-		// Shows banner during development. Remove for production.
-		overrides: { country: 'DE' },
 	});
 
 	return (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,11 +94,7 @@ export {
 } from './libs/policy';
 export type { PrefetchOptions } from './libs/prefetch';
 // Export prefetch utilities
-export {
-	buildPrefetchScript,
-	ensurePrefetchedInitialData,
-	getPrefetchedInitialData,
-} from './libs/prefetch';
+export { buildPrefetchScript } from './libs/prefetch';
 // Export script loader
 export {
 	getLoadedScriptIds,
@@ -130,7 +126,9 @@ export type {
 	PolicyUiProfile,
 	PolicyUiSurfaceConfig,
 	SSRInitialData,
+	SSRInitRequestContext,
 	SSRInitRequestMetadata,
+	SSRSkippedReason,
 	StoreOptions,
 } from './store/type';
 // Export default translation config

--- a/packages/core/src/libs/init-consent-manager/__tests__/index.test.ts
+++ b/packages/core/src/libs/init-consent-manager/__tests__/index.test.ts
@@ -209,17 +209,60 @@ describe('initConsentManager', () => {
 			expect(mockManager.init).toHaveBeenCalled();
 		});
 
-		it('should skip initial data when overrides are present', async () => {
+		it('reuses initial data when overrides match the stored request context', async () => {
 			const mockResponse = createMockConsentBannerResponse();
 			const ssrData = Promise.resolve({
 				init: mockResponse,
 				gvl: undefined,
+				metadata: {
+					requestContext: {
+						backendURL: `${window.location.origin}/api/c15t`,
+						country: 'DE',
+						region: 'BE',
+						language: 'de',
+						gpc: false,
+					},
+				},
 			});
 
 			mockState.overrides = {
 				country: 'DE',
 				region: 'BE',
 				language: 'de',
+			};
+
+			const result = await initConsentManager({
+				manager: mockManager,
+				get: storeGet,
+				set: storeSet,
+				ssrData,
+				backendURL: '/api/c15t',
+			});
+
+			expect(result).toEqual(mockResponse);
+			expect(mockManager.init).not.toHaveBeenCalled();
+		});
+
+		it('falls back to API when overrides mismatch the stored request context', async () => {
+			const mockResponse = createMockConsentBannerResponse();
+			const ssrData = Promise.resolve({
+				init: mockResponse,
+				gvl: undefined,
+				metadata: {
+					requestContext: {
+						backendURL: `${window.location.origin}/api/c15t`,
+						country: 'DE',
+						region: 'BE',
+						language: 'de',
+						gpc: false,
+					},
+				},
+			});
+
+			mockState.overrides = {
+				country: 'DE',
+				region: 'BE',
+				language: 'fr',
 			};
 
 			const apiResponse = createMockConsentBannerResponse({
@@ -236,10 +279,58 @@ describe('initConsentManager', () => {
 				get: storeGet,
 				set: storeSet,
 				ssrData,
+				backendURL: '/api/c15t',
 			});
 
 			expect(result).toEqual(apiResponse);
 			expect(mockManager.init).toHaveBeenCalled();
+			expect(mockSet).toHaveBeenCalledWith({
+				ssrDataUsed: false,
+				ssrSkippedReason: 'context_mismatch',
+			});
+		});
+
+		it('falls back to API when GPC mismatches the stored request context', async () => {
+			const mockResponse = createMockConsentBannerResponse();
+			const ssrData = Promise.resolve({
+				init: mockResponse,
+				gvl: undefined,
+				metadata: {
+					requestContext: {
+						backendURL: `${window.location.origin}/api/c15t`,
+						country: null,
+						region: null,
+						language: null,
+						gpc: false,
+					},
+				},
+			});
+
+			mockState.overrides = {
+				gpc: true,
+			};
+
+			const apiResponse = createMockConsentBannerResponse();
+
+			mockManager.init = vi.fn().mockResolvedValue({
+				data: apiResponse,
+				error: null,
+			});
+
+			const result = await initConsentManager({
+				manager: mockManager,
+				get: storeGet,
+				set: storeSet,
+				ssrData,
+				backendURL: '/api/c15t',
+			});
+
+			expect(result).toEqual(apiResponse);
+			expect(mockManager.init).toHaveBeenCalled();
+			expect(mockSet).toHaveBeenCalledWith({
+				ssrDataUsed: false,
+				ssrSkippedReason: 'context_mismatch',
+			});
 		});
 
 		it('reopens consent UI when the active material policy fingerprint changes', async () => {

--- a/packages/core/src/libs/init-consent-manager/index.ts
+++ b/packages/core/src/libs/init-consent-manager/index.ts
@@ -9,6 +9,10 @@
 
 import type { ResponseContext } from '../../client/types';
 import type { InitDataSource, SSRInitialData } from '../../store/type';
+import {
+	createRuntimeRequestContextMatcher,
+	matchesStoredRequestContext,
+} from '../request-context';
 import { sanitizeSubjectIdentifiers } from '../sanitize-subject-identifiers';
 import {
 	PENDING_CONSENT_SYNC_KEY,
@@ -24,6 +28,27 @@ export type { ConsentBannerResponse, InitConsentManagerConfig } from './types';
 interface InitSourceMetadata {
 	initDataSource: InitDataSource;
 	initDataSourceDetail: string | null;
+}
+
+function shouldReuseSSRData(
+	config: InitConsentManagerConfig,
+	data: SSRInitialData
+): boolean {
+	const requestContext = data.metadata?.requestContext;
+	if (!requestContext || !config.backendURL) {
+		return true;
+	}
+
+	const matcher = createRuntimeRequestContextMatcher({
+		backendURL: config.backendURL,
+		overrides: config.get().overrides,
+		credentials: config.requestCredentials,
+	});
+	if (!matcher) {
+		return true;
+	}
+
+	return matchesStoredRequestContext(requestContext, matcher);
 }
 
 /**
@@ -93,15 +118,19 @@ export async function initConsentManager(
 async function tryUseSSRData(
 	config: InitConsentManagerConfig
 ): Promise<ConsentBannerResponse | undefined> {
-	const { ssrData, get, set } = config;
+	const { ssrData, set } = config;
 
-	// Skip SSR data if overrides are present (need fresh fetch)
-	if (!ssrData || get().overrides) {
+	if (!ssrData) {
 		set({ ssrDataUsed: false, ssrSkippedReason: 'no_data' });
 		return undefined;
 	}
 
 	const data = await ssrData;
+
+	if (data?.init && !shouldReuseSSRData(config, data)) {
+		set({ ssrDataUsed: false, ssrSkippedReason: 'context_mismatch' });
+		return undefined;
+	}
 
 	if (data?.init) {
 		const initSourceMetadata = inferSSRInitSourceMetadata(data);

--- a/packages/core/src/libs/init-consent-manager/types.ts
+++ b/packages/core/src/libs/init-consent-manager/types.ts
@@ -24,6 +24,12 @@ export interface InitConsentManagerConfig {
 	/** SSR-prefetched data (init + optional GVL) */
 	ssrData?: Promise<SSRInitialData | undefined>;
 
+	/** Canonical backend URL for hosted-mode request matching */
+	backendURL?: string;
+
+	/** Effective client credentials mode for hosted-mode request matching */
+	requestCredentials?: RequestCredentials;
+
 	/** Initial translation configuration to merge with server response */
 	initialTranslationConfig?: Partial<TranslationConfig>;
 

--- a/packages/core/src/libs/prefetch/index.ts
+++ b/packages/core/src/libs/prefetch/index.ts
@@ -2,7 +2,7 @@
  * Browser-side prefetch utilities for c15t consent init data.
  *
  * These functions let any framework start the `/init` request early
- * (before hydration) and share the result with the consent provider.
+ * (before hydration) so the runtime can consume matching data automatically.
  *
  * @remarks
  * Framework adapters like `@c15t/nextjs` provide thin wrappers
@@ -10,9 +10,5 @@
  * framework-specific script injection.
  */
 
-export {
-	buildPrefetchScript,
-	ensurePrefetchedInitialData,
-	getPrefetchedInitialData,
-} from './prefetch';
+export { buildPrefetchScript } from './prefetch';
 export type { PrefetchOptions } from './types';

--- a/packages/core/src/libs/prefetch/prefetch.test.ts
+++ b/packages/core/src/libs/prefetch/prefetch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	getMatchingPrefetchedInitialData,
+	primePrefetchedInitialData,
+} from './prefetch';
+
+describe('prefetch utilities', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		delete (window as Window & { __c15tInitialDataPromises?: unknown })
+			.__c15tInitialDataPromises;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('stores request-context metadata with canonical backend URL, credentials, and ambient GPC', async () => {
+		Object.defineProperty(window.navigator, 'globalPrivacyControl', {
+			configurable: true,
+			value: true,
+		});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						jurisdiction: 'CCPA',
+						location: { countryCode: 'US', regionCode: 'CA' },
+						translations: { language: 'de', translations: {} },
+						branding: 'c15t',
+						gvl: null,
+					}),
+					{
+						status: 200,
+						headers: {
+							'content-type': 'application/json',
+						},
+					}
+				)
+			)
+		);
+
+		const result = primePrefetchedInitialData({
+			backendURL: '/api/c15t/',
+			overrides: { language: 'de' },
+			credentials: 'same-origin',
+		});
+
+		await expect(result).resolves.toMatchObject({
+			metadata: {
+				requestContext: {
+					backendURL: `${window.location.origin}/api/c15t`,
+					country: null,
+					region: null,
+					language: 'de',
+					gpc: true,
+					credentials: 'same-origin',
+				},
+			},
+		});
+	});
+
+	it('finds only exact runtime-context matches', async () => {
+		Object.defineProperty(window.navigator, 'globalPrivacyControl', {
+			configurable: true,
+			value: false,
+		});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						jurisdiction: 'GDPR',
+						location: { countryCode: 'DE', regionCode: 'BE' },
+						translations: { language: 'de', translations: {} },
+						branding: 'c15t',
+						gvl: null,
+					}),
+					{
+						status: 200,
+						headers: {
+							'content-type': 'application/json',
+						},
+					}
+				)
+			)
+		);
+
+		const dePromise = primePrefetchedInitialData({
+			backendURL: '/api/c15t',
+			overrides: { country: 'DE' },
+		});
+		await dePromise;
+
+		const frPromise = primePrefetchedInitialData({
+			backendURL: '/api/c15t',
+			overrides: { country: 'FR' },
+		});
+		await frPromise;
+
+		expect(
+			getMatchingPrefetchedInitialData({
+				backendURL: '/api/c15t',
+				overrides: { country: 'DE' },
+			})
+		).toBe(dePromise);
+		expect(
+			getMatchingPrefetchedInitialData({
+				backendURL: '/api/c15t',
+			})
+		).toBeUndefined();
+		expect(
+			getMatchingPrefetchedInitialData({
+				backendURL: '/api/c15t',
+				overrides: { country: 'GB' },
+			})
+		).toBeUndefined();
+	});
+
+	it('does not reuse prefetched data when ambient GPC changes', async () => {
+		Object.defineProperty(window.navigator, 'globalPrivacyControl', {
+			configurable: true,
+			value: false,
+		});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						jurisdiction: 'CCPA',
+						location: { countryCode: 'US', regionCode: 'CA' },
+						translations: { language: 'en', translations: {} },
+						branding: 'c15t',
+						gvl: null,
+					}),
+					{
+						status: 200,
+						headers: {
+							'content-type': 'application/json',
+						},
+					}
+				)
+			)
+		);
+
+		await primePrefetchedInitialData({
+			backendURL: '/api/c15t',
+		});
+
+		Object.defineProperty(window.navigator, 'globalPrivacyControl', {
+			configurable: true,
+			value: true,
+		});
+
+		expect(
+			getMatchingPrefetchedInitialData({
+				backendURL: '/api/c15t',
+			})
+		).toBeUndefined();
+	});
+});

--- a/packages/core/src/libs/prefetch/prefetch.ts
+++ b/packages/core/src/libs/prefetch/prefetch.ts
@@ -1,48 +1,34 @@
 import type { InitOutput } from '@c15t/schema/types';
 import type { SSRInitialData } from '../../store/type';
+import {
+	buildRequestContextHeaders,
+	createBrowserRequestContext,
+	createRuntimeRequestContextMatcher,
+	matchesStoredRequestContext,
+} from '../request-context';
 import type { PrefetchOptions } from './types';
 
-const WINDOW_PROMISE_KEY = '__c15tInitialDataPromise';
 const WINDOW_PROMISES_KEY = '__c15tInitialDataPromises';
 
 type PrefetchPromise = Promise<SSRInitialData | undefined>;
+type PrefetchEntry = {
+	promise: PrefetchPromise;
+	requestContext: NonNullable<SSRInitialData['metadata']>['requestContext'];
+};
 
 type BrowserWindow = Window & {
-	[WINDOW_PROMISE_KEY]?: PrefetchPromise;
-	[WINDOW_PROMISES_KEY]?: Record<string, PrefetchPromise>;
+	[WINDOW_PROMISES_KEY]?: Record<string, PrefetchEntry>;
 };
 
 function buildInitURL(backendURL: string): string {
-	const normalizedBackendURL = backendURL.endsWith('/')
-		? backendURL.slice(0, -1)
-		: backendURL;
-
-	return `${normalizedBackendURL}/init`;
-}
-
-function buildInitHeaders(options: PrefetchOptions): Record<string, string> {
-	const headers: Record<string, string> = {};
-	const { overrides } = options;
-
-	if (overrides?.country) {
-		headers['x-c15t-country'] = overrides.country;
-	}
-
-	if (overrides?.region) {
-		headers['x-c15t-region'] = overrides.region;
-	}
-
-	if (overrides?.language) {
-		headers['accept-language'] = overrides.language;
-	}
-
-	return headers;
+	return `${backendURL}/init`;
 }
 
 interface PrefetchConfig {
 	url: string;
 	credentials: RequestCredentials;
 	headers: Record<string, string>;
+	requestContext: NonNullable<SSRInitialData['metadata']>['requestContext'];
 	cacheKey: string;
 }
 
@@ -50,36 +36,55 @@ function buildPrefetchCacheKey(options: {
 	url: string;
 	credentials: RequestCredentials;
 	headers: Record<string, string>;
+	gpc: boolean;
 }): string {
 	const sortedHeaders = Object.entries(options.headers)
 		.sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
 		.map(([key, value]) => `${key}:${value}`)
 		.join('|');
 
-	return `${options.url}|${options.credentials}|${sortedHeaders}`;
+	return `${options.url}|${options.credentials}|gpc:${options.gpc}|${sortedHeaders}`;
 }
 
 function buildPrefetchConfig(options: PrefetchOptions): PrefetchConfig {
-	const url = buildInitURL(options.backendURL);
-	const credentials = options.credentials ?? 'include';
-	const headers = buildInitHeaders(options);
+	const requestContext = createBrowserRequestContext(options);
+	if (!requestContext) {
+		throw new Error(`Invalid backend URL: ${options.backendURL}`);
+	}
+
+	const url = buildInitURL(requestContext.backendURL);
+	const credentials = requestContext.credentials ?? 'include';
+	const headers = buildRequestContextHeaders(options.overrides);
 
 	return {
 		url,
 		credentials,
 		headers,
-		cacheKey: buildPrefetchCacheKey({ url, credentials, headers }),
+		requestContext,
+		cacheKey: buildPrefetchCacheKey({
+			url,
+			credentials,
+			headers,
+			gpc: requestContext.gpc,
+		}),
 	};
 }
 
 function toInitialData(
+	config: Pick<PrefetchConfig, 'requestContext'>,
 	init: InitOutput | undefined
 ): SSRInitialData | undefined {
 	if (!init) {
 		return undefined;
 	}
 
-	return { init, gvl: init.gvl };
+	return {
+		init,
+		gvl: init.gvl,
+		metadata: {
+			requestContext: config.requestContext,
+		},
+	};
 }
 
 function getBrowserWindow(): BrowserWindow | undefined {
@@ -92,7 +97,7 @@ function getBrowserWindow(): BrowserWindow | undefined {
 
 function getPromiseMap(
 	browserWindow: BrowserWindow
-): Record<string, PrefetchPromise> {
+): Record<string, PrefetchEntry> {
 	if (!browserWindow[WINDOW_PROMISES_KEY]) {
 		browserWindow[WINDOW_PROMISES_KEY] = {};
 	}
@@ -100,8 +105,8 @@ function getPromiseMap(
 	return browserWindow[WINDOW_PROMISES_KEY];
 }
 
-function createPrefetchPromise(config: PrefetchConfig): PrefetchPromise {
-	return fetch(config.url, {
+function createPrefetchEntry(config: PrefetchConfig): PrefetchEntry {
+	const promise = fetch(config.url, {
 		method: 'GET',
 		credentials: config.credentials,
 		headers: config.headers,
@@ -109,8 +114,51 @@ function createPrefetchPromise(config: PrefetchConfig): PrefetchPromise {
 		.then((response) =>
 			response.ok ? (response.json() as Promise<InitOutput>) : undefined
 		)
-		.then((init) => toInitialData(init))
+		.then((init) => toInitialData(config, init))
 		.catch(() => undefined);
+
+	return {
+		promise,
+		requestContext: config.requestContext,
+	};
+}
+
+function getMatchingPrefetchEntry(options: {
+	backendURL: string;
+	overrides?: PrefetchOptions['overrides'];
+	credentials?: RequestCredentials;
+}): PrefetchEntry | undefined {
+	const browserWindow = getBrowserWindow();
+	if (!browserWindow) {
+		return undefined;
+	}
+
+	const matcher = createRuntimeRequestContextMatcher({
+		backendURL: options.backendURL,
+		overrides: options.overrides,
+		credentials: options.credentials,
+	});
+	if (!matcher) {
+		return undefined;
+	}
+
+	const entries = Object.values(browserWindow[WINDOW_PROMISES_KEY] ?? {});
+	const matches = entries.filter((entry) => {
+		const requestContext = entry.requestContext;
+		return requestContext
+			? matchesStoredRequestContext(requestContext, matcher)
+			: false;
+	});
+
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+export function getMatchingPrefetchedInitialData(options: {
+	backendURL: string;
+	overrides?: PrefetchOptions['overrides'];
+	credentials?: RequestCredentials;
+}): PrefetchPromise | undefined {
+	return getMatchingPrefetchEntry(options)?.promise;
 }
 
 /**
@@ -127,80 +175,105 @@ function createPrefetchPromise(config: PrefetchConfig): PrefetchPromise {
  * vanilla HTML).
  */
 export function buildPrefetchScript(options: PrefetchOptions): string {
-	const payload = buildPrefetchConfig(options);
+	const payload = {
+		backendURL: options.backendURL,
+		credentials: options.credentials ?? 'include',
+		headers: buildRequestContextHeaders(options.overrides),
+		requestContext: {
+			country: options.overrides?.country ?? null,
+			region: options.overrides?.region ?? null,
+			language: options.overrides?.language ?? null,
+		},
+	};
 
 	const json = JSON.stringify(payload).replace(/</g, '\\u003c');
 
 	return `(() => {
-  const legacyKey = '${WINDOW_PROMISE_KEY}';
   const mapKey = '${WINDOW_PROMISES_KEY}';
   if (typeof window === 'undefined') {
     return;
   }
-  const config = ${json};
-  const promises = (window[mapKey] = window[mapKey] || {});
-  if (promises[config.cacheKey]) {
-    if (!window[legacyKey]) {
-      window[legacyKey] = promises[config.cacheKey];
+  const payload = ${json};
+  const trimTrailingSlash = (value) => {
+    if (value === '/') {
+      return value;
     }
+    return value.endsWith('/') ? value.slice(0, -1) : value;
+  };
+  const canonicalizeBackendURL = (backendURL) => {
+    try {
+      const normalizedBackendURL = trimTrailingSlash(backendURL);
+      if (/^https?:\\/\\//.test(normalizedBackendURL)) {
+        return trimTrailingSlash(new URL(normalizedBackendURL).toString());
+      }
+      if (!normalizedBackendURL.startsWith('/')) {
+        return undefined;
+      }
+      return trimTrailingSlash(
+        new URL(normalizedBackendURL, window.location.origin).toString()
+      );
+    } catch {
+      return undefined;
+    }
+  };
+  const buildCacheKey = (url, credentials, headers, gpc) => {
+    const sortedHeaders = Object.entries(headers)
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([key, value]) => key + ':' + value)
+      .join('|');
+    return url + '|' + credentials + '|gpc:' + String(gpc) + '|' + sortedHeaders;
+  };
+  const detectGpc = () => {
+    try {
+      const value = window.navigator.globalPrivacyControl;
+      return value === true || value === '1';
+    } catch {
+      return false;
+    }
+  };
+  const backendURL = canonicalizeBackendURL(payload.backendURL);
+  if (!backendURL) {
     return;
   }
-  const promise = fetch(config.url, {
+  const gpc = detectGpc();
+  const requestContext = {
+    backendURL,
+    country: payload.requestContext.country,
+    region: payload.requestContext.region,
+    language: payload.requestContext.language,
+    gpc,
+    credentials: payload.credentials
+  };
+  const url = backendURL + '/init';
+  const cacheKey = buildCacheKey(url, payload.credentials, payload.headers, gpc);
+  const promises = (window[mapKey] = window[mapKey] || {});
+  if (promises[cacheKey]) {
+    return;
+  }
+  const promise = fetch(url, {
     method: 'GET',
-    credentials: config.credentials,
-    headers: config.headers
+    credentials: payload.credentials,
+    headers: payload.headers
   })
     .then((response) => (response.ok ? response.json() : undefined))
-    .then((init) => (init ? { init, gvl: init.gvl } : undefined))
+    .then((init) => (init
+      ? {
+          init,
+          gvl: init.gvl,
+          metadata: {
+            requestContext
+          }
+        }
+      : undefined))
     .catch(() => undefined);
-  promises[config.cacheKey] = promise;
-  if (!window[legacyKey]) {
-    window[legacyKey] = promise;
-  }
+  promises[cacheKey] = {
+    promise,
+    requestContext
+  };
 })();`;
 }
 
-/**
- * Reads the browser-prefetched initial data Promise, if it exists.
- *
- * @param options - Optional prefetch options. Provide the same options used
- * with the prefetch script or `ensurePrefetchedInitialData` to resolve the
- * matching entry.
- * @returns The existing prefetch Promise or `undefined` when not available.
- */
-export function getPrefetchedInitialData(): PrefetchPromise | undefined;
-export function getPrefetchedInitialData(
-	options: PrefetchOptions
-): PrefetchPromise | undefined;
-export function getPrefetchedInitialData(
-	options?: PrefetchOptions
-): PrefetchPromise | undefined {
-	const browserWindow = getBrowserWindow();
-	if (!browserWindow) {
-		return undefined;
-	}
-
-	if (options) {
-		return browserWindow[WINDOW_PROMISES_KEY]?.[
-			buildPrefetchConfig(options).cacheKey
-		];
-	}
-
-	return browserWindow[WINDOW_PROMISE_KEY];
-}
-
-/**
- * Gets the existing browser-prefetched initial data Promise or creates one.
- *
- * @remarks
- * Useful in static apps where you want SSR-like hydration behavior
- * without server-side data fetching. The first call creates the fetch
- * Promise; subsequent calls return the same Promise.
- *
- * @returns A shared Promise that resolves to the same shape as server-side
- * `fetchSSRData()`.
- */
-export function ensurePrefetchedInitialData(
+export function primePrefetchedInitialData(
 	options: PrefetchOptions
 ): PrefetchPromise | undefined {
 	const browserWindow = getBrowserWindow();
@@ -212,12 +285,8 @@ export function ensurePrefetchedInitialData(
 	const promises = getPromiseMap(browserWindow);
 
 	if (!promises[config.cacheKey]) {
-		promises[config.cacheKey] = createPrefetchPromise(config);
+		promises[config.cacheKey] = createPrefetchEntry(config);
 	}
 
-	if (!browserWindow[WINDOW_PROMISE_KEY]) {
-		browserWindow[WINDOW_PROMISE_KEY] = promises[config.cacheKey];
-	}
-
-	return promises[config.cacheKey];
+	return promises[config.cacheKey]?.promise;
 }

--- a/packages/core/src/libs/request-context.ts
+++ b/packages/core/src/libs/request-context.ts
@@ -1,0 +1,152 @@
+import type { SSRInitRequestContext } from '../store/type';
+import type { Overrides } from '../types';
+import { hasGlobalPrivacyControlSignal } from './global-privacy-control';
+
+const ABSOLUTE_URL_REGEX = /^https?:\/\//;
+
+function trimTrailingSlash(value: string): string {
+	if (value === '/') {
+		return value;
+	}
+
+	return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function normalizeAbsoluteURL(url: URL): string {
+	const normalized = url.toString();
+	return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+}
+
+export function buildRequestContextHeaders(
+	overrides?: Pick<Overrides, 'country' | 'region' | 'language'>
+): Record<string, string> {
+	const headers: Record<string, string> = {};
+
+	if (overrides?.country) {
+		headers['x-c15t-country'] = overrides.country;
+	}
+
+	if (overrides?.region) {
+		headers['x-c15t-region'] = overrides.region;
+	}
+
+	if (overrides?.language) {
+		headers['accept-language'] = overrides.language;
+	}
+
+	return headers;
+}
+
+export function canonicalizeBrowserBackendURL(
+	backendURL: string
+): string | undefined {
+	try {
+		const normalizedBackendURL = trimTrailingSlash(backendURL);
+		if (ABSOLUTE_URL_REGEX.test(normalizedBackendURL)) {
+			return normalizeAbsoluteURL(new URL(normalizedBackendURL));
+		}
+
+		if (!normalizedBackendURL.startsWith('/')) {
+			return undefined;
+		}
+
+		return normalizeAbsoluteURL(
+			new URL(normalizedBackendURL, window.location.origin)
+		);
+	} catch {
+		return undefined;
+	}
+}
+
+export interface RuntimeRequestContextMatcher {
+	backendURL: string;
+	country?: string;
+	region?: string;
+	language?: string;
+	gpc: boolean;
+	credentials: RequestCredentials;
+}
+
+export function createBrowserRequestContext(options: {
+	backendURL: string;
+	overrides?: Pick<Overrides, 'country' | 'region' | 'language'>;
+	credentials?: RequestCredentials;
+	gpc?: boolean;
+}): SSRInitRequestContext | undefined {
+	const normalizedBackendURL = canonicalizeBrowserBackendURL(
+		options.backendURL
+	);
+	if (!normalizedBackendURL) {
+		return undefined;
+	}
+	const detectedGpc = hasGlobalPrivacyControlSignal();
+
+	return {
+		backendURL: normalizedBackendURL,
+		country: options.overrides?.country ?? null,
+		region: options.overrides?.region ?? null,
+		language: options.overrides?.language ?? null,
+		gpc:
+			options.gpc ?? (typeof detectedGpc === 'boolean' ? detectedGpc : false),
+		credentials: options.credentials ?? 'include',
+	};
+}
+
+export function createRuntimeRequestContextMatcher(options: {
+	backendURL: string;
+	overrides?: Overrides;
+	credentials?: RequestCredentials;
+}): RuntimeRequestContextMatcher | undefined {
+	const normalizedBackendURL = canonicalizeBrowserBackendURL(
+		options.backendURL
+	);
+	if (!normalizedBackendURL) {
+		return undefined;
+	}
+	const detectedGpc = hasGlobalPrivacyControlSignal();
+
+	return {
+		backendURL: normalizedBackendURL,
+		country: options.overrides?.country,
+		region: options.overrides?.region,
+		language: options.overrides?.language,
+		gpc:
+			options.overrides?.gpc ??
+			(typeof detectedGpc === 'boolean' ? detectedGpc : false),
+		credentials: options.credentials ?? 'include',
+	};
+}
+
+export function matchesStoredRequestContext(
+	stored: SSRInitRequestContext,
+	matcher: RuntimeRequestContextMatcher
+): boolean {
+	if (stored.backendURL !== matcher.backendURL) {
+		return false;
+	}
+
+	if (stored.gpc !== matcher.gpc) {
+		return false;
+	}
+
+	if (matcher.country !== undefined && stored.country !== matcher.country) {
+		return false;
+	}
+
+	if (matcher.region !== undefined && stored.region !== matcher.region) {
+		return false;
+	}
+
+	if (matcher.language !== undefined && stored.language !== matcher.language) {
+		return false;
+	}
+
+	if (
+		stored.credentials !== undefined &&
+		stored.credentials !== matcher.credentials
+	) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/core/src/runtime/__tests__/index.test.ts
+++ b/packages/core/src/runtime/__tests__/index.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ConsentRuntimeOptions } from '../index';
 import { clearConsentRuntimeCache, getOrCreateConsentRuntime } from '../index';
 
 const configureConsentManagerMock = vi.fn();
 const createConsentManagerStoreMock = vi.fn();
+const getMatchingPrefetchedInitialDataMock = vi.fn();
 
 vi.mock('../../client', () => ({
 	configureConsentManager: (options: unknown) =>
@@ -16,6 +17,11 @@ vi.mock('../../store', () => ({
 		createConsentManagerStoreMock(manager, options),
 }));
 
+vi.mock('../../libs/prefetch/prefetch', () => ({
+	getMatchingPrefetchedInitialData: (options: unknown) =>
+		getMatchingPrefetchedInitialDataMock(options),
+}));
+
 describe('runtime', () => {
 	let managerCount = 0;
 	let storeCount = 0;
@@ -25,6 +31,7 @@ describe('runtime', () => {
 		storeCount = 0;
 		vi.clearAllMocks();
 		clearConsentRuntimeCache();
+		getMatchingPrefetchedInitialDataMock.mockReset();
 
 		configureConsentManagerMock.mockImplementation(() => ({
 			id: `manager-${++managerCount}`,
@@ -32,6 +39,10 @@ describe('runtime', () => {
 		createConsentManagerStoreMock.mockImplementation(() => ({
 			id: `store-${++storeCount}`,
 		}));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it('reuses runtime instances for the same cache key', () => {
@@ -89,6 +100,10 @@ describe('runtime', () => {
 					pkg: '@c15t/react',
 					version: '2.0.0',
 					mode: 'hosted',
+					meta: {
+						backendURL: '/api/c15t',
+						requestCredentials: 'include',
+					},
 				},
 			})
 		);
@@ -282,5 +297,92 @@ describe('runtime', () => {
 				}),
 			})
 		);
+	});
+
+	it('uses matching browser-prefetched data on first hosted initialization', () => {
+		const prefetchedData = Promise.resolve(undefined);
+		getMatchingPrefetchedInitialDataMock.mockReturnValue(prefetchedData);
+		vi.stubGlobal('window', {} as Window);
+
+		getOrCreateConsentRuntime(
+			{
+				mode: 'hosted',
+				backendURL: '/api/c15t',
+			} as ConsentRuntimeOptions,
+			{
+				pkg: '@c15t/react',
+				version: '2.0.0',
+			}
+		);
+
+		expect(getMatchingPrefetchedInitialDataMock).toHaveBeenCalledWith({
+			backendURL: '/api/c15t',
+			overrides: undefined,
+			credentials: 'include',
+		});
+		expect(createConsentManagerStoreMock).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				ssrData: prefetchedData,
+				__internal: {
+					backendURL: '/api/c15t',
+					requestCredentials: 'include',
+				},
+			})
+		);
+	});
+
+	it('prefers explicit ssrData over browser-prefetched data', () => {
+		const explicitSSRData = Promise.resolve(undefined);
+		getMatchingPrefetchedInitialDataMock.mockReturnValue(
+			Promise.resolve(undefined)
+		);
+		vi.stubGlobal('window', {} as Window);
+
+		getOrCreateConsentRuntime(
+			{
+				mode: 'hosted',
+				backendURL: '/api/c15t',
+				ssrData: explicitSSRData,
+			} as ConsentRuntimeOptions,
+			{
+				pkg: '@c15t/react',
+				version: '2.0.0',
+			}
+		);
+
+		expect(getMatchingPrefetchedInitialDataMock).not.toHaveBeenCalled();
+		expect(createConsentManagerStoreMock).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				ssrData: explicitSSRData,
+			})
+		);
+	});
+
+	it('does not adopt newly available prefetched data once a store is cached', () => {
+		vi.stubGlobal('window', {} as Window);
+
+		const options = {
+			mode: 'hosted',
+			backendURL: '/api/c15t',
+		} as ConsentRuntimeOptions;
+		const pkgInfo = {
+			pkg: '@c15t/react',
+			version: '2.0.0',
+		};
+
+		getMatchingPrefetchedInitialDataMock.mockReturnValueOnce(undefined);
+		const first = getOrCreateConsentRuntime(options, pkgInfo);
+
+		const laterPrefetchedData = Promise.resolve(undefined);
+		getMatchingPrefetchedInitialDataMock.mockReturnValueOnce(
+			laterPrefetchedData
+		);
+		const second = getOrCreateConsentRuntime(options, pkgInfo);
+
+		expect(first.consentStore).toBe(second.consentStore);
+		expect(getMatchingPrefetchedInitialDataMock).toHaveBeenCalledTimes(1);
+		expect(createConsentManagerStoreMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -9,6 +9,7 @@ import {
 	clearClientRegistry,
 	configureConsentManager,
 } from '../client';
+import { getMatchingPrefetchedInitialData } from '../libs/prefetch/prefetch';
 import { createConsentManagerStore } from '../store';
 import type { StoreOptions } from '../store/type';
 import type { AllConsentNames, TranslationConfig } from '../types';
@@ -100,6 +101,12 @@ export function getOrCreateConsentRuntime(
 		retryConfig?: unknown;
 		endpointHandlers?: unknown;
 	};
+	type InternalStoreOptions = StoreOptions & {
+		__internal?: {
+			backendURL?: string;
+			requestCredentials?: RequestCredentials;
+		};
+	};
 
 	const {
 		mode,
@@ -123,12 +130,16 @@ export function getOrCreateConsentRuntime(
 	const {
 		initialI18nConfig: _unusedTopLevelInitialI18nConfig,
 		initialTranslationConfig: _unusedTopLevelInitialTranslationConfig,
+		ssrData: topLevelSSRData,
+		config: topLevelConfig,
 		...cleanStoreOptionOverrides
 	} = storeOptionOverrides as Partial<StoreOptions>;
 
 	const {
 		initialI18nConfig: _unusedStoreInitialI18nConfig,
 		initialTranslationConfig: _unusedStoreInitialTranslationConfig,
+		ssrData: storeSSRData,
+		config: storeConfig,
 		...storeWithoutTranslationInputs
 	} = store ?? {};
 
@@ -152,6 +163,8 @@ export function getOrCreateConsentRuntime(
 	const resolvedStorageConfig =
 		storageConfig ?? storeWithoutTranslationInputs.storageConfig;
 	const resolvedEnabled = enabled ?? storeWithoutTranslationInputs.enabled;
+	const resolvedBackendURL = backendURL || DEFAULT_BACKEND_URL;
+	const explicitSSRData = topLevelSSRData ?? storeSSRData;
 
 	const cacheKey = generateRuntimeCacheKey({
 		mode,
@@ -210,12 +223,34 @@ export function getOrCreateConsentRuntime(
 		const normalizedMode = normalizeRuntimeMode(
 			mode as RuntimeMode | undefined
 		);
+		const userConfig = storeConfig ?? topLevelConfig;
+		const autoPrefetchedSSRData =
+			normalizedMode === 'hosted' &&
+			typeof window !== 'undefined' &&
+			!explicitSSRData
+				? getMatchingPrefetchedInitialData({
+						backendURL: resolvedBackendURL,
+						overrides: options.overrides,
+						credentials: 'include',
+					})
+				: undefined;
+		const resolvedSSRData = explicitSSRData ?? autoPrefetchedSSRData;
 
 		consentStore = createConsentManagerStore(consentManager, {
 			config: {
+				...(userConfig ?? {}),
 				pkg: pkgInfo?.pkg || 'c15t',
 				version: pkgInfo?.version || version,
 				mode: normalizedMode,
+				meta: {
+					...(userConfig?.meta ?? {}),
+					...(normalizedMode === 'hosted'
+						? {
+								backendURL: resolvedBackendURL,
+								requestCredentials: 'include',
+							}
+						: {}),
+				},
 			},
 			...cleanStoreOptionOverrides,
 			...storeWithoutTranslationInputs,
@@ -225,8 +260,16 @@ export function getOrCreateConsentRuntime(
 			enabled: resolvedEnabled,
 			initialTranslationConfig: normalizedInitialTranslationConfig,
 			initialConsentCategories: consentCategories,
+			ssrData: resolvedSSRData,
 			debug,
-		});
+			__internal:
+				normalizedMode === 'hosted'
+					? {
+							backendURL: resolvedBackendURL,
+							requestCredentials: 'include',
+						}
+					: undefined,
+		} as InternalStoreOptions);
 
 		storeCache.set(cacheKey, consentStore);
 	}

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -133,6 +133,12 @@ export const createConsentManagerStore = (
 	manager: ConsentManagerInterface,
 	options: StoreOptions = {}
 ) => {
+	const internalOptions = options as StoreOptions & {
+		__internal?: {
+			backendURL?: string;
+			requestCredentials?: RequestCredentials;
+		};
+	};
 	const {
 		namespace = 'c15tStore',
 		// Extract options that shouldn't be spread directly into state
@@ -328,6 +334,8 @@ export const createConsentManagerStore = (
 			initConsentManager({
 				manager,
 				ssrData: options.ssrData,
+				backendURL: internalOptions.__internal?.backendURL,
+				requestCredentials: internalOptions.__internal?.requestCredentials,
 				initialTranslationConfig: normalizedInitialTranslationConfig,
 				iabConfig: iab as IABConfig | undefined,
 				get,
@@ -423,6 +431,8 @@ export const createConsentManagerStore = (
 
 			return await initConsentManager({
 				manager,
+				backendURL: internalOptions.__internal?.backendURL,
+				requestCredentials: internalOptions.__internal?.requestCredentials,
 				initialTranslationConfig: normalizedInitialTranslationConfig,
 				get,
 				set,

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -191,6 +191,11 @@ export type OfflinePolicyConfig = {
  */
 export interface SSRInitRequestMetadata {
 	/**
+	 * Effective request inputs used to fetch `/init`.
+	 */
+	requestContext?: SSRInitRequestContext;
+
+	/**
 	 * End-to-end request duration in milliseconds (server-side measurement).
 	 */
 	requestDurationMs?: number;
@@ -210,6 +215,49 @@ export interface SSRInitRequestMetadata {
 		detail: string | null;
 	};
 }
+
+/**
+ * Effective request inputs used to fetch `/init`.
+ *
+ * @public
+ */
+export interface SSRInitRequestContext {
+	/**
+	 * Canonical absolute backend URL without a trailing slash.
+	 */
+	backendURL: string;
+
+	/**
+	 * Explicit country override used for the request, if any.
+	 */
+	country: string | null;
+
+	/**
+	 * Explicit region override used for the request, if any.
+	 */
+	region: string | null;
+
+	/**
+	 * Explicit language override used for the request, if any.
+	 */
+	language: string | null;
+
+	/**
+	 * Effective GPC signal used for the request.
+	 */
+	gpc: boolean;
+
+	/**
+	 * Fetch credentials mode for browser-prefetched requests.
+	 */
+	credentials?: RequestCredentials;
+}
+
+export type SSRSkippedReason =
+	| 'no_data'
+	| 'fetch_failed'
+	| 'context_mismatch'
+	| null;
 
 /**
  * Initial data structure for SSR prefetching.
@@ -687,8 +735,9 @@ export interface StoreRuntimeState extends StoreConfig {
 	 * - `null` if SSR data was used successfully
 	 * - `'no_data'` if no SSR data was provided
 	 * - `'fetch_failed'` if SSR data was provided but the fetch returned no data
+	 * - `'context_mismatch'` if SSR data did not match the current runtime request context
 	 */
-	ssrSkippedReason: 'no_data' | 'fetch_failed' | null;
+	ssrSkippedReason: SSRSkippedReason;
 }
 
 /**

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -9,12 +9,7 @@
  */
 
 export * from '@c15t/react';
-export {
-	buildPrefetchScript,
-	ensurePrefetchedInitialData,
-	getPrefetchedInitialData,
-	type PrefetchOptions,
-} from 'c15t';
+export { buildPrefetchScript, type PrefetchOptions } from 'c15t';
 export { C15tPrefetch } from './libs/browser-initial-data';
 export { fetchInitialData } from './libs/initial-data';
 export type {

--- a/packages/nextjs/src/libs/browser-initial-data.tsx
+++ b/packages/nextjs/src/libs/browser-initial-data.tsx
@@ -8,8 +8,8 @@ const DEFAULT_SCRIPT_ID = 'c15t-initial-data-prefetch';
  * Next.js script component that starts `/init` prefetching before hydration.
  *
  * @remarks
- * Use in `app/layout.tsx` for static routes. Pair with
- * `getPrefetchedInitialData()` or `ensurePrefetchedInitialData()` in your client provider.
+ * Use in `app/layout.tsx` for static routes. Matching prefetched data is
+ * consumed automatically by the runtime during first store initialization.
  */
 export function C15tPrefetch({
 	id = DEFAULT_SCRIPT_ID,

--- a/packages/react/src/hooks/use-ssr-status.ts
+++ b/packages/react/src/hooks/use-ssr-status.ts
@@ -25,8 +25,9 @@ export interface SSRStatus {
 	 *
 	 * - `'no_data'` — no `ssrData` prop was provided to the provider
 	 * - `'fetch_failed'` — `ssrData` was provided but the Promise resolved with no data
+	 * - `'context_mismatch'` — `ssrData` did not match the current runtime request context
 	 */
-	ssrSkippedReason: 'no_data' | 'fetch_failed' | null;
+	ssrSkippedReason: 'no_data' | 'fetch_failed' | 'context_mismatch' | null;
 }
 
 /**

--- a/packages/react/src/server/fetch-ssr-data.test.ts
+++ b/packages/react/src/server/fetch-ssr-data.test.ts
@@ -55,6 +55,13 @@ describe('fetchSSRData', () => {
 			isHit: true,
 			detail: 'x-vercel-cache=HIT, age=10',
 		});
+		expect(result?.metadata?.requestContext).toEqual({
+			backendURL: 'https://example.com/api/c15t',
+			country: 'US',
+			region: null,
+			language: null,
+			gpc: false,
+		});
 		expect(typeof result?.metadata?.requestDurationMs).toBe('number');
 		expect(result?.metadata?.requestDurationMs).toBeGreaterThanOrEqual(0);
 	});
@@ -131,11 +138,54 @@ describe('fetchSSRData', () => {
 			gvl: null,
 		});
 		expect(result?.metadata).toEqual({
+			requestContext: {
+				backendURL: 'https://consent.example.com/api/c15t',
+				country: 'US',
+				region: null,
+				language: null,
+				gpc: false,
+			},
 			cache: {
 				isHit: false,
 				detail: null,
 			},
 			requestDurationMs: expect.any(Number),
+		});
+	});
+
+	it('records overrides and gpc in request-context metadata', async () => {
+		const headers = createRequestHeaders();
+		headers.set('accept-language', 'en-GB');
+		headers.set('sec-gpc', '1');
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ gvl: null, categories: [] }), {
+					status: 200,
+					headers: {
+						'content-type': 'application/json',
+					},
+				})
+			)
+		);
+
+		const result = await fetchSSRData({
+			backendURL: '/api/c15t',
+			headers,
+			overrides: {
+				country: 'DE',
+				region: 'BE',
+				language: 'de',
+			},
+		});
+
+		expect(result?.metadata?.requestContext).toEqual({
+			backendURL: 'https://example.com/api/c15t',
+			country: 'DE',
+			region: 'BE',
+			language: 'de',
+			gpc: true,
 		});
 	});
 

--- a/packages/react/src/server/fetch-ssr-data.ts
+++ b/packages/react/src/server/fetch-ssr-data.ts
@@ -8,6 +8,23 @@ interface SSRFetchResult {
 	metadata?: SSRInitialData['metadata'];
 }
 
+function buildRequestContext(options: {
+	backendURL: string;
+	headers: Record<string, string>;
+	overrides?: FetchSSRDataOptions['overrides'];
+}): NonNullable<SSRInitialData['metadata']>['requestContext'] {
+	return {
+		backendURL: options.backendURL,
+		country:
+			options.overrides?.country ?? options.headers['x-c15t-country'] ?? null,
+		region:
+			options.overrides?.region ?? options.headers['x-c15t-region'] ?? null,
+		language:
+			options.overrides?.language ?? options.headers['accept-language'] ?? null,
+		gpc: options.headers['sec-gpc'] === '1',
+	};
+}
+
 /**
  * Performs the init fetch request.
  * All async work (header resolution) should be done before calling this.
@@ -16,6 +33,7 @@ interface SSRFetchResult {
 function performInitFetch(
 	normalizedURL: string,
 	relevantHeaders: Record<string, string>,
+	requestContext: NonNullable<SSRInitialData['metadata']>['requestContext'],
 	debug?: boolean
 ): Promise<SSRFetchResult> {
 	const startTime = getNowMs();
@@ -28,6 +46,7 @@ function performInitFetch(
 			const requestDurationMs = Math.max(0, Math.round(getNowMs() - startTime));
 			const cache = inspectCacheHeaders(response.headers);
 			const metadata: SSRInitialData['metadata'] = {
+				requestContext,
 				requestDurationMs,
 				cache,
 			};
@@ -235,7 +254,16 @@ export async function fetchSSRData(
 	}
 
 	// Fetch init data (GVL is included in response when server has it configured)
-	const initResult = await performInitFetch(normalizedURL, initHeaders, debug);
+	const initResult = await performInitFetch(
+		normalizedURL,
+		initHeaders,
+		buildRequestContext({
+			backendURL: normalizedURL,
+			headers: initHeaders,
+			overrides,
+		}),
+		debug
+	);
 	const init = initResult.init;
 
 	if (!init) {


### PR DESCRIPTION
## Overview
Replace the RC static-prefetch consumer flow with automatic request-context matching so static routes only need to start `/init` early while dynamic SSR continues to use `fetchInitialData()` unchanged. This adds canonical request-context metadata to SSR and browser-prefetch payloads, auto-consumes matching prefetched data during first hosted store initialization, and updates docs/templates/examples to the smaller GA API surface.

## Related Issue
Fixes #711

## Type of Change
- [x] ✨ Enhancement (improves existing functionality)
- [x] 📚 Documentation
- [x] 🏗️ Refactor (no functional changes)
- [x] ⚡ Performance

## Implementation Details
### Key Changes
1. Added request-context metadata and matching helpers for SSR and browser-prefetch payloads, including canonical backend URL handling and ambient GPC checks.
2. Switched hosted runtime initialization to auto-consume matching prefetched data on first store creation, and changed SSR reuse to skip only on `context_mismatch` instead of any override.
3. Removed the public RC prefetch consumer exports and updated docs, templates, and benchmark/example providers to the automatic model.

### Before / After
Static route setup no longer needs a separate consumer API in the provider.

```tsx
// Before
import { ConsentManagerProvider, getPrefetchedInitialData } from '@c15t/nextjs';

<ConsentManagerProvider
  options={{
    mode: 'hosted',
    backendURL: '/api/c15t',
    ssrData: getPrefetchedInitialData({
      backendURL: '/api/c15t',
      overrides: { country: 'DE', region: 'BE', language: 'de' },
    }),
  }}
/>

// After
import { ConsentManagerProvider } from '@c15t/nextjs';

<ConsentManagerProvider
  options={{
    mode: 'hosted',
    backendURL: '/api/c15t',
    overrides: { country: 'DE', region: 'BE', language: 'de' },
  }}
/>
```

SSR-prefetched data is now reused when the effective request context matches instead of being invalidated by any override.

```ts
// Before
if (!ssrData || get().overrides) {
  set({ ssrDataUsed: false, ssrSkippedReason: 'no_data' });
  return undefined;
}

// After
if (!ssrData) {
  set({ ssrDataUsed: false, ssrSkippedReason: 'no_data' });
  return undefined;
}

if (data?.init && !shouldReuseSSRData(config, data)) {
  set({ ssrDataUsed: false, ssrSkippedReason: 'context_mismatch' });
  return undefined;
}
```

### Technical Notes
Dynamic SSR stays explicit and unchanged; browser-prefetch reuse is internal-only and first-initialization-only, so cached runtimes do not adopt newly discovered prefetched data later.

## Testing
### Test Plan
- [x] Scenario 1: request-context matching for runtime/prefetch/init-manager

  ```ts
  bunx vitest run -c vitest.config.ts src/runtime/__tests__/index.test.ts src/libs/prefetch/prefetch.test.ts src/libs/init-consent-manager/__tests__/index.test.ts
  ```

  ✓ Expected: matching prefetched or SSR data is reused, mismatches fall back to `/init`, and cached runtime behavior stays stable.

- [x] Scenario 2: SSR metadata and package verification

  ```ts
  bunx vitest run -c vitest.config.ts src/server/fetch-ssr-data.test.ts
  bun run build
  bun run check-types
  ```

  ✓ Expected: SSR payloads include canonical request-context metadata and the updated core/react/nextjs packages build or type-check successfully.

### Edge Cases
- [x] Error handling: unmatched backend URL, override, credential, or GPC context falls back to a normal client `/init`.
- [x] Performance: static routes avoid duplicate `/init` requests when the prefetched request context matches the runtime context.
- [ ] Security: no new security-sensitive behavior beyond existing inline prefetch script escaping and same-origin/runtime matching rules.

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
