### PR TITLE
Add explicit theme slots for consent branding tags

### DIFF
--- a/.changeset/rare-buckets-whisper.md
+++ b/.changeset/rare-buckets-whisper.md
@@ -1,0 +1,15 @@
+---
+'@c15t/react': minor
+'@c15t/ui': minor
+---
+
+Remove the legacy stock-branding theme keys and require the new explicit tag slots for prebuilt consent surfaces.
+
+- `@c15t/react`: stop resolving stock banner/dialog/widget/IAB branding tags through legacy footer-branding aliases and render the standalone widget/dialog tags without the old footer-wrapper compatibility path.
+- `@c15t/ui`: add explicit branding tag slots for each prebuilt surface: `consentBannerTag`, `consentDialogTag`, `consentWidgetTag`, `iabConsentBannerTag`, and `iabConsentDialogTag`.
+
+Breaking change:
+
+- `consentWidgetBranding` has been removed. Use `consentWidgetTag`.
+- `consentDialogFooter` no longer styles the stock dialog branding tag. Use `consentDialogTag`.
+- Style stock banner and IAB branding tags via the new explicit tag slots instead of footer-related keys.

--- a/benchmarks/bundle-test-app/next.config.ts
+++ b/benchmarks/bundle-test-app/next.config.ts
@@ -10,8 +10,15 @@ const withBundleAnalyzer = bundleAnalyzer({
 	openAnalyzer: true,
 });
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 	turbopack: {
 		root: monorepoRoot,
 	},

--- a/benchmarks/css-layer-preview/next.config.ts
+++ b/benchmarks/css-layer-preview/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from 'next';
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 };
 
 export default config;

--- a/benchmarks/nextjs-browser-bench/next.config.ts
+++ b/benchmarks/nextjs-browser-bench/next.config.ts
@@ -5,8 +5,15 @@ import type { NextConfig } from 'next';
 const projectDir = dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = resolve(projectDir, '../..');
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 	turbopack: {
 		root: monorepoRoot,
 	},

--- a/benchmarks/no-tw-test/next.config.ts
+++ b/benchmarks/no-tw-test/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from 'next';
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 };
 
 export default config;

--- a/benchmarks/react-browser-bench/next.config.ts
+++ b/benchmarks/react-browser-bench/next.config.ts
@@ -5,8 +5,15 @@ import type { NextConfig } from 'next';
 const projectDir = dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = resolve(projectDir, '../..');
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 	turbopack: {
 		root: monorepoRoot,
 	},

--- a/benchmarks/script-lifecycle-bench/next.config.ts
+++ b/benchmarks/script-lifecycle-bench/next.config.ts
@@ -5,8 +5,15 @@ import type { NextConfig } from 'next';
 const projectDir = dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = resolve(projectDir, '../..');
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 	turbopack: {
 		root: monorepoRoot,
 	},

--- a/benchmarks/tw3-test/next.config.ts
+++ b/benchmarks/tw3-test/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from 'next';
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 };
 
 export default config;

--- a/benchmarks/tw4-test/next.config.ts
+++ b/benchmarks/tw4-test/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from 'next';
 
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
 const config: NextConfig = {
-	transpilePackages: ['@c15t/benchmarking'],
+	transpilePackages,
 };
 
 export default config;

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -26,7 +26,7 @@
 
   ## Branding
 
-  Hide the c15t branding in the dialog footer:
+  Hide the c15t branding tag:
 
   ```tsx
   <ConsentDialog hideBranding />
@@ -35,7 +35,7 @@
   ## Styling First
 
   <Callout type="info">
-    If you are only changing visuals, stay with the stock dialog and use the theme system first. Start with tokens and slots such as `consentDialogCard`, `consentDialogHeader`, and `consentDialogFooter`. See [Styling Overview](/docs/frameworks/react/styling/overview).
+    If you are only changing visuals, stay with the stock dialog and use the theme system first. Start with tokens and slots such as `consentDialogCard`, `consentWidgetFooter`, and `consentDialogTag`. See [Styling Overview](/docs/frameworks/react/styling/overview).
   </Callout>
 
   ```tsx
