### PR TITLE
Fix published declaration exports for TS consumers

### DIFF
--- a/.changeset/green-moons-switch.md
+++ b/.changeset/green-moons-switch.md
@@ -1,0 +1,15 @@
+---
+'@c15t/backend': patch
+'@c15t/cli': patch
+'@c15t/dev-tools': patch
+'@c15t/logger': patch
+'@c15t/node-sdk': patch
+'@c15t/react': patch
+'@c15t/scripts': patch
+---
+
+Fix published TypeScript declaration packaging so consumers stay compatible across both TypeScript 5 and TypeScript 6.
+
+- `@c15t/react`: correct the `./primitives` type export entries so they point at the published `dist-types` files instead of missing declaration paths.
+- `@c15t/backend`, `@c15t/cli`, `@c15t/dev-tools`, `@c15t/logger`, `@c15t/node-sdk`, and `@c15t/scripts`: normalize emitted `dist-types` imports during builds so published declarations no longer reference sibling `.d.ts` files directly, which could break consumers on newer TypeScript versions.
+- Tooling: make declaration normalization discover package targets dynamically so the compatibility fix applies consistently across published packages instead of only a hardcoded subset.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -110,10 +110,10 @@
 	],
 	"scripts": {
 		"prebuild": "genversion --esm --semi src/version.ts",
-		"build": "bun prebuild && rslib build && bun ../../scripts/agent-docs/generate-package-docs.ts @c15t/backend",
+		"build": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs && bun ../../scripts/agent-docs/generate-package-docs.ts @c15t/backend",
 		"build:agent-docs": "bun ../../scripts/agent-docs/generate-package-docs.ts @c15t/backend",
 		"check-types": "bun prebuild && tsc --noEmit",
-		"dev": "bun prebuild && rslib build",
+		"dev": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"knip": "knip",
 		"lint": "bun biome lint ./src",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,9 +22,9 @@
 		"dist-types"
 	],
 	"scripts": {
-		"build": "rslib build",
+		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "tsc --noEmit",
-		"dev": "rslib build",
+		"dev": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"knip": "knip",
 		"lint": "bun biome lint ./src",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -36,7 +36,7 @@
 	],
 	"scripts": {
 		"prebuild": "bunx genversion --esm --semi src/version.ts",
-		"build": "bun prebuild && rslib build",
+		"build": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "bun prebuild && tsc --noEmit",
 		"dev": "bun prebuild && rslib build --watch",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -26,7 +26,7 @@
 		"dist-types"
 	],
 	"scripts": {
-		"build": "rslib build",
+		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "tsc --noEmit",
 		"dev": "rslib build --watch",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -47,7 +47,7 @@
 		"dist-types"
 	],
 	"scripts": {
-		"build": "rslib build",
+		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "tsc --noEmit",
 		"check-types:test": "tsc -p tsconfig.test.json",
 		"dev": "rslib build --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,12 +36,12 @@
 		"./iab/styles.css": "./dist/iab/styles.css",
 		"./iab/styles.tw3.css": "./dist/iab/styles.tw3.css",
 		"./primitives": {
-			"types": "./dist/primitives.d.ts",
+			"types": "./dist-types/primitives.d.ts",
 			"import": "./dist/primitives.js",
 			"require": "./dist/primitives.cjs"
 		},
 		"./primitives/*": {
-			"types": "./dist/primitives/*.d.ts",
+			"types": "./dist-types/primitives/*.d.ts",
 			"import": "./dist/primitives/*.js",
 			"require": "./dist/primitives/*.cjs"
 		},

--- a/packages/react/src/components/shared/ui/switch/index.ts
+++ b/packages/react/src/components/shared/ui/switch/index.ts
@@ -1,2 +1,7 @@
 export * from './switch';
-export * from './switch.types';
+export type {
+	SwitchCSSVariables,
+	SwitchRootCSSVariables,
+	SwitchThumbCSSVariables,
+	SwitchTrackCSSVariables,
+} from './switch.types';

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -23,7 +23,7 @@
 		"dist-types"
 	],
 	"scripts": {
-		"build": "rslib build",
+		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "tsc --noEmit",
 		"dev": "rslib build --watch",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -46,7 +46,7 @@
 			"require": "./dist/styles/primitives/index.cjs"
 		},
 		"./styles/primitives/*": {
-			"types": "./dist/styles/primitives/*.d.ts",
+			"types": "./dist-types/styles/primitives/*.d.ts",
 			"import": "./dist/styles/primitives/*.js",
 			"require": "./dist/styles/primitives/*.cjs"
 		},

