### PR TITLE
Add token-first legal document terms demo

### DIFF
--- a/.changeset/wise-badgers-share.md
+++ b/.changeset/wise-badgers-share.md
@@ -1,0 +1,11 @@
+---
+"c15t": patch
+"@c15t/backend": patch
+"@c15t/schema": patch
+---
+
+Add token-first legal-document consent groundwork for `2.0`.
+
+- `c15t`: expand the unstable policy-consent input types so legal-document writes can prefer `documentSnapshotToken`, fall back to `policyHash`, and keep `policyId` only as a compatibility path.
+- `@c15t/backend`: update legal-document consent writes to resolve append-only consent against a verified document snapshot token when configured, or against a provided document hash when only lighter-weight release proof is available.
+- `@c15t/schema`: extend the subject consent schema and error shapes for legal-document snapshot tokens and hash-based legal-document resolution.

--- a/bun.lock
+++ b/bun.lock
@@ -394,7 +394,6 @@
         "kysely": "0.28.15",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
-        "next-themes": "^0.4.6",
         "pg": "^8.20.0",
         "posthog-js": "1.364.3",
         "react": "19.2.4",
@@ -3644,8 +3643,6 @@
     "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
 
     "next": ["next@15.3.3", "", { "dependencies": { "@next/env": "15.3.3", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.3.3", "@next/swc-darwin-x64": "15.3.3", "@next/swc-linux-arm64-gnu": "15.3.3", "@next/swc-linux-arm64-musl": "15.3.3", "@next/swc-linux-x64-gnu": "15.3.3", "@next/swc-linux-x64-musl": "15.3.3", "@next/swc-win32-arm64-msvc": "15.3.3", "@next/swc-win32-x64-msvc": "15.3.3", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-JqNj29hHNmCLtNvd090SyRbXJiivQ+58XjCcrC50Crb5g5u2zi7Y2YivbsEfzk6AtVI80akdOQbaMZwWB1Hthw=="],
-
-    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,7 @@
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.6.0",
         "input-otp": "1.4.2",
+        "jose": "6.2.2",
         "kysely": "0.28.15",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",

--- a/docs/self-host/guides/legal-document-snapshot-integration.md
+++ b/docs/self-host/guides/legal-document-snapshot-integration.md
@@ -1,0 +1,137 @@
+# Legal Document Snapshot Integration
+
+This guide defines the 2.0 groundwork for legal-document consent flows such as terms and conditions, privacy policies, and DPAs.
+
+## Goal
+
+The client should be able to record acceptance for the exact document release the user saw without needing to know c15t's internal `policyId`.
+
+That means the preferred client contract is:
+
+1. A terms server renders or resolves the active legal document release.
+2. The terms server issues a signed `documentSnapshotToken` for that release.
+3. The client sends that token back when the user accepts or rejects the document.
+4. c15t verifies the token and stores append-only consent evidence against the matching legal-document release.
+
+## System Responsibilities
+
+### Terms Server
+
+The terms server is the source of truth for the document release that was shown to the user.
+
+It is responsible for:
+
+- resolving the current legal document release
+- knowing the release metadata:
+  - `type`
+  - `hash`
+  - `version`
+  - `effectiveDate`
+- minting a signed `documentSnapshotToken`
+- returning the rendered document and token to the client
+
+The terms server should own signing. c15t should not expose a production-safe browser helper that can mint these tokens because doing that would require shipping the signing key to the client.
+
+### Client SDK / UI
+
+The client should:
+
+- render the document content from the terms server
+- hold the `documentSnapshotToken` returned for that rendered release
+- call c15t accept or reject primitives with that token when the user acts
+
+The client may know `policyHash`, but it should not need to know `policyId`.
+
+### c15t Backend
+
+The c15t backend is responsible for:
+
+- verifying the signed `documentSnapshotToken`
+- extracting authoritative release metadata from the token
+- resolving the matching legal-document policy row
+- storing append-only consent evidence for the subject and document release
+
+## Preferred Request Contract
+
+For legal-document consent writes, the preferred lookup order is:
+
+1. `documentSnapshotToken`
+2. `policyHash`
+3. `policyId` as a compatibility fallback only
+
+`documentSnapshotToken` is the auditable path because it proves which release the user saw without forcing the client to understand c15t internals.
+
+`policyHash` remains useful as a lightweight fallback for integrations that can identify the rendered document release but do not yet have a signing service.
+
+`policyId` should not be the long-term client contract.
+
+## Snapshot Token Claims
+
+The signed token should carry enough metadata for c15t to verify and resolve the document release:
+
+- `iss`: token issuer
+- `aud`: intended c15t audience
+- `sub`: release hash
+- `tenantId`: tenant that owns the release, when applicable
+- `type`: legal document type
+- `version`: release version string
+- `hash`: stable release hash
+- `effectiveDate`: ISO timestamp for the effective date
+- `iat`: issued-at timestamp
+- `exp`: expiration timestamp
+
+The current demo helper uses that shape so the wire contract is established now, even though real issuance should move to a dedicated server flow.
+
+## Auditability and Compliance
+
+For a fully auditable flow:
+
+- the rendered release must be versioned
+- the release must have stable metadata, especially `hash`
+- acceptance must be append-only
+- the evidence should tie the subject, action, time, and exact release together
+- signed snapshot tokens should be issued by a trusted server, not the browser
+
+This gives c15t a defensible record of what document release was accepted and when.
+
+## What Ships in 2.0
+
+This PR is groundwork, not the full terms-platform rollout.
+
+Included now:
+
+- token-first legal-document consent inputs in c15t
+- `policyHash` fallback support
+- an example terms demo that identifies the user first and then records acceptance
+- a demo-only unsafe browser signer in `examples/demo` for local testing when no real terms server exists yet
+
+Deferred until the next phase:
+
+- a production terms server that owns rendering and token issuance
+- automatic release resolution from a real document service
+- signed snapshot delivery from server to client as part of document rendering
+
+## Demo-Only Unsafe Signer
+
+`examples/demo/lib/unsafe-demo-legal-document-snapshot.ts` exists only to let the example app exercise the contract before the real terms server lands.
+
+It is intentionally unsafe for production use because it requires exposing a signing key to the browser bundle.
+
+Use it only for local development or temporary internal demos.
+
+## If You Already Have a Privacy Policy Without a Hash
+
+That is not a blocker for 2.0 groundwork, but it is not the end state either.
+
+Short term:
+
+- you can continue using existing legal-document records
+- `policyId` compatibility can still exist server-side
+- `policyHash` fallback can be added once release hashing exists
+
+Long term:
+
+- every rendered legal-document release should have a stable hash
+- the terms server should issue snapshot tokens using that hash
+
+Without a stable release hash, the audit trail is weaker because the acceptance cannot be tied as precisely to the rendered document version.

--- a/examples/demo/app/(main)/layout.tsx
+++ b/examples/demo/app/(main)/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
 			<body
 				className={`${geist.variable} ${geistMono.variable} font-sans antialiased`}
 			>
-				<ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+				<ThemeProvider defaultTheme="light" enableSystem>
 					<ConsentManager>
 						{children}
 						<Analytics />

--- a/examples/demo/app/(main)/layout.tsx
+++ b/examples/demo/app/(main)/layout.tsx
@@ -1,9 +1,9 @@
 import { Analytics } from '@vercel/analytics/next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import { ThemeProvider } from 'next-themes';
 import type React from 'react';
 import '../globals.css';
 import { ConsentManager } from '../../components/consent-manager/provider';
+import { ThemeProvider } from '../../components/theme-provider';
 
 const geist = Geist({
 	subsets: ['latin'],

--- a/examples/demo/app/(main)/terms/page.tsx
+++ b/examples/demo/app/(main)/terms/page.tsx
@@ -1,6 +1,19 @@
 import { TermsDemo } from '../../../components/terms/terms-demo';
 import { getDemoTermsRelease } from '../../../lib/demo-c15t-instance';
 
+/**
+ * Renders the demo-only terms page for the active release returned by
+ * `getDemoTermsRelease()`.
+ *
+ * The page passes the current release metadata into `TermsDemo` so the demo can
+ * identify a user and record consent against the current terms version.
+ *
+ * @returns {JSX.Element} The `/terms` demo page.
+ *
+ * @example
+ * This route is mounted at `/terms` in the demo app and is intended only as an
+ * integration example.
+ */
 export default function TermsPage() {
 	const policy = getDemoTermsRelease();
 

--- a/examples/demo/app/(main)/terms/page.tsx
+++ b/examples/demo/app/(main)/terms/page.tsx
@@ -1,0 +1,17 @@
+import { TermsDemo } from '../../../components/terms/terms-demo';
+import { getDemoTermsRelease } from '../../../lib/demo-c15t-instance';
+
+export default function TermsPage() {
+	const policy = getDemoTermsRelease();
+
+	return (
+		<TermsDemo
+			policy={{
+				title: policy.title,
+				version: policy.version,
+				hash: policy.hash,
+				effectiveDate: policy.effectiveDate,
+			}}
+		/>
+	);
+}

--- a/examples/demo/app/api/self-host/[[...all]]/route.ts
+++ b/examples/demo/app/api/self-host/[[...all]]/route.ts
@@ -1,121 +1,23 @@
-import { c15tInstance } from '@c15t/backend';
-import { createUpstashRedisAdapter } from '@c15t/backend/cache';
-import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
-import { LibsqlDialect } from '@libsql/kysely-libsql';
-import { Kysely, PostgresDialect } from 'kysely';
 import type { NextRequest } from 'next/server';
-import { Pool } from 'pg';
 import {
-	DEFAULT_DEMO_POLICY_EXAMPLE,
-	DEMO_POLICY_SNAPSHOT_KEY,
-	demoI18nMessages,
-	getDemoPolicies,
-} from '../../../../lib/policies';
-
-export const postgresDb = kyselyAdapter({
-	db: new Kysely({
-		dialect: new PostgresDialect({
-			pool: new Pool({
-				connectionString: process.env.DATABASE_URL,
-				ssl: { rejectUnauthorized: false },
-			}),
-		}),
-	}),
-	provider: 'postgresql',
-});
-
-export const tursoDb = kyselyAdapter({
-	db: new Kysely({
-		dialect: new LibsqlDialect({
-			url: 'http://127.0.0.1:8080',
-		}),
-	}),
-	provider: 'sqlite',
-});
-
-function createDemoHandler(example = DEFAULT_DEMO_POLICY_EXAMPLE) {
-	let cacheConfig:
-		| {
-				adapter: ReturnType<typeof createUpstashRedisAdapter>;
-		  }
-		| undefined;
-
-	if (process.env.REDIS_URL && process.env.REDIS_TOKEN) {
-		cacheConfig = {
-			adapter: createUpstashRedisAdapter({
-				url: process.env.REDIS_URL,
-				token: process.env.REDIS_TOKEN,
-			}),
-		};
-	}
-
-	return c15tInstance({
-		appName: 'c15t-self-host',
-		basePath: '/api/self-host',
-		adapter: postgresDb,
-		trustedOrigins: ['localhost', '*.localhost', 'vercel.app'],
-		tenantId: 'ins_1',
-		branding: 'c15t',
-		i18n: {
-			defaultProfile: 'default',
-			messages: demoI18nMessages,
-		},
-		policyPacks: getDemoPolicies(example),
-		policySnapshot: {
-			signingKey: DEMO_POLICY_SNAPSHOT_KEY,
-			ttlSeconds: 60 * 60,
-		},
-		openapi: {
-			enabled: true,
-		},
-		cache: cacheConfig,
-		iab: {
-			enabled: true,
-			cmpId: 10,
-			vendorIds: [
-				1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-				21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-				39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
-				57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
-				75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
-				93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108,
-				109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122,
-				123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
-				137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150,
-				151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
-				165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
-				179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192,
-				193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206,
-				207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
-				221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234,
-				235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
-				249, 250,
-			],
-			customVendors: [
-				{
-					id: 'demo-analytics',
-					name: 'Demo Analytics',
-					privacyPolicyUrl: 'https://example.com/privacy',
-					purposes: [1, 8],
-					dataCategories: [1, 2],
-					usesCookies: true,
-					cookieMaxAgeSeconds: 31536000,
-					usesNonCookieAccess: false,
-				},
-			],
-		},
-	});
-}
+	createDemoInstance,
+	postgresDb,
+	tursoDb,
+} from '../../../../lib/demo-c15t-instance';
+import { DEFAULT_DEMO_POLICY_EXAMPLE } from '../../../../lib/policies';
 
 const handleRequest = async (request: NextRequest) => {
 	const example =
 		request.nextUrl.searchParams.get('example') ?? DEFAULT_DEMO_POLICY_EXAMPLE;
-	return createDemoHandler(example).handler(request);
+	return createDemoInstance(example).handler(request);
 };
 
 export {
 	handleRequest as GET,
 	handleRequest as POST,
 	handleRequest as PATCH,
+	handleRequest as PUT,
 	handleRequest as OPTIONS,
+	postgresDb,
+	tursoDb,
 };

--- a/examples/demo/components/consent-manager/provider.tsx
+++ b/examples/demo/components/consent-manager/provider.tsx
@@ -18,6 +18,8 @@ import { useEffect, useState } from 'react';
 import { useThemePreset } from './theme-switcher';
 
 const SEARCH_CHANGE_EVENT = 'c15t:search-change';
+const DEFAULT_BACKEND_URL = 'https://test-consent-io.inth.app/';
+const TERMS_BACKEND_URL = '/api/self-host';
 
 /**
  * Props for the ConsentManager component
@@ -173,6 +175,8 @@ export function ConsentManager({ children }: ConsentManagerProps) {
 
 	const isPolicyDemo = pathname === '/policy';
 	const isPolicyActionsDemo = pathname === '/policy-actions';
+	const isTermsDemo = pathname.startsWith('/terms');
+	const backendURL = isTermsDemo ? TERMS_BACKEND_URL : DEFAULT_BACKEND_URL;
 
 	if (isPolicyActionsDemo) {
 		return (
@@ -187,10 +191,7 @@ export function ConsentManager({ children }: ConsentManagerProps) {
 		<ConsentManagerProvider
 			options={{
 				mode: 'c15t',
-				// backendURL: 'https://instance-worker-test.consent-ef4.workers.dev/',
-				// backendURL: 'https://minecraft-europe-hypixel.c15t.xyz',
-				// backendURL: '/api/self-host',
-				backendURL: 'https://test-consent-io.inth.app/',
+				backendURL,
 				consentCategories: [
 					'necessary',
 					'functionality',

--- a/examples/demo/components/consent-manager/provider.tsx
+++ b/examples/demo/components/consent-manager/provider.tsx
@@ -176,7 +176,13 @@ export function ConsentManager({ children }: ConsentManagerProps) {
 	const isPolicyDemo = pathname === '/policy';
 	const isPolicyActionsDemo = pathname === '/policy-actions';
 	const isTermsDemo = pathname.startsWith('/terms');
-	const backendURL = isTermsDemo ? TERMS_BACKEND_URL : DEFAULT_BACKEND_URL;
+	let backendURL: string;
+
+	if (isTermsDemo) {
+		backendURL = TERMS_BACKEND_URL;
+	} else {
+		backendURL = DEFAULT_BACKEND_URL;
+	}
 
 	if (isPolicyActionsDemo) {
 		return (

--- a/examples/demo/components/consent-manager/provider.tsx
+++ b/examples/demo/components/consent-manager/provider.tsx
@@ -190,7 +190,7 @@ export function ConsentManager({ children }: ConsentManagerProps) {
 				// backendURL: 'https://instance-worker-test.consent-ef4.workers.dev/',
 				// backendURL: 'https://minecraft-europe-hypixel.c15t.xyz',
 				// backendURL: '/api/self-host',
-				backendURL: 'https://consent-io-eu-central-1-test.c15t.dev',
+				backendURL: 'https://test-consent-io.inth.app/',
 				consentCategories: [
 					'necessary',
 					'functionality',

--- a/examples/demo/components/consent-manager/theme-switcher.tsx
+++ b/examples/demo/components/consent-manager/theme-switcher.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { cn } from '../../lib/utils';
+import { useTheme } from '../theme-provider';
 import { Button } from '../ui/button';
 import { type ThemePresetName, themePresets } from './theme-presets';
 

--- a/examples/demo/components/header.tsx
+++ b/examples/demo/components/header.tsx
@@ -56,6 +56,12 @@ export function Header() {
 						>
 							Compound DX
 						</a>
+						<a
+							href="/terms"
+							className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+						>
+							Terms Demo
+						</a>
 					</nav>
 
 					<div className="flex items-center gap-4">

--- a/examples/demo/components/terms/terms-demo.tsx
+++ b/examples/demo/components/terms/terms-demo.tsx
@@ -439,9 +439,17 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 										setFeedback(null);
 										startTransition(async () => {
 											try {
-												const documentSnapshotToken =
-													policy.documentSnapshotToken ??
-													(await createDemoSnapshotToken());
+												let documentSnapshotToken =
+													policy.documentSnapshotToken ?? undefined;
+
+												if (!documentSnapshotToken) {
+													try {
+														documentSnapshotToken =
+															await createDemoSnapshotToken();
+													} catch {
+														documentSnapshotToken = undefined;
+													}
+												}
 												const result = await unstable_acceptPolicyConsent(
 													documentSnapshotToken
 														? {
@@ -504,7 +512,10 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 
 						<section className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
 							<div
+								aria-atomic="true"
+								aria-live="polite"
 								className={`rounded-[24px] border p-5 text-sm shadow-sm ${feedbackClassName}`}
+								role="status"
 							>
 								<p className="text-xs uppercase tracking-[0.18em]">
 									Request status

--- a/examples/demo/components/terms/terms-demo.tsx
+++ b/examples/demo/components/terms/terms-demo.tsx
@@ -9,6 +9,7 @@ import {
 	UserRound,
 } from 'lucide-react';
 import { useMemo, useState, useTransition } from 'react';
+import { createUnsafeDemoLegalDocumentSnapshotToken } from '../../lib/unsafe-demo-legal-document-snapshot';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import {
@@ -26,6 +27,7 @@ type TermsPolicySummary = {
 	version: string;
 	hash: string;
 	effectiveDate: string;
+	documentSnapshotToken?: string | null;
 };
 
 type IdentityState = {
@@ -44,7 +46,7 @@ type AcceptanceState = IdentityState & {
 const termsHighlights = [
 	'Users agree that consent evidence is stored with the active legal-document release.',
 	'Future releases can be versioned without overwriting the previous acceptance trail.',
-	'The write can target a legal-document release by hash instead of requiring the policy ID in the UI.',
+	'The preferred client contract is a signed document snapshot token; the hash path is a fallback for lighter integrations.',
 ];
 
 function formatDate(value: string) {
@@ -126,6 +128,17 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 				? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
 				: 'border-border bg-muted/70 text-muted-foreground';
 
+	const createDemoSnapshotToken = async () => {
+		const tokenResult = await createUnsafeDemoLegalDocumentSnapshotToken({
+			type: 'terms_and_conditions',
+			version: policy.version,
+			hash: policy.hash,
+			effectiveDate: policy.effectiveDate,
+		});
+
+		return tokenResult.token;
+	};
+
 	return (
 		<div className="relative overflow-hidden bg-background text-foreground">
 			<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(16,185,129,0.14),transparent_24%),linear-gradient(180deg,rgba(15,23,42,0.04),transparent_48%)]" />
@@ -149,7 +162,8 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 								<code className="mx-1 rounded bg-muted px-1.5 py-0.5 text-sm">
 									terms_and_conditions
 								</code>
-								consent against a legal-document release hash.
+								consent against a signed legal-document snapshot when available,
+								otherwise against a release hash.
 							</p>
 						</div>
 
@@ -169,8 +183,9 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 								</p>
 								<p className="mt-2 font-medium">Resolve the current release</p>
 								<p className="mt-1 text-muted-foreground text-sm">
-									The page carries the current terms release hash instead of a
-									precomputed policy ID.
+									The preferred input is a signed snapshot token. The release
+									hash stays available as a lighter fallback when the client
+									only knows the rendered document version.
 								</p>
 							</div>
 							<div className="rounded-2xl border border-border/70 bg-background/75 p-4 backdrop-blur">
@@ -424,15 +439,36 @@ export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
 										setFeedback(null);
 										startTransition(async () => {
 											try {
-												const result = await unstable_acceptPolicyConsent({
-													type: 'terms_and_conditions',
-													policyHash: policy.hash,
-													uiSource: 'terms-demo',
-													metadata: {
-														source: 'examples/demo/terms',
-														release: policy.version,
-													},
-												});
+												const documentSnapshotToken =
+													policy.documentSnapshotToken ??
+													(await createDemoSnapshotToken());
+												const result = await unstable_acceptPolicyConsent(
+													documentSnapshotToken
+														? {
+																type: 'terms_and_conditions',
+																documentSnapshotToken,
+																uiSource: 'terms-demo',
+																metadata: {
+																	source: 'examples/demo/terms',
+																	release: policy.version,
+																},
+															}
+														: {
+																type: 'terms_and_conditions',
+																policyHash: policy.hash,
+																uiSource: 'terms-demo',
+																metadata: {
+																	source: 'examples/demo/terms',
+																	release: policy.version,
+																},
+															}
+												);
+
+												if (!result) {
+													throw new Error(
+														'Unable to record the terms acceptance with c15t.'
+													);
+												}
 
 												setAcceptance({
 													subjectId: result.subjectId,

--- a/examples/demo/components/terms/terms-demo.tsx
+++ b/examples/demo/components/terms/terms-demo.tsx
@@ -1,0 +1,517 @@
+'use client';
+
+import { useConsentManager } from '@c15t/react';
+import {
+	Check,
+	FileText,
+	Fingerprint,
+	ShieldCheck,
+	UserRound,
+} from 'lucide-react';
+import { useMemo, useState, useTransition } from 'react';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '../ui/card';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+
+type TermsPolicySummary = {
+	title: string;
+	version: string;
+	hash: string;
+	effectiveDate: string;
+};
+
+type IdentityState = {
+	externalId: string;
+	identityProvider: string;
+};
+
+type AcceptanceState = IdentityState & {
+	subjectId: string;
+	consentId: string;
+	policyVersion: string;
+	policyHash: string;
+	acceptedAt: string;
+};
+
+const termsHighlights = [
+	'Users agree that consent evidence is stored with the active legal-document release.',
+	'Future releases can be versioned without overwriting the previous acceptance trail.',
+	'The write can target a legal-document release by hash instead of requiring the policy ID in the UI.',
+];
+
+function formatDate(value: string) {
+	return new Intl.DateTimeFormat('en', {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	}).format(new Date(value));
+}
+
+export function TermsDemo({ policy }: { policy: TermsPolicySummary }) {
+	const { consentInfo, identifyUser, unstable_acceptPolicyConsent, user } =
+		useConsentManager();
+	const [form, setForm] = useState({
+		externalId: 'demo-user-123',
+		identityProvider: 'demo-auth',
+	});
+	const [identified, setIdentified] = useState<IdentityState | null>(null);
+	const [acceptance, setAcceptance] = useState<AcceptanceState | null>(null);
+	const [feedback, setFeedback] = useState<{
+		tone: 'neutral' | 'success' | 'error';
+		message: string;
+	} | null>(null);
+	const [isPending, startTransition] = useTransition();
+	const defaultIdentityProvider = form.identityProvider.trim() || 'demo-auth';
+	const identifiedUser =
+		identified ??
+		(user?.id
+			? {
+					externalId: user.id,
+					identityProvider:
+						user.identityProvider ??
+						consentInfo?.identityProvider ??
+						defaultIdentityProvider,
+				}
+			: consentInfo?.externalId
+				? {
+						externalId: consentInfo.externalId,
+						identityProvider:
+							consentInfo.identityProvider ?? defaultIdentityProvider,
+					}
+				: null);
+
+	const statusRows = useMemo(
+		() => [
+			{
+				label: 'Policy version',
+				value: policy.version,
+			},
+			{
+				label: 'Effective date',
+				value: formatDate(policy.effectiveDate),
+			},
+			{
+				label: 'Policy hash',
+				value: acceptance?.policyHash || policy.hash,
+			},
+			{
+				label: 'Subject ID',
+				value:
+					acceptance?.subjectId ||
+					consentInfo?.subjectId ||
+					'Created when terms are accepted',
+			},
+		],
+		[
+			acceptance?.policyHash,
+			acceptance?.subjectId,
+			consentInfo?.subjectId,
+			policy.effectiveDate,
+			policy.hash,
+			policy.version,
+		]
+	);
+
+	const feedbackClassName =
+		feedback?.tone === 'error'
+			? 'border-destructive/30 bg-destructive/10 text-destructive'
+			: feedback?.tone === 'success'
+				? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+				: 'border-border bg-muted/70 text-muted-foreground';
+
+	return (
+		<div className="relative overflow-hidden bg-background text-foreground">
+			<div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_top_right,rgba(16,185,129,0.14),transparent_24%),linear-gradient(180deg,rgba(15,23,42,0.04),transparent_48%)]" />
+			<div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-border to-transparent" />
+
+			<div className="relative mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-10 px-4 pt-28 pb-16 sm:px-6 lg:px-8">
+				<section className="grid gap-6 lg:grid-cols-[1.25fr_0.95fr]">
+					<div className="space-y-6">
+						<div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/80 px-3 py-1 text-xs uppercase tracking-[0.18em] backdrop-blur">
+							<FileText className="size-3.5" />
+							c15t legal-document example
+						</div>
+
+						<div className="max-w-3xl space-y-4">
+							<h1 className="max-w-2xl text-balance font-semibold text-4xl tracking-tight sm:text-5xl">
+								Identify a user first, then capture a terms acceptance with the
+								active c15t release.
+							</h1>
+							<p className="max-w-2xl text-base text-muted-foreground sm:text-lg">
+								This demo creates or links a subject, then records a
+								<code className="mx-1 rounded bg-muted px-1.5 py-0.5 text-sm">
+									terms_and_conditions
+								</code>
+								consent against a legal-document release hash.
+							</p>
+						</div>
+
+						<div className="grid gap-4 sm:grid-cols-3">
+							<div className="rounded-2xl border border-border/70 bg-background/75 p-4 backdrop-blur">
+								<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+									Step 1
+								</p>
+								<p className="mt-2 font-medium">Identify the subject</p>
+								<p className="mt-1 text-muted-foreground text-sm">
+									Link the c15t subject to an authenticated external user ID.
+								</p>
+							</div>
+							<div className="rounded-2xl border border-border/70 bg-background/75 p-4 backdrop-blur">
+								<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+									Step 2
+								</p>
+								<p className="mt-2 font-medium">Resolve the current release</p>
+								<p className="mt-1 text-muted-foreground text-sm">
+									The page carries the current terms release hash instead of a
+									precomputed policy ID.
+								</p>
+							</div>
+							<div className="rounded-2xl border border-border/70 bg-background/75 p-4 backdrop-blur">
+								<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+									Step 3
+								</p>
+								<p className="mt-2 font-medium">Append acceptance evidence</p>
+								<p className="mt-1 text-muted-foreground text-sm">
+									Consent is written as an append-only record with subject and
+									release evidence.
+								</p>
+							</div>
+						</div>
+					</div>
+
+					<div className="rounded-[28px] border border-border/70 bg-background/85 p-6 shadow-sm backdrop-blur">
+						<div className="flex items-start justify-between gap-4">
+							<div>
+								<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+									Current release
+								</p>
+								<h2 className="mt-2 font-semibold text-2xl">{policy.title}</h2>
+							</div>
+							<Badge variant="outline">Active</Badge>
+						</div>
+
+						<div className="mt-6 grid gap-4 sm:grid-cols-2">
+							{statusRows.map((row) => (
+								<div
+									key={row.label}
+									className="rounded-2xl border border-border/70 bg-muted/45 p-4"
+								>
+									<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+										{row.label}
+									</p>
+									<p className="mt-2 break-all font-medium text-sm">
+										{row.value}
+									</p>
+								</div>
+							))}
+						</div>
+
+						<div className="mt-6 rounded-2xl border border-border border-dashed bg-muted/30 p-4">
+							<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+								Release hash
+							</p>
+							<p className="mt-2 font-mono text-sm">{policy.hash}</p>
+						</div>
+					</div>
+				</section>
+
+				<section className="grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+					<Card className="border-border/70 bg-background/90 shadow-sm">
+						<CardHeader>
+							<div className="flex items-center gap-3">
+								<div className="rounded-2xl bg-primary/10 p-3 text-primary">
+									<UserRound className="size-5" />
+								</div>
+								<div>
+									<CardTitle>Identify the user</CardTitle>
+									<CardDescription>
+										Use c15t's identify flow to store the external account and
+										link immediately if a subject already exists.
+									</CardDescription>
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent className="space-y-5">
+							<div className="space-y-2">
+								<Label htmlFor="external-id">External user ID</Label>
+								<Input
+									id="external-id"
+									value={form.externalId}
+									onChange={(event) =>
+										setForm((current) => ({
+											...current,
+											externalId: event.target.value,
+										}))
+									}
+									placeholder="user_123"
+								/>
+							</div>
+
+							<div className="space-y-2">
+								<Label htmlFor="identity-provider">Identity provider</Label>
+								<Input
+									id="identity-provider"
+									value={form.identityProvider}
+									onChange={(event) =>
+										setForm((current) => ({
+											...current,
+											identityProvider: event.target.value,
+										}))
+									}
+									placeholder="clerk"
+								/>
+							</div>
+
+							<Button
+								className="w-full"
+								disabled={isPending}
+								onClick={() => {
+									setFeedback(null);
+									startTransition(async () => {
+										const externalId = form.externalId.trim();
+										const identityProvider =
+											form.identityProvider.trim() || 'demo-auth';
+
+										if (!externalId) {
+											setFeedback({
+												tone: 'error',
+												message:
+													'External user ID is required before you can identify the subject.',
+											});
+											return;
+										}
+
+										const hasExistingSubject = Boolean(consentInfo?.subjectId);
+
+										try {
+											await identifyUser({
+												id: externalId,
+												identityProvider,
+											});
+
+											setIdentified({
+												externalId,
+												identityProvider,
+											});
+											setAcceptance(null);
+											setFeedback({
+												tone: 'success',
+												message: hasExistingSubject
+													? `c15t linked subject ${consentInfo.subjectId} to ${externalId}.`
+													: `c15t stored ${externalId} in client state. The first consent write will create or reuse the subject and attach the user identity.`,
+											});
+										} catch (error) {
+											setFeedback({
+												tone: 'error',
+												message:
+													error instanceof Error
+														? error.message
+														: 'Unable to identify the user with c15t.',
+											});
+										}
+									});
+								}}
+							>
+								{isPending ? 'Linking subject...' : 'Identify user'}
+							</Button>
+
+							<div className="rounded-2xl border border-border/70 bg-muted/35 p-4 text-sm">
+								<p className="font-medium">What this step does</p>
+								<p className="mt-2 text-muted-foreground">
+									This button now uses the consent manager's
+									<code className="mx-1 rounded bg-background px-1.5 py-0.5 text-xs">
+										identifyUser()
+									</code>
+									flow. If a subject already exists, c15t patches it
+									immediately. If not, c15t keeps the user identity in client
+									state and applies it on the first consent write.
+								</p>
+							</div>
+						</CardContent>
+					</Card>
+
+					<div className="space-y-6">
+						<section className="rounded-[28px] border border-border/70 bg-background/90 p-6 shadow-sm">
+							<div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+								<div className="max-w-2xl">
+									<div className="flex items-center gap-3">
+										<div className="rounded-2xl bg-emerald-500/12 p-3 text-emerald-700 dark:text-emerald-300">
+											<ShieldCheck className="size-5" />
+										</div>
+										<div>
+											<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+												Terms excerpt
+											</p>
+											<h2 className="mt-1 font-semibold text-2xl">
+												PigeonPost messaging terms
+											</h2>
+										</div>
+									</div>
+
+									<div className="mt-6 max-w-2xl space-y-4 text-muted-foreground text-sm leading-7 sm:text-base">
+										<p>
+											By accepting these terms you authorize PigeonPost to store
+											a versioned legal-document consent for your authenticated
+											account, including the subject ID, release hash,
+											timestamp, and source metadata required for audit
+											evidence.
+										</p>
+										<p>
+											The acceptance is append-only. A future release can
+											supersede this one without erasing the fact that version
+											<code className="mx-1 rounded bg-muted px-1.5 py-0.5 text-sm">
+												{policy.version}
+											</code>
+											was accepted today.
+										</p>
+									</div>
+								</div>
+
+								<div className="min-w-0 flex-1 rounded-3xl border border-border/70 bg-muted/35 p-5">
+									<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+										Implementation notes
+									</p>
+									<div className="mt-4 space-y-3">
+										{termsHighlights.map((item) => (
+											<div
+												key={item}
+												className="flex items-start gap-3 text-sm"
+											>
+												<Check className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-300" />
+												<p className="text-muted-foreground">{item}</p>
+											</div>
+										))}
+									</div>
+								</div>
+							</div>
+
+							<div className="mt-8 flex flex-col gap-4 rounded-3xl border border-border/70 bg-muted/20 p-5 sm:flex-row sm:items-center sm:justify-between">
+								<div>
+									<p className="font-medium text-sm">
+										{identifiedUser
+											? `Ready to record acceptance for ${identifiedUser.externalId}`
+											: 'Identify the user before recording acceptance'}
+									</p>
+									<p className="mt-1 text-muted-foreground text-sm">
+										c15t will store the acceptance with subject, consent, and
+										policy evidence through the unstable
+										<code className="mx-1 rounded bg-background px-1.5 py-0.5 text-xs">
+											unstable_acceptPolicyConsent()
+										</code>
+										store primitive.
+									</p>
+								</div>
+								<Button
+									size="lg"
+									disabled={!identifiedUser || isPending}
+									onClick={() => {
+										if (!identifiedUser) {
+											setFeedback({
+												tone: 'error',
+												message:
+													'Identify the user first so c15t has a subject to attach the terms consent to.',
+											});
+											return;
+										}
+
+										setFeedback(null);
+										startTransition(async () => {
+											try {
+												const result = await unstable_acceptPolicyConsent({
+													type: 'terms_and_conditions',
+													policyHash: policy.hash,
+													uiSource: 'terms-demo',
+													metadata: {
+														source: 'examples/demo/terms',
+														release: policy.version,
+													},
+												});
+
+												setAcceptance({
+													subjectId: result.subjectId,
+													externalId: identifiedUser.externalId,
+													identityProvider: identifiedUser.identityProvider,
+													consentId: result.consentId,
+													policyVersion: policy.version,
+													policyHash: policy.hash,
+													acceptedAt: new Date(result.givenAt).toISOString(),
+												});
+												setFeedback({
+													tone: 'success',
+													message: `Terms accepted and stored as consent ${result.consentId}.`,
+												});
+											} catch (error) {
+												setFeedback({
+													tone: 'error',
+													message:
+														error instanceof Error
+															? error.message
+															: 'Unable to record the terms acceptance with c15t.',
+												});
+											}
+										});
+									}}
+								>
+									{isPending
+										? 'Recording acceptance...'
+										: 'Accept terms and conditions'}
+								</Button>
+							</div>
+						</section>
+
+						<section className="grid gap-6 lg:grid-cols-[1fr_0.9fr]">
+							<div
+								className={`rounded-[24px] border p-5 text-sm shadow-sm ${feedbackClassName}`}
+							>
+								<p className="text-xs uppercase tracking-[0.18em]">
+									Request status
+								</p>
+								<p className="mt-2 leading-7">
+									{feedback?.message ||
+										'No write has been sent yet. Identify a user to begin the flow.'}
+								</p>
+							</div>
+
+							<div className="rounded-[24px] border border-border/70 bg-background/90 p-5 shadow-sm">
+								<p className="text-muted-foreground text-xs uppercase tracking-[0.18em]">
+									Latest acceptance
+								</p>
+								<div className="mt-4 space-y-4">
+									<div className="flex items-start gap-3">
+										<Fingerprint className="mt-0.5 size-4 text-muted-foreground" />
+										<div className="min-w-0">
+											<p className="font-medium text-sm">Consent ID</p>
+											<p className="break-all text-muted-foreground text-sm">
+												{acceptance?.consentId || 'Pending'}
+											</p>
+										</div>
+									</div>
+									<div className="flex items-start gap-3">
+										<FileText className="mt-0.5 size-4 text-muted-foreground" />
+										<div className="min-w-0">
+											<p className="font-medium text-sm">
+												Stored against release
+											</p>
+											<p className="text-muted-foreground text-sm">
+												{acceptance
+													? `${acceptance.policyVersion} at ${formatDate(acceptance.acceptedAt)}`
+													: 'No acceptance has been recorded yet'}
+											</p>
+										</div>
+									</div>
+								</div>
+							</div>
+						</section>
+					</div>
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/examples/demo/components/theme-provider.tsx
+++ b/examples/demo/components/theme-provider.tsx
@@ -5,6 +5,7 @@ import {
 	type ReactNode,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useState,
 } from 'react';
@@ -37,8 +38,38 @@ function applyTheme(theme: ResolvedTheme) {
 	document.documentElement.style.colorScheme = theme;
 }
 
+function resolveInitialTheme(
+	defaultTheme: ThemeMode,
+	enableSystem: boolean
+): ThemeMode {
+	if (typeof window === 'undefined') {
+		return defaultTheme;
+	}
+
+	const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+	if (storedTheme === 'light' || storedTheme === 'dark') {
+		return storedTheme;
+	}
+
+	if (storedTheme === 'system' && enableSystem) {
+		return storedTheme;
+	}
+
+	return defaultTheme;
+}
+
+function resolveThemeMode(
+	theme: ThemeMode,
+	enableSystem: boolean
+): ResolvedTheme {
+	if (theme === 'system' && enableSystem) {
+		return getSystemTheme();
+	}
+
+	return theme === 'dark' ? 'dark' : 'light';
+}
+
 type ThemeProviderProps = {
-	attribute?: 'class';
 	children: ReactNode;
 	defaultTheme?: ThemeMode;
 	enableSystem?: boolean;
@@ -49,33 +80,31 @@ export function ThemeProvider({
 	defaultTheme = 'light',
 	enableSystem = true,
 }: ThemeProviderProps) {
-	const [theme, setThemeState] = useState<ThemeMode>(defaultTheme);
-	const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('light');
+	const [theme, setThemeState] = useState<ThemeMode>(() =>
+		resolveInitialTheme(defaultTheme, enableSystem)
+	);
+	const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+		resolveThemeMode(
+			resolveInitialTheme(defaultTheme, enableSystem),
+			enableSystem
+		)
+	);
 
 	useEffect(() => {
-		const storedTheme = window.localStorage.getItem(
-			STORAGE_KEY
-		) as ThemeMode | null;
-		const nextTheme =
-			storedTheme &&
-			(storedTheme === 'light' ||
-				storedTheme === 'dark' ||
-				(storedTheme === 'system' && enableSystem))
-				? storedTheme
-				: defaultTheme;
-
+		const nextTheme = resolveInitialTheme(defaultTheme, enableSystem);
 		setThemeState(nextTheme);
+		setResolvedTheme(resolveThemeMode(nextTheme, enableSystem));
 	}, [defaultTheme, enableSystem]);
+
+	useLayoutEffect(() => {
+		applyTheme(resolvedTheme);
+	}, [resolvedTheme]);
 
 	useEffect(() => {
 		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
 		const syncTheme = () => {
-			const nextResolvedTheme =
-				theme === 'system' && enableSystem ? getSystemTheme() : theme;
-
-			setResolvedTheme(nextResolvedTheme === 'dark' ? 'dark' : 'light');
-			applyTheme(nextResolvedTheme === 'dark' ? 'dark' : 'light');
+			setResolvedTheme(resolveThemeMode(theme, enableSystem));
 		};
 
 		syncTheme();
@@ -92,10 +121,11 @@ export function ThemeProvider({
 			resolvedTheme,
 			setTheme: (nextTheme) => {
 				setThemeState(nextTheme);
+				setResolvedTheme(resolveThemeMode(nextTheme, enableSystem));
 				window.localStorage.setItem(STORAGE_KEY, nextTheme);
 			},
 		}),
-		[resolvedTheme, theme]
+		[enableSystem, resolvedTheme, theme]
 	);
 
 	return (

--- a/examples/demo/components/theme-provider.tsx
+++ b/examples/demo/components/theme-provider.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+type ResolvedTheme = 'light' | 'dark';
+
+type ThemeContextValue = {
+	theme: ThemeMode;
+	resolvedTheme: ResolvedTheme;
+	setTheme: (theme: ThemeMode) => void;
+};
+
+const STORAGE_KEY = 'pigeon-post-theme';
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getSystemTheme(): ResolvedTheme {
+	if (typeof window === 'undefined') {
+		return 'light';
+	}
+
+	return window.matchMedia('(prefers-color-scheme: dark)').matches
+		? 'dark'
+		: 'light';
+}
+
+function applyTheme(theme: ResolvedTheme) {
+	document.documentElement.classList.toggle('dark', theme === 'dark');
+	document.documentElement.style.colorScheme = theme;
+}
+
+type ThemeProviderProps = {
+	attribute?: 'class';
+	children: ReactNode;
+	defaultTheme?: ThemeMode;
+	enableSystem?: boolean;
+};
+
+export function ThemeProvider({
+	children,
+	defaultTheme = 'light',
+	enableSystem = true,
+}: ThemeProviderProps) {
+	const [theme, setThemeState] = useState<ThemeMode>(defaultTheme);
+	const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>('light');
+
+	useEffect(() => {
+		const storedTheme = window.localStorage.getItem(
+			STORAGE_KEY
+		) as ThemeMode | null;
+		const nextTheme =
+			storedTheme &&
+			(storedTheme === 'light' ||
+				storedTheme === 'dark' ||
+				(storedTheme === 'system' && enableSystem))
+				? storedTheme
+				: defaultTheme;
+
+		setThemeState(nextTheme);
+	}, [defaultTheme, enableSystem]);
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+		const syncTheme = () => {
+			const nextResolvedTheme =
+				theme === 'system' && enableSystem ? getSystemTheme() : theme;
+
+			setResolvedTheme(nextResolvedTheme === 'dark' ? 'dark' : 'light');
+			applyTheme(nextResolvedTheme === 'dark' ? 'dark' : 'light');
+		};
+
+		syncTheme();
+		mediaQuery.addEventListener('change', syncTheme);
+
+		return () => {
+			mediaQuery.removeEventListener('change', syncTheme);
+		};
+	}, [enableSystem, theme]);
+
+	const value = useMemo<ThemeContextValue>(
+		() => ({
+			theme,
+			resolvedTheme,
+			setTheme: (nextTheme) => {
+				setThemeState(nextTheme);
+				window.localStorage.setItem(STORAGE_KEY, nextTheme);
+			},
+		}),
+		[resolvedTheme, theme]
+	);
+
+	return (
+		<ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+	);
+}
+
+export function useTheme() {
+	const context = useContext(ThemeContext);
+
+	if (!context) {
+		throw new Error('useTheme must be used within ThemeProvider');
+	}
+
+	return context;
+}

--- a/examples/demo/lib/demo-c15t-instance.ts
+++ b/examples/demo/lib/demo-c15t-instance.ts
@@ -1,0 +1,123 @@
+import 'server-only';
+
+import { c15tInstance } from '@c15t/backend';
+import { createUpstashRedisAdapter } from '@c15t/backend/cache';
+import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
+import { LibsqlDialect } from '@libsql/kysely-libsql';
+import { Kysely, PostgresDialect } from 'kysely';
+import { Pool } from 'pg';
+import {
+	DEFAULT_DEMO_POLICY_EXAMPLE,
+	DEMO_POLICY_SNAPSHOT_KEY,
+	demoI18nMessages,
+	getDemoPolicies,
+} from './policies';
+
+export const postgresDb = kyselyAdapter({
+	db: new Kysely({
+		dialect: new PostgresDialect({
+			pool: new Pool({
+				connectionString: process.env.DATABASE_URL,
+				ssl: { rejectUnauthorized: false },
+			}),
+		}),
+	}),
+	provider: 'postgresql',
+});
+
+export const tursoDb = kyselyAdapter({
+	db: new Kysely({
+		dialect: new LibsqlDialect({
+			url: 'http://127.0.0.1:8080',
+		}),
+	}),
+	provider: 'sqlite',
+});
+
+export const DEMO_TERMS_RELEASE = {
+	title: 'PigeonPost Terms & Conditions',
+	type: 'terms_and_conditions' as const,
+	version: '2026-04-13',
+	hash: 'pigeonpost-terms-v2026-04-13',
+	effectiveDate: '2026-04-13T00:00:00.000Z',
+};
+
+export function createDemoInstance(example = DEFAULT_DEMO_POLICY_EXAMPLE) {
+	let cacheConfig:
+		| {
+				adapter: ReturnType<typeof createUpstashRedisAdapter>;
+		  }
+		| undefined;
+
+	if (process.env.REDIS_URL && process.env.REDIS_TOKEN) {
+		cacheConfig = {
+			adapter: createUpstashRedisAdapter({
+				url: process.env.REDIS_URL,
+				token: process.env.REDIS_TOKEN,
+			}),
+		};
+	}
+
+	return c15tInstance({
+		appName: 'c15t-self-host',
+		basePath: '/api/self-host',
+		adapter: postgresDb,
+		trustedOrigins: ['localhost', '*.localhost', 'vercel.app'],
+		tenantId: 'ins_1',
+		branding: 'c15t',
+		i18n: {
+			defaultProfile: 'default',
+			messages: demoI18nMessages,
+		},
+		policyPacks: getDemoPolicies(example),
+		policySnapshot: {
+			signingKey: DEMO_POLICY_SNAPSHOT_KEY,
+			ttlSeconds: 60 * 60,
+		},
+		openapi: {
+			enabled: true,
+		},
+		cache: cacheConfig,
+		iab: {
+			enabled: true,
+			cmpId: 10,
+			vendorIds: [
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+				21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+				39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+				57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
+				75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92,
+				93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108,
+				109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122,
+				123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136,
+				137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150,
+				151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+				165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178,
+				179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192,
+				193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206,
+				207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220,
+				221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234,
+				235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248,
+				249, 250,
+			],
+			customVendors: [
+				{
+					id: 'demo-analytics',
+					name: 'Demo Analytics',
+					privacyPolicyUrl: 'https://example.com/privacy',
+					purposes: [1, 8],
+					dataCategories: [1, 2],
+					usesCookies: true,
+					cookieMaxAgeSeconds: 31536000,
+					usesNonCookieAccess: false,
+				},
+			],
+		},
+	});
+}
+
+export function getDemoTermsRelease() {
+	return {
+		...DEMO_TERMS_RELEASE,
+	};
+}

--- a/examples/demo/lib/demo-c15t-instance.ts
+++ b/examples/demo/lib/demo-c15t-instance.ts
@@ -14,12 +14,34 @@ import {
 	getDemoPolicies,
 } from './policies';
 
+function resolvePostgresSslConfig(connectionString?: string) {
+	if (!connectionString) {
+		return undefined;
+	}
+
+	try {
+		const hostname = new URL(connectionString).hostname;
+		const isLocalhost =
+			hostname === 'localhost' ||
+			hostname === '127.0.0.1' ||
+			hostname === '::1';
+
+		return isLocalhost
+			? { rejectUnauthorized: false }
+			: { rejectUnauthorized: true };
+	} catch {
+		return process.env.NODE_ENV === 'development'
+			? { rejectUnauthorized: false }
+			: { rejectUnauthorized: true };
+	}
+}
+
 export const postgresDb = kyselyAdapter({
 	db: new Kysely({
 		dialect: new PostgresDialect({
 			pool: new Pool({
 				connectionString: process.env.DATABASE_URL,
-				ssl: { rejectUnauthorized: false },
+				ssl: resolvePostgresSslConfig(process.env.DATABASE_URL),
 			}),
 		}),
 	}),

--- a/examples/demo/lib/demo-c15t-instance.ts
+++ b/examples/demo/lib/demo-c15t-instance.ts
@@ -6,6 +6,7 @@ import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
 import { LibsqlDialect } from '@libsql/kysely-libsql';
 import { Kysely, PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
+import { DEMO_LEGAL_DOCUMENT_SNAPSHOT } from './demo-legal-document-snapshot';
 import {
 	DEFAULT_DEMO_POLICY_EXAMPLE,
 	DEMO_POLICY_SNAPSHOT_KEY,
@@ -73,6 +74,10 @@ export function createDemoInstance(example = DEFAULT_DEMO_POLICY_EXAMPLE) {
 		policySnapshot: {
 			signingKey: DEMO_POLICY_SNAPSHOT_KEY,
 			ttlSeconds: 60 * 60,
+		},
+		legalDocumentSnapshot: {
+			signingKey: DEMO_LEGAL_DOCUMENT_SNAPSHOT.signingKey,
+			issuer: DEMO_LEGAL_DOCUMENT_SNAPSHOT.issuer,
 		},
 		openapi: {
 			enabled: true,

--- a/examples/demo/lib/demo-legal-document-snapshot.ts
+++ b/examples/demo/lib/demo-legal-document-snapshot.ts
@@ -1,0 +1,8 @@
+export const DEMO_LEGAL_DOCUMENT_SNAPSHOT = {
+	signingKey: 'demo-legal-document-snapshot-signing-key',
+	tenantId: 'ins_1',
+	issuer: 'c15t-demo',
+	ttlSeconds: 1800,
+} as const;
+
+export const DEMO_LEGAL_DOCUMENT_SNAPSHOT_AUDIENCE = `c15t-legal-document-snapshot:${DEMO_LEGAL_DOCUMENT_SNAPSHOT.tenantId}`;

--- a/examples/demo/lib/unsafe-demo-legal-document-snapshot.ts
+++ b/examples/demo/lib/unsafe-demo-legal-document-snapshot.ts
@@ -1,0 +1,78 @@
+import { SignJWT } from 'jose';
+import {
+	DEMO_LEGAL_DOCUMENT_SNAPSHOT,
+	DEMO_LEGAL_DOCUMENT_SNAPSHOT_AUDIENCE,
+} from './demo-legal-document-snapshot';
+
+type LegalDocumentType = 'privacy_policy' | 'terms_and_conditions' | 'dpa';
+
+export interface UnsafeDemoLegalDocumentSnapshotInput {
+	type: LegalDocumentType;
+	version: string;
+	hash: string;
+	effectiveDate: string;
+}
+
+export interface UnsafeDemoLegalDocumentSnapshotResult {
+	token: string;
+	payload: {
+		iss: string;
+		aud: string;
+		sub: string;
+		tenantId?: string;
+		type: LegalDocumentType;
+		version: string;
+		hash: string;
+		effectiveDate: string;
+		iat: number;
+		exp: number;
+	};
+}
+
+const DEFAULT_ISSUER = 'c15t';
+const DEFAULT_TTL_SECONDS = 1800;
+
+function resolveAudience(input: UnsafeDemoLegalDocumentSnapshotInput) {
+	return DEMO_LEGAL_DOCUMENT_SNAPSHOT_AUDIENCE;
+}
+
+/**
+ * Demo-only helper for local development until the real terms server can issue
+ * authoritative snapshot tokens. This must never be treated as production-safe
+ * because it requires exposing a signing key to the browser bundle.
+ */
+export async function createUnsafeDemoLegalDocumentSnapshotToken(
+	input: UnsafeDemoLegalDocumentSnapshotInput
+): Promise<UnsafeDemoLegalDocumentSnapshotResult> {
+	const iat = Math.floor(Date.now() / 1000);
+	const exp =
+		iat + (DEMO_LEGAL_DOCUMENT_SNAPSHOT.ttlSeconds ?? DEFAULT_TTL_SECONDS);
+	const iss = DEMO_LEGAL_DOCUMENT_SNAPSHOT.issuer || DEFAULT_ISSUER;
+	const aud = resolveAudience(input);
+	const payload = {
+		iss,
+		aud,
+		sub: input.hash,
+		tenantId: DEMO_LEGAL_DOCUMENT_SNAPSHOT.tenantId,
+		type: input.type,
+		version: input.version,
+		hash: input.hash,
+		effectiveDate: input.effectiveDate,
+		iat,
+		exp,
+	};
+
+	const token = await new SignJWT(payload)
+		.setProtectedHeader({
+			alg: 'HS256',
+			typ: 'JWT',
+		})
+		.setIssuedAt(iat)
+		.setExpirationTime(exp)
+		.sign(new TextEncoder().encode(DEMO_LEGAL_DOCUMENT_SNAPSHOT.signingKey));
+
+	return {
+		token,
+		payload,
+	};
+}

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -82,6 +82,7 @@
 		"date-fns": "4.1.0",
 		"embla-carousel-react": "8.6.0",
 		"input-otp": "1.4.2",
+		"jose": "6.2.2",
 		"kysely": "0.28.15",
 		"lucide-react": "^1.7.0",
 		"next": "16.2.1",

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -85,7 +85,6 @@
 		"kysely": "0.28.15",
 		"lucide-react": "^1.7.0",
 		"next": "16.2.1",
-		"next-themes": "^0.4.6",
 		"pg": "^8.20.0",
 		"posthog-js": "1.364.3",
 		"react": "19.2.4",

--- a/packages/backend/src/handlers/subject/post.handler.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.test.ts
@@ -903,7 +903,7 @@ describe('postSubjectHandler legal document snapshots', () => {
 		});
 	});
 
-	it('rejects legal document consent without token or policyId when verification is disabled', async () => {
+	it('rejects legal document consent without token, policyId, or policyHash when verification is disabled', async () => {
 		const db = createMockDb(null);
 		const registry = createMockRegistry();
 		const mockCtx = createMockContext(db, registry);
@@ -916,7 +916,7 @@ describe('postSubjectHandler legal document snapshots', () => {
 		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
 			status: 409,
 			message:
-				'Legal document consent requires policyId when snapshot verification is disabled',
+				'Legal document consent requires policyId or policyHash when snapshot verification is disabled',
 			cause: {
 				code: 'LEGAL_DOCUMENT_PROOF_REQUIRED',
 			},

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -416,6 +416,10 @@ export const postSubjectHandler = async (c: Context) => {
 
 		const inputPolicyId =
 			'policyId' in input ? (input.policyId as string | undefined) : undefined;
+		const inputPolicyHash =
+			'policyHash' in input
+				? (input.policyHash as string | undefined)
+				: undefined;
 		if (legalDocumentConsent && legalDocumentSnapshotVerification.valid) {
 			if (legalDocumentSnapshotVerification.payload.type !== type) {
 				throw buildLegalDocumentSnapshotHttpException('invalid');
@@ -436,33 +440,67 @@ export const postSubjectHandler = async (c: Context) => {
 			});
 			policyId = documentPolicy.id;
 		} else if (legalDocumentConsent) {
-			if (!ctx.legalDocumentSnapshot?.signingKey && !inputPolicyId) {
+			if (
+				!ctx.legalDocumentSnapshot?.signingKey &&
+				!inputPolicyId &&
+				!inputPolicyHash
+			) {
 				throw buildLegalDocumentProofHttpException(
-					'Legal document consent requires policyId when snapshot verification is disabled'
+					'Legal document consent requires policyId or policyHash when snapshot verification is disabled'
 				);
 			}
 
-			if (!inputPolicyId) {
+			if (!inputPolicyId && !inputPolicyHash) {
 				throw buildLegalDocumentProofHttpException(
-					'Legal document consent requires a valid document snapshot token or policyId'
+					'Legal document consent requires a valid document snapshot token, policyId, or policyHash'
 				);
 			}
 
-			policyId = inputPolicyId;
+			if (inputPolicyId) {
+				policyId = inputPolicyId;
 
-			// Verify the policy exists and is active
-			const policy = await registry.findConsentPolicyById(inputPolicyId);
-			if (!policy) {
-				throw new HTTPException(404, {
-					message: 'Policy not found',
-					cause: { code: 'POLICY_NOT_FOUND', policyId, type },
-				});
-			}
-			if (!policy.isActive) {
-				throw new HTTPException(400, {
-					message: 'Policy is inactive',
-					cause: { code: 'POLICY_INACTIVE', policyId, type },
-				});
+				// Verify the policy exists and is active
+				const policy = await registry.findConsentPolicyById(inputPolicyId);
+				if (!policy) {
+					throw new HTTPException(404, {
+						message: 'Policy not found',
+						cause: { code: 'POLICY_NOT_FOUND', policyId, type },
+					});
+				}
+				if (!policy.isActive) {
+					throw new HTTPException(400, {
+						message: 'Policy is inactive',
+						cause: { code: 'POLICY_INACTIVE', policyId, type },
+					});
+				}
+			} else if (inputPolicyHash) {
+				const policy = await registry.findLegalDocumentPolicyByHash(
+					type,
+					inputPolicyHash
+				);
+				if (!policy) {
+					throw new HTTPException(404, {
+						message: 'Policy not found',
+						cause: {
+							code: 'POLICY_NOT_FOUND',
+							type,
+							policyHash: inputPolicyHash,
+						},
+					});
+				}
+				if (!policy.isActive) {
+					throw new HTTPException(400, {
+						message: 'Policy is inactive',
+						cause: {
+							code: 'POLICY_INACTIVE',
+							policyId: policy.id,
+							type,
+							policyHash: inputPolicyHash,
+						},
+					});
+				}
+
+				policyId = policy.id;
 			}
 		} else if (inputPolicyId) {
 			policyId = inputPolicyId;
@@ -553,6 +591,13 @@ export const postSubjectHandler = async (c: Context) => {
 			}
 
 			purposeIds = purposes;
+		}
+
+		if (!policyId) {
+			throw new HTTPException(500, {
+				message: 'Failed to resolve policy',
+				cause: { code: 'POLICY_RESOLUTION_FAILED', type },
+			});
 		}
 
 		const expiryDays = effectivePolicy?.consent?.expiryDays;

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -450,12 +450,6 @@ export const postSubjectHandler = async (c: Context) => {
 				);
 			}
 
-			if (!inputPolicyId && !inputPolicyHash) {
-				throw buildLegalDocumentProofHttpException(
-					'Legal document consent requires a valid document snapshot token, policyId, or policyHash'
-				);
-			}
-
 			if (inputPolicyId) {
 				policyId = inputPolicyId;
 

--- a/packages/backend/src/routes/subject.ts
+++ b/packages/backend/src/routes/subject.ts
@@ -67,7 +67,7 @@ export const createSubjectRoutes = () => {
 
 **Request body by \`type\`:**
 - \`cookie_banner\` – Requires \`preferences\` object
-- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\` – Requires a valid \`documentSnapshotToken\` when legal-document verification is enabled, otherwise an explicit \`policyId\`
+- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\` – Requires a valid \`documentSnapshotToken\` when legal-document verification is enabled, otherwise a \`policyId\` or release \`policyHash\`
 - \`marketing_communications\`, \`age_verification\`, \`other\` – Optional \`preferences\``,
 			tags: ['Subject', 'Consent'],
 			responses: {

--- a/packages/backend/src/routes/subject.ts
+++ b/packages/backend/src/routes/subject.ts
@@ -67,7 +67,7 @@ export const createSubjectRoutes = () => {
 
 **Request body by \`type\`:**
 - \`cookie_banner\` – Requires \`preferences\` object
-- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\` – Requires a valid \`documentSnapshotToken\` when legal-document verification is enabled, otherwise a \`policyId\` or release \`policyHash\`
+- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\` – Prefer a signed \`documentSnapshotToken\`; otherwise use a release \`policyHash\`, with \`policyId\` kept only for compatibility
 - \`marketing_communications\`, \`age_verification\`, \`other\` – Optional \`preferences\``,
 			tags: ['Subject', 'Consent'],
 			responses: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,6 +150,8 @@ export type {
 	SSRInitRequestMetadata,
 	SSRSkippedReason,
 	StoreOptions,
+	UnstableGenericPolicyConsentInput,
+	UnstableLegalDocumentConsentInput,
 	UnstablePolicyConsentInput,
 } from './store/type';
 // Export default translation config

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,6 +150,7 @@ export type {
 	SSRInitRequestMetadata,
 	SSRSkippedReason,
 	StoreOptions,
+	UnstablePolicyConsentInput,
 } from './store/type';
 // Export default translation config
 export { defaultTranslationConfig } from './translations';

--- a/packages/core/src/libs/__tests__/policy.test.ts
+++ b/packages/core/src/libs/__tests__/policy.test.ts
@@ -158,6 +158,20 @@ describe('applyPolicyPurposeAllowlist', () => {
 			preferences
 		);
 	});
+
+	it('preserves necessary even when it is missing from the allowlist', () => {
+		const preferences = {
+			necessary: true,
+			marketing: true,
+			measurement: true,
+		};
+
+		expect(applyPolicyPurposeAllowlist(preferences, ['marketing'])).toEqual({
+			necessary: true,
+			marketing: true,
+			measurement: false,
+		});
+	});
 });
 
 describe('stripDisallowedPreferenceKeys', () => {
@@ -206,6 +220,19 @@ describe('stripDisallowedPreferenceKeys', () => {
 		expect(stripDisallowedPreferenceKeys(preferences, ['*'])).toEqual(
 			preferences
 		);
+	});
+
+	it('preserves necessary key even when not in allowlist', () => {
+		const preferences = {
+			necessary: true,
+			marketing: true,
+			measurement: true,
+		};
+
+		expect(stripDisallowedPreferenceKeys(preferences, ['marketing'])).toEqual({
+			necessary: true,
+			marketing: true,
+		});
 	});
 });
 

--- a/packages/core/src/libs/__tests__/policy.test.ts
+++ b/packages/core/src/libs/__tests__/policy.test.ts
@@ -4,6 +4,7 @@ import {
 	applyPolicyScopeForRuntimeGating,
 	filterConsentCategoriesByPolicy,
 	getEffectivePolicy,
+	stripDisallowedPreferenceKeys,
 	validateUIAgainstPolicy,
 } from '../policy';
 
@@ -154,6 +155,55 @@ describe('applyPolicyPurposeAllowlist', () => {
 		};
 
 		expect(applyPolicyPurposeAllowlist(preferences, ['*'])).toEqual(
+			preferences
+		);
+	});
+});
+
+describe('stripDisallowedPreferenceKeys', () => {
+	it('returns unchanged preferences when no allowlist is provided', () => {
+		const preferences = {
+			necessary: true,
+			marketing: true,
+		};
+
+		expect(stripDisallowedPreferenceKeys(preferences, undefined)).toEqual(
+			preferences
+		);
+	});
+
+	it('omits non-allowlisted preference keys', () => {
+		const preferences = {
+			necessary: true,
+			marketing: true,
+			measurement: true,
+			functionality: false,
+			experience: false,
+		};
+
+		expect(
+			stripDisallowedPreferenceKeys(preferences, [
+				'necessary',
+				'measurement',
+				'marketing',
+			])
+		).toEqual({
+			necessary: true,
+			marketing: true,
+			measurement: true,
+		});
+	});
+
+	it('returns unchanged preferences when allowlist includes wildcard', () => {
+		const preferences = {
+			necessary: true,
+			marketing: true,
+			measurement: true,
+			functionality: true,
+			experience: false,
+		};
+
+		expect(stripDisallowedPreferenceKeys(preferences, ['*'])).toEqual(
 			preferences
 		);
 	});

--- a/packages/core/src/libs/__tests__/save-consents.test.ts
+++ b/packages/core/src/libs/__tests__/save-consents.test.ts
@@ -931,9 +931,7 @@ describe('saveConsents', () => {
 				body: expect.objectContaining({
 					preferences: {
 						necessary: true,
-						functionality: false,
 						measurement: true,
-						experience: false,
 						marketing: true,
 					},
 				}),

--- a/packages/core/src/libs/policy.ts
+++ b/packages/core/src/libs/policy.ts
@@ -73,6 +73,35 @@ export function applyPolicyPurposeAllowlist<T extends Record<string, boolean>>(
 }
 
 /**
+ * Strips preference keys that are outside the active policy allowlist.
+ *
+ * Use this for API payloads when the backend enforces strict purpose scope and
+ * rejects unknown preference keys entirely.
+ */
+export function stripDisallowedPreferenceKeys<
+	T extends Record<string, boolean>,
+>(preferences: T, allowedPurposeIds?: string[]): Partial<T> {
+	if (
+		!allowedPurposeIds ||
+		allowedPurposeIds.length === 0 ||
+		allowedPurposeIds.includes('*')
+	) {
+		return preferences;
+	}
+
+	const allowed = new Set(['necessary', ...allowedPurposeIds]);
+	const next: Partial<T> = {};
+
+	for (const [key, value] of Object.entries(preferences)) {
+		if (allowed.has(key)) {
+			next[key as keyof T] = value as T[keyof T];
+		}
+	}
+
+	return next;
+}
+
+/**
  * Filters consent categories against a policy purpose allowlist.
  *
  * When allowlist is active, only categories present in it are kept and

--- a/packages/core/src/libs/policy.ts
+++ b/packages/core/src/libs/policy.ts
@@ -48,7 +48,8 @@ function flattenLayout(layout?: PolicyUiActionGroup[]): PolicyUiAction[] {
  * Any preference key not in `allowedPurposeIds` is forced to `false`.
  * This prevents backend allowlist enforcement errors when clients hold
  * additional consent keys (for example from IAB category mapping).
- * When `allowedPurposeIds` contains `*`, no filtering is applied.
+ * When `allowedPurposeIds` contains `*`, no filtering is applied. `necessary`
+ * is always retained.
  */
 export function applyPolicyPurposeAllowlist<T extends Record<string, boolean>>(
 	preferences: T,
@@ -62,7 +63,7 @@ export function applyPolicyPurposeAllowlist<T extends Record<string, boolean>>(
 		return preferences;
 	}
 
-	const allowed = new Set(allowedPurposeIds);
+	const allowed = new Set(['necessary', ...allowedPurposeIds]);
 	const next = {} as T;
 
 	for (const [key, value] of Object.entries(preferences)) {
@@ -76,7 +77,8 @@ export function applyPolicyPurposeAllowlist<T extends Record<string, boolean>>(
  * Strips preference keys that are outside the active policy allowlist.
  *
  * Use this for API payloads when the backend enforces strict purpose scope and
- * rejects unknown preference keys entirely.
+ * rejects unknown preference keys entirely. `necessary` is always retained to
+ * stay aligned with `applyPolicyPurposeAllowlist()`.
  */
 export function stripDisallowedPreferenceKeys<
 	T extends Record<string, boolean>,

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -31,7 +31,7 @@ export interface PendingConsentSync {
 	subjectId: string;
 	externalId?: string;
 	identityProvider?: string;
-	preferences: ConsentState;
+	preferences: Partial<ConsentState>;
 	givenAt: number;
 	jurisdiction?: string;
 	jurisdictionModel?: string | null;
@@ -194,7 +194,7 @@ export async function saveConsents({
 	const requestPreferences = stripDisallowedPreferenceKeys(
 		effectiveConsents,
 		policyCategories
-	) as ConsentState;
+	);
 	const didChange = haveConsentsChanged(
 		previousConsents,
 		effectiveConsents,

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -10,7 +10,11 @@ import type {
 } from '../types';
 import { saveConsentToStorage } from './cookie';
 import { generateSubjectId } from './generate-subject-id';
-import { applyPolicyPurposeAllowlist, getEffectivePolicy } from './policy';
+import {
+	applyPolicyPurposeAllowlist,
+	getEffectivePolicy,
+	stripDisallowedPreferenceKeys,
+} from './policy';
 import { sanitizeSubjectIdentifiers } from './sanitize-subject-identifiers';
 
 /**
@@ -187,6 +191,10 @@ export async function saveConsents({
 		newConsents,
 		policyCategories
 	);
+	const requestPreferences = stripDisallowedPreferenceKeys(
+		effectiveConsents,
+		policyCategories
+	) as ConsentState;
 	const didChange = haveConsentsChanged(
 		previousConsents,
 		effectiveConsents,
@@ -278,7 +286,7 @@ export async function saveConsents({
 		const pendingSync: PendingConsentSync = {
 			type,
 			subjectId,
-			preferences: effectiveConsents,
+			preferences: requestPreferences,
 			givenAt,
 			jurisdiction: locationInfo?.jurisdiction ?? undefined,
 			jurisdictionModel: model,
@@ -335,7 +343,7 @@ export async function saveConsents({
 		body: {
 			type: 'cookie_banner',
 			domain: window.location.hostname,
-			preferences: effectiveConsents,
+			preferences: requestPreferences,
 			subjectId,
 			jurisdiction: locationInfo?.jurisdiction ?? undefined,
 			jurisdictionModel: model ?? undefined,

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -11,8 +11,10 @@ import type { StorageConfig } from '../libs/cookie';
 import {
 	deleteConsentFromStorage,
 	getConsentFromStorage,
+	saveConsentToStorage,
 } from '../libs/cookie';
 import { setDebugEnabled } from '../libs/debug';
+import { generateSubjectId } from '../libs/generate-subject-id';
 import {
 	extractConsentNamesFromCondition,
 	type HasCondition,
@@ -23,6 +25,7 @@ import { createIframeManager } from '../libs/iframe-blocker/store';
 import { initConsentManager } from '../libs/init-consent-manager';
 import { createNetworkBlockerManager } from '../libs/network-blocker/store';
 import { filterConsentCategoriesByPolicy } from '../libs/policy';
+import { sanitizeSubjectIdentifiers } from '../libs/sanitize-subject-identifiers';
 import { saveConsents } from '../libs/save-consents';
 import { createScriptManager } from '../libs/script-loader';
 import type {
@@ -442,6 +445,104 @@ export const createConsentManagerStore = (
 					identityProvider: user.identityProvider,
 				},
 			});
+		},
+		unstable_acceptPolicyConsent: async (input) => {
+			const currentState = get();
+			const currentInfo = currentState.consentInfo;
+			const subjectId = currentInfo?.subjectId ?? generateSubjectId();
+			const storedIdentifiers = sanitizeSubjectIdentifiers({
+				externalId: currentInfo?.externalId,
+				identityProvider: currentInfo?.identityProvider,
+			});
+			const userIdentifiers = sanitizeSubjectIdentifiers({
+				externalId: currentState.user?.id,
+				identityProvider: currentState.user?.identityProvider,
+			});
+			const inputIdentifiers = sanitizeSubjectIdentifiers({
+				externalId: input.externalId,
+				identityProvider: input.identityProvider,
+			});
+			const externalId =
+				inputIdentifiers.externalId ??
+				storedIdentifiers.externalId ??
+				userIdentifiers.externalId;
+			const identityProvider =
+				inputIdentifiers.identityProvider ??
+				storedIdentifiers.identityProvider ??
+				userIdentifiers.identityProvider;
+			const givenAt = input.givenAt ?? Date.now();
+			const domain =
+				input.domain ??
+				(typeof window !== 'undefined'
+					? window.location.hostname
+					: 'localhost');
+
+			const response = await manager.setConsent({
+				body: {
+					type: input.type,
+					subjectId,
+					domain,
+					givenAt,
+					uiSource: input.uiSource ?? 'api',
+					...(input.policyId ? { policyId: input.policyId } : {}),
+					...(input.policyHash ? { policyHash: input.policyHash } : {}),
+					...(input.documentSnapshotToken
+						? { documentSnapshotToken: input.documentSnapshotToken }
+						: {}),
+					...(input.metadata ? { metadata: input.metadata } : {}),
+					...(input.preferences ? { preferences: input.preferences } : {}),
+					...(externalId ? { externalSubjectId: externalId } : {}),
+					...(identityProvider ? { identityProvider } : {}),
+				},
+			});
+
+			if (!response.ok || !response.data) {
+				const errorMsg =
+					response.error?.message ?? 'Failed to accept policy consent';
+				currentState.callbacks.onError?.({
+					error: errorMsg,
+				});
+				throw new Error(errorMsg);
+			}
+
+			const consent = {
+				...response.data,
+				givenAt:
+					response.data.givenAt instanceof Date
+						? response.data.givenAt
+						: new Date(response.data.givenAt),
+			};
+
+			const nextConsentInfo = {
+				...currentInfo,
+				time: givenAt,
+				subjectId,
+				...(externalId ? { externalId } : {}),
+				...(identityProvider ? { identityProvider } : {}),
+			};
+
+			set({
+				consentInfo: nextConsentInfo,
+				...(externalId
+					? {
+							user: {
+								id: externalId,
+								identityProvider,
+							},
+						}
+					: {}),
+			});
+
+			saveConsentToStorage(
+				{
+					consents: currentState.consents,
+					consentInfo: nextConsentInfo,
+				},
+				undefined,
+				currentState.storageConfig
+			);
+
+			return consent;
 		},
 
 		setOverrides: async (

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -476,25 +476,31 @@ export const createConsentManagerStore = (
 				(typeof window !== 'undefined'
 					? window.location.hostname
 					: 'localhost');
-			const legalDocumentFields =
-				'policyId' in input ||
-				'policyHash' in input ||
-				'documentSnapshotToken' in input
-					? {
-							...('policyId' in input && input.policyId
-								? { policyId: input.policyId }
-								: {}),
-							...('policyHash' in input && input.policyHash
-								? { policyHash: input.policyHash }
-								: {}),
-							...('documentSnapshotToken' in input &&
-							input.documentSnapshotToken
-								? {
-										documentSnapshotToken: input.documentSnapshotToken,
-									}
-								: {}),
-						}
-					: {};
+			const isLegalDocumentType =
+				input.type === 'privacy_policy' ||
+				input.type === 'terms_and_conditions' ||
+				input.type === 'dpa';
+			let legalDocumentFields: Record<string, string> = {};
+
+			if (isLegalDocumentType) {
+				if (input.documentSnapshotToken) {
+					legalDocumentFields = {
+						documentSnapshotToken: input.documentSnapshotToken,
+					};
+				} else if (input.policyHash) {
+					legalDocumentFields = {
+						policyHash: input.policyHash,
+					};
+				} else if (input.policyId) {
+					legalDocumentFields = {
+						policyId: input.policyId,
+					};
+				} else {
+					throw new Error(
+						'Legal document consent requires documentSnapshotToken, policyHash, or policyId.'
+					);
+				}
+			}
 
 			const response = await manager.setConsent({
 				body: {
@@ -514,7 +520,7 @@ export const createConsentManagerStore = (
 			if (!response.ok || !response.data) {
 				const errorMsg =
 					response.error?.message ?? 'Failed to accept policy consent';
-				currentState.callbacks.onError?.({
+				get().callbacks.onError?.({
 					error: errorMsg,
 				});
 				const error = new Error(errorMsg) as Error & {
@@ -536,8 +542,10 @@ export const createConsentManagerStore = (
 						: new Date(response.data.givenAt),
 			};
 
+			const latestState = get();
+			const latestInfo = latestState.consentInfo;
 			const nextConsentInfo = {
-				...currentInfo,
+				...latestInfo,
 				time: givenAt,
 				subjectId,
 				...(externalId ? { externalId } : {}),
@@ -558,11 +566,11 @@ export const createConsentManagerStore = (
 
 			saveConsentToStorage(
 				{
-					consents: currentState.consents,
+					consents: latestState.consents,
 					consentInfo: nextConsentInfo,
 				},
 				undefined,
-				currentState.storageConfig
+				latestState.storageConfig
 			);
 
 			return consent;

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -476,6 +476,25 @@ export const createConsentManagerStore = (
 				(typeof window !== 'undefined'
 					? window.location.hostname
 					: 'localhost');
+			const legalDocumentFields =
+				'policyId' in input ||
+				'policyHash' in input ||
+				'documentSnapshotToken' in input
+					? {
+							...('policyId' in input && input.policyId
+								? { policyId: input.policyId }
+								: {}),
+							...('policyHash' in input && input.policyHash
+								? { policyHash: input.policyHash }
+								: {}),
+							...('documentSnapshotToken' in input &&
+							input.documentSnapshotToken
+								? {
+										documentSnapshotToken: input.documentSnapshotToken,
+									}
+								: {}),
+						}
+					: {};
 
 			const response = await manager.setConsent({
 				body: {
@@ -484,11 +503,7 @@ export const createConsentManagerStore = (
 					domain,
 					givenAt,
 					uiSource: input.uiSource ?? 'api',
-					...(input.policyId ? { policyId: input.policyId } : {}),
-					...(input.policyHash ? { policyHash: input.policyHash } : {}),
-					...(input.documentSnapshotToken
-						? { documentSnapshotToken: input.documentSnapshotToken }
-						: {}),
+					...legalDocumentFields,
 					...(input.metadata ? { metadata: input.metadata } : {}),
 					...(input.preferences ? { preferences: input.preferences } : {}),
 					...(externalId ? { externalSubjectId: externalId } : {}),
@@ -502,7 +517,15 @@ export const createConsentManagerStore = (
 				currentState.callbacks.onError?.({
 					error: errorMsg,
 				});
-				throw new Error(errorMsg);
+				const error = new Error(errorMsg) as Error & {
+					code?: string;
+					details?: Record<string, unknown> | null;
+					status?: number;
+				};
+				error.code = response.error?.code;
+				error.details = response.error?.details ?? null;
+				error.status = response.error?.status;
+				throw error;
 			}
 
 			const consent = {

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -13,6 +13,7 @@ import type {
 	PolicyUiActionGroup,
 	PolicyUiProfile,
 	PolicyUiSurfaceConfig,
+	PostSubjectOutput,
 } from '@c15t/schema/types';
 import type { Model } from '~/libs/determine-model';
 import type { StorageConfig } from '../libs/cookie';
@@ -102,6 +103,31 @@ export interface PolicySurfaceState {
 	uiProfile?: PolicyUiProfile;
 	/** Scroll lock hint from backend runtime policy. */
 	scrollLock?: boolean;
+}
+
+/**
+ * Experimental input for policy-based consent writes.
+ *
+ * @experimental
+ */
+export interface UnstablePolicyConsentInput {
+	type:
+		| 'privacy_policy'
+		| 'terms_and_conditions'
+		| 'dpa'
+		| 'marketing_communications'
+		| 'age_verification'
+		| 'other';
+	policyId?: string;
+	policyHash?: string;
+	documentSnapshotToken?: string;
+	domain?: string;
+	givenAt?: number;
+	metadata?: Record<string, unknown>;
+	preferences?: Record<string, boolean>;
+	uiSource?: string;
+	externalId?: string;
+	identityProvider?: string;
 }
 
 /**
@@ -789,6 +815,15 @@ export interface StoreActions {
 	 * @throws {Error} When the underlying identify-user request fails
 	 */
 	identifyUser: (user: User) => Promise<void>;
+
+	/**
+	 * Writes a policy-based consent such as terms and conditions.
+	 *
+	 * @experimental
+	 */
+	unstable_acceptPolicyConsent: (
+		input: UnstablePolicyConsentInput
+	) => Promise<PostSubjectOutput>;
 
 	/**
 	 * Updates the selected consent state for a specific consent type.

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -105,6 +105,10 @@ export interface PolicySurfaceState {
 	scrollLock?: boolean;
 }
 
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Keys extends keyof T
+	? Required<Pick<T, Keys>> & Partial<Omit<T, Keys>>
+	: never;
+
 /**
  * Experimental input for legal-document consent writes.
  *
@@ -116,7 +120,7 @@ export interface PolicySurfaceState {
  *
  * @experimental
  */
-export interface UnstableLegalDocumentConsentInput {
+type UnstableLegalDocumentConsentInputBase = {
 	type: 'privacy_policy' | 'terms_and_conditions' | 'dpa';
 	policyId?: string;
 	policyHash?: string;
@@ -128,7 +132,16 @@ export interface UnstableLegalDocumentConsentInput {
 	uiSource?: string;
 	externalId?: string;
 	identityProvider?: string;
-}
+};
+
+export type UnstableLegalDocumentConsentInput =
+	UnstableLegalDocumentConsentInputBase &
+		RequireAtLeastOne<
+			Pick<
+				UnstableLegalDocumentConsentInputBase,
+				'policyId' | 'policyHash' | 'documentSnapshotToken'
+			>
+		>;
 
 /**
  * Experimental input for non-legal policy consent writes.

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -106,18 +106,18 @@ export interface PolicySurfaceState {
 }
 
 /**
- * Experimental input for policy-based consent writes.
+ * Experimental input for legal-document consent writes.
+ *
+ * @remarks
+ * Preferred identifier flow:
+ * - `documentSnapshotToken` for authoritative, signed release metadata
+ * - `policyHash` when the caller only knows the rendered document hash
+ * - `policyId` only as a compatibility fallback for older backends
  *
  * @experimental
  */
-export interface UnstablePolicyConsentInput {
-	type:
-		| 'privacy_policy'
-		| 'terms_and_conditions'
-		| 'dpa'
-		| 'marketing_communications'
-		| 'age_verification'
-		| 'other';
+export interface UnstableLegalDocumentConsentInput {
+	type: 'privacy_policy' | 'terms_and_conditions' | 'dpa';
 	policyId?: string;
 	policyHash?: string;
 	documentSnapshotToken?: string;
@@ -129,6 +129,31 @@ export interface UnstablePolicyConsentInput {
 	externalId?: string;
 	identityProvider?: string;
 }
+
+/**
+ * Experimental input for non-legal policy consent writes.
+ *
+ * @experimental
+ */
+export interface UnstableGenericPolicyConsentInput {
+	type: 'marketing_communications' | 'age_verification' | 'other';
+	domain?: string;
+	givenAt?: number;
+	metadata?: Record<string, unknown>;
+	preferences?: Record<string, boolean>;
+	uiSource?: string;
+	externalId?: string;
+	identityProvider?: string;
+}
+
+/**
+ * Experimental input for policy-based consent writes.
+ *
+ * @experimental
+ */
+export type UnstablePolicyConsentInput =
+	| UnstableLegalDocumentConsentInput
+	| UnstableGenericPolicyConsentInput;
 
 /**
  * Offline policy preview payload for the headless runtime.

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -66,6 +66,7 @@ export const subjectPolicyBasedInputSchema = v.object({
 	...baseSubjectConsentSchema.entries,
 	type: v.picklist(['privacy_policy', 'dpa', 'terms_and_conditions']),
 	policyId: v.optional(v.string()),
+	policyHash: v.optional(v.string()),
 	preferences: v.optional(v.record(v.string(), v.boolean())),
 });
 

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -61,6 +61,10 @@ export const subjectCookieBannerInputSchema = v.object({
 
 /**
  * Policy-based consent
+ *
+ * For legal documents, callers should prefer `documentSnapshotToken` when
+ * available. `policyHash` is intended as a lighter-weight fallback when the
+ * client knows the rendered release hash but not the internal c15t policy ID.
  */
 export const subjectPolicyBasedInputSchema = v.object({
 	...baseSubjectConsentSchema.entries,


### PR DESCRIPTION
## Overview
Add the 2.0 groundwork for token-first legal-document consent and ship a working `/terms` demo in `examples/demo`.
The branch adds a terms acceptance flow that identifies the user first, records legal-document consent through `useConsentManager()`, prefers signed `documentSnapshotToken` proof, and falls back to `policyHash` when needed.
It also routes the terms demo to the local self-host backend, enables local legal-document snapshot verification for the demo path, fixes strict cookie-banner payload filtering, and documents the future terms-server contract.

## Related Issue
Fixes #743

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [x] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Add a new `/terms` demo page and UI that uses `identifyUser()` plus `unstable_acceptPolicyConsent()` to store append-only terms acceptance against the active legal-document release.
2. Extend core, backend, and schema legal-document consent flows to support `documentSnapshotToken` and `policyHash`, while keeping `policyId` as a compatibility path and surfacing structured write errors.
3. Route `/terms` to the local self-host backend, add shared demo legal-document snapshot signing config plus an unsafe demo-only browser signer, and replace `next-themes` in the demo app with a local theme provider to avoid the client script-tag render error.
4. Add the legal-document snapshot integration guide and a changeset covering the token-first legal-document groundwork.

### Technical Notes
- The demo-only signer is intentionally unsafe and exists only in `examples/demo` to exercise the contract before the real terms server issues tokens.
- The local self-host demo instance now enables `legalDocumentSnapshot` verification with the same static demo signing configuration used by the `/terms` demo.
- Cookie-banner saves now strip disallowed preference keys from outbound payloads so strict purpose policies stop rejecting writes.

## Testing
### Test Plan
- [x] Scenario 1: typecheck the demo and legal-document backend path

  ```ts
  bunx tsc -p examples/demo/tsconfig.json --noEmit
  bunx tsc -p packages/backend/tsconfig.json --noEmit
  ```

  ✓ Expected: the demo terms flow and backend legal-document snapshot configuration typecheck cleanly.

- [x] Scenario 2: typecheck the shared core/schema consent changes

  ```ts
  bunx tsc -p packages/core/tsconfig.json --noEmit
  bunx tsc -p packages/schema/tsconfig.json --noEmit
  ```

  ✓ Expected: token-first legal-document consent inputs and schema updates typecheck cleanly.

### Edge Cases
- [x] Error handling: `unstable_acceptPolicyConsent()` now throws structured errors with `code`, `status`, and `details` from the backend response.
- [ ] Performance: no meaningful performance impact expected beyond the demo-only signer path.
- [x] Security: the browser snapshot signer is demo-only and intentionally unsafe; production flows should use a trusted server-side signer.

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-first consent handling with signed document snapshot tokens and policy hash fallback options for legal document consent flows.
  * Added Terms Demo page demonstrating the new consent acceptance workflow.

* **Documentation**
  * Added comprehensive guide for legal-document snapshot token integration and consent flow architecture.

* **Improvements**
  * Enhanced preference filtering to include only allowed policy categories in consent writes.
  * Replaced theme provider with custom implementation supporting persistent storage and system preference detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->