### PR TITLE
Clarify hosted docs positioning

### DIFF
--- a/docs/frameworks/javascript/policy-packs.mdx
+++ b/docs/frameworks/javascript/policy-packs.mdx
@@ -3,7 +3,7 @@ title: Policy Packs
 description: Configure regional consent policies in the headless JavaScript runtime — hosted mode, presets, and offline fallback.
 ---
 
-Policy packs configure how c15t handles regional consent in the headless runtime. When connected to a backend, the runtime receives the resolved policy automatically via the `/init` response. For local experimentation or when no backend is available, pass policies directly and c15t resolves them locally.
+Policy packs configure how c15t handles regional consent in the headless runtime. When connected to a backend, the runtime receives the resolved policy automatically via the `/init` response. For local development, testing, previews, or temporary outage fallback, you can pass policies directly and c15t resolves them locally.
 
 ## Hosted Runtime (Recommended)
 
@@ -25,7 +25,7 @@ Configure your presets on the backend side. The frontend receives the resolved p
 
 ## Offline / Fallback
 
-For local development, demos, or as a resilience fallback, pass presets directly:
+For local development, demos, automated tests, or as a resilience fallback during a temporary outage, pass presets directly:
 
 ```ts
 import {
@@ -109,7 +109,7 @@ The omitted-config fallback is intentionally conservative: if the backend is unr
 - Framework wrappers built on top of `c15t`
 - Resilience fallback when the backend is temporarily unreachable
 
-For production apps, keep the canonical pack on the backend and use offline policies only as a fallback or for local experimentation.
+For production apps, keep the canonical pack on the backend and use offline policies only for development, testing, previews, or outage fallback.
 
 <Callout type="info">
   For the full concept model (matchers, scope modes, re-prompting), see [Policy Packs concepts](/docs/frameworks/javascript/concepts/policy-packs). For backend setup, see the [self-host guide](/docs/self-host/guides/policy-packs).

--- a/docs/frameworks/javascript/quickstart.mdx
+++ b/docs/frameworks/javascript/quickstart.mdx
@@ -21,6 +21,14 @@ const { consentManager, consentStore } = getOrCreateConsentRuntime({
 });
 ```
 
