### PR TITLE
Rename CLI consent.io refs to inth.com

### DIFF
--- a/packages/cli/src/auth/base-url.ts
+++ b/packages/cli/src/auth/base-url.ts
@@ -3,7 +3,7 @@ import { URLS } from '../constants';
 /**
  * Resolve the control-plane base URL for auth + hosted project management.
  *
- * Default: consent.io
+ * Default: inth.com
  * Override: CONSENT_URL
  */
 export function getControlPlaneBaseUrl(): string {

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -200,9 +200,9 @@ async function statusAction(context: CliContext): Promise<void> {
 export const loginCommand: CliCommand = {
 	name: 'login',
 	label: 'Login',
-	hint: 'Authenticate with consent.io',
+	hint: 'Authenticate with inth.com',
 	description:
-		'Log in to your consent.io account using device flow authentication',
+		'Log in to your inth.com account using device flow authentication',
 	action: loginAction,
 };
 
@@ -212,8 +212,8 @@ export const loginCommand: CliCommand = {
 export const logoutCommand: CliCommand = {
 	name: 'logout',
 	label: 'Logout',
-	hint: 'Sign out of consent.io',
-	description: 'Log out of your consent.io account',
+	hint: 'Sign out of inth.com',
+	description: 'Log out of your inth.com account',
 	action: logoutAction,
 };
 

--- a/packages/cli/src/commands/generate/prompts/mode-select.ts
+++ b/packages/cli/src/commands/generate/prompts/mode-select.ts
@@ -14,7 +14,7 @@ export const MODE_OPTIONS = [
 	{
 		value: STORAGE_MODES.HOSTED,
 		label: 'Cloud Hosted',
-		hint: 'Managed by consent.io (Recommended)',
+		hint: 'Managed by inth.com (Recommended)',
 		description:
 			'Store consent data securely in the cloud with zero infrastructure',
 	},

--- a/packages/cli/src/commands/generate/templates/config.ts
+++ b/packages/cli/src/commands/generate/templates/config.ts
@@ -34,7 +34,7 @@ export function generateClientConfigContent(
 }
 
 /**
- * Hosted mode config (consent.io or self-hosted backend)
+ * Hosted mode config (inth.com or self-hosted backend)
  */
 function generateHostedConfig(
 	backendURL?: string,

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -8,7 +8,7 @@
 // --- URLs ---
 export const URLS = {
 	/** Default c15t cloud platform URL */
-	CONSENT_IO: 'https://consent.io',
+	CONSENT_IO: 'https://inth.com',
 	/** First-party telemetry logs endpoint */
 	TELEMETRY: 'https://telemetry.c15t.com/c15t/v1/logs',
 	/** Documentation website */

--- a/packages/cli/src/core/errors.ts
+++ b/packages/cli/src/core/errors.ts
@@ -92,7 +92,7 @@ export const ERROR_CATALOG = {
 	},
 	CONTROL_PLANE_CONNECTION_FAILED: {
 		code: 'CONTROL_PLANE_CONNECTION_FAILED',
-		message: 'Could not connect to consent.io',
+		message: 'Could not connect to inth.com',
 		hint: `Check if ${URLS.CONSENT_IO} is accessible`,
 	},
 	API_ERROR: {

--- a/packages/cli/src/machines/generate/actors/prompts.ts
+++ b/packages/cli/src/machines/generate/actors/prompts.ts
@@ -93,7 +93,7 @@ export const modeSelectionActor = fromPromise<
 			{
 				value: 'hosted',
 				label: 'Hosted',
-				hint: 'consent.io or self-hosted backend URL',
+				hint: 'inth.com or self-hosted backend URL',
 			},
 			{
 				value: 'offline',
@@ -117,7 +117,7 @@ export const modeSelectionActor = fromPromise<
 
 // --- Hosted Mode Prompt ---
 
-type HostedProvider = 'consent.io' | 'self-hosted';
+type HostedProvider = 'inth.com' | 'self-hosted';
 type ConsentSetupMethod = 'sign-in' | 'manual-url';
 
 export interface HostedModeInput {
@@ -363,7 +363,7 @@ async function selectOrCreateInstance(
 	cliContext: CliContext
 ): Promise<Instance> {
 	const baseUrl = getControlPlaneBaseUrl();
-	const listSpinner = createTaskSpinner('Fetching your consent.io projects...');
+	const listSpinner = createTaskSpinner('Fetching your inth.com projects...');
 	listSpinner.start();
 
 	const client = await createControlPlaneClientFromConfig(baseUrl);
@@ -394,7 +394,7 @@ async function selectOrCreateInstance(
 				{
 					value: '__create__',
 					label: 'Create new project',
-					hint: 'Provision a new consent.io project now',
+					hint: 'Provision a new inth.com project now',
 				},
 			],
 		});
@@ -431,8 +431,8 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 				message: 'Choose your hosted backend option:',
 				options: [
 					{
-						value: 'consent.io',
-						label: 'consent.io (Recommended)',
+						value: 'inth.com',
+						label: 'inth.com (Recommended)',
 						hint: 'Managed infrastucture',
 					},
 					{
@@ -441,7 +441,7 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 						hint: 'Use your own deployed c15t backend',
 					},
 				],
-				initialValue: 'consent.io',
+				initialValue: 'inth.com',
 			});
 
 			if (isCancel(providerSelection)) {
@@ -463,20 +463,17 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 		}
 
 		if (!isV2ModeEnabled()) {
-			cliContext.logger.info(
-				'consent.io sign-in is currently disabled. Set V2=1 to enable sign-in and project selection.'
-			);
 			const url = await promptBackendURL({
-				message: 'Enter your consent.io project URL:',
+				message: 'Enter your inth.com project URL:',
 				placeholder: 'https://your-project.inth.app',
 				initialURL,
 				stage: 'consent_manual_url',
 			});
-			return { url, provider: 'consent.io' };
+			return { url, provider: 'inth.com' };
 		}
 
 		const setupMethod = await p.select<ConsentSetupMethod | symbol>({
-			message: 'How do you want to configure consent.io?',
+			message: 'How do you want to configure inth.com?',
 			options: [
 				{
 					value: 'sign-in',
@@ -498,12 +495,12 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 
 		if (setupMethod === 'manual-url') {
 			const url = await promptBackendURL({
-				message: 'Enter your consent.io project URL:',
+				message: 'Enter your inth.com project URL:',
 				placeholder: 'https://your-project.inth.app',
 				initialURL,
 				stage: 'consent_manual_url',
 			});
-			return { url, provider: 'consent.io' };
+			return { url, provider: 'inth.com' };
 		}
 
 		await runConsentLogin(cliContext);
@@ -516,7 +513,7 @@ export const hostedModeActor = fromPromise<HostedModeOutput, HostedModeInput>(
 
 		return {
 			url: instance.url,
-			provider: 'consent.io',
+			provider: 'inth.com',
 		};
 	}
 );

--- a/packages/cli/src/machines/generate/machine.ts
+++ b/packages/cli/src/machines/generate/machine.ts
@@ -54,7 +54,7 @@ function getHostedProviderFromMode(
 		return 'self-hosted';
 	}
 	if (mode === 'c15t') {
-		return 'consent.io';
+		return 'inth.com';
 	}
 
 	return null;

--- a/packages/cli/src/machines/generate/types.ts
+++ b/packages/cli/src/machines/generate/types.ts
@@ -60,10 +60,10 @@ export interface GenerateMachineContext extends BaseMachineContext {
 	/** Mode passed as CLI argument */
 	modeArg: StorageMode | null;
 	/** Hosted provider selection when mode is hosted */
-	hostedProvider: 'consent.io' | 'self-hosted' | null;
+	hostedProvider: 'inth.com' | 'self-hosted' | null;
 
 	// --- Backend Options ---
-	/** Backend URL for hosted mode (consent.io or self-hosted provider) */
+	/** Backend URL for hosted mode (inth.com or self-hosted provider) */
 	backendURL: string | null;
 	/** Whether to store backend URL in .env file */
 	useEnvFile: boolean;


### PR DESCRIPTION
## Overview
Refresh CLI branding so hosted/auth flows reference `inth.com` instead of `consent.io`, and remove the outdated disabled sign-in log from the generate flow.
This keeps auth help text, hosted prompts, default control-plane URLs, and hosted-provider labels aligned across the CLI.

## Related Issue
Fixes #748

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Replaced CLI-facing `consent.io` auth, hosted-project, and connection copy with `inth.com`.
2. Updated the CLI's default control-plane URL and hosted-provider identifiers to match the new branding.
3. Removed the `consent.io sign-in is currently disabled` log from the hosted generate flow.

### Technical Notes
The PR diff is limited to `packages/cli/src` and does not change runtime behavior outside CLI branding and prompt text.

## Testing
### Test Plan
- [ ] Scenario 1: Check login/logout help text

  ```sh
  bun run --cwd packages/cli start --help
  ```

  ✓ Expected: auth command descriptions reference `inth.com`

- [ ] Scenario 2: Review hosted generate prompts

  ```sh
  bun run --cwd packages/cli start generate
  ```
  
  ✓ Expected: hosted-mode prompts and project URL labels reference `inth.com`, with no disabled `consent.io` sign-in log

### Edge Cases
- [x] Error handling: connection error copy now points at `https://inth.com`
- [ ] Performance: no performance impact
- [ ] Security: no security-sensitive logic changed

## Checklist
### Required
- [x] Issue is linked
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
