### PR TITLE
fix: use subjectId for identifyUser path

### DIFF
--- a/.changeset/bright-hairs-shop.md
+++ b/.changeset/bright-hairs-shop.md
@@ -1,0 +1,4 @@
+"c15t": patch
+---
+
+- fix `identifyUser()` to consistently use the consent `subjectId` for `PATCH /subjects/:id`, keep the legacy `id` alias backward compatible, and tighten request typing plus retry handling for malformed pending identify submissions.

--- a/packages/core/src/client/client-interface.ts
+++ b/packages/core/src/client/client-interface.ts
@@ -43,9 +43,28 @@ export type SetConsentResponse = PostSubjectOutput;
 
 /**
  * Request body for identifyUser (links external ID to subject).
- * Requires subjectId in path, externalId and identityProvider in body.
+ * Uses `subjectId` as the canonical field for the PATCH path.
+ * The legacy `id` alias is still accepted for backwards compatibility.
  */
-export type IdentifyUserRequestBody = PatchSubjectFullInput;
+export type IdentifyUserRequestBody = {
+	/**
+	 * Subject ID for the PATCH /subjects/:id path.
+	 * Prefer this field in all new code.
+	 */
+	subjectId?: string;
+
+	/**
+	 * @deprecated Use `subjectId` instead.
+	 * Kept to avoid breaking older low-level client integrations.
+	 */
+	id?: string;
+
+	/** External user ID to link to the subject */
+	externalId: string;
+
+	/** Identity provider name (optional) */
+	identityProvider?: string;
+};
 
 /**
  * Response from identifyUser.

--- a/packages/core/src/client/client-interface.ts
+++ b/packages/core/src/client/client-interface.ts
@@ -46,25 +46,35 @@ export type SetConsentResponse = PostSubjectOutput;
  * Uses `subjectId` as the canonical field for the PATCH path.
  * The legacy `id` alias is still accepted for backwards compatibility.
  */