@@ -49,7 +49,8 @@
         slots: {
           consentDialogCard: 'rounded-[32px] shadow-xl',
           consentDialogHeader: 'gap-3',
-          consentDialogFooter: 'border-t border-black/10 px-6',
+          consentWidgetFooter: 'gap-3 pt-6',
+          consentDialogTag: 'shadow-none',
         },
       },
     }}

--- a/docs/shared/react/styling/slots.mdx
+++ b/docs/shared/react/styling/slots.mdx
@@ -3,7 +3,7 @@
 <section id="content">
   ## What are Slots?
 
-  Slots let you target specific parts of consent components with styles. Each component is built from named slots such as `consentBannerTitle` and `consentDialogFooter`.
+  Slots let you target specific parts of consent components with styles. Each component is built from named slots such as `consentBannerTitle` and `consentDialogTag`.
 
   Use slots after the stock component APIs and design tokens:
 

--- a/examples/demo/components/policy/policy-demo.tsx
+++ b/examples/demo/components/policy/policy-demo.tsx
@@ -368,6 +368,33 @@ const policyDemoTheme: Theme = {
 			variant: 'primary',
 		},
 	},
+	slots: {
+		consentBannerTag: {
+			style: {
+				borderRadius: '0',
+			},
+		},
+		consentDialogTag: {
+			style: {
+				borderRadius: '0',
+			},
+		},
+		consentWidgetTag: {
+			style: {
+				borderRadius: '0',
+			},
+		},
+		iabConsentBannerTag: {
+			style: {
+				borderRadius: '0',
+			},
+		},
+		iabConsentDialogTag: {
+			style: {
+				borderRadius: '0',
+			},
+		},
+	},
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/components/__tests__/consent-flow.e2e.test.tsx
+++ b/packages/react/src/components/__tests__/consent-flow.e2e.test.tsx
@@ -370,6 +370,26 @@ describe('Consent Flow E2E Tests', () => {
 				{ timeout: 3000 }
 			);
 		});
+
+		test('should render stock dialog branding without an empty footer wrapper', async () => {
+			render(
+				<ConsentManagerProvider options={defaultOptions}>
+					<ConsentDialog open={true} />
+				</ConsentManagerProvider>
+			);
+
+			await vi.waitFor(
+				() => {
+					expect(
+						document.querySelector('[data-testid="consent-dialog-branding"]')
+					).toBeInTheDocument();
+					expect(
+						document.querySelector('[data-testid="consent-dialog-footer"]')
+					).not.toBeInTheDocument();
+				},
+				{ timeout: 3000 }
+			);
+		});
 	});
 
 	describe('Complete Flow', () => {

--- a/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
+++ b/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
@@ -59,7 +59,8 @@ function createMockState(
 
 function renderBanner(
 	props: ComponentProps<typeof ConsentBanner>,
-	stateOverrides: Partial<ConsentStoreState> = {}
+	stateOverrides: Partial<ConsentStoreState> = {},
+	themeSlotOverrides: Record<string, string> = {}
 ) {
 	const state = createMockState(stateOverrides);
 
@@ -70,6 +71,7 @@ function renderBanner(
 					slots: {
 						buttonPrimary: 'button-primary-marker',
 						buttonSecondary: 'button-secondary-marker',
+						...themeSlotOverrides,
 					},
 				},
 			}}
@@ -220,5 +222,15 @@ describe('ConsentBanner policy ordering', () => {
 		expect(
 			document.querySelector('[data-testid="consent-banner-branding"]')
 		).not.toBeInTheDocument();
+	});
+
+	test('applies the consentBannerTag theme slot to the stock banner tag', async () => {
+		renderBanner({}, {}, { consentBannerTag: 'consent-banner-tag-marker' });
+
+		await waitForBanner();
+
+		expect(
+			document.querySelector('[data-testid="consent-banner-branding"]')
+		)?.toHaveClass('consent-banner-tag-marker');
 	});
 });

