### PR TITLE
Fix CLI build outputs and align Axiom telemetry

### DIFF
--- a/examples/demo/app/(showcase)/theme/page.tsx
+++ b/examples/demo/app/(showcase)/theme/page.tsx
@@ -3,6 +3,7 @@
 import {
 	ConsentBanner,
 	ConsentManagerProvider,
+	policyPackPresets,
 	type Theme,
 	useConsentManager,
 } from '@c15t/react';
@@ -596,6 +597,13 @@ export default function ThemeShowcasePage() {
 						mode: 'offline',
 						consentCategories: ['necessary', 'marketing', 'measurement'],
 						theme: activeTheme,
+						offlinePolicy: {
+							policyPacks: [
+								policyPackPresets.europeOptIn(),
+								policyPackPresets.californiaOptOut(),
+								policyPackPresets.worldNoBanner(),
+							],
+						},
 					}}
 				>
 					<ForceBannerShow />

--- a/examples/demo/app/(showcase)/theme/regressions/page.tsx
+++ b/examples/demo/app/(showcase)/theme/regressions/page.tsx
@@ -4,6 +4,7 @@ import {
 	ConsentBanner,
 	ConsentManagerProvider,
 	ConsentWidget,
+	policyPackPresets,
 	type Theme,
 	useConsentManager,
 } from '@c15t/react';
