### PR TITLE
Fi branding sizing across host pages

### DIFF
--- a/.changeset/green-pans-heal.md
+++ b/.changeset/green-pans-heal.md
@@ -4,8 +4,8 @@
 '@c15t/ui': patch
 ---
 
-Harden the prebuilt consent-surface branding against host-page CSS so the INTH wordmark stays correctly sized across docs, marketing sites, and other embedded app shells.
+Harden the prebuilt consent-surface branding against host-page CSS so the INTH and c15t wordmarks stay correctly sized across docs, marketing sites, and other embedded app shells.
 
-- `@c15t/react`: wrap the INTH full logo in the shared wordmark container instead of attaching the branding sizing class directly to the raw `svg`, so the stock branding path behaves consistently with the c15t wordmark.
-- `@c15t/ui`: move the logo constraints onto the internal branding wrapper and the nested `svg`, adding explicit flex, max-width, block-layout, and aspect-ratio rules so global host-page `svg` styles cannot blow up or collapse the INTH mark.
+- `@c15t/react`: wrap both prebuilt full-logo branding paths in shared internal wordmark containers instead of attaching sizing classes directly to the raw `svg` elements.
+- `@c15t/ui`: move the logo constraints onto the internal branding wrappers and nested `svg` elements, adding explicit flex, max-width, block-layout, and aspect-ratio rules so global host-page `svg` styles cannot blow up or collapse either wordmark.
 - `@c15t/nextjs`: keep the published styled surface behavior aligned with the hardened React/UI branding path used by the prebuilt consent banner and dialog components.

--- a/.changeset/green-pans-heal.md
+++ b/.changeset/green-pans-heal.md
@@ -1,0 +1,11 @@
+---
+'@c15t/react': patch
+'@c15t/nextjs': patch
+'@c15t/ui': patch
+---
+
+Harden the prebuilt consent-surface branding against host-page CSS so the INTH wordmark stays correctly sized across docs, marketing sites, and other embedded app shells.
+
+- `@c15t/react`: wrap the INTH full logo in the shared wordmark container instead of attaching the branding sizing class directly to the raw `svg`, so the stock branding path behaves consistently with the c15t wordmark.
+- `@c15t/ui`: move the logo constraints onto the internal branding wrapper and the nested `svg`, adding explicit flex, max-width, block-layout, and aspect-ratio rules so global host-page `svg` styles cannot blow up or collapse the INTH mark.
+- `@c15t/nextjs`: keep the published styled surface behavior aligned with the hardened React/UI branding path used by the prebuilt consent banner and dialog components.

--- a/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
+++ b/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
@@ -168,6 +168,28 @@ describe('BrandingLink', () => {
 		});
 	});
 