--- a/packages/react/src/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/components/consent-banner/consent-banner.tsx
@@ -308,6 +308,7 @@ export const ConsentBanner: FC<ConsentBannerProps> = ({
 					<BrandingLink
 						hideBranding={hideBranding}
 						variant="banner-tag"
+						themeKey="consentBannerTag"
 						data-testid="consent-banner-branding"
 					/>
 					<ConsentBannerCard aria-label={consentBanner.title}>

--- a/packages/react/src/components/consent-dialog/atoms/card.tsx
+++ b/packages/react/src/components/consent-dialog/atoms/card.tsx
@@ -191,7 +191,7 @@ const ConsentDialogFooter = forwardRef<
 				ref={ref as Ref<HTMLDivElement>}
 				baseClassName={cn(
 					styles.footer,
-					children == null && styles.brandingFooter
+					children == null && !hideBranding && styles.brandingFooter
 				)}
 				data-testid={testId ?? 'consent-dialog-footer'}
 				{...props}
@@ -201,6 +201,7 @@ const ConsentDialogFooter = forwardRef<
 					<Branding
 						hideBranding={hideBranding ?? false}
 						variant="dialog-tag"
+						themeKey="consentDialogTag"
 						data-testid="consent-dialog-branding"
 					/>
 				)}
@@ -212,6 +213,7 @@ const ConsentDialogFooter = forwardRef<
 type BrandingProps = {
 	hideBranding: boolean;
 	variant?: BrandingVariant;
+	themeKey?: import('~/components/shared/ui/branding').BrandingThemeKey;
 	className?: string;
 	'data-testid'?: string;
 };
@@ -261,7 +263,13 @@ const ConsentCustomizationCard = ({
 			<ConsentDialogContent>
 				<ConsentWidget hideBranding noStyle={noStyle} useProvider={true} />
 			</ConsentDialogContent>
-			<ConsentDialogFooter hideBranding={hideBranding} />
+			<ConsentDialogFooter hideBranding />
+			<Branding
+				hideBranding={hideBranding ?? false}
+				variant="dialog-tag"
+				themeKey="consentDialogTag"
+				data-testid="consent-dialog-branding"
+			/>
 		</ConsentDialogCard>
 	);
 };

--- a/packages/react/src/components/consent-dialog/atoms/card.tsx
+++ b/packages/react/src/components/consent-dialog/atoms/card.tsx
@@ -263,7 +263,6 @@ const ConsentCustomizationCard = ({
 			<ConsentDialogContent>
 				<ConsentWidget hideBranding noStyle={noStyle} useProvider={true} />
 			</ConsentDialogContent>
-			<ConsentDialogFooter hideBranding />
 			<Branding
 				hideBranding={hideBranding ?? false}
 				variant="dialog-tag"

--- a/packages/react/src/components/consent-dialog/index.ts
+++ b/packages/react/src/components/consent-dialog/index.ts
@@ -82,7 +82,8 @@ export interface ConsentDialogCompoundComponent extends FC<ConsentDialogProps> {
  *     theme: {
  *       slots: {
  *         consentDialogCard: 'rounded-3xl shadow-xl',
- *         consentDialogFooter: 'border-t border-black/10',
+ *         consentWidgetFooter: 'gap-3 pt-6',
+ *         consentDialogTag: 'shadow-none',
  *       },
  *     },
  *   }}

--- a/packages/react/src/components/consent-widget/__tests__/policy-actions.test.tsx
+++ b/packages/react/src/components/consent-widget/__tests__/policy-actions.test.tsx
@@ -118,6 +118,38 @@ async function renderDefaultPolicyActions(
 	);
 }
 
