### PR TITLE
fix: align consent switch sizing and Storybook loading

### DIFF
--- a/.changeset/bright-emus-build.md
+++ b/.changeset/bright-emus-build.md
@@ -1,0 +1,11 @@
+---
+'@c15t/ui': patch
+'@c15t/react': patch
+'@c15t/nextjs': patch
+---
+
+Fix consent switch sizing so it renders consistently in Tailwind and non-Tailwind apps.
+
+- `@c15t/ui`: make the shared switch primitive use an explicit `border-box` layout, size its track independently of host box-model resets, and clip the track so the thumb ring does not bleed past the edge.
+- `@c15t/react`: publish the updated prebuilt consent UI styling so React consumers pick up the normalized switch sizing.
+- `@c15t/nextjs`: publish the updated stylesheet bridge so Next.js installs pick up the normalized switch sizing as well.

--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -4,8 +4,9 @@ import type { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
 
 const storybookDir = path.dirname(fileURLToPath(import.meta.url));
-const ui = (...segments: string[]) =>
-	path.resolve(storybookDir, '../../../packages/ui/src', ...segments);
+const workspace = (...segments: string[]) =>
+	path.resolve(storybookDir, '../../..', ...segments);
+const ui = (...segments: string[]) => workspace('packages/ui/src', ...segments);
 
 const config: StorybookConfig = {
 	addons: ['@storybook/addon-a11y'],
@@ -37,24 +38,37 @@ const config: StorybookConfig = {
 					},
 					{
 						find: '@c15t/react/primitives',
-						replacement: path.resolve(
-							storybookDir,
-							'../../../packages/react/src/primitives.ts'
-						),
+						replacement: workspace('packages/react/src/primitives.ts'),
 					},
 					{
 						find: /^@c15t\/react$/,
-						replacement: path.resolve(
-							storybookDir,
-							'../../../packages/react/src/index.ts'
+						replacement: workspace('packages/react/src/index.ts'),
+					},
+					{
+						find: /^@c15t\/iab$/,
+						replacement: workspace('packages/iab/src/index.ts'),
+					},
+					{
+						find: /^@c15t\/schema\/types$/,
+						replacement: workspace('packages/schema/src/types.ts'),
+					},
+					{
+						find: /^@c15t\/schema$/,
+						replacement: workspace('packages/schema/src/index.ts'),
+					},
+					{
+						find: /^c15t$/,
+						replacement: workspace('packages/core/src/index.ts'),
+					},
+					{
+						find: /^@iabtechlabtcf\/core$/,
+						replacement: workspace(
+							'packages/iab/node_modules/@iabtechlabtcf/core'
 						),
 					},
 					{
 						find: /^~\/(.*)$/,
-						replacement: path.resolve(
-							storybookDir,
-							'../../../packages/react/src/$1'
-						),
+						replacement: workspace('packages/react/src/$1'),
 					},
 					// @c15t/ui — resolve all subpath imports to source
 					{
@@ -90,22 +104,20 @@ const config: StorybookConfig = {
 						replacement: ui('theme', 'index.ts'),
 					},
 					{
+						find: /^@c15t\/ui\/utils$/,
+						replacement: ui('utils', 'index.ts'),
+					},
+					{
 						find: /^@c15t\/ui\/utils\/(.+)$/,
 						replacement: ui('utils', '$1.ts'),
 					},
 					{
 						find: '@c15t/translations/all',
-						replacement: path.resolve(
-							storybookDir,
-							'../../../packages/translations/src/all.ts'
-						),
+						replacement: workspace('packages/translations/src/all.ts'),
 					},
 					{
 						find: /^@c15t\/translations$/,
-						replacement: path.resolve(
-							storybookDir,
-							'../../../packages/translations/src/index.ts'
-						),
+						replacement: workspace('packages/translations/src/index.ts'),
 					},
 				],
 			},

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -3,7 +3,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"storybook": "portless run --name storybook-react sh -c 'storybook dev --port \"$PORT\" --host \"$HOST\"'",
+		"prestorybook": "bun --cwd ../../packages/core prebuild && bun --cwd ../../packages/react prebuild && bun --cwd ../../packages/iab prebuild",
+		"storybook": "bun run prestorybook && portless run --name storybook-react sh -c 'storybook dev --port \"$PORT\" --host \"$HOST\"'",
 		"build": "storybook build",
 		"test-storybook": "test-storybook --url ${STORYBOOK_URL:-http://127.0.0.1:6006}"
 	},

--- a/packages/ui/src/styles/primitives/__tests__/switch-theme-contract.test.ts
+++ b/packages/ui/src/styles/primitives/__tests__/switch-theme-contract.test.ts
@@ -16,6 +16,8 @@ const switchCss = readFileSync(
 describe('switch theme contract', () => {
 	test('defines internal switch variables on the root element', () => {
 		expect(switchCss).toContain('.root {');
+		expect(switchCss).toContain('box-sizing: border-box;');
+		expect(switchCss).toContain('padding: 0;');
 		expect(switchCss).toContain(
 			'--switch-background-color: var(--c15t-switch-track);'
 		);
@@ -27,6 +29,9 @@ describe('switch theme contract', () => {
 
 	test('uses the token-backed variables for checked and unchecked track states', () => {
 		expect(switchCss).toContain('.track {');
+		expect(switchCss).toContain('height: 100%;');
+		expect(switchCss).toContain('width: 100%;');
+		expect(switchCss).toContain('overflow: hidden;');
 		expect(switchCss).toContain(
 			'background-color: var(--switch-background-color);'
 		);

--- a/packages/ui/src/styles/primitives/switch.module.css
+++ b/packages/ui/src/styles/primitives/switch.module.css
@@ -44,7 +44,8 @@
 		height: var(--switch-height);
 		width: var(--switch-width);
 		flex-shrink: 0;
-		padding: var(--switch-padding);
+		box-sizing: border-box;
+		padding: 0;
 		outline: none;
 		font-family: inherit;
 		font-size: 100%;
@@ -62,8 +63,10 @@
 		display: flex;
 		align-items: center;
 		position: relative;
-		height: calc(var(--switch-height) - 2 * var(--switch-padding));
-		width: calc(var(--switch-width) - 2 * var(--switch-padding));
+		box-sizing: border-box;
+		overflow: hidden;
+		height: 100%;
+		width: 100%;
 		border-radius: 9999px;
 		padding: var(--switch-padding);
 		background-color: var(--switch-background-color);
@@ -153,6 +156,7 @@
 	.thumb {
 		position: relative;
 		display: block;
+		box-sizing: border-box;
 		pointer-events: none;
 		width: var(--switch-thumb-size);
 		height: var(--switch-thumb-size);
@@ -164,6 +168,7 @@
 	.thumb::before {
 		content: "";
 		position: absolute;
+		box-sizing: border-box;
 		inset-block: 0;
 		left: 0;
 		width: 100%;
@@ -185,6 +190,7 @@
 	.thumb::after {
 		content: "";
 		position: absolute;
+		box-sizing: border-box;
 		inset-block: 0;
 		left: 0;
 		width: 100%;
@@ -232,8 +238,8 @@
 	}
 
 	.track-small {
-		width: calc(var(--switch-width) - 2 * var(--switch-padding));
-		height: calc(var(--switch-height) - 2 * var(--switch-padding));
+		width: 100%;
+		height: 100%;
 	}
 
 	.thumb-small {


### PR DESCRIPTION
## Overview
- Fixes React consent Storybook source-loading failures by completing the Vite source alias graph and generating required version files before startup.
- Fixes consent switch sizing drift in Tailwind environments by making the primitive's box model explicit and clipping the track.
- Keeps Storybook and app renders aligned instead of relying on host CSS defaults.

## Related Issue
Fixes #752

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Added missing `c15t`, `@c15t/schema`, `@c15t/iab`, `@iabtechlabtcf/core`, and root `@c15t/ui/utils` source aliases in React Storybook.
2. Added a `prestorybook` step to generate ignored `src/version.ts` files before Storybook starts.
3. Updated the switch primitive to use an explicit `border-box` layout and `overflow: hidden` so Tailwind preflight no longer shrinks the track or lets the thumb ring bleed.
4. Extended the switch CSS contract test to lock in the box-model assumptions.

### Technical Notes
- Repro before fix: `consent-cats.storybook-react.localhost` failed to load consent stories from source, and `consent-cats.pigeon-post.localhost` rendered a smaller switch track than Storybook.
- Measured mismatch before the switch fix: demo app track `24x12`, Storybook track `28x16` for the same primitive.

## Testing
### Test Plan
- [x] Scenario 1: React Storybook consent banner/dialog source loading

  ```ts
  // Verified in a fresh Storybook instance
  http://127.0.0.1:6006/iframe.html?id=components-core-consent-banner--default&viewMode=story
  ```

  ✓ Expected: consent stories load without dynamic import failures

- [x] Scenario 2: Switch CSS contract

  ```ts
  bunx vitest run packages/ui/src/styles/primitives/__tests__/switch-theme-contract.test.ts
  ```

  ✓ Expected: switch layout and token contract assertions pass

### Edge Cases
- [x] Error handling: Storybook now resolves the full source import graph instead of failing with 404 module loads.
- [ ] Performance: No meaningful runtime impact beyond a small prestorybook generation step.
- [x] Security: No security-sensitive behavior changed.

### Visual Changes
| Before | After |
|--------|-------|
| Tailwind app switch track rendered thinner than Storybook and the thumb ring could bleed at the edge. | Switch sizing is normalized across Tailwind and non-Tailwind renders, with the track clipping the thumb ring correctly. |

## Checklist
### Required
- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