-export type IdentifyUserRequestBody = {
-	/**
-	 * Subject ID for the PATCH /subjects/:id path.
-	 * Prefer this field in all new code.
-	 */
-	subjectId?: string;
-
-	/**
-	 * @deprecated Use `subjectId` instead.
-	 * Kept to avoid breaking older low-level client integrations.
-	 */
-	id?: string;
-
+type IdentifyUserRequestBodyBase = {
 	/** External user ID to link to the subject */
 	externalId: string;
 
 	/** Identity provider name (optional) */
 	identityProvider?: string;
 };
+
+type IdentifyUserRequestBodyWithSubjectId = IdentifyUserRequestBodyBase & {
+	/**
+	 * Subject ID for the PATCH /subjects/:id path.
+	 * Prefer this field in all new code.
+	 */
+	subjectId: string;
+	id?: never;
+};
+
+type IdentifyUserRequestBodyWithLegacyId = IdentifyUserRequestBodyBase & {
+	/**
+	 * @deprecated Use `subjectId` instead.
+	 * Kept to avoid breaking older low-level client integrations.
+	 */
+	id: string;
+	subjectId?: never;
+};
+
+export type IdentifyUserRequestBody =
+	| IdentifyUserRequestBodyWithSubjectId
+	| IdentifyUserRequestBodyWithLegacyId;
 
 /**
  * Response from identifyUser.

--- a/packages/core/src/client/hosted/__tests__/identify-user.test.ts
+++ b/packages/core/src/client/hosted/__tests__/identify-user.test.ts
@@ -117,6 +117,8 @@ describe('Hosted Client identifyUser Tests', () => {
 		expect(pendingSubmissions).toBeTruthy();
 		const parsed = JSON.parse(pendingSubmissions || '[]');
 		expect(parsed).toHaveLength(1);
+		expect(parsed[0].subjectId).toBe('sub_test123abc');
+		expect(parsed[0].id).toBeUndefined();
 		expect(parsed[0].externalId).toBe('user_123');
 		setDebugEnabled(false);
 	});

--- a/packages/core/src/client/hosted/__tests__/identify-user.test.ts
+++ b/packages/core/src/client/hosted/__tests__/identify-user.test.ts
@@ -38,7 +38,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Call identifyUser
 		const response = await client.identifyUser({
 			body: {
-				id: 'sub_test123abc',
+				subjectId: 'sub_test123abc',
 				externalId: 'user_123',
 				identityProvider: 'clerk',
 			},
@@ -66,7 +66,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Call identifyUser without subject ID
 		const response = await client.identifyUser({
 			body: {
-				id: '', // Empty ID
+				subjectId: '', // Empty subject ID
 				externalId: 'user_123',
 			},
 		});
@@ -99,7 +99,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Call identifyUser
 		const response = await client.identifyUser({
 			body: {
-				id: 'sub_test123abc',
+				subjectId: 'sub_test123abc',
 				externalId: 'user_123',
 				identityProvider: 'clerk',
 			},
@@ -145,7 +145,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Call identifyUser
 		await client.identifyUser({
 			body: {
-				id: 'sub_test123abc',
+				subjectId: 'sub_test123abc',
 				externalId: 'user_123',
 				identityProvider: 'clerk',
 			},
@@ -186,7 +186,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Switch to account B
 		const response = await client.identifyUser({
 			body: {
-				id: 'sub_test123abc',
+				subjectId: 'sub_test123abc',
 				externalId: 'user_account_b',
 				identityProvider: 'clerk',
 			},
@@ -221,12 +221,47 @@ describe('Hosted Client identifyUser Tests', () => {
 		// Call identifyUser
 		const response = await client.identifyUser({
 			body: {
-				id: 'sub_nonexistent',
+				subjectId: 'sub_nonexistent',
 				externalId: 'user_123',
 			},
 		});
 
 		// Assertions - 404 should use fallback (optimistic)
+		expect(response.ok).toBe(true);
+	});
+
+	it('should still support the legacy id alias for subjectId', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					id: 'sub_test123abc',
+					externalId: 'user_123',
+				}),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}
+			)
+		);
+
+		const client = configureConsentManager({
+			mode: 'hosted',
+			backendURL: '/api/c15t',
+		});
+
+		const response = await client.identifyUser({
+			body: {
+				id: 'sub_test123abc',
+				externalId: 'user_123',
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.stringContaining(`${API_ENDPOINTS.PATCH_SUBJECT}/sub_test123abc`),
+			expect.objectContaining({
+				method: 'PATCH',
+			})
+		);
 		expect(response.ok).toBe(true);
 	});
 });

--- a/packages/core/src/client/hosted/identify-user.ts
+++ b/packages/core/src/client/hosted/identify-user.ts
@@ -13,6 +13,12 @@ import type { FetcherContext } from './fetcher';
 import { createResponseContext } from './fetcher';
 import { withFallback } from './with-fallback';
 
+function getIdentifySubjectId(
+	body?: IdentifyUserRequestBody
+): string | undefined {
+	return body?.subjectId || body?.id;
+}
+
 /**
  * Provides offline mode fallback for identifyUser API.
  * Queues the identify request for retry on next page load.
@@ -22,6 +28,7 @@ export async function offlineFallbackForIdentifyUser(
 	options?: FetchOptions<IdentifyUserResponse, IdentifyUserRequestBody>
 ): Promise<ResponseContext<IdentifyUserResponse>> {
 	const pendingSubmissionsKey = 'c15t-pending-identify-submissions';
+	const newSubjectId = getIdentifySubjectId(options?.body);
 
 	try {
 		if (typeof window !== 'undefined' && options?.body && window.localStorage) {
@@ -44,7 +51,7 @@ export async function offlineFallbackForIdentifyUser(
 			const newSubmission = options.body;
 			const isDuplicate = pendingSubmissions.some(
 				(submission) =>
-					submission.id === newSubmission.id &&
+					getIdentifySubjectId(submission) === newSubjectId &&
 					submission.externalId === newSubmission.externalId
 			);
 
@@ -100,8 +107,9 @@ export async function identifyUser(
 	options: FetchOptions<IdentifyUserResponse, IdentifyUserRequestBody>
 ): Promise<ResponseContext<IdentifyUserResponse>> {
 	const { body, ...restOptions } = options;
+	const subjectId = getIdentifySubjectId(body);
 
-	if (!body?.id) {
+	if (!body || !subjectId) {
 		return {
 			ok: false,
 			data: null,
@@ -128,7 +136,7 @@ export async function identifyUser(
 			consentInfo: {
 				...existingData?.consentInfo,
 				time: existingData?.consentInfo?.time || Date.now(),
-				subjectId: body.id,
+				subjectId,
 				externalId: body.externalId,
 				identityProvider: body.identityProvider,
 			},
@@ -138,10 +146,10 @@ export async function identifyUser(
 	);
 
 	// 2. Build the path with the subject ID
-	const path = `${API_ENDPOINTS.PATCH_SUBJECT}/${body.id}`;
+	const path = `${API_ENDPOINTS.PATCH_SUBJECT}/${subjectId}`;
 
 	// Extract the body fields (excluding id which goes in the path)
-	const { id: _subjectId, ...patchBody } = body;
+	const { subjectId: _subjectId, id: _legacySubjectId, ...patchBody } = body;
 
 	// 3. Make API call with fallback
 	return withFallback<IdentifyUserResponse, typeof patchBody>(
@@ -153,8 +161,8 @@ export async function identifyUser(
 			body: patchBody,
 		},
 		async (fallbackOptions) => {
-			// Re-add the id for the fallback queue
-			const fullBody = { id: body.id, ...fallbackOptions?.body };
+			// Re-add the subject ID for the fallback queue
+			const fullBody = { subjectId, ...fallbackOptions?.body };
 			return offlineFallbackForIdentifyUser({
 				...fallbackOptions,
 				body: fullBody as IdentifyUserRequestBody,

--- a/packages/core/src/client/hosted/identify-user.ts
+++ b/packages/core/src/client/hosted/identify-user.ts
@@ -11,13 +11,8 @@ import type { FetchOptions, ResponseContext } from '../types';
 import { API_ENDPOINTS } from '../types';
 import type { FetcherContext } from './fetcher';
 import { createResponseContext } from './fetcher';
+import { getIdentifySubjectId } from './utils';
 import { withFallback } from './with-fallback';
-
-function getIdentifySubjectId(
-	body?: IdentifyUserRequestBody
-): string | undefined {
-	return body?.subjectId || body?.id;
-}
 
 /**
  * Provides offline mode fallback for identifyUser API.

--- a/packages/core/src/client/hosted/pending-submissions.ts
+++ b/packages/core/src/client/hosted/pending-submissions.ts
@@ -20,6 +20,12 @@ import { delay } from './utils';
 const PENDING_CONSENT_KEY = 'c15t-pending-consent-submissions';
 const PENDING_IDENTIFY_KEY = 'c15t-pending-identify-submissions';
 
+function getIdentifySubjectId(
+	submission?: IdentifyUserRequestBody
+): string | undefined {
+	return submission?.subjectId || submission?.id;
+}
+
 /**
  * Check for pending consent submissions on initialization
  * @internal
@@ -242,12 +248,25 @@ export async function processPendingIdentifySubmissions(
 				continue;
 			}
 
+			const subjectId = getIdentifySubjectId(submission);
+			if (!subjectId) {
+				console.warn(
+					'Dropping pending identify submission without a subject ID'
+				);
+				successfulSubmissions.push(j);
+				continue;
+			}
+
 			try {
 				getDebugLogger().log('Retrying identify user submission:', submission);
 
 				// Build the path with the subject ID
-				const path = `${API_ENDPOINTS.PATCH_SUBJECT}/${submission.id}`;
-				const { id: _subjectId, ...patchBody } = submission;
+				const path = `${API_ENDPOINTS.PATCH_SUBJECT}/${subjectId}`;
+				const {
+					subjectId: _subjectId,
+					id: _legacySubjectId,
+					...patchBody
+				} = submission;
 
 				const response = await fetcher<IdentifyUserResponse, typeof patchBody>(
 					context,

--- a/packages/core/src/client/hosted/pending-submissions.ts
+++ b/packages/core/src/client/hosted/pending-submissions.ts
@@ -15,16 +15,10 @@ import type {
 import { API_ENDPOINTS } from '../types';
 import type { FetcherContext } from './fetcher';
 import { fetcher } from './fetcher';
-import { delay } from './utils';
+import { delay, getIdentifySubjectId } from './utils';
 
 const PENDING_CONSENT_KEY = 'c15t-pending-consent-submissions';
 const PENDING_IDENTIFY_KEY = 'c15t-pending-identify-submissions';
-
-function getIdentifySubjectId(
-	submission?: IdentifyUserRequestBody
-): string | undefined {
-	return submission?.subjectId || submission?.id;
-}
 
 /**
  * Check for pending consent submissions on initialization
@@ -252,6 +246,13 @@ export async function processPendingIdentifySubmissions(
 			if (!subjectId) {
 				console.warn(
 					'Dropping pending identify submission without a subject ID'
+				);
+				successfulSubmissions.push(j);
+				continue;
+			}
+			if (!submission.externalId) {
+				console.warn(
+					'Dropping pending identify submission without an externalId'
 				);
 				successfulSubmissions.push(j);
 				continue;

--- a/packages/core/src/client/hosted/utils.ts
+++ b/packages/core/src/client/hosted/utils.ts
@@ -1,3 +1,5 @@
+import type { IdentifyUserRequestBody } from '../client-interface';
+
 /**
  * Helper function to introduce a delay
  * @param ms - Delay duration in milliseconds
@@ -6,6 +8,16 @@
  */
 export const delay = (ms: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resolves the subject identifier used by identify-user requests.
+ * Supports the canonical `subjectId` field and the deprecated `id` alias.
+ */
+export function getIdentifySubjectId(
+	submission?: IdentifyUserRequestBody
+): string | undefined {
+	return submission?.subjectId || submission?.id;
+}
 
 /**
  * Generates a UUID v4 for request identification

--- a/packages/core/src/store/__tests__/consent-store.test.ts
+++ b/packages/core/src/store/__tests__/consent-store.test.ts
@@ -969,7 +969,7 @@ describe('Consent Store', () => {
 
 			expect(mockManager.identifyUser).toHaveBeenCalledWith({
 				body: {
-					id: 'test-subject-id',
+					subjectId: 'test-subject-id',
 					externalId: 'user-123',
 					identityProvider: 'custom',
 				},

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -426,7 +426,7 @@ export const createConsentManagerStore = (
 			// Make API call to link the user to the subject
 			await manager.identifyUser({
 				body: {
-					id: subjectId,
+					subjectId,
 					externalId: user.id,
 					identityProvider: user.identityProvider,
 				},


### PR DESCRIPTION
## Overview
The hosted `identifyUser` flow accepted an ambiguous `body.id` field, which made it easy to send an auth user ID in the `/subjects/:id` path instead of the consent subject ID. This change makes `subjectId` the canonical client field, keeps the legacy `id` alias for compatibility, and updates retry handling plus store wiring so the PATCH path always uses the subject identifier.

## Related Issue
Fixes #726

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Made `subjectId` the canonical identify-user request field and retained legacy `id` support in the hosted client.
2. Updated the store call path and pending submission retry logic to resolve the PATCH route from the subject ID only.
3. Expanded hosted client and store tests to cover the new request shape and legacy alias compatibility.

### Technical Notes
The store-level `identifyUser` API still derives the current subject ID from consent state automatically; this change tightens the lower-level client contract used to build `PATCH /subjects/:id`.

## Testing
### Test Plan
- [x] Scenario 1: Hosted client sends the subject ID in the PATCH path

  ```ts
  await client.identifyUser({
    body: { subjectId: "sub_test123abc", externalId: "user_123" },
  });
  ```

  ✓ Expected: request goes to `/subjects/sub_test123abc` and excludes the path ID from the PATCH body

- [x] Scenario 2: Store-driven identifyUser still resolves the subject automatically

  ```ts
  store.setState({ consentInfo: { time: Date.now(), type: "all", subjectId: "test-subject-id" } });
  await store.getState().identifyUser({ id: "user-123", identityProvider: "custom" });
  ```

  ✓ Expected: manager receives `{ body: { subjectId: "test-subject-id", externalId: "user-123" } }`

### Edge Cases
- [x] Error handling: missing subject IDs still return `MISSING_SUBJECT_ID`, and malformed pending identify submissions are dropped instead of retried forever
- [ ] Performance: no material performance impact
- [x] Security: keeps external user IDs out of the route parameter expected to be a `sub_*` subject ID

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the identify user request structure to use `subjectId` as the primary field for subject identification across API calls
  * The legacy `id` field remains supported for backward compatibility with existing code
  * Enhanced handling of offline submissions to properly manage both the new and legacy field variants
  * Updated validation logic to accept either field when processing identify user requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->