+async function renderWidget(
+	stateOverrides: Partial<ConsentStoreState> = {},
+	themeSlots: Record<string, string> = {}
+) {
+	const state = createMockState(stateOverrides);
+
+	await render(
+		<GlobalThemeContext.Provider
+			value={{
+				noStyle: false,
+				theme: {
+					slots: themeSlots,
+				},
+			}}
+		>
+			<ConsentStateContext.Provider
+				value={{
+					state,
+					store: {
+						getState: () => state,
+						subscribe: () => () => undefined,
+						setState: () => undefined,
+					},
+					manager: null,
+				}}
+			>
+				<ConsentWidget hideBranding={false} />
+			</ConsentStateContext.Provider>
+		</GlobalThemeContext.Provider>
+	);
+}
+
 describe('ConsentWidget.PolicyActions', () => {
 	test('renders policy group ordering', async () => {
 		await renderPolicyActions();
@@ -225,5 +257,24 @@ describe('ConsentWidget.PolicyActions', () => {
 		).toHaveTextContent(
 			defaultTranslationConfig.translations.en.common.acceptAll
 		);
+	});
+
+	test('renders the widget branding tag without the legacy dialog footer wrapper', async () => {
+		await renderWidget();
+
+		expect(
+			document.querySelector('[data-testid="consent-widget-branding"]')
+		).toBeInTheDocument();
+		expect(
+			document.querySelector('[data-testid="consent-dialog-footer"]')
+		).not.toBeInTheDocument();
+	});
+
+	test('applies the consentWidgetTag theme slot to the stock widget tag', async () => {
+		await renderWidget({}, { consentWidgetTag: 'consent-widget-tag-marker' });
+
+		expect(
+			document.querySelector('[data-testid="consent-widget-branding"]')
+		)?.toHaveClass('consent-widget-tag-marker');
 	});
 });

--- a/packages/react/src/components/consent-widget/atoms/root.tsx
+++ b/packages/react/src/components/consent-widget/atoms/root.tsx
@@ -6,6 +6,7 @@
  * Implements context provider pattern with theme support and state management.
  */
 
+import styles from '@c15t/ui/styles/components/consent-widget.module.js';
 import type { FC, ReactNode } from 'react';
 import { Box } from '~/components/shared/primitives/box';
 import {
@@ -125,6 +126,7 @@ const ConsentWidgetRoot: FC<ConsentWidgetRootProps> = ({
 
 	const content = (
 		<Box
+			baseClassName={styles.widget}
 			data-testid="consent-widget-root"
 			themeKey="consentWidget"
 			dir={textDirection}

--- a/packages/react/src/components/consent-widget/consent-widget.tsx
+++ b/packages/react/src/components/consent-widget/consent-widget.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react';
 import type { AccordionRootProps } from '~/components/shared/ui/accordion';
+import { BrandingLink } from '~/components/shared/ui/branding';
 import { useTheme } from '~/hooks/use-theme';
-import { ConsentDialogFooter } from '../consent-dialog/atoms/card';
 import {
 	ConsentWidgetAccordion,
 	ConsentWidgetAccordionItems,
@@ -44,9 +44,10 @@ export const ConsentWidget = ({
 				<ConsentWidgetAccordionItems />
 			</ConsentWidgetAccordion>
 			<ConsentWidgetPolicyActions />
-			<ConsentDialogFooter
-				themeKey="consentWidgetBranding"
+			<BrandingLink
 				hideBranding={hideBranding ?? true}
+				variant="dialog-tag"
+				themeKey="consentWidgetTag"
 				data-testid="consent-widget-branding"
 			/>
 		</ConsentWidgetRoot>

--- a/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
+++ b/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
@@ -164,6 +164,7 @@ export const IABConsentBanner: FC<IABConsentBannerProps> = ({
 				<BrandingLink
 					hideBranding={false}
 					variant="banner-tag"
+					themeKey="iabConsentBannerTag"
 					data-testid="iab-consent-banner-branding"
 				/>
 				<Box

--- a/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -1015,6 +1015,7 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 					<Branding
 						hideBranding={hideBranding ?? false}
 						variant="dialog-tag"
+						themeKey="iabConsentDialogTag"
 						data-testid="iab-consent-dialog-branding"
 					/>
 				</div>

--- a/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
+++ b/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentDialogFooter } from '~/components/consent-dialog/atoms/card';
 import { ConsentStateContext } from '~/context/consent-manager-context';
+import { GlobalThemeContext } from '~/context/theme-context';
 import { BrandingCompactLogo, BrandingLink } from '../branding';
 
 function createMockState(
@@ -55,24 +56,31 @@ function createMockState(
 
 async function renderWithConsentState(
 	ui: ReactElement,
-	stateOverrides: Partial<ConsentStoreState> = {}
+	stateOverrides: Partial<ConsentStoreState> = {},
+	themeOverrides: {
+		theme?: {
+			slots?: Record<string, string>;
+		};
+	} = {}
 ) {
 	const state = createMockState(stateOverrides);
 
 	await render(
-		<ConsentStateContext.Provider
-			value={{
-				state,
-				store: {
-					getState: () => state,
-					subscribe: () => () => undefined,
-					setState: () => undefined,
-				},
-				manager: null,
-			}}
-		>
-			{ui}
-		</ConsentStateContext.Provider>
+		<GlobalThemeContext.Provider value={themeOverrides}>
+			<ConsentStateContext.Provider
+				value={{
+					state,
+					store: {
+						getState: () => state,
+						subscribe: () => () => undefined,
+						setState: () => undefined,
+					},
+					manager: null,
+				}}
+			>
+				{ui}
+			</ConsentStateContext.Provider>
+		</GlobalThemeContext.Provider>
 	);
 }
 
@@ -145,6 +153,33 @@ describe('BrandingLink', () => {
 			expect(link).toBeInTheDocument();
 			expect(link).toHaveAttribute('data-branding', 'inth');
 			expect(link).toHaveAttribute('data-variant', 'dialog-tag');
+		});
+	});
+
+	test('applies theme slot styles to branding tags', async () => {
+		await renderWithConsentState(
+			<BrandingLink
+				hideBranding={false}
+				variant="banner-tag"
+				themeKey="consentBannerTag"
+				data-testid="branding-link"
+			/>,
+			{},
+			{
+				theme: {
+					slots: {
+						consentBannerTag: 'branding-theme-marker',
+					},
+				},
+			}
+		);
+
+		await vi.waitFor(() => {
+			const link = document.querySelector(
+				'[data-testid="branding-link"]'
+			) as HTMLAnchorElement | null;
+			expect(link).toBeInTheDocument();
+			expect(link?.className).toContain('branding-theme-marker');
 		});
 	});
 

--- a/packages/react/src/components/shared/ui/branding.tsx
+++ b/packages/react/src/components/shared/ui/branding.tsx
@@ -1,18 +1,35 @@
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
+import { resolveStyles, sanitizeDOMStyleProps } from '@c15t/ui/utils';
 import type { Branding } from 'c15t';
 import type { SVGProps } from 'react';
+import { useMemo } from 'react';
 import { useConsentManager } from '~/hooks/use-consent-manager';
+import { useTheme } from '~/hooks/use-theme';
 import { useTranslations } from '~/hooks/use-translations';
+import type {
+	AllThemeKeys,
+	ClassNameStyle,
+	CSSPropertiesWithVars,
+} from '~/types/theme';
 import { cnExt as cn } from '~/utils/cn';
+import { mergeStyles } from '~/utils/merge-styles';
 import { C15TIconOnly, InthIconOnly, InthLogo } from './logo';
 
 export type ResolvedBranding = 'c15t' | 'inth' | 'none';
 export type BrandingVariant = 'footer' | 'dialog-tag' | 'banner-tag';
+export type BrandingThemeKey =
+	| 'consentBannerTag'
+	| 'consentDialogTag'
+	| 'consentWidgetTag'
+	| 'iabConsentBannerTag'
+	| 'iabConsentDialogTag';
 
 type BrandingProps = {
 	hideBranding: boolean;
 	variant?: BrandingVariant;
+	themeKey?: BrandingThemeKey;
 	className?: string;
+	style?: CSSPropertiesWithVars;
 	'data-testid'?: string;
 };
 
@@ -80,29 +97,48 @@ export function BrandingCompactLogo({
 export function BrandingLink({
 	hideBranding,
 	variant = 'footer',
+	themeKey,
 	className,
+	style,
 	'data-testid': testId,
 }: BrandingProps) {
 	const { branding } = useConsentManager();
+	const { noStyle: contextNoStyle, theme } = useTheme();
 	const { common } = useTranslations();
 	const resolvedBranding = resolveBranding(branding);
+	const refParam =
+		typeof window !== 'undefined' ? `?ref=${window.location.hostname}` : '';
+	const brandingStyle = useMemo(() => {
+		const componentStyle: ClassNameStyle = {
+			baseClassName: cn(
+				styles.branding,
+				variant !== 'footer' && styles.brandingTag,
+				variant === 'dialog-tag' && styles.brandingTagDialog,
+				variant === 'banner-tag' && styles.brandingTagBanner
+			),
+			className,
+			style,
+		};
+		if (themeKey && theme?.slots && themeKey in theme.slots) {
+			return resolveStyles(
+				themeKey as AllThemeKeys,
+				theme,
+				componentStyle,
+				contextNoStyle
+			);
+		}
+
+		return mergeStyles({}, componentStyle);
+	}, [className, contextNoStyle, style, theme, themeKey, variant]);
+	const domStyleProps = sanitizeDOMStyleProps(brandingStyle);
 
 	if (resolvedBranding === 'none' || hideBranding) {
 		return null;
 	}
 
-	const refParam =
-		typeof window !== 'undefined' ? `?ref=${window.location.hostname}` : '';
-
 	return (
 		<a
-			className={cn(
-				styles.branding,
-				variant !== 'footer' && styles.brandingTag,
-				variant === 'dialog-tag' && styles.brandingTagDialog,
-				variant === 'banner-tag' && styles.brandingTagBanner,
-				className
-			)}
+			{...domStyleProps}
 			href={getBrandingHref(branding, refParam)}
 			data-branding={resolvedBranding}
 			data-variant={variant}

--- a/packages/ui/src/styles/components/consent-dialog.module.css
+++ b/packages/ui/src/styles/components/consent-dialog.module.css
@@ -395,6 +395,7 @@
 	}
 
 	.card {
+		position: relative;
 		box-sizing: border-box;
 		width: min(100%, var(--consent-dialog-max-width));
 		max-height: 100%;

--- a/packages/ui/src/styles/components/consent-widget.module.css
+++ b/packages/ui/src/styles/components/consent-widget.module.css
@@ -70,6 +70,8 @@
 
 @layer components {
 	.widget {
+		position: relative;
+		width: 100%;
 		font-family: var(--consent-widget-font-family);
 		line-height: var(--consent-widget-line-height);
 		-webkit-font-smoothing: antialiased;

--- a/packages/ui/src/theme/types.ts
+++ b/packages/ui/src/theme/types.ts
@@ -344,6 +344,8 @@ export interface ComponentSlots {
 	consentBannerFooter?: SlotStyle;
 	/** Nested button group inside the banner footer. */
 	consentBannerFooterSubGroup?: SlotStyle;
+	/** Branding tag rendered above the consent banner card. */
+	consentBannerTag?: SlotStyle;
 	/** Backdrop overlay rendered behind the banner when enabled. */
 	consentBannerOverlay?: SlotStyle;
 
@@ -360,8 +362,10 @@ export interface ComponentSlots {
 	consentDialogDescription?: SlotStyle;
 	/** Dialog content region (typically holds ConsentWidget). */
 	consentDialogContent?: SlotStyle;
-	/** Dialog footer container with actions/branding. */
+	/** Footer container used by compound dialog layouts. */
 	consentDialogFooter?: SlotStyle;
+	/** Branding tag rendered below the stock consent dialog card. */
+	consentDialogTag?: SlotStyle;
 	/** Backdrop overlay rendered behind the dialog. */
 	consentDialogOverlay?: SlotStyle;
 
@@ -372,8 +376,8 @@ export interface ComponentSlots {
 	consentWidgetAccordion?: SlotStyle;
 	/** Footer area for widget actions and links. */
 	consentWidgetFooter?: SlotStyle;
-	/** Branding element rendered in the widget footer. */
-	consentWidgetBranding?: SlotStyle;
+	/** Branding tag rendered below the standalone consent widget. */
+	consentWidgetTag?: SlotStyle;
 
 	// --- FRAME SLOTS ---
 	/** Frame wrapper used by blocking placeholders (e.g., iframe blocking). */
@@ -388,6 +392,8 @@ export interface ComponentSlots {
 	iabConsentBannerHeader?: SlotStyle;
 	/** Footer container for IAB banner actions. */
 	iabConsentBannerFooter?: SlotStyle;
+	/** Branding tag rendered above the IAB banner card. */
+	iabConsentBannerTag?: SlotStyle;
 	/** Backdrop overlay rendered behind the IAB banner. */
 	iabConsentBannerOverlay?: SlotStyle;
 
@@ -400,6 +406,8 @@ export interface ComponentSlots {
 	iabConsentDialogHeader?: SlotStyle;
 	/** Footer container for IAB dialog actions. */
 	iabConsentDialogFooter?: SlotStyle;
+	/** Branding tag rendered below the IAB dialog card. */
+	iabConsentDialogTag?: SlotStyle;
 	/** Backdrop overlay rendered behind the IAB dialog. */
 	iabConsentDialogOverlay?: SlotStyle;
 


### PR DESCRIPTION
## Overview
Replace the legacy stock branding footer hooks with explicit tag slots across the prebuilt consent banner, dialog, widget, and IAB surfaces. The React/UI theme contract now exposes dedicated tag slots, removes the old widget branding key from the stock path, and documents the breaking migration.

## Related Issue
Fixes #733

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [x] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Added explicit branding tag slots for stock consent banner, dialog, widget, and IAB surfaces in the shared theme contract.
2. Removed the stock widget/dialog legacy footer-branding path and updated docs, changeset notes, and slot coverage tests around the new API.

### Technical Notes
The stock dialog/footer compound slot still exists for composed layouts, but stock branding tags now style only through the explicit tag keys.

## Testing
### Test Plan
- [x] Scenario 1: Confirm the new stock branding surfaces resolve dedicated theme slots

  ```ts
  theme.slots.consentBannerTag
  theme.slots.consentDialogTag
  theme.slots.consentWidgetTag
  theme.slots.iabConsentBannerTag
  theme.slots.iabConsentDialogTag
  ```

  ✓ Expected: each stock branding tag picks up its matching slot instead of footer-branding aliases.

- [x] Scenario 2: Confirm the changed files pass the scoped formatter/lint check

  ```ts
  bunx biome check packages/react/src/components/shared/ui/branding.tsx \
    packages/react/src/components/consent-widget/consent-widget.tsx \
    packages/react/src/components/consent-dialog/atoms/card.tsx
  ```

  ✓ Expected: Biome passes for the touched runtime files.

### Edge Cases
- [x] Error handling: branding remains hidden when `hideBranding` is true or branding is `none`.
- [ ] Performance: no meaningful runtime impact beyond normal style resolution.
- [x] Security: no security-sensitive behavior changed.

### Visual Changes
| Before | After |
|--------|-------|
| Legacy stock branding depended on footer/widget branding keys. | Stock branding tags use explicit tag slots and no longer rely on legacy footer aliases. |

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
**Changes:**
- `consentWidgetBranding` is removed; use `consentWidgetTag`.
- Stock dialog branding no longer inherits styling from `consentDialogFooter`; use `consentDialogTag`.

**Migration:**
```ts
// Before
theme.slots = {
  consentWidgetBranding: "my-widget-branding",
  consentDialogFooter: "my-dialog-branding",
}

// After
theme.slots = {
  consentWidgetTag: "my-widget-branding",
  consentDialogTag: "my-dialog-branding",
}
```
