### PR TITLE
fix: accept inth.app hosted backend URLs in CLI

### DIFF
--- a/.changeset/bright-mice-wait.md
+++ b/.changeset/bright-mice-wait.md
@@ -1,0 +1,7 @@
+---
+'@c15t/cli': patch
+---
+
+Update the CLI hosted-backend URL contract to recognize the new `*.inth.app` project domain alongside legacy `*.c15t.dev` URLs.
+
+- `@c15t/cli`: accept `https://<project>.inth.app` as a valid hosted backend URL, refresh validation and prompt copy to point at the new domain, and update generated hosted config/env/rewrite examples accordingly.

--- a/packages/cli/src/__tests__/constants.test.ts
+++ b/packages/cli/src/__tests__/constants.test.ts
@@ -33,6 +33,12 @@ describe('constants', () => {
 			expect(REGEX.URL.test('not-a-url')).toBe(false);
 		});
 
+		test('C15T_URL regex should match hosted project domains', () => {
+			expect(REGEX.C15T_URL.test('https://project.c15t.dev')).toBe(true);
+			expect(REGEX.C15T_URL.test('https://project.inth.app')).toBe(true);
+			expect(REGEX.C15T_URL.test('https://project.inth.dev')).toBe(false);
+		});
+
 		test('DYNAMIC_SEGMENT regex should match route segments', () => {
 			expect(REGEX.DYNAMIC_SEGMENT.test('[locale]')).toBe(true);
 			expect(REGEX.DYNAMIC_SEGMENT.test('[id]')).toBe(true);

--- a/packages/cli/src/__tests__/utils/validation.test.ts
+++ b/packages/cli/src/__tests__/utils/validation.test.ts
@@ -29,12 +29,15 @@ describe('validation utilities', () => {
 		test('should accept valid c15t URLs', () => {
 			expect(isValidC15tUrl('https://my-app.c15t.dev')).toBe(true);
 			expect(isValidC15tUrl('https://test-project.c15t.dev')).toBe(true);
+			expect(isValidC15tUrl('https://my-app.inth.app')).toBe(true);
+			expect(isValidC15tUrl('https://test-project.inth.app')).toBe(true);
 		});
 
 		test('should reject invalid c15t URLs', () => {
 			expect(isValidC15tUrl('https://example.com')).toBe(false);
 			expect(isValidC15tUrl('http://my-app.c15t.dev')).toBe(false);
 			expect(isValidC15tUrl('https://v2.c15t.com')).toBe(false);
+			expect(isValidC15tUrl('https://my-app.inth.dev')).toBe(false);
 		});
 	});
 

--- a/packages/cli/src/commands/generate/templates/config.ts
+++ b/packages/cli/src/commands/generate/templates/config.ts
@@ -43,7 +43,7 @@ function generateHostedConfig(
 ): string {
 	const url = useEnvFile
 		? 'process.env.NEXT_PUBLIC_C15T_URL'
-		: `'${backendURL || 'https://your-project.c15t.dev'}'`;
+		: `'${backendURL || 'https://your-project.inth.app'}'`;
 	const devToolsImport = enableDevTools
 		? "import { createDevTools } from '@c15t/dev-tools';\n"
 		: '';

--- a/packages/cli/src/commands/generate/templates/env.ts
+++ b/packages/cli/src/commands/generate/templates/env.ts
@@ -33,5 +33,5 @@ export function generateEnvFileContent(
  */
 export function generateEnvExampleContent(pkg: AvailablePackages): string {
 	const envVarName = getEnvVarName(pkg);
-	return `\n# c15t Configuration\n${envVarName}=https://your-project.c15t.dev\n`;
+	return `\n# c15t Configuration\n${envVarName}=https://your-project.inth.app\n`;
 }

--- a/packages/cli/src/commands/generate/templates/next-config.ts
+++ b/packages/cli/src/commands/generate/templates/next-config.ts
@@ -155,7 +155,7 @@ function generateRewriteDestination(
 	}
 
 	return {
-		destination: `${backendURL || 'https://your-project.c15t.dev'}/:path*`,
+		destination: `${backendURL || 'https://your-project.inth.app'}/:path*`,
 		isTemplateLiteral: false,
 	};
 }

--- a/packages/cli/src/commands/generate/templates/next/pages/layout.ts
+++ b/packages/cli/src/commands/generate/templates/next/pages/layout.ts
@@ -137,7 +137,7 @@ function addServerSideDataComment(
 	} else if (useEnvFile) {
 		urlExample = 'process.env.NEXT_PUBLIC_C15T_URL!';
 	} else {
-		urlExample = `'${backendURL || 'https://your-project.c15t.dev'}'`;
+		urlExample = `'${backendURL || 'https://your-project.inth.app'}'`;
 	}
 
 	const serverSideComment = `/**

--- a/packages/cli/src/commands/generate/templates/shared/options.ts
+++ b/packages/cli/src/commands/generate/templates/shared/options.ts
@@ -41,7 +41,7 @@ export function getBackendURLValue(
 		return `process.env.${envVarPrefix}_C15T_URL!`;
 	}
 
-	return `'${backendURL || 'https://your-project.c15t.dev'}'`;
+	return `'${backendURL || 'https://your-project.inth.app'}'`;
 }
 
 /**

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -49,8 +49,8 @@ export const PATHS = {
 export const REGEX = {
 	/** Generic URL pattern */
 	URL: /^https?:\/\/.+/,
-	/** c15t platform URL pattern */
-	C15T_URL: /^https:\/\/[\w-]+\.c15t\.dev$/,
+	/** Hosted c15t platform URL pattern (legacy and current domains) */
+	C15T_URL: /^https:\/\/[\w-]+\.(?:c15t\.dev|inth\.app)$/,
 	/** Dynamic route segment pattern (e.g., [locale]) */
 	DYNAMIC_SEGMENT: /\[[\w-]+\]/,
 	/** Semantic version pattern */

--- a/packages/cli/src/core/errors.ts
+++ b/packages/cli/src/core/errors.ts
@@ -105,7 +105,7 @@ export const ERROR_CATALOG = {
 	URL_INVALID: {
 		code: 'URL_INVALID',
 		message: 'Invalid URL format',
-		hint: 'Expected format: https://your-project.c15t.dev',
+		hint: 'Expected format: https://your-project.inth.app',
 	},
 	INSTANCE_NOT_FOUND: {
 		code: 'INSTANCE_NOT_FOUND',

--- a/packages/cli/src/machines/generate/actors/prompts.ts
+++ b/packages/cli/src/machines/generate/actors/prompts.ts
@@ -468,7 +468,7 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 			);
 			const url = await promptBackendURL({
 				message: 'Enter your consent.io project URL:',
-				placeholder: 'https://your-project.c15t.dev',
+				placeholder: 'https://your-project.inth.app',
 				initialURL,
 				stage: 'consent_manual_url',
 			});
@@ -499,7 +499,7 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 		if (setupMethod === 'manual-url') {
 			const url = await promptBackendURL({
 				message: 'Enter your consent.io project URL:',
-				placeholder: 'https://your-project.c15t.dev',
+				placeholder: 'https://your-project.inth.app',
 				initialURL,
 				stage: 'consent_manual_url',
 			});

--- a/packages/cli/src/utils/validation.ts
+++ b/packages/cli/src/utils/validation.ts
@@ -120,7 +120,7 @@ export const validateUrl = createValidator(
  */
 export const validateC15tUrl = createValidator(
 	isValidC15tUrl,
-	'Please enter a valid c15t URL (e.g., https://my-app.c15t.dev)'
+	'Please enter a valid hosted URL (e.g., https://my-app.inth.app)'
 );
 
 /**


### PR DESCRIPTION
## Overview
The CLI still treated hosted backend URLs as `*.c15t.dev` only, even though new hosted projects are issued under `*.inth.app`.
This updates the hosted URL matcher to accept both domains, refreshes prompt and validation copy to point users at the current hosted domain, and updates generated hosted config, env, rewrite, and server-side examples accordingly.
Keeping legacy `*.c15t.dev` support avoids regressions while making current hosted projects work out of the box.

## Related Issue
Fixes #745

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Expanded the CLI hosted-backend URL regex and validation coverage to accept `https://<project>.inth.app` while preserving legacy `https://<project>.c15t.dev` support.
2. Updated hosted-mode prompt text, error messaging, and generated template defaults so newly scaffolded examples point at the current hosted domain.

### Technical Notes
The acceptance logic remains intentionally narrow to the two hosted project domains rather than allowing arbitrary hosts in the shared hosted URL validator.

## Testing
### Test Plan
- [x] Scenario 1: Hosted URL validation accepts the new domain and preserves the legacy domain

  ```ts
  bun test packages/cli/src/__tests__/utils/validation.test.ts packages/cli/src/__tests__/constants.test.ts
  ```

  ✓ Expected: `isValidC15tUrl` and `REGEX.C15T_URL` accept `*.inth.app` and `*.c15t.dev`, and reject unrelated domains.

- [x] Scenario 2: Generated hosted examples use the current domain

  ```ts
  git diff origin/2.0.0...HEAD
  ```
  
  ✓ Expected: hosted template defaults, env examples, rewrite destinations, and prompt copy reference `https://your-project.inth.app`.

### Edge Cases
- [x] Error handling: Invalid or unrelated hosted URLs still fail validation and continue to surface a clear hosted URL example.
- [x] Performance: No runtime performance impact beyond a trivial regex update.
- [x] Security: Validation remains scoped to the known hosted domains instead of broadening to arbitrary external URLs.

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)