### PR TITLE
Fix branding tag contrast on bright themes

### DIFF
--- a/.changeset/cold-pens-judge.md
+++ b/.changeset/cold-pens-judge.md
@@ -1,0 +1,8 @@
+---
+'@c15t/ui': patch
+---
+
+Derive `textOnPrimary` automatically from the active `primary` theme color when it is omitted, so primary-filled surfaces such as stock branding tags keep a readable foreground by default.
+
+- add a shared contrast helper in the UI theme utilities and use it as the fallback for `textOnPrimary`
+- preserve explicit `textOnPrimary` overrides for consumers who need a fixed branded foreground

--- a/docs/shared/react/styling/color-scheme.mdx
+++ b/docs/shared/react/styling/color-scheme.mdx
@@ -18,7 +18,7 @@
 
   ## How Dark Mode Works
 
-  When dark mode is active, c15t applies the `dark` token values as CSS variable overrides. Only tokens specified in `dark` are overridden - unset tokens fall back to the `colors` values.
+  When dark mode is active, c15t applies the `dark` token values as CSS variable overrides. Only tokens specified in `dark` are overridden - unset tokens fall back to the `colors` values. This also applies to `textOnPrimary`: if you omit it, c15t derives a readable foreground from the active `primary` color in that scheme.
 
   ```tsx
   const theme = {

--- a/docs/shared/react/styling/overview.mdx
+++ b/docs/shared/react/styling/overview.mdx
@@ -63,6 +63,7 @@
   - Banner card background -> `theme.colors.surface`
   - Banner footer background -> `theme.colors.surfaceHover`
   - Shared copy color -> `theme.colors.text` and `theme.colors.textMuted`
+  - Primary-filled surfaces such as stock branding tags and filled actions -> `theme.colors.primary` with `theme.colors.textOnPrimary` as the matching foreground override
 
   ```tsx
   options={{
@@ -74,6 +75,8 @@
     },
   }}
   ```
+
+  If you set `theme.colors.primary` but omit `theme.colors.textOnPrimary`, c15t derives a readable foreground automatically. Add `textOnPrimary` only when you need to force a specific branded foreground color.
 
   ### 3. Component slots
 

--- a/docs/shared/react/styling/tokens.mdx
+++ b/docs/shared/react/styling/tokens.mdx
@@ -5,6 +5,8 @@
 
   Color tokens define the palette for all consent components. Set `colors` for light mode and `dark` for dark mode overrides.
 
+  When `textOnPrimary` is omitted, c15t derives it automatically from `primary` to keep text readable on primary-filled surfaces such as stock branding tags and buttons. Set `textOnPrimary` explicitly when you need a specific foreground color.
+
   ```tsx
   const theme = {
     colors: {

--- a/packages/ui/src/theme/__tests__/utils.test.ts
+++ b/packages/ui/src/theme/__tests__/utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 import type { Theme } from '../types';
-import { defaultTheme, generateThemeCSS, themeToVars } from '../utils';
+import {
+	defaultTheme,
+	generateThemeCSS,
+	getContrastColor,
+	themeToVars,
+} from '../utils';
 
 describe('defaultTheme', () => {
 	test('has all required color tokens', () => {
@@ -194,6 +199,57 @@ describe('themeToVars', () => {
 		const vars = themeToVars(theme);
 		expect(vars['--c15t-primary']).toBe('#ff0000');
 		expect(vars['--c15t-surface']).toBeUndefined();
+	});
+
+	test('derives text-on-primary when primary is bright', () => {
+		const vars = themeToVars({
+			colors: {
+				primary: '#2ed1c3',
+			},
+		});
+
+		expect(vars['--c15t-text-on-primary']).toBe('#000000');
+	});
+
+	test('derives text-on-primary from dark primary overrides', () => {
+		const vars = themeToVars(
+			{
+				colors: {
+					primary: '#fafafa',
+				},
+				dark: {
+					primary: '#16324f',
+				},
+			},
+			true
+		);
+
+		expect(vars['--c15t-text-on-primary']).toBe('#ffffff');
+	});
+
+	test('preserves explicit text-on-primary overrides', () => {
+		const vars = themeToVars({
+			colors: {
+				primary: '#2ed1c3',
+				textOnPrimary: '#112233',
+			},
+		});
+
+		expect(vars['--c15t-text-on-primary']).toBe('#112233');
+	});
+});
+
+describe('getContrastColor', () => {
+	test('returns dark text for bright backgrounds', () => {
+		expect(getContrastColor('#2ed1c3')).toBe('#000000');
+	});
+
+	test('returns light text for dark backgrounds', () => {
+		expect(getContrastColor('hsl(210, 57%, 20%)')).toBe('#ffffff');
+	});
+
+	test('supports rgb color inputs', () => {
+		expect(getContrastColor('rgb(255, 214, 10)')).toBe('#000000');
 	});
 });
 

--- a/packages/ui/src/theme/types.ts
+++ b/packages/ui/src/theme/types.ts
@@ -76,7 +76,7 @@ export interface ColorTokens {
 	text?: string;
 	/** Muted text color for secondary content. */
 	textMuted?: string;
-	/** Text color for content on primary background. */
+	/** Text color for content on primary background. Auto-derived from `primary` when omitted. */
 	textOnPrimary?: string;
 	/** Overlay color for modal backdrops. */
 	overlay?: string;
@@ -243,7 +243,7 @@ export interface ThemeCSSVariables {
 	'--c15t-text'?: string;
 	/** `colors.textMuted` (default: `hsl(0, 0%, 40%)`) */
 	'--c15t-text-muted'?: string;
-	/** `colors.textOnPrimary` (default: `hsl(0, 0%, 100%)`) */
+	/** `colors.textOnPrimary` (auto-derived from `colors.primary` when omitted) */
 	'--c15t-text-on-primary'?: string;
 	/** `colors.overlay` (default: `hsla(0, 0%, 0%, 0.5)`) */
 	'--c15t-overlay'?: string;

--- a/packages/ui/src/theme/utils.ts
+++ b/packages/ui/src/theme/utils.ts
@@ -5,6 +5,15 @@
 
 import type { ColorTokens, Theme, ThemeCSSVariables } from './types';
 
+type RGBColor = {
+	r: number;
+	g: number;
+	b: number;
+};
+
+const DEFAULT_LIGHT_CONTRAST_COLOR = '#ffffff';
+const DEFAULT_DARK_CONTRAST_COLOR = '#000000';
+
 /**
  * Default design tokens for the v2 theme system.
  */
@@ -94,6 +103,239 @@ export const defaultTheme: Required<Omit<Theme, 'slots'>> = {
 	},
 };
 
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+function parsePercentage(value: string): number | null {
+	if (!value.trim().endsWith('%')) {
+		return null;
+	}
+
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) ? clamp(parsed / 100, 0, 1) : null;
+}
+
+function parseRGBChannel(value: string): number | null {
+	const percent = parsePercentage(value);
+	if (percent !== null) {
+		return Math.round(percent * 255);
+	}
+
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) ? clamp(parsed, 0, 255) : null;
+}
+
+function parseHue(value: string): number | null {
+	const trimmedValue = value.trim().toLowerCase();
+	const parsed = Number.parseFloat(trimmedValue);
+
+	if (!Number.isFinite(parsed)) {
+		return null;
+	}
+
+	if (trimmedValue.endsWith('turn')) {
+		return parsed * 360;
+	}
+
+	if (trimmedValue.endsWith('rad')) {
+		return (parsed * 180) / Math.PI;
+	}
+
+	if (trimmedValue.endsWith('grad')) {
+		return parsed * 0.9;
+	}
+
+	return parsed;
+}
+
+function parseColorChannels(value: string): string[] {
+	const [channels] = value.split('/');
+	return channels.includes(',')
+		? channels.split(/\s*,\s*/)
+		: channels.trim().split(/\s+/);
+}
+
+function hslToRgb(h: number, s: number, l: number): RGBColor {
+	const normalizedHue = ((h % 360) + 360) % 360;
+	const saturation = clamp(s, 0, 1);
+	const lightness = clamp(l, 0, 1);
+
+	if (saturation === 0) {
+		const channel = Math.round(lightness * 255);
+		return { r: channel, g: channel, b: channel };
+	}
+
+	const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+	const huePrime = normalizedHue / 60;
+	const secondary = chroma * (1 - Math.abs((huePrime % 2) - 1));
+	let red = 0;
+	let green = 0;
+	let blue = 0;
+
+	if (huePrime >= 0 && huePrime < 1) {
+		red = chroma;
+		green = secondary;
+	} else if (huePrime >= 1 && huePrime < 2) {
+		red = secondary;
+		green = chroma;
+	} else if (huePrime >= 2 && huePrime < 3) {
+		green = chroma;
+		blue = secondary;
+	} else if (huePrime >= 3 && huePrime < 4) {
+		green = secondary;
+		blue = chroma;
+	} else if (huePrime >= 4 && huePrime < 5) {
+		red = secondary;
+		blue = chroma;
+	} else {
+		red = chroma;
+		blue = secondary;
+	}
+
+	const match = lightness - chroma / 2;
+
+	return {
+		r: Math.round((red + match) * 255),
+		g: Math.round((green + match) * 255),
+		b: Math.round((blue + match) * 255),
+	};
+}
+
+function parseHexColor(value: string): RGBColor | null {
+	const trimmedValue = value.trim();
+	const hex = trimmedValue.startsWith('#')
+		? trimmedValue.slice(1)
+		: trimmedValue;
+
+	if (!/^[\da-f]{3,4}$|^[\da-f]{6}$|^[\da-f]{8}$/i.test(hex)) {
+		return null;
+	}
+
+	const normalizedHex =
+		hex.length <= 4
+			? hex
+					.slice(0, 3)
+					.split('')
+					.map((channel) => `${channel}${channel}`)
+					.join('')
+			: hex.slice(0, 6);
+
+	return {
+		r: Number.parseInt(normalizedHex.slice(0, 2), 16),
+		g: Number.parseInt(normalizedHex.slice(2, 4), 16),
+		b: Number.parseInt(normalizedHex.slice(4, 6), 16),
+	};
+}
+
+function parseRGBColor(value: string): RGBColor | null {
+	const match = value.trim().match(/^rgba?\((.+)\)$/i);
+
+	if (!match) {
+		return null;
+	}
+
+	const channels = parseColorChannels(match[1] ?? '').slice(0, 3);
+
+	if (channels.length !== 3) {
+		return null;
+	}
+
+	const [red, green, blue] = channels.map(parseRGBChannel);
+
+	if ([red, green, blue].some((channel) => channel === null)) {
+		return null;
+	}
+
+	return {
+		r: red ?? 0,
+		g: green ?? 0,
+		b: blue ?? 0,
+	};
+}
+
+function parseHSLColor(value: string): RGBColor | null {
+	const match = value.trim().match(/^hsla?\((.+)\)$/i);
+
+	if (!match) {
+		return null;
+	}
+
+	const channels = parseColorChannels(match[1] ?? '').slice(0, 3);
+
+	if (channels.length !== 3) {
+		return null;
+	}
+
+	const hue = parseHue(channels[0] ?? '');
+	const saturation = parsePercentage(channels[1] ?? '');
+	const lightness = parsePercentage(channels[2] ?? '');
+
+	if (hue === null || saturation === null || lightness === null) {
+		return null;
+	}
+
+	return hslToRgb(hue, saturation, lightness);
+}
+
+function parseColor(value: string): RGBColor | null {
+	return parseHexColor(value) ?? parseRGBColor(value) ?? parseHSLColor(value);
+}
+
+function srgbToLinear(channel: number): number {
+	const normalizedChannel = channel / 255;
+	return normalizedChannel <= 0.04045
+		? normalizedChannel / 12.92
+		: ((normalizedChannel + 0.055) / 1.055) ** 2.4;
+}
+
+function getRelativeLuminance(color: RGBColor): number {
+	return (
+		0.2126 * srgbToLinear(color.r) +
+		0.7152 * srgbToLinear(color.g) +
+		0.0722 * srgbToLinear(color.b)
+	);
+}
+
+function getContrastRatio(foreground: RGBColor, background: RGBColor): number {
+	const foregroundLuminance = getRelativeLuminance(foreground);
+	const backgroundLuminance = getRelativeLuminance(background);
+	const lighterColor = Math.max(foregroundLuminance, backgroundLuminance);
+	const darkerColor = Math.min(foregroundLuminance, backgroundLuminance);
+
+	return (lighterColor + 0.05) / (darkerColor + 0.05);
+}
+
+/**
+ * Resolves a readable foreground color for a given background color.
+ *
+ * Supports `#rgb`, `#rrggbb`, `rgb()`, and `hsl()` input formats.
+ * Falls back to white when the background color cannot be parsed.
+ */
+export function getContrastColor(
+	backgroundColor: string,
+	{
+		light = DEFAULT_LIGHT_CONTRAST_COLOR,
+		dark = DEFAULT_DARK_CONTRAST_COLOR,
+	}: {
+		light?: string;
+		dark?: string;
+	} = {}
+): string {
+	const background = parseColor(backgroundColor);
+	const lightColor = parseColor(light);
+	const darkColor = parseColor(dark);
+
+	if (!background || !lightColor || !darkColor) {
+		return light;
+	}
+
+	return getContrastRatio(darkColor, background) >=
+		getContrastRatio(lightColor, background)
+		? dark
+		: light;
+}
+
 type ThemeCSSVariableResolver = (
 	theme: Theme,
 	colors?: ColorTokens
@@ -111,7 +353,9 @@ const themeCSSVariableResolvers: Record<
 	'--c15t-border-hover': (_theme, colors) => colors?.borderHover,
 	'--c15t-text': (_theme, colors) => colors?.text,
 	'--c15t-text-muted': (_theme, colors) => colors?.textMuted,
-	'--c15t-text-on-primary': (_theme, colors) => colors?.textOnPrimary,
+	'--c15t-text-on-primary': (_theme, colors) =>
+		colors?.textOnPrimary ??
+		(colors?.primary ? getContrastColor(colors.primary) : undefined),
 	'--c15t-overlay': (_theme, colors) => colors?.overlay,
 	'--c15t-switch-track': (_theme, colors) => colors?.switchTrack,
 	'--c15t-switch-track-active': (_theme, colors) => colors?.switchTrackActive,

--- a/packages/ui/src/theme/utils.ts
+++ b/packages/ui/src/theme/utils.ts
@@ -150,7 +150,7 @@ function parseHue(value: string): number | null {
 }
 
 function parseColorChannels(value: string): string[] {
-	const [channels] = value.split('/');
+	const channels = value.split('/')[0] ?? '';
 	return channels.includes(',')
 		? channels.split(/\s*,\s*/)
 		: channels.trim().split(/\s+/);


### PR DESCRIPTION
## Overview
Auto-derive `textOnPrimary` from the active theme `primary` color when consumers omit it, so stock branding tags and other primary-filled surfaces keep readable foreground contrast by default. This keeps explicit `textOnPrimary` overrides intact and documents the new fallback in the shared styling docs.

## Related Issue
Fixes #741

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Added a shared `getContrastColor()` helper in the UI theme utilities and used it as the fallback for `--c15t-text-on-primary` when `colors.textOnPrimary` is omitted.
2. Added theme utility coverage for bright, dark, and explicit override cases, and documented the derived foreground behavior in the shared styling docs.

### Technical Notes
The fallback parser currently supports `hex`, `rgb()`, and `hsl()` theme color inputs. Consumers using unsupported color syntaxes can still set `textOnPrimary` explicitly.

## Testing
### Test Plan
- [x] Scenario 1: Bright primary colors derive a dark readable foreground

  ```ts
  bun vitest run packages/ui/src/theme/__tests__/utils.test.ts
  ```

  ✓ Expected: `themeToVars()` emits `--c15t-text-on-primary` as `#000000` for bright `primary` values.

- [x] Scenario 2: Dark mode primary overrides derive the correct foreground and explicit overrides still win

  ```ts
  bun vitest run packages/ui/src/theme/__tests__/utils.test.ts
  ```

  ✓ Expected: dark `primary` overrides emit a readable light foreground, while explicit `textOnPrimary` values are preserved.

### Edge Cases
- [x] Error handling: Unparseable background values fall back to the existing light foreground default, and consumers can override `textOnPrimary` explicitly.
- [x] Performance: The additional work is limited to theme variable derivation and does not add per-render component logic.
- [x] Security: No security-sensitive behavior changed.

### Visual Changes
| Before | After |
|--------|-------|
| Bright custom `primary` colors could leave stock branding tags with low-contrast white text. | Primary-filled surfaces derive a readable foreground automatically unless `textOnPrimary` is explicitly set. |

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