@@ -266,6 +267,13 @@ function LiveRegressionPreview({ check }: { check: RegressionCheck }) {
 								check.previewKind === 'banner'
 									? positionedBannerTheme(check.theme, stageRect)
 									: check.theme,
+							offlinePolicy: {
+								policyPacks: [
+									policyPackPresets.europeOptIn(),
+									policyPackPresets.californiaOptOut(),
+									policyPackPresets.worldNoBanner(),
+								],
+							},
 						}}
 					>
 						{check.previewKind === 'banner' ? (

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"build:workspace-deps": "bunx turbo run build --filter=@c15t/nextjs --filter=@c15t/dev-tools --filter=@c15t/node-sdk",
+		"build:workspace-deps": "bunx turbo run build --filter=@c15t/nextjs --filter=@c15t/dev-tools --filter=@c15t/node-sdk --filter=@c15t/cli",
 		"predev": "bun run build:workspace-deps",
 		"predev:localhost": "bun run build:workspace-deps",
 		"prebuild": "bun run build:workspace-deps",

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -93,6 +93,8 @@ export const ENV_VARS = {
 	TELEMETRY_ENDPOINT: 'C15T_TELEMETRY_ENDPOINT',
 	/** Optional write key for telemetry ingest */
 	TELEMETRY_WRITE_KEY: 'C15T_TELEMETRY_WRITE_KEY',
+	/** Optional Axiom org ID for telemetry ingest */
+	TELEMETRY_ORG_ID: 'C15T_TELEMETRY_ORG_ID',
 	/** Control-plane/dashboard base URL override */
 	CONSENT_URL: 'CONSENT_URL',
 	/** c15t backend URL */

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -103,13 +103,6 @@ type TelemetryObject = { [key: string]: TelemetryValue };
 type TelemetryValue = TelemetryPrimitive | TelemetryValue[] | TelemetryObject;
 type TelemetryProperties = Record<string, TelemetryValue | undefined>;
 
-type TelemetryBatchPayload = {
-	schemaVersion: 1;
-	source: 'c15t-cli';
-	sentAt: string;
-	events: WideEvent[];
-};
-
 type EventLike = Record<string, unknown>;
 
 const DEFAULT_QUEUE_LIMIT = 250;
@@ -386,15 +379,13 @@ export class Telemetry {
 	private buildHeaders(
 		overrides?: Record<string, string>
 	): Record<string, string> {
-		const cliVersion =
-			this.readString(this.defaultProperties.cliVersion) ?? 'unknown';
 		const writeKey = process.env[ENV_VARS.TELEMETRY_WRITE_KEY];
+		const orgId = process.env[ENV_VARS.TELEMETRY_ORG_ID];
 
 		return {
 			'Content-Type': 'application/json',
-			'User-Agent': `c15t-cli/${cliVersion}`,
-			'X-C15T-Telemetry-Source': 'cli',
 			...(writeKey ? { Authorization: `Bearer ${writeKey}` } : {}),
+			...(orgId ? { 'X-Axiom-Org-Id': orgId } : {}),
 			...overrides,
 		};
 	}
@@ -425,18 +416,12 @@ export class Telemetry {
 
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
-		const payload: TelemetryBatchPayload = {
-			schemaVersion: 1,
-			source: 'c15t-cli',
-			sentAt: new Date().toISOString(),
-			events,
-		};
 
 		try {
 			const response = await this.fetchImpl(this.endpoint, {
 				method: 'POST',
 				headers: this.headers,
-				body: JSON.stringify(payload),
+				body: JSON.stringify(events),
 				signal: controller.signal,
 			});
 

--- a/packages/cli/test/utils/telemetry.test.ts
+++ b/packages/cli/test/utils/telemetry.test.ts
@@ -36,8 +36,15 @@ describe('Telemetry', () => {
 	let fetchMock: ReturnType<typeof vi.fn>;
 	let storageDir: string;
 	let mockLogger: CliLogger;
+	let originalTelemetryWriteKey: string | undefined;
+	let originalTelemetryOrgId: string | undefined;
 
 	beforeEach(async () => {
+		originalTelemetryWriteKey = process.env.C15T_TELEMETRY_WRITE_KEY;
+		originalTelemetryOrgId = process.env.C15T_TELEMETRY_ORG_ID;
+		delete process.env.C15T_TELEMETRY_WRITE_KEY;
+		delete process.env.C15T_TELEMETRY_ORG_ID;
+
 		fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
 		storageDir = await fs.mkdtemp(
 			path.join(os.tmpdir(), 'c15t-cli-telemetry-')
@@ -61,6 +68,16 @@ describe('Telemetry', () => {
 
 	afterEach(async () => {
 		await telemetry.shutdown();
+		if (originalTelemetryWriteKey === undefined) {
+			delete process.env.C15T_TELEMETRY_WRITE_KEY;
+		} else {
+			process.env.C15T_TELEMETRY_WRITE_KEY = originalTelemetryWriteKey;
+		}
+		if (originalTelemetryOrgId === undefined) {
+			delete process.env.C15T_TELEMETRY_ORG_ID;
+		} else {
+			process.env.C15T_TELEMETRY_ORG_ID = originalTelemetryOrgId;
+		}
 		await fs.rm(storageDir, { recursive: true, force: true });
 	});
 
@@ -104,22 +121,20 @@ describe('Telemetry', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const [, requestInit] = fetchMock.mock.calls[0]!;
-		const payload = JSON.parse(String(requestInit?.body)) as {
-			source: string;
-			events: Array<Record<string, unknown>>;
-		};
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
 
-		expect(payload.source).toBe('c15t-cli');
-		expect(payload.events).toHaveLength(1);
-		expect(payload.events[0]).toMatchObject({
+		expect(payload).toHaveLength(1);
+		expect(payload[0]).toMatchObject({
 			event: TelemetryEventName.CLI_INVOKED,
 			framework: 'next',
 			nested: { mode: 'hosted' },
 			source: 'c15t-cli',
 		});
-		expect(payload.events[0].installId).toEqual(expect.any(String));
-		expect(payload.events[0].sessionId).toEqual(expect.any(String));
-		expect(payload.events[0].sequence).toBe(1);
+		expect(payload[0].installId).toEqual(expect.any(String));
+		expect(payload[0].sessionId).toEqual(expect.any(String));
+		expect(payload[0].sequence).toBe(1);
 	});
 
 	it('tracks commands with sanitized args and flags', async () => {
@@ -132,10 +147,10 @@ describe('Telemetry', () => {
 		await flushTelemetry(telemetry);
 
 		const [, requestInit] = fetchMock.mock.calls[0]!;
-		const payload = JSON.parse(String(requestInit?.body)) as {
-			events: Array<Record<string, unknown>>;
-		};
-		const event = payload.events[0]!;
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
+		const event = payload[0]!;
 
 		expect(event).toMatchObject({
 			event: TelemetryEventName.COMMAND_EXECUTED,
@@ -163,10 +178,10 @@ describe('Telemetry', () => {
 		await flushTelemetry(telemetry);
 
 		const [, requestInit] = fetchMock.mock.calls[0]!;
-		const payload = JSON.parse(String(requestInit?.body)) as {
-			events: Array<Record<string, unknown>>;
-		};
-		const event = payload.events[0]!;
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
+		const event = payload[0]!;
 
 		expect(event.event).toBe(TelemetryEventName.ERROR_OCCURRED);
 		expect(event.level).toBe('error');
@@ -192,10 +207,10 @@ describe('Telemetry', () => {
 		await flushTelemetry(telemetry);
 
 		const [, requestInit] = fetchMock.mock.calls[0]!;
-		const payload = JSON.parse(String(requestInit?.body)) as {
-			events: Array<Record<string, unknown>>;
-		};
-		const event = payload.events[0]!;
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
+		const event = payload[0]!;
 
 		expect(event.token).toBe('[redacted]');
 		expect(event.nested).toEqual({ password: '[redacted]' });
@@ -252,11 +267,51 @@ describe('Telemetry', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const [, requestInit] = fetchMock.mock.calls[0]!;
-		const payload = JSON.parse(String(requestInit?.body)) as {
-			events: Array<Record<string, unknown>>;
-		};
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
 
-		expect(payload.events).toHaveLength(1);
-		expect(payload.events[0]?.stage).toBe('enabled');
+		expect(payload).toHaveLength(1);
+		expect(payload[0]?.stage).toBe('enabled');
+	});
+
+	it('sends axiom-compatible headers and a raw events array', async () => {
+		process.env.C15T_TELEMETRY_WRITE_KEY = 'axiom-token';
+		process.env.C15T_TELEMETRY_ORG_ID = 'axiom-org';
+
+		const axiomTelemetry = new Telemetry({
+			fetch: fetchMock as unknown as typeof fetch,
+			storageDir,
+			logger: mockLogger,
+			drainOptions: {
+				retry: {
+					maxAttempts: 1,
+					backoff: 'fixed',
+					initialDelayMs: 10,
+					maxDelayMs: 10,
+				},
+			},
+		});
+
+		axiomTelemetry.trackEvent(TelemetryEventName.CLI_INVOKED, {
+			stage: 'axiom',
+		});
+		await flushTelemetry(axiomTelemetry);
+		await axiomTelemetry.shutdown();
+
+		const [, requestInit] = fetchMock.mock.calls[0]!;
+		const headers = requestInit?.headers as Record<string, string>;
+		const payload = JSON.parse(String(requestInit?.body)) as Array<
+			Record<string, unknown>
+		>;
+
+		expect(headers).toMatchObject({
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer axiom-token',
+			'X-Axiom-Org-Id': 'axiom-org',
+		});
+		expect(payload).toHaveLength(1);
+		expect(payload[0]?.stage).toBe('axiom');
+		expect(payload[0]).not.toHaveProperty('events');
 	});
 });

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
 				"../../docs/**",
 				"../../scripts/agent-docs/**"
 			],
-			"outputs": ["dist/**", "docs/**"],
+			"outputs": ["dist/**", "dist-types/**", "docs/**"],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/react#build": {
@@ -27,7 +27,7 @@
 				"../../docs/**",
 				"../../scripts/agent-docs/**"
 			],
-			"outputs": ["dist/**", "docs/**"],
+			"outputs": ["dist/**", "dist-types/**", "docs/**"],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/nextjs#build": {
@@ -38,7 +38,7 @@
 				"../../docs/**",
 				"../../scripts/agent-docs/**"
 			],
-			"outputs": ["dist/**", "docs/**"],
+			"outputs": ["dist/**", "dist-types/**", "docs/**"],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/backend#build": {
@@ -49,7 +49,7 @@
 				"../../docs/**",
 				"../../scripts/agent-docs/**"
 			],
-			"outputs": ["dist/**", "docs/**"],
+			"outputs": ["dist/**", "dist-types/**", "docs/**"],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"fmt": {


### PR DESCRIPTION
## Overview
This fixes two regressions in the current workspace diff: cached package builds could omit `dist-types` and break `@c15t/cli` declaration generation, and CLI telemetry batches were not using the same raw event payload shape as evlog's Axiom adapter. It updates Turbo outputs so cached builds restore declaration artifacts, aligns CLI telemetry headers and request bodies with Axiom expectations, and wires the demo theme previews to explicit offline policy pack presets while ensuring the demo prebuild step also builds the CLI.

## Related Issue
Fixes #722

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Added `dist-types/**` to the package-specific Turbo build outputs for `c15t`, `@c15t/react`, `@c15t/nextjs`, and `@c15t/backend` so cached builds restore declaration artifacts needed by downstream packages like `@c15t/cli`.
2. Changed CLI telemetry to send raw `WideEvent[]` JSON with optional `Authorization` and `X-Axiom-Org-Id` headers, and added regression tests for the Axiom-compatible wire format.
3. Updated the demo workspace prebuild script to include `@c15t/cli` and configured the theme showcase/regression previews with explicit offline policy pack presets.

### Technical Notes
The CLI build failure came from `@c15t/backend` cache hits restoring `dist/**` without `dist-types/**`, leaving TypeScript path mappings unresolved during CLI declaration generation.

## Testing
### Test Plan
- [x] Scenario 1: CLI telemetry uses the raw Axiom payload shape

  ```ts
  bun test packages/cli/test/utils/telemetry.test.ts
  ```

  ✓ Expected: telemetry tests pass, including the Axiom-compatible headers/body assertion

- [x] Scenario 2: CLI build succeeds with backend declaration outputs available

  ```ts
  bunx turbo run build --filter=@c15t/cli
  ```

  ✓ Expected: `@c15t/cli#build` completes without `TS7016` declaration errors

### Edge Cases
- [x] Error handling: dropped telemetry batches still persist and replay using the raw event array format
- [ ] Performance: no material performance change expected
- [x] Security: telemetry continues to redact sensitive fields and now only adds optional Axiom auth/org headers

## Checklist

### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
