### PR TITLE
docs: remove @c15t/cli rc tag from examples

### DIFF
--- a/docs/ai-agents.mdx
+++ b/docs/ai-agents.mdx
@@ -59,7 +59,7 @@ c15t publishes agent skills that give AI coding assistants deep knowledge of c15
 
 Via the c15t CLI:
 
-<PackageCommandTabs command="@c15t/cli@rc install-skills" />
+<PackageCommandTabs command="@c15t/cli install-skills" />
 
 Or directly:
 

--- a/docs/frameworks/javascript/quickstart.mdx
+++ b/docs/frameworks/javascript/quickstart.mdx
@@ -123,7 +123,7 @@ console.log('Location:', state?.locationInfo);
 
 Install c15t agent skills to let AI agents help with styling, i18n, scripts & other configuration.
 
-<PackageCommandTabs command="@c15t/cli@rc skills" />
+<PackageCommandTabs command="@c15t/cli skills" />
 
 See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -16,7 +16,7 @@ availableIn:
 
 ## Via CLI
 
-<PackageCommandTabs command="@c15t/cli@rc" />
+<PackageCommandTabs command="@c15t/cli" />
 
 ## Manual Installation
 
@@ -159,7 +159,7 @@ import { DevTools } from '@c15t/dev-tools/react';
 
 Install c15t agent skills to let AI agents help with styling, i18n, scripts & other configuration.
 
-<PackageCommandTabs command="@c15t/cli@rc skills" />
+<PackageCommandTabs command="@c15t/cli skills" />
 
 See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -16,7 +16,7 @@ availableIn:
 
 ## Via CLI
 
-<PackageCommandTabs command="@c15t/cli@rc" />
+<PackageCommandTabs command="@c15t/cli" />
 
 ## Manual Installation
 
@@ -153,7 +153,7 @@ import { DevTools } from '@c15t/dev-tools/react';
 
 Install c15t agent skills to let AI agents help with styling, i18n, scripts & other configuration.
 
-<PackageCommandTabs command="@c15t/cli@rc skills" />
+<PackageCommandTabs command="@c15t/cli skills" />
 
 See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 

--- a/docs/self-host/guides/database-setup.mdx
+++ b/docs/self-host/guides/database-setup.mdx
@@ -94,7 +94,7 @@ export const c15t = c15tInstance({
 
 To create & update the database you can use the migrator which is included in the CLI:
 
-<PackageCommandTabs command="@c15t/cli@rc" />
+<PackageCommandTabs command="@c15t/cli" />
 
 ## Table Prefix
 

--- a/docs/self-host/quickstart.mdx
+++ b/docs/self-host/quickstart.mdx
@@ -80,7 +80,7 @@ If you want a fully managed experience we recommend using [inth.com](https://int
 
     The easiest way to migrate your database is via the c15t cli:
 
-    <PackageCommandTabs mode="run" command="@c15t/cli@rc" />
+    <PackageCommandTabs mode="run" command="@c15t/cli" />
 
     See [Database Setup](/docs/self-host/guides/database-setup) for adapter-specific migration guides. If you plan to use policy packs with runtime audit storage, also apply the runtime policy decision migration from the [Policy Packs guide](/docs/self-host/guides/policy-packs).
   </Step>
@@ -129,7 +129,7 @@ If you want a fully managed experience we recommend using [inth.com](https://int
 
 Install c15t agent skills to let AI agents help with styling, i18n, scripts & other configuration.
 
-<PackageCommandTabs command="@c15t/cli@rc skills" />
+<PackageCommandTabs command="@c15t/cli skills" />
 
 See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 

--- a/scripts/agent-docs/convert.test.ts
+++ b/scripts/agent-docs/convert.test.ts
@@ -57,7 +57,7 @@ describe('convertMdxFile', () => {
 		);
 		const { markdown } = await convertMdxFile(filePath, remarkPlugins);
 
-		expect(markdown).toContain('|npm|`npx @c15t/cli@rc`|');
+		expect(markdown).toContain('|npm|`npx @c15t/cli`|');
 		expect(markdown).toContain('1. **Install package**');
 		expect(markdown).toContain('> ℹ️ Info:');
 		expect(markdown).not.toContain('<PackageCommandTabs');


### PR DESCRIPTION
## Overview

This updates the documentation to use the stable `@c15t/cli` package name instead of `@c15t/cli@rc` in quickstart, self-hosting, and AI agent command examples. It also updates the agent docs conversion test so the generated npm command assertion matches the new docs output. This keeps the published setup instructions consistent and avoids directing users to a release-candidate tag.

## Related Issue

Fixes #750

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Replaced `@c15t/cli@rc` with `@c15t/cli` in the affected docs command snippets.
2. Updated the agent docs conversion test expectation to assert the stable npm command output.

### Technical Notes

The change is string-only and limited to command examples plus the matching test fixture expectation.

## Testing

### Test Plan

- [x] Scenario 1: Verify documentation snippets use the stable CLI package

  ```sh
  rg -n --fixed-strings '@c15t/cli@rc'
  ```

  ✓ Expected: No matches remain in the repository

- [x] Scenario 2: Verify committed diff is limited to the intended docs cleanup

  ```sh
  git diff origin/2.0.0...
  ```

  ✓ Expected: Only the updated docs references and the related test assertion appear

### Edge Cases

- [x] Error handling: No runtime behavior changes; only command text and a test expectation changed
- [x] Performance: No performance impact
- [x] Security: No security impact

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