--- a/scripts/normalize-dist-types.mjs
+++ b/scripts/normalize-dist-types.mjs
@@ -2,7 +2,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
-const FROM_SPECIFIER_REGEX = /(from\s+['"])([^'"]+)(['"])/g;
+const SPECIFIER_REGEXES = [
+	/(from\s+['"])([^'"]+)(['"])/g,
+	/(import\(\s*['"])([^'"]+)(['"]\s*\))/g,
+];
 const PACKAGE_TARGETS = [
 	{
 		distDir: path.join(REPO_ROOT, 'packages/core/dist-types'),
@@ -79,6 +82,14 @@ function toExplicitRelativeSpecifier(fromFilePath, targetFilePath) {
 		relativePath = `./${relativePath}`;
 	}
 
+	if (relativePath.endsWith('/index.d.ts')) {
+		return relativePath.slice(0, -'/index.d.ts'.length);
+	}
+
+	if (relativePath.endsWith('.d.ts')) {
+		return relativePath.slice(0, -'.d.ts'.length);
+	}
+
 	return relativePath;
 }
 
@@ -131,7 +142,9 @@ async function resolveDeclarationTarget(fromFilePath, specifier) {
 
 async function normalizeDeclarationFile(filePath, currentTarget) {
 	const original = await fs.readFile(filePath, 'utf8');
-	const matches = Array.from(original.matchAll(FROM_SPECIFIER_REGEX));
+	const matches = SPECIFIER_REGEXES.flatMap((regex) =>
+		Array.from(original.matchAll(regex))
+	);
 
 	if (matches.length === 0) {
 		return;
@@ -170,11 +183,15 @@ async function normalizeDeclarationFile(filePath, currentTarget) {
 		);
 	}
 
-	const normalized = original.replace(
-		FROM_SPECIFIER_REGEX,
-		(fullMatch, prefix, specifier, suffix) =>
-			`${prefix}${resolvedSpecifiers.get(specifier) ?? specifier}${suffix}`
-	);
+	let normalized = original;
+
+	for (const regex of SPECIFIER_REGEXES) {
+		normalized = normalized.replace(
+			regex,
+			(fullMatch, prefix, specifier, suffix) =>
+				`${prefix}${resolvedSpecifiers.get(specifier) ?? specifier}${suffix}`
+		);
+	}
 
 	if (normalized !== original) {
 		await fs.writeFile(filePath, normalized);

--- a/scripts/normalize-dist-types.mjs
+++ b/scripts/normalize-dist-types.mjs
@@ -2,40 +2,67 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+const PACKAGES_ROOT = path.join(REPO_ROOT, 'packages');
 const SPECIFIER_REGEXES = [
 	/(from\s+['"])([^'"]+)(['"])/g,
 	/(import\(\s*['"])([^'"]+)(['"]\s*\))/g,
 ];
-const PACKAGE_TARGETS = [
-	{
-		distDir: path.join(REPO_ROOT, 'packages/core/dist-types'),
-		specifier: 'c15t',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/iab/dist-types'),
-		specifier: '@c15t/iab',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/nextjs/dist-types'),
-		specifier: '@c15t/nextjs',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/react/dist-types'),
-		specifier: '@c15t/react',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/schema/dist-types'),
-		specifier: '@c15t/schema',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/translations/dist-types'),
-		specifier: '@c15t/translations',
-	},
-	{
-		distDir: path.join(REPO_ROOT, 'packages/ui/dist-types'),
-		specifier: '@c15t/ui',
-	},
-];
+
+async function discoverPackageTargets() {
+	try {
+		const entries = await fs.readdir(PACKAGES_ROOT, { withFileTypes: true });
+		const packageTargets = await Promise.all(
+			entries
+				.filter((entry) => entry.isDirectory())
+				.map(async (entry) => {
+					const packageRoot = path.join(PACKAGES_ROOT, entry.name);
+					const packageJsonPath = path.join(packageRoot, 'package.json');
+
+					try {
+						const packageJson = JSON.parse(
+							await fs.readFile(packageJsonPath, 'utf8')
+						);
+
+						if (
+							!packageJson ||
+							typeof packageJson !== 'object' ||
+							typeof packageJson.name !== 'string'
+						) {
+							return null;
+						}
+
+						return {
+							distDir: path.join(packageRoot, 'dist-types'),
+							specifier: packageJson.name,
+						};
+					} catch (error) {
+						if (
+							error &&
+							typeof error === 'object' &&
+							'code' in error &&
+							error.code === 'ENOENT'
+						) {
+							return null;
+						}
+
+						throw error;
+					}
+				})
+		);
+
+		return packageTargets.filter(Boolean);
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error) {
+			if (error.code === 'ENOENT') {
+				return [];
+			}
+		}
+
+		throw error;
+	}
+}
+
+const PACKAGE_TARGETS = await discoverPackageTargets();
 
 function normalizePath(filePath) {
 	return filePath.split(path.sep).join('/');


### PR DESCRIPTION
## Overview
Fixes published declaration output so TypeScript consumers keep concrete `c15t` types instead of falling back to `any`.
This updates the dist-types normalizer to rewrite both `from` and inline `import()` specifiers to package-valid paths, corrects the `@c15t/ui/styles/primitives/*` types export to point at `dist-types`, and avoids duplicate `Switch` type re-exports in React.
This approach fixes the underlying declaration graph instead of adding app-level workarounds.

## Related Issue
Fixes #728

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Extended `scripts/normalize-dist-types.mjs` to normalize same-package declaration specifiers for both `from "..."` and `import("...")` forms while stripping `.d.ts` suffixes.
2. Corrected `@c15t/ui` subpath type exports for `./styles/primitives/*` so consumers resolve declarations from `dist-types`.
3. Narrowed the React switch barrel exports to avoid duplicate `SwitchSize` and `SwitchVariantsProps` declarations in generated types.

### Technical Notes
The resulting built declaration graph now preserves `manager`, `manager.setConsent`, and `identifyUser` typing for external TypeScript consumers.

## Testing
### Test Plan
- [x] Scenario 1: Rebuild the affected packages with fresh declaration output

  ```ts
  bunx turbo run build --force --filter=@c15t/schema --filter=@c15t/translations --filter=c15t --filter=@c15t/ui --filter=@c15t/react
  ```

  ✓ Expected: dist and dist-types are regenerated without invalid `.d.ts` specifiers in the published declaration graph

- [x] Scenario 2: Run a focused consumer-style TypeScript check against the built packages

  ```ts
  bunx tsc -p .context/typecheck/tsconfig.json
  ```

  ✓ Expected: `useConsentManager()` preserves concrete types for `manager` and `identifyUser`

### Edge Cases
- [x] Error handling: Declaration normalization now covers inline `import()` references in addition to standard re-exports
- [x] Performance: No runtime impact; changes are limited to package metadata and declaration post-processing
- [x] Security: No security impact

## Checklist
### Required
- [x] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed TypeScript declaration file packaging to ensure compatibility across TypeScript 5 and 6.
* Resolved type export path resolution inconsistencies that could cause module loading errors in newer TypeScript versions.

## Chores
* Updated build processes to include declaration normalization steps across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->