+	test('wraps the c15t full logo mark in the shared wordmark container', async () => {
+		await renderWithConsentState(
+			<BrandingLink
+				hideBranding={false}
+				variant="banner-tag"
+				data-testid="branding-link"
+			/>
+		);
+
+		await vi.waitFor(() => {
+			const link = document.querySelector(
+				'[data-testid="branding-link"]'
+			) as HTMLAnchorElement | null;
+			const wordmark = link?.querySelector('[dir="ltr"]');
+			const mark = wordmark?.querySelector('[class*="brandingC15TMark"]');
+			expect(wordmark).toBeInTheDocument();
+			expect(mark).toBeInTheDocument();
+			expect(mark?.querySelector('svg')).toBeInTheDocument();
+			expect(wordmark).toHaveTextContent('c15t');
+		});
+	});
+
 	test('hides branding when disabled', async () => {
 		await renderWithConsentState(
 			<BrandingLink

--- a/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
+++ b/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
@@ -148,6 +148,26 @@ describe('BrandingLink', () => {
 		});
 	});
 
+	test('wraps the INTH full logo in the shared LTR wordmark container', async () => {
+		await renderWithConsentState(
+			<BrandingLink
+				hideBranding={false}
+				variant="banner-tag"
+				data-testid="branding-link"
+			/>,
+			{ branding: 'inth' }
+		);
+
+		await vi.waitFor(() => {
+			const link = document.querySelector(
+				'[data-testid="branding-link"]'
+			) as HTMLAnchorElement | null;
+			const wordmark = link?.querySelector('[dir="ltr"]');
+			expect(wordmark).toBeInTheDocument();
+			expect(wordmark?.querySelector('svg')).toBeInTheDocument();
+		});
+	});
+
 	test('hides branding when disabled', async () => {
 		await renderWithConsentState(
 			<BrandingLink

--- a/packages/react/src/components/shared/ui/branding.tsx
+++ b/packages/react/src/components/shared/ui/branding.tsx
@@ -51,7 +51,11 @@ export function BrandingFullLogo({
 	className,
 }: BrandingFullLogoProps) {
 	if (resolveBranding(branding) === 'inth') {
-		return <InthLogo className={className} />;
+		return (
+			<span dir="ltr" className={cn(styles.brandingWordmark, className)}>
+				<InthLogo aria-hidden="true" />
+			</span>
+		);
 	}
 
 	return (

--- a/packages/react/src/components/shared/ui/branding.tsx
+++ b/packages/react/src/components/shared/ui/branding.tsx
@@ -60,7 +60,9 @@ export function BrandingFullLogo({
 
 	return (
 		<span dir="ltr" className={cn(styles.brandingWordmark, className)}>
-			<C15TIconOnly className={styles.brandingC15TMark} aria-hidden="true" />
+			<span className={styles.brandingC15TMark}>
+				<C15TIconOnly aria-hidden="true" />
+			</span>
 			<span className={styles.brandingWordmarkLabel}>c15t</span>
 		</span>
 	);

--- a/packages/ui/src/styles/components/consent-dialog.module.css
+++ b/packages/ui/src/styles/components/consent-dialog.module.css
@@ -201,6 +201,8 @@
 	.brandingC15T {
 		display: inline-flex;
 		align-items: center;
+		flex: none;
+		max-width: 100%;
 		width: auto;
 		height: auto;
 	}
@@ -209,7 +211,9 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
+		flex: none;
 		min-width: 0;
+		max-width: 100%;
 		white-space: nowrap;
 	}
 
@@ -220,8 +224,21 @@
 	}
 
 	.brandingInth {
+		display: inline-flex;
+		align-items: center;
+		flex: none;
+		max-width: 100%;
 		width: var(--consent-dialog-branding-icon-width);
 		height: var(--consent-dialog-branding-icon-height);
+	}
+
+	.brandingInth > svg {
+		display: block;
+		flex: none;
+		aspect-ratio: 88 / 90;
+		width: auto;
+		height: 100%;
+		max-width: 100%;
 	}
 
 	.brandingTag {

--- a/packages/ui/src/styles/components/consent-dialog.module.css
+++ b/packages/ui/src/styles/components/consent-dialog.module.css
@@ -218,9 +218,21 @@
 	}
 
 	.brandingC15TMark {
+		display: inline-flex;
+		align-items: center;
+		flex: none;
+		max-width: 100%;
 		width: auto;
 		height: var(--consent-dialog-branding-icon-height);
+	}
+
+	.brandingC15TMark > svg {
+		display: block;
 		flex: none;
+		aspect-ratio: 446 / 445;
+		width: auto;
+		height: 100%;
+		max-width: 100%;
 	}
 
 	.brandingInth {


### PR DESCRIPTION
## Overview
The prebuilt consent surfaces treated the INTH full logo differently from the c15t wordmark, which left the raw `svg` exposed to host-page CSS and caused it to either balloon or collapse in consumer apps. This change wraps the INTH wordmark in the shared internal container and adds explicit sizing rules on the wrapper and nested `svg`, so the stock branding path stays stable across docs, marketing pages, and other embedded shells.

## Related Issue
Fixes #719

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Wrap the INTH full logo in the shared LTR wordmark container in `@c15t/react` so it uses the same internal structure as the c15t branding path.
2. Add explicit flex, max-width, display, and aspect-ratio rules in `@c15t/ui` so host-page `svg` rules cannot blow up or collapse the INTH logo.

### Technical Notes
`@c15t/nextjs` is included because its styled surfaces consume the same React/UI branding path and should ship aligned package versions with the CSS hardening.

## Testing
### Test Plan
- [x] Scenario 1: branding regression test

  ```ts
  bun prebuild && bunx vitest run src/components/shared/ui/__tests__/branding.test.tsx
  ```

  ✓ Expected: the INTH branding link renders with the shared wordmark wrapper and the targeted tests pass.

- [x] Scenario 2: consumer app verification

  ```ts
  // Verified locally in linked consumer apps after rebuilding/installing:
  // - c15t-docs.localhost:1355
  // - http://localhost:3101 (consent-io)
  ```

  ✓ Expected: the `Secured by INTH` tag renders at the intended size without oversized or missing-logo regressions.

### Edge Cases
- [x] Error handling: host pages with broad global `svg` rules no longer distort the INTH logo.
- [ ] Performance: no meaningful runtime impact beyond static markup/CSS changes.
- [x] Security: no security-sensitive behavior changed.

### Visual Changes
| Before | After |
|--------|-------|
| INTH branding could render oversized or disappear when host-page CSS targeted `svg` elements broadly. | INTH branding renders with the intended compact tag size across the docs and consent-io consumer apps. |

## Checklist

### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