+<Callout type="info">
+  Hosted mode is the recommended production setup because the backend resolves jurisdiction and translations, stores consent decisions outside the current browser, and can re-sync after temporary outages.
+</Callout>
+
+<Callout type="warn">
+  You can switch to `mode: 'offline'` for local-only storage, demos, or static previews, but that removes backend audit history, automatic jurisdiction detection, and server-side consent awareness. Review [Client Modes](/docs/frameworks/javascript/concepts/client-modes) before using offline mode in production.
+</Callout>
+
 ## Subscribe to State Changes
 
 The store is a [Zustand vanilla store](https://zustand.docs.pmnd.rs/guides/extracting-actions). Use `subscribe()` for UI and general state updates, `subscribeToConsentChanges()` for change-only consent integrations, and `getState()` to read the current state:

--- a/docs/frameworks/next/policy-packs.mdx
+++ b/docs/frameworks/next/policy-packs.mdx
@@ -40,7 +40,7 @@ For production Next.js apps, you can optionally hydrate the first `/init` respon
 
 ## Offline / Fallback
 
-For local development, static sites, or when the backend is unreachable, pass policies directly:
+For local development, previews, automated tests, or when the backend is temporarily unreachable, pass policies directly:
 
 ```tsx title="components/consent-manager/provider.tsx"
 'use client';

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -86,8 +86,12 @@ availableIn:
     }
     ```
 
+    <Callout type="info">
+      Hosted mode is the recommended production setup because the backend resolves jurisdiction and policy, keeps durable consent records, and lets c15t recover from temporary network failures by re-syncing later.
+    </Callout>
+
     <Callout type="warn">
-      Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but review the [browser-only storage consequences](/docs/frameworks/next/concepts/client-modes#offline-mode) before choosing it for production.
+      Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/next/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
   </Step>
 

--- a/docs/frameworks/react/policy-packs.mdx
+++ b/docs/frameworks/react/policy-packs.mdx
@@ -36,7 +36,7 @@ export function ConsentManager({ children }: { children: ReactNode }) {
 
 ## Offline / Fallback
 
-For local development, static sites, or when the backend is unreachable, pass policies directly:
+For local development, previews, automated tests, or when the backend is temporarily unreachable, pass policies directly:
 
 ```tsx
 import type { ReactNode } from 'react';

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -82,8 +82,12 @@ availableIn:
     }
     ```
 
+    <Callout type="info">
+      Hosted mode is the recommended production setup because the backend resolves jurisdiction and policy, keeps durable consent records, and lets c15t recover from temporary network failures by re-syncing later.
+    </Callout>
+
     <Callout type="warn">
-      Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but review the [browser-only storage consequences](/docs/frameworks/react/concepts/client-modes#offline-mode) before choosing it for production.
+      Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/react/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
   </Step>
 

--- a/docs/shared/concepts/client-modes.mdx
+++ b/docs/shared/concepts/client-modes.mdx
@@ -3,12 +3,12 @@
 <section id="overview">
   c15t supports three client modes that determine how consent data is stored and synchronized. Choose the mode that matches your infrastructure:
 
-  - **Hosted mode** - Full backend integration with geolocation, API sync, and analytics
-  - **Offline mode** - Local-only storage with no network requests
+  - **Hosted mode** - Recommended for production. Backend-backed consent with geolocation, centralized policy resolution, audit history, and offline fallback.
+  - **Offline mode** - Browser-only storage with no network requests. Best for local development, demos, static deployments, or controlled fallback scenarios.
   - **Custom mode** - Bring your own backend with custom endpoint handlers
 
   <Callout type="warn">
-    Offline mode is browser-only storage. If browser storage is blocked or cleared, consent cannot be remembered and prior choices cannot be verified.
+    If you need durable consent records, server-side enforcement, or automatic jurisdiction detection, use hosted mode. Offline mode cannot provide those guarantees because consent lives only in the browser.
   </Callout>
 </section>
 
@@ -32,6 +32,13 @@
   **Configuration:**
 
   - `backendURL` (required) - API endpoint path
+
+  **Why it is the default for production:**
+
+  - The backend stays the source of truth for policy, translations, and jurisdiction logic
+  - Consent decisions can be stored beyond the current browser session for audit and support workflows
+  - Server-side systems can preload consent-aware behavior instead of waiting for client-only storage
+  - If the backend is temporarily unavailable, c15t can fall back locally and re-sync later
 
   **Best for:** Production apps that need geolocation-based jurisdiction detection, consent record storage, and compliance audit trails.
 </section>
@@ -65,10 +72,12 @@
 
   - No automatic geolocation or jurisdiction detection
   - No consent audit trail
+  - No centralized policy or translation updates without shipping frontend changes
   - No cross-device sync
+  - No server-side visibility before client initialization
   - Works without any backend infrastructure
 
-  **Best for:** Static sites, development/testing, or as a starting point before setting up a backend.
+  **Best for:** Local development, Storybook/static demos, resilience fallback, or simpler sites that explicitly accept browser-only consent storage.
 </section>
 
 <section id="custom-mode">
@@ -93,7 +102,10 @@
   | Feature | Hosted | Offline | Custom |
   |---------|------|---------|--------|
   | Geolocation | Automatic | Manual via overrides | Your implementation |
+  | Policy source of truth | Backend-managed | Bundled into the frontend | Your implementation |
   | Consent sync | API | Local only | Your implementation |
+  | Audit trail | Backend records | Not available | Your implementation |
+  | Server-side consent awareness | Supported | Not available | Your implementation |
   | SSR data | Supported | Not available | Your implementation |
   | Analytics | Built-in | Not available | Your implementation |
   | Infrastructure | c15t backend | None | Your backend |

--- a/docs/shared/concepts/policy-packs.mdx
+++ b/docs/shared/concepts/policy-packs.mdx
@@ -9,9 +9,9 @@
 
   1. **consent.io (recommended)** — use [consent.io](https://consent.io) as your hosted backend. Configure packs visually in the dashboard or via API — no code changes required. Works with any frontend, including static sites.
   2. **Self-hosted backend** — define packs in code via `policyPacks` and resolve them from real request geo data. Full control over policy logic and storage.
-  3. **Offline fallback** — pass the same policy shapes to the frontend via `offlinePolicy.policyPacks`. Used as a resilience fallback when the backend is unreachable, or for quick local experimentation and demos. If you omit `offlinePolicy.policyPacks`, c15t falls back to a synthetic worldwide opt-in banner instead of no-banner mode.
+  3. **Offline fallback** — pass the same policy shapes to the frontend via `offlinePolicy.policyPacks`. Use this mainly for local development, demos, deterministic testing, or resilience when the backend is temporarily unreachable. If you omit `offlinePolicy.policyPacks`, c15t falls back to a synthetic worldwide opt-in banner instead of no-banner mode.
 
-  In both hosted and self-hosted modes, the **backend is always the source of truth**. Offline packs never override a live backend decision.
+  In both hosted and self-hosted modes, the **backend is always the source of truth**. Offline packs are a preview or fallback layer and never override a live backend decision.
 </section>
 
 <section id="quickstart">

--- a/docs/shared/react/components/consent-manager-provider.mdx
+++ b/docs/shared/react/components/consent-manager-provider.mdx
@@ -106,7 +106,7 @@
 
   ### Fallback: Offline Policies
 
-  When no backend is available, `ConsentManagerProvider` accepts `offlinePolicy.policyPacks` for local policy resolution:
+  When no backend is available, `ConsentManagerProvider` accepts `offlinePolicy.policyPacks` for local policy resolution during development, testing, previews, or temporary backend outages:
 
   ```tsx
   <ConsentManagerProvider
@@ -157,6 +157,7 @@
   Notes:
 
   - `offlinePolicy` is only used in `offline` mode.
+  - Treat offline policies as a development/testing tool or resilience fallback, not the primary production source of truth.
   - `offlinePolicy.i18n` lets offline mode mirror hosted `messageProfile` and profile-local `fallbackLanguage` behavior.
   - Omitting `offlinePolicy.policyPacks` uses the built-in synthetic opt-in fallback banner. Hosted network fallback uses the same opt-in banner.
   - `offlinePolicy: { policyPacks: [] }` is explicit no-banner mode.

--- a/docs/shared/react/guides/policy-packs.mdx
+++ b/docs/shared/react/guides/policy-packs.mdx
@@ -5,7 +5,7 @@
 
   **For most apps, you just need a `ConsentManagerProvider` pointing at your backend with presets configured there.** The frontend receives the resolved policy via the `/init` response — no client-side policy config required.
 
-  When a backend isn't available — local development, static previews, Storybook, or as a resilience fallback — you can pass policies directly to the provider via `offlinePolicy.policyPacks` and c15t resolves them locally.
+  When a backend isn't available — local development, static previews, Storybook, automated tests, or as a resilience fallback during a temporary outage — you can pass policies directly to the provider via `offlinePolicy.policyPacks` and c15t resolves them locally.
 
   <Callout type="info">
     For QA and testing, use the [c15t DevTools](/docs/frameworks/react/dev-tools) to simulate different regions and policy responses against your real backend, rather than switching to offline mode.
@@ -31,9 +31,9 @@
 
   The backend resolves the correct policy based on the visitor's geo data and returns it in the `/init` response. Configure your presets on the backend side.
 
-  ## Offline Presets (Fallback)
+  ## Offline Presets (Development and Fallback)
 
-  When no backend is available, pass presets directly to the provider:
+  Use offline presets mainly for local development, Storybook, deterministic tests, or temporary backend outages:
 
   ```tsx
   import { policyPackPresets } from '@c15t/react';
@@ -83,7 +83,7 @@
   ## Provider Shape
 
   Configure packs through `offlinePolicy.policyPacks`. Add `offlinePolicy.i18n`
-  when you want offline mode to mirror hosted policy-profile language behavior:
+  when you want local previews or fallback behavior to mirror hosted policy-profile language behavior:
 
   ```tsx
   <ConsentManagerProvider
@@ -144,7 +144,7 @@
   | `offlinePolicy: { policyPacks: [] }` | Explicit no-banner mode |
   | Non-empty pack, no match, no default | Explicit no-banner mode |
 
-  Omitting the option gives you a safe opt-in default for local development and outage scenarios. Providing it tells c15t you want policy-driven behavior exactly as configured.
+  Omitting the option gives you a safe opt-in default for local development and outage scenarios. Providing it tells c15t you want deterministic preview or fallback behavior exactly as configured.
 </section>
 
 <section id="qa-and-debugging">
@@ -158,7 +158,7 @@
   - Open the DevTools Policy panel to inspect matcher resolution and fingerprints
   - Compare your frontend preview with the backend `/init` response before shipping
 
-  If you need fully deterministic resolution without a backend (e.g., in automated tests or Storybook), pair `offlinePolicy.policyPacks` with `overrides`:
+  If you need fully deterministic resolution without a backend during testing or preview work (for example, in automated tests or Storybook), pair `offlinePolicy.policyPacks` with `overrides`:
 
   ```tsx
   options={{


### PR DESCRIPTION
## Overview
Clarifies the docs so hosted is presented as the recommended production path, while offline policies are framed as development, testing, preview, and outage-fallback tooling. This updates the quickstarts, client mode docs, policy-pack docs, and provider guidance to make the tradeoffs explicit and consistent.

## Related Issue
Fixes #717

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Strengthened hosted-vs-offline messaging in the React, Next.js, and JavaScript quickstarts plus the shared client-modes doc.
2. Repositioned offline policies in shared/framework policy-pack docs and provider guidance as development, testing, preview, and temporary outage fallback tooling.

### Technical Notes
This is a docs-only change. Hosted remains the production source of truth, and the offline examples now consistently describe preview/fallback use instead of an equal production path.

## Testing
### Test Plan
- [x] Scenario 1: Review the branch diff against `origin/2.0.0`

  ```ts
  git diff origin/2.0.0...
  ```

  ✓ Expected: Only the intended 10 documentation files are changed, and the copy consistently favors hosted for production.

- [x] Scenario 2: Verify the working tree is clean after commit

  ```ts
  git status --short
  ```

  ✓ Expected: No uncommitted tracked changes remain before creating the PR.

### Edge Cases
- [x] Error handling: Offline mode is still documented as a resilience fallback during temporary backend outages.
- [x] Performance: No runtime or build behavior changed; docs-only update.
- [x] Security: No security-sensitive code paths changed.

## Checklist
### Required
- [x] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
