### PR TITLE
fix: restore css layer preview and CORS test payload

### DIFF
--- a/benchmarks/css-layer-preview/package.json
+++ b/benchmarks/css-layer-preview/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/react": "workspace:*",
 		"next": "15.3.3",
 		"react": "19.2.3",
 		"react-dom": "19.2.3"

--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,7 @@
       "name": "@c15t/css-layer-preview",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/react": "workspace:*",
         "next": "15.3.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",

--- a/packages/core/src/client/__tests__/client-cors.browser.test.ts
+++ b/packages/core/src/client/__tests__/client-cors.browser.test.ts
@@ -238,7 +238,10 @@ describe('CORS functionality', () => {
 				'X-Custom-Header': 'value', // Custom header would trigger preflight
 			},
 			body: {
-				type: 'cookie_banner',
+				type: 'terms_and_conditions',
+				externalSubjectId: '',
+				givenAt: Date.now(),
+				subjectId: '',
 				domain: 'example.com',
 				preferences: {
 					analytics: true,

--- a/packages/ui/src/styles/components/consent-dialog.module.css
+++ b/packages/ui/src/styles/components/consent-dialog.module.css
@@ -245,6 +245,7 @@
 	.brandingTag .brandingCopy {
 		font-size: var(--consent-dialog-branding-label-size);
 		letter-spacing: 0.01em;
+		color: var(--c15t-text-on-primary, #fff);
 	}
 
 	.brandingTag .brandingText,
@@ -259,14 +260,17 @@
 
 	.brandingTag .brandingWordmark {
 		gap: 0.3125rem;
+		color: var(--c15t-text-on-primary, #fff);
 	}
 
 	.brandingTag .brandingC15TMark {
 		height: 0.9375rem;
+		color: var(--c15t-text-on-primary, #fff);
 	}
 
 	.brandingTag .brandingInth {
 		height: 0.9375rem;
+		color: var(--c15t-text-on-primary, #fff);
 	}
 
 	.brandingTagBanner {


### PR DESCRIPTION
## Overview
Fixes the CSS layer review regressions by wiring `@c15t/css-layer-preview` directly to `@c15t/react` and by forcing the branding tag internals to use `--c15t-text-on-primary` instead of inheriting host link color. It also updates the hosted CORS browser test fixture to match the current consent payload shape.

## Related Issue
Fixes #724

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Added the missing `@c15t/react` workspace dependency to `@c15t/css-layer-preview` and refreshed `bun.lock` so the shared runtime resolves correctly in CSS-layer review builds.
2. Set explicit badge foreground color on branding tag copy and logos so Tailwind 4 and plain CSS are not broken by host-level `a { color: inherit; }` rules.
3. Updated the hosted CORS browser test fixture to use the current consent payload fields.

### Technical Notes
The badge regression only reproduced in the layered stylesheet paths because unlayered app globals overrode anchor color on the tag root; moving the foreground color to inner elements keeps the contrast stable across environments.

## Testing
### Test Plan
- [x] Scenario 1: CSS layer benchmark build succeeds

  ```ts
  bun run css-layer:build
  ```

  ✓ Expected: preview, Tailwind 3, Tailwind 4, and plain CSS benchmark apps all build successfully.

- [x] Scenario 2: Hosted CORS browser fixture still passes

  ```ts
  bun run --cwd packages/core test -- src/client/__tests__/client-cors.browser.test.ts
  ```

  ✓ Expected: the targeted Vitest file passes with the updated payload shape.

### Edge Cases
- [x] Error handling: missing workspace resolution for `@c15t/react` no longer breaks the CSS-layer preview build.
- [ ] Performance: no material runtime or bundle-size change beyond the added direct workspace dependency declaration.
- [x] Security: no new network or permission surface was introduced.

### Visual Changes
| Before | After |
|--------|-------|
| Tailwind 4 and plain CSS rendered the branding badge with dark text on a dark badge background. | All three CSS-layer environments render the branding badge with readable white foreground text. |

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
