### PR TITLE
fix: TanStack devtools integration and repro demo

### DIFF
--- a/.changeset/green-hounds-beg.md
+++ b/.changeset/green-hounds-beg.md
@@ -1,0 +1,17 @@
+---
+'@c15t/dev-tools': patch
+---
+
+Improve the TanStack Devtools integration so c15t behaves like a first-class
+TanStack plugin.
+
+- Add the `c15tDevtools()` plugin factory and keep `c15tDevtoolsPlugin` as a
+  backward-compatible alias.
+- Render the embedded c15t panel through TanStack's React plugin API instead of
+  a custom imperative mount pattern.
+- Keep the embedded panel instance alive across TanStack tab switches so the
+  c15t store connection does not drop when the plugin view remounts.
+- Restyle the embedded c15t panel to better match TanStack Devtools' dark
+  palette and use a flat tab-button row instead of the overflow dropdown.
+- Add a demo page that mounts TanStack Query and c15t side-by-side for repro and
+  regression testing.

--- a/bun.lock
+++ b/bun.lock
@@ -410,6 +410,9 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "@tanstack/react-devtools": "0.6.4",
+        "@tanstack/react-query": "5.87.1",
+        "@tanstack/react-query-devtools": "5.87.1",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -436,6 +439,7 @@
     },
     "internals/storybook-tests": {
       "name": "@c15t/storybook-tests",
+      "version": "0.0.1",
       "dependencies": {
         "storybook": "10.3.1",
       },
@@ -446,7 +450,7 @@
     },
     "internals/typescript-config": {
       "name": "@c15t/typescript-config",
-      "version": "0.0.1-beta.1",
+      "version": "0.0.1",
     },
     "internals/vitest-config": {
       "name": "@c15t/vitest-config",
@@ -459,7 +463,7 @@
     },
     "packages/backend": {
       "name": "@c15t/backend",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/logger": "workspace:*",
         "@c15t/schema": "workspace:*",
@@ -493,7 +497,7 @@
     },
     "packages/cli": {
       "name": "@c15t/cli",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "bin": {
         "cli": "dist/index.mjs",
       },
@@ -532,7 +536,7 @@
     },
     "packages/core": {
       "name": "c15t",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/schema": "workspace:*",
         "@c15t/translations": "workspace:*",
@@ -547,7 +551,7 @@
     },
     "packages/dev-tools": {
       "name": "@c15t/dev-tools",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -577,7 +581,7 @@
     },
     "packages/iab": {
       "name": "@c15t/iab",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/schema": "workspace:*",
         "@iabtechlabtcf/core": "^1.5.21",
@@ -591,7 +595,7 @@
     },
     "packages/logger": {
       "name": "@c15t/logger",
-      "version": "1.0.2-rc.1",
+      "version": "2.0.0",
       "dependencies": {
         "chalk": "^5.6.2",
         "neverthrow": "^8.2.0",
@@ -604,7 +608,7 @@
     },
     "packages/nextjs": {
       "name": "@c15t/nextjs",
-      "version": "2.0.0-rc.9",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/react": "workspace:*",
         "@c15t/translations": "workspace:*",
@@ -624,7 +628,7 @@
     },
     "packages/node-sdk": {
       "name": "@c15t/node-sdk",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/backend": "workspace:*",
         "@orpc/client": "1.13.13",
@@ -648,7 +652,7 @@
     },
     "packages/react": {
       "name": "@c15t/react",
-      "version": "2.0.0-rc.9",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/ui": "workspace:*",
         "c15t": "workspace:*",
@@ -669,7 +673,7 @@
     },
     "packages/schema": {
       "name": "@c15t/schema",
-      "version": "2.0.0-rc.5",
+      "version": "2.0.0",
       "dependencies": {
         "valibot": "1.3.1",
       },
@@ -680,7 +684,7 @@
     },
     "packages/scripts": {
       "name": "@c15t/scripts",
-      "version": "1.1.0-rc.1",
+      "version": "2.0.0",
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
@@ -713,7 +717,7 @@
     },
     "packages/translations": {
       "name": "@c15t/translations",
-      "version": "2.0.0-rc.8",
+      "version": "2.0.0",
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
@@ -722,7 +726,7 @@
     },
     "packages/ui": {
       "name": "@c15t/ui",
-      "version": "2.0.0-rc.9",
+      "version": "2.0.0",
       "dependencies": {
         "@c15t/translations": "workspace:*",
         "c15t": "workspace:*",
@@ -1961,6 +1965,14 @@
 
     "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
 
+    "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.5", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA=="],
+
+    "@solid-primitives/keyboard": ["@solid-primitives/keyboard@1.3.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.5", "@solid-primitives/rootless": "^1.5.3", "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ=="],
+
+    "@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA=="],
+
+    "@solid-primitives/utils": ["@solid-primitives/utils@6.4.0", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A=="],
+
     "@sqltools/formatter": ["@sqltools/formatter@1.2.5", "", {}, "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="],
 
     "@standard-community/standard-json": ["@standard-community/standard-json@0.3.5", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "@types/json-schema": "^7.0.15", "@valibot/to-json-schema": "^1.3.0", "arktype": "^2.1.20", "effect": "^3.16.8", "quansync": "^0.2.11", "sury": "^10.0.0", "typebox": "^1.0.17", "valibot": "^1.1.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "typebox", "valibot", "zod", "zod-to-json-schema"] }, "sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA=="],
@@ -2068,6 +2080,22 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
+
+    "@tanstack/devtools": ["@tanstack/devtools@0.6.8", "", { "dependencies": { "@solid-primitives/keyboard": "^1.2.8", "@tanstack/devtools-event-bus": "0.3.2", "@tanstack/devtools-ui": "0.3.4", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.7" } }, "sha512-/S57+aQCBOzqMZ3tZlK50527TzMIAcy90GgIEt+R1EUKHkF9J1txTnI+Nh583CvRSG4JLI8S/zI5FWNAzHT0kg=="],
+
+    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.3.2", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-yJT2As/drc+Epu0nsqCsJaKaLcaNGufiNxSlp/+/oeTD0jsBxF9/PJBfh66XVpYXkKr97b8689mSu7QMef0Rrw=="],
+
+    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.3.4", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.7" } }, "sha512-W3FnFhot91c30I/DyZUKSCd5gan5FRe35EvxUrZTxMN3qQ4kOtZSmYi8N8cAP4rmAp54ivv6pvT3LXlpjEeE0w=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.87.1", "", {}, "sha512-HOFHVvhOCprrWvtccSzc7+RNqpnLlZ5R6lTmngb8aq7b4rc2/jDT0w+vLdQ4lD9bNtQ+/A4GsFXy030Gk4ollA=="],
+
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.86.0", "", {}, "sha512-/JDw9BP80eambEK/EsDMGAcsL2VFT+8F5KCOwierjPU7QP8Wt1GT32yJpn3qOinBM8/zS3Jy36+F0GiyJp411A=="],
+
+    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.6.4", "", { "dependencies": { "@tanstack/devtools": "0.6.8" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-cBRTi4whO9iVSsSYKdQjA00Hr0bu3OPbLBqLmgg3J/E3+PTLAqW8PMKSggfSkGDQu6tct7OBDSWw4NWW/oSbJg=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.87.1", "", { "dependencies": { "@tanstack/query-core": "5.87.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-YKauf8jfMowgAqcxj96AHs+Ux3m3bWT1oSVKamaRPXSnW2HqSznnTCEkAVqctF1e/W9R/mPcyzzINIgpOH94qg=="],
+
+    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.87.1", "", { "dependencies": { "@tanstack/query-devtools": "5.86.0" }, "peerDependencies": { "@tanstack/react-query": "^5.87.1", "react": "^18 || ^19" } }, "sha512-YPuEub8RQrrsXOxoiMJn33VcGPIeuVINWBgLu9RLSQB8ueXaKlGLZ3NJkahGpbt2AbWf749FQ6R+1jBFk3kdCA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -3020,6 +3048,8 @@
     "global-prefix": ["global-prefix@0.1.5", "", { "dependencies": { "homedir-polyfill": "^1.0.0", "ini": "^1.3.4", "is-windows": "^0.2.0", "which": "^1.2.12" } }, "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 

--- a/docs/shared/react/components/dev-tools.mdx
+++ b/docs/shared/react/components/dev-tools.mdx
@@ -38,6 +38,39 @@
   | **IAB** | IAB TCF state (when enabled) - TC string, vendor consents, purposes |
   | **Events** | Timeline of consent events and state changes |
   | **Actions** | Buttons to trigger consent actions (accept all, reject all, reset) |
+
+  ## TanStack Devtools
+
+  `@c15t/dev-tools/tanstack` exposes a panel component and plugin factory that match TanStack Devtools' plugin API, so c15t can sit beside Query and Router without a custom mount adapter:
+
+  ```tsx
+  import * as React from 'react';
+  import { useRouter } from '@tanstack/react-router';
+  import { TanStackDevtools } from '@tanstack/react-devtools';
+  import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools';
+  import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
+  import { c15tDevtools } from '@c15t/dev-tools/tanstack';
+
+  export function AppDevtools() {
+    const router = useRouter();
+
+    return (
+      <TanStackDevtools
+        plugins={[
+          {
+            name: 'TanStack Query',
+            render: <ReactQueryDevtoolsPanel />,
+          },
+          {
+            name: 'TanStack Router',
+            render: <TanStackRouterDevtoolsPanel router={router} />,
+          },
+          c15tDevtools(),
+        ]}
+      />
+    );
+  }
+  ```
 </section>
 
 <section id="props">

--- a/examples/demo/app/(main)/tanstack-devtools/page.tsx
+++ b/examples/demo/app/(main)/tanstack-devtools/page.tsx
@@ -1,0 +1,5 @@
+import { TanStackDevtoolsDemo } from '../../../components/tanstack-devtools-demo';
+
+export default function TanStackDevtoolsPage() {
+	return <TanStackDevtoolsDemo />;
+}

--- a/examples/demo/components/header.tsx
+++ b/examples/demo/components/header.tsx
@@ -62,6 +62,12 @@ export function Header() {
 						>
 							Terms Demo
 						</a>
+						<a
+							href="/tanstack-devtools"
+							className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+						>
+							TanStack Devtools
+						</a>
 					</nav>
 
 					<div className="flex items-center gap-4">

--- a/examples/demo/components/tanstack-devtools-demo.tsx
+++ b/examples/demo/components/tanstack-devtools-demo.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { c15tDevtools } from '@c15t/dev-tools/tanstack';
+import { useConsentManager } from '@c15t/react';
+import { TanStackDevtools } from '@tanstack/react-devtools';
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+	useQueryClient,
+} from '@tanstack/react-query';
+import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools';
+import {
+	ArrowUpRight,
+	DatabaseZap,
+	RefreshCcw,
+	ShieldCheck,
+} from 'lucide-react';
+import Link from 'next/link';
+import * as React from 'react';
+import { Button } from './ui/button';
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		window.setTimeout(resolve, ms);
+	});
+}
+
+function QueryProbe() {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: ['tanstack-devtools-example'],
+		queryFn: async () => {
+			await wait(180);
+
+			return {
+				generatedAt: new Date().toISOString(),
+				seed: Math.random().toString(36).slice(2, 8),
+			};
+		},
+		refetchInterval: 10_000,
+		staleTime: 2_500,
+	});
+
+	return (
+		<div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<p className="font-medium text-muted-foreground text-sm uppercase tracking-[0.2em]">
+						Query panel
+					</p>
+					<h2 className="mt-2 font-semibold text-2xl text-foreground">
+						Reference TanStack plugin
+					</h2>
+					<p className="mt-2 max-w-xl text-muted-foreground text-sm">
+						This query gives the built-in TanStack Query panel something live to
+						inspect while you switch between plugins.
+					</p>
+				</div>
+
+				<div className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 font-medium text-emerald-700 text-xs dark:text-emerald-300">
+					{query.isFetching ? 'Refreshing' : 'Idle'}
+				</div>
+			</div>
+
+			<div className="mt-5 grid gap-3 sm:grid-cols-2">
+				<div className="rounded-xl border border-border/80 bg-background/70 p-4">
+					<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+						Last payload
+					</p>
+					<pre className="mt-3 overflow-x-auto rounded-lg bg-muted/50 p-3 font-mono text-foreground text-xs">
+						{JSON.stringify(query.data ?? null, null, 2)}
+					</pre>
+				</div>
+
+				<div className="rounded-xl border border-border/80 bg-background/70 p-4">
+					<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+						Actions
+					</p>
+					<div className="mt-3 flex flex-wrap gap-3">
+						<Button
+							onClick={() => {
+								void query.refetch();
+							}}
+							size="sm"
+							variant="outline"
+						>
+							<RefreshCcw className="mr-2 h-4 w-4" />
+							Refetch query
+						</Button>
+						<Button
+							onClick={() => {
+								void queryClient.invalidateQueries({
+									queryKey: ['tanstack-devtools-example'],
+								});
+							}}
+							size="sm"
+							variant="outline"
+						>
+							<DatabaseZap className="mr-2 h-4 w-4" />
+							Invalidate cache
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ConsentProbe() {
+	const {
+		activeUI,
+		consents,
+		hasConsented,
+		model,
+		resetConsents,
+		setActiveUI,
+	} = useConsentManager();
+
+	return (
+		<div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<p className="font-medium text-muted-foreground text-sm uppercase tracking-[0.2em]">
+						c15t store
+					</p>
+					<h2 className="mt-2 font-semibold text-2xl text-foreground">
+						Live consent state
+					</h2>
+					<p className="mt-2 max-w-xl text-muted-foreground text-sm">
+						The c15t TanStack panel should stay connected to this store even
+						after you switch to other plugins and back again.
+					</p>
+				</div>
+
+				<div className="rounded-full border border-sky-500/20 bg-sky-500/10 px-3 py-1 font-medium text-sky-700 text-xs dark:text-sky-300">
+					{hasConsented ? 'Has consent' : 'Needs action'}
+				</div>
+			</div>
+
+			<div className="mt-5 grid gap-3 sm:grid-cols-3">
+				<div className="rounded-xl border border-border/80 bg-background/70 p-4">
+					<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+						Model
+					</p>
+					<p className="mt-2 font-semibold text-foreground text-lg">{model}</p>
+				</div>
+				<div className="rounded-xl border border-border/80 bg-background/70 p-4">
+					<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+						Active UI
+					</p>
+					<p className="mt-2 font-semibold text-foreground text-lg">
+						{activeUI ?? 'none'}
+					</p>
+				</div>
+				<div className="rounded-xl border border-border/80 bg-background/70 p-4">
+					<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+						Selected consents
+					</p>
+					<p className="mt-2 font-semibold text-foreground text-lg">
+						{
+							Object.values(consents ?? {}).filter((value) => value === true)
+								.length
+						}
+					</p>
+				</div>
+			</div>
+
+			<div className="mt-5 flex flex-wrap gap-3">
+				<Button
+					onClick={() => {
+						setActiveUI('banner');
+					}}
+					size="sm"
+				>
+					Show banner
+				</Button>
+				<Button
+					onClick={() => {
+						setActiveUI('dialog');
+					}}
+					size="sm"
+					variant="outline"
+				>
+					Show preferences
+				</Button>
+				<Button
+					onClick={() => {
+						resetConsents();
+					}}
+					size="sm"
+					variant="outline"
+				>
+					Reset consents
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function TanStackDevtoolsExampleShell() {
+	const [queryClient] = React.useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						retry: false,
+						refetchOnWindowFocus: false,
+					},
+				},
+			})
+	);
+
+	return (
+		<QueryClientProvider client={queryClient}>
+			<div className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_38%),linear-gradient(180deg,rgba(15,23,42,0.02),transparent_55%)]">
+				<div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-24">
+					<div className="flex flex-wrap items-center gap-3">
+						<div className="rounded-full border border-foreground/10 bg-background/80 px-3 py-1 font-medium text-foreground text-xs">
+							Repro page
+						</div>
+						<div className="rounded-full border border-foreground/10 bg-background/80 px-3 py-1 font-medium text-foreground text-xs">
+							/tanstack-devtools
+						</div>
+					</div>
+
+					<div className="grid gap-6 lg:grid-cols-[1.3fr_0.7fr]">
+						<div>
+							<h1 className="max-w-3xl font-semibold text-4xl text-foreground tracking-tight sm:text-5xl">
+								Test the c15t TanStack plugin against real tab switches
+							</h1>
+							<p className="mt-4 max-w-2xl text-base text-muted-foreground sm:text-lg">
+								This page mounts TanStack Devtools with the official Query panel
+								plus the c15t panel. Switch between them repeatedly. The c15t
+								panel should keep its store connection and never fall back to
+								&quot;can&apos;t connect to store&quot;.
+							</p>
+						</div>
+
+						<div className="rounded-3xl border border-border bg-card/85 p-6 shadow-sm">
+							<p className="font-medium text-muted-foreground text-xs uppercase tracking-[0.2em]">
+								How to repro
+							</p>
+							<ol className="mt-4 space-y-3 text-foreground text-sm">
+								<li>
+									1. Open the TanStack Devtools tray in the bottom corner.
+								</li>
+								<li>
+									2. Select the `c15t` plugin and confirm it shows live state.
+								</li>
+								<li>3. Switch to `TanStack Query`, then back to `c15t`.</li>
+								<li>
+									4. Use the controls below and verify the c15t panel stays
+									connected.
+								</li>
+							</ol>
+
+							<div className="mt-6 flex flex-wrap gap-3">
+								<Button asChild size="sm" variant="outline">
+									<Link href="/policy-actions">
+										Compare with floating DevTools
+										<ArrowUpRight className="ml-2 h-4 w-4" />
+									</Link>
+								</Button>
+								<Button asChild size="sm" variant="outline">
+									<Link href="/policy">
+										Policy pack demo
+										<ArrowUpRight className="ml-2 h-4 w-4" />
+									</Link>
+								</Button>
+							</div>
+						</div>
+					</div>
+
+					<div className="grid gap-6 lg:grid-cols-2">
+						<QueryProbe />
+						<ConsentProbe />
+					</div>
+
+					<div className="rounded-3xl border border-border bg-card/85 p-6 shadow-sm">
+						<div className="flex items-start gap-3">
+							<div className="rounded-2xl bg-emerald-500/10 p-3 text-emerald-600 dark:text-emerald-300">
+								<ShieldCheck className="h-5 w-5" />
+							</div>
+							<div>
+								<h2 className="font-semibold text-foreground text-xl">
+									Public API used on this page
+								</h2>
+								<pre className="mt-3 overflow-x-auto rounded-2xl bg-muted/55 p-4 font-mono text-foreground text-xs">
+									{`<TanStackDevtools
+  plugins={[
+    {
+      name: 'TanStack Query',
+      render: <ReactQueryDevtoolsPanel />,
+    },
+    c15tDevtools(),
+  ]}
+/>`}
+								</pre>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<TanStackDevtools
+					plugins={[
+						{
+							name: 'TanStack Query',
+							render: <ReactQueryDevtoolsPanel />,
+						},
+						c15tDevtools({
+							defaultOpen: true,
+						}),
+					]}
+				/>
+			</div>
+		</QueryClientProvider>
+	);
+}
+
+export function TanStackDevtoolsDemo() {
+	return <TanStackDevtoolsExampleShell />;
+}

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -101,6 +101,9 @@
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.2.2",
+		"@tanstack/react-devtools": "0.6.4",
+		"@tanstack/react-query": "5.87.1",
+		"@tanstack/react-query-devtools": "5.87.1",
 		"@types/node": "^25.5.0",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",

--- a/packages/dev-tools/README.md
+++ b/packages/dev-tools/README.md
@@ -77,20 +77,55 @@ devtools.destroy();
 
 ### TanStack DevTools Plugin
 
-Integrate with TanStack DevTools:
+Integrate c15t into TanStack Devtools with the same `render: <Panel />` pattern
+used by the official TanStack plugins:
 
 ```tsx
+import * as React from 'react';
+import { useRouter } from '@tanstack/react-router';
 import { TanStackDevtools } from '@tanstack/react-devtools';
-import { c15tDevtoolsPlugin } from '@c15t/dev-tools/tanstack';
+import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools';
+import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools';
+import { c15tDevtools } from '@c15t/dev-tools/tanstack';
 
-function App() {
+export function AppDevtools() {
+  const router = useRouter();
+
   return (
-    <>
-      <YourApp />
-      <TanStackDevtools plugins={[c15tDevtoolsPlugin()]} />
-    </>
+    <TanStackDevtools
+      plugins={[
+        {
+          name: 'TanStack Query',
+          render: <ReactQueryDevtoolsPanel />,
+        },
+        {
+          name: 'TanStack Router',
+          render: <TanStackRouterDevtoolsPanel router={router} />,
+        },
+        c15tDevtools({
+          defaultOpen: true,
+        }),
+      ]}
+    />
   );
 }
+```
+
+If you want full control over the plugin entry, you can also render the exported
+panel component directly:
+
+```tsx
+import { C15tTanStackDevtoolsPanel } from '@c15t/dev-tools/tanstack';
+
+<TanStackDevtools
+  plugins={[
+    {
+      id: 'c15t',
+      name: 'c15t',
+      render: <C15tTanStackDevtoolsPanel namespace="c15tStore" />,
+    },
+  ]}
+/>
 ```
 
 ## Console API

--- a/packages/dev-tools/src/__tests__/core/tanstack.test.ts
+++ b/packages/dev-tools/src/__tests__/core/tanstack.test.ts
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createDevToolsPanelMock } = vi.hoisted(() => ({
+	createDevToolsPanelMock: vi.fn(),
+}));
+
+vi.mock('../../core/devtools', () => ({
+	createDevToolsPanel: createDevToolsPanelMock,
+}));
+
+import {
+	C15tTanStackDevtoolsPanel,
+	c15tDevtools,
+	c15tDevtoolsPlugin,
+} from '../../tanstack';
+
+describe('tanstack integration', () => {
+	let mountNode: HTMLDivElement;
+	let root: Root | null;
+	let destroyCallbacks: Array<ReturnType<typeof vi.fn>>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mountNode = document.createElement('div');
+		document.body.appendChild(mountNode);
+		root = createRoot(mountNode);
+		destroyCallbacks = [];
+
+		createDevToolsPanelMock.mockImplementation(() => {
+			const element = document.createElement('section');
+			element.setAttribute('data-testid', 'embedded-panel');
+			const destroy = vi.fn();
+			destroyCallbacks.push(destroy);
+			return {
+				element,
+				destroy,
+			};
+		});
+	});
+
+	afterEach(async () => {
+		if (root) {
+			await act(async () => {
+				root?.unmount();
+			});
+		}
+		await act(async () => {
+			await vi.runOnlyPendingTimersAsync();
+		});
+		vi.useRealTimers();
+		root = null;
+		mountNode.remove();
+		createDevToolsPanelMock.mockReset();
+	});
+
+	it('creates a React-compatible plugin config', () => {
+		const plugin = c15tDevtools({
+			namespace: 'testStore',
+			defaultOpen: true,
+		});
+
+		expect(plugin.id).toBe('c15t');
+		expect(plugin.name).toBe('c15t');
+		expect(plugin.defaultOpen).toBe(true);
+		expect(React.isValidElement(plugin.render)).toBe(true);
+	});
+
+	it('keeps c15tDevtoolsPlugin as a backward-compatible alias', () => {
+		expect(c15tDevtoolsPlugin).toBe(c15tDevtools);
+	});
+
+	it('mounts and destroys the embedded panel with React lifecycle', async () => {
+		await act(async () => {
+			root?.render(
+				React.createElement(C15tTanStackDevtoolsPanel, {
+					namespace: 'testStore',
+					'data-testid': 'panel-shell',
+				})
+			);
+		});
+
+		expect(createDevToolsPanelMock).toHaveBeenCalledWith({
+			namespace: 'testStore',
+			mode: 'embedded',
+		});
+
+		const shell = mountNode.querySelector('[data-testid="panel-shell"]');
+		expect(
+			shell?.querySelector('[data-testid="embedded-panel"]')
+		).not.toBeNull();
+
+		await act(async () => {
+			root?.unmount();
+		});
+		root = null;
+
+		expect(destroyCallbacks).toHaveLength(1);
+		expect(destroyCallbacks[0]).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+
+		expect(destroyCallbacks[0]).toHaveBeenCalledTimes(1);
+	});
+
+	it('reuses the embedded panel after a remount', async () => {
+		const plugin = c15tDevtools({
+			namespace: 'testStore',
+		});
+
+		await act(async () => {
+			root?.render(plugin.render);
+		});
+
+		await act(async () => {
+			root?.unmount();
+		});
+		root = createRoot(mountNode);
+
+		await act(async () => {
+			root.render(plugin.render);
+		});
+
+		expect(createDevToolsPanelMock).toHaveBeenCalledTimes(1);
+		expect(destroyCallbacks[0]).not.toHaveBeenCalled();
+	});
+});

--- a/packages/dev-tools/src/core/devtools.ts
+++ b/packages/dev-tools/src/core/devtools.ts
@@ -22,7 +22,7 @@ import {
 	persistOverrides,
 } from './override-storage';
 import { createPanelRenderer } from './panel-renderer';
-import { clearElement, div } from './renderer';
+import { button, clearElement, div } from './renderer';
 import {
 	createStateManager,
 	type DevToolsPosition,
@@ -175,6 +175,153 @@ function createStateCopy(state: ConsentStoreState): Record<string, unknown> {
 			id: script.id,
 		})),
 		loadedScripts: state.loadedScripts,
+	};
+}
+
+interface EmbeddedTabsInstance {
+	element: HTMLElement;
+	setActiveTab: (tab: DevToolsTab) => void;
+	destroy: () => void;
+}
+
+const EMBEDDED_TABS: Array<{ id: DevToolsTab; label: string }> = [
+	{ id: 'location', label: 'Location' },
+	{ id: 'policy', label: 'Policy' },
+	{ id: 'consents', label: 'Consents' },
+	{ id: 'scripts', label: 'Scripts' },
+	{ id: 'iab', label: 'IAB' },
+	{ id: 'actions', label: 'Actions' },
+	{ id: 'events', label: 'Events' },
+];
+
+const EMBEDDED_THEME_VARIABLES: Record<string, string> = {
+	'--c15t-surface': '#1f222b',
+	'--c15t-surface-hover': '#272b35',
+	'--c15t-surface-muted': '#252933',
+	'--c15t-border': 'rgba(255, 255, 255, 0.08)',
+	'--c15t-border-hover': 'rgba(255, 255, 255, 0.16)',
+	'--c15t-text': '#eef2ff',
+	'--c15t-text-muted': '#99a2b3',
+	'--c15t-primary': '#8b5cf6',
+	'--c15t-primary-hover': '#7c3aed',
+	'--c15t-text-on-primary': '#f7f3ff',
+	'--c15t-shadow-sm': 'none',
+	'--c15t-shadow-md': 'none',
+	'--c15t-devtools-surface-elevated': '#1f222b',
+	'--c15t-devtools-surface-muted': '#272b35',
+	'--c15t-devtools-surface-subtle': '#181b22',
+	'--c15t-devtools-border-strong': 'rgba(255, 255, 255, 0.08)',
+	'--c15t-devtools-code-surface': '#15181f',
+	'--c15t-devtools-accent-soft': 'rgba(139, 92, 246, 0.18)',
+	'--c15t-devtools-focus-ring': '#8b5cf6',
+	'--c15t-devtools-badge-success-bg': 'rgba(16, 185, 129, 0.16)',
+	'--c15t-devtools-badge-error-bg': 'rgba(248, 113, 113, 0.18)',
+	'--c15t-devtools-badge-warning-bg': 'rgba(251, 191, 36, 0.18)',
+	'--c15t-devtools-badge-info-bg': 'rgba(96, 165, 250, 0.18)',
+	'--c15t-devtools-badge-neutral-bg': 'rgba(148, 163, 184, 0.16)',
+	'--c15t-devtools-embedded-tab-active-border': 'rgba(139, 92, 246, 0.55)',
+};
+
+function createEmbeddedTabs(options: {
+	activeTab: DevToolsTab;
+	onTabChange: (tab: DevToolsTab) => void;
+	disabledTabs?: DevToolsTab[];
+}): EmbeddedTabsInstance {
+	const { onTabChange, disabledTabs = [] } = options;
+	let activeTab = options.activeTab;
+	const buttons = new Map<DevToolsTab, HTMLButtonElement>();
+
+	const tabList = div({
+		role: 'tablist',
+		ariaLabel: 'DevTools tabs',
+		style: {
+			display: 'flex',
+			flexWrap: 'wrap',
+			gap: '0.5rem',
+			alignItems: 'center',
+			paddingBottom: '0.25rem',
+			borderBottom:
+				'1px solid var(--c15t-devtools-border-strong, rgba(255, 255, 255, 0.08))',
+		},
+	});
+
+	function applyButtonState(
+		tab: DevToolsTab,
+		buttonElement: HTMLButtonElement
+	): void {
+		const isActive = tab === activeTab;
+		const isDisabled = disabledTabs.includes(tab);
+
+		buttonElement.disabled = isDisabled;
+		buttonElement.setAttribute('aria-selected', isActive ? 'true' : 'false');
+		buttonElement.style.borderColor = isActive
+			? 'var(--c15t-devtools-embedded-tab-active-border, rgba(139, 92, 246, 0.55))'
+			: 'transparent';
+		buttonElement.style.backgroundColor = isActive
+			? 'var(--c15t-devtools-accent-soft, rgba(139, 92, 246, 0.18))'
+			: 'transparent';
+		buttonElement.style.color = isActive
+			? 'var(--c15t-text, #eef2ff)'
+			: 'var(--c15t-text-muted, #99a2b3)';
+		buttonElement.style.opacity = isDisabled ? '0.45' : '1';
+		buttonElement.style.cursor = isDisabled ? 'not-allowed' : 'pointer';
+		buttonElement.style.boxShadow = isActive
+			? 'inset 0 0 0 1px var(--c15t-devtools-embedded-tab-active-border, rgba(139, 92, 246, 0.55))'
+			: 'none';
+	}
+
+	for (const tab of EMBEDDED_TABS) {
+		const buttonElement = button({
+			role: 'tab',
+			text: tab.label,
+			onClick: () => {
+				if (disabledTabs.includes(tab.id)) {
+					return;
+				}
+				activeTab = tab.id;
+				for (const [tabId, tabButton] of buttons) {
+					applyButtonState(tabId, tabButton);
+				}
+				onTabChange(tab.id);
+			},
+			style: {
+				display: 'inline-flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				minHeight: '1.875rem',
+				padding: '0.3125rem 0.75rem',
+				border: '1px solid transparent',
+				borderRadius: '999px',
+				backgroundColor: 'transparent',
+				fontFamily: 'inherit',
+				fontSize: 'var(--c15t-devtools-font-size-xs, 0.75rem)',
+				fontWeight: '500',
+				lineHeight: '1.25',
+				transition:
+					'background-color var(--c15t-duration-fast, 100ms) var(--c15t-easing, cubic-bezier(0.4, 0, 0.2, 1)), border-color var(--c15t-duration-fast, 100ms) var(--c15t-easing, cubic-bezier(0.4, 0, 0.2, 1)), box-shadow var(--c15t-duration-fast, 100ms) var(--c15t-easing, cubic-bezier(0.4, 0, 0.2, 1)), color var(--c15t-duration-fast, 100ms) var(--c15t-easing, cubic-bezier(0.4, 0, 0.2, 1))',
+			},
+		});
+
+		if (tab.id === 'iab') {
+			buttonElement.title = 'Available when IAB TCF mode is enabled';
+		}
+
+		applyButtonState(tab.id, buttonElement);
+		buttons.set(tab.id, buttonElement);
+		tabList.appendChild(buttonElement);
+	}
+
+	return {
+		element: tabList,
+		setActiveTab: (tab) => {
+			activeTab = tab;
+			for (const [tabId, tabButton] of buttons) {
+				applyButtonState(tabId, tabButton);
+			}
+		},
+		destroy: () => {
+			buttons.clear();
+		},
 	};
 }
 
@@ -488,9 +635,11 @@ export function createDevToolsPanel(options: {
 	element: HTMLElement;
 	destroy: () => void;
 } {
-	const { namespace = 'c15tStore' } = options;
+	const { namespace = 'c15tStore', mode = 'standalone' } = options;
+	const isEmbedded = mode === 'embedded';
 	let detachInstrumentation: (() => void) | null = null;
 	let detachScriptDebug: (() => void) | null = null;
+	let contentArea: HTMLDivElement | null = null;
 
 	// Create state manager without floating button behavior
 	const stateManager = createStateManager({
@@ -527,6 +676,7 @@ export function createDevToolsPanel(options: {
 					});
 				}
 			}
+			renderActivePanel();
 		},
 		onDisconnect: () => {
 			stateManager.setConnected(false);
@@ -534,6 +684,7 @@ export function createDevToolsPanel(options: {
 			detachInstrumentation = null;
 			detachScriptDebug?.();
 			detachScriptDebug = null;
+			renderActivePanel();
 		},
 	});
 	const panelRenderer = createPanelRenderer({
@@ -570,30 +721,40 @@ export function createDevToolsPanel(options: {
 			display: 'flex',
 			flexDirection: 'column',
 			height: '100%',
-			fontFamily: 'var(--c15t-devtools-font-family)',
+			boxSizing: 'border-box',
+			gap: '0.75rem',
+			padding: '0.75rem',
+			fontFamily: 'inherit',
 			fontSize: 'var(--c15t-devtools-font-size-sm)',
-			color: 'var(--c15t-devtools-text)',
-			backgroundColor: 'var(--c15t-devtools-surface)',
+			color: isEmbedded ? 'var(--c15t-text, #eef2ff)' : 'inherit',
+			backgroundColor: 'transparent',
+			colorScheme: isEmbedded ? 'dark' : undefined,
+			...(isEmbedded ? EMBEDDED_THEME_VARIABLES : {}),
 		},
 	});
 
 	// Create content area (before tabs so we can pass render function)
-	const contentArea = div({
+	contentArea = div({
 		style: {
 			flex: '1',
+			minHeight: '0',
 			overflowY: 'auto',
 			overscrollBehavior: 'contain',
+			backgroundColor: 'transparent',
 		},
 	});
 
 	// Render active panel
 	function renderActivePanel(): void {
+		if (!contentArea) {
+			return;
+		}
 		const activeTab = syncTabs();
 		panelRenderer.renderPanel(contentArea, activeTab);
 	}
 
-	let tabsInstance: TabsInstance | null = null;
-	let iabDisabled = true;
+	let tabsInstance: EmbeddedTabsInstance | null = null;
+	let disabledTabsKey = '';
 
 	function getDisabledTabs(): DevToolsTab[] {
 		const disabledTabs: DevToolsTab[] = [];
@@ -606,16 +767,16 @@ export function createDevToolsPanel(options: {
 
 	function syncTabs(): DevToolsTab {
 		const disabledTabs = getDisabledTabs();
-		const nextIabDisabled = disabledTabs.includes('iab');
+		const nextDisabledTabsKey = disabledTabs.join('|');
 		let activeTab = stateManager.getState().activeTab;
 		if (disabledTabs.includes(activeTab)) {
 			activeTab = 'consents';
 			stateManager.setActiveTab(activeTab);
 		}
 
-		if (!tabsInstance || iabDisabled !== nextIabDisabled) {
+		if (!tabsInstance || disabledTabsKey !== nextDisabledTabsKey) {
 			tabsInstance?.destroy();
-			tabsInstance = createTabs({
+			tabsInstance = createEmbeddedTabs({
 				activeTab,
 				onTabChange: (tab) => {
 					stateManager.setActiveTab(tab);
@@ -623,9 +784,13 @@ export function createDevToolsPanel(options: {
 				},
 				disabledTabs,
 			});
-			iabDisabled = nextIabDisabled;
+			disabledTabsKey = nextDisabledTabsKey;
 			if (!tabsInstance.element.parentElement) {
-				container.appendChild(tabsInstance.element);
+				if (contentArea?.parentElement === container) {
+					container.insertBefore(tabsInstance.element, contentArea);
+				} else {
+					container.appendChild(tabsInstance.element);
+				}
 			}
 		} else {
 			tabsInstance.setActiveTab(activeTab);

--- a/packages/dev-tools/src/tanstack.ts
+++ b/packages/dev-tools/src/tanstack.ts
@@ -1,7 +1,8 @@
 /**
- * TanStack DevTools Plugin
+ * TanStack DevTools integration
  *
- * Provides c15t integration for TanStack DevTools
+ * Provides a React panel component and plugin factory that follow
+ * TanStack Devtools' documented `render: <Panel />` API.
  *
  * @example
  * ```tsx
@@ -21,53 +22,195 @@
  * @packageDocumentation
  */
 
+'use client';
+
+import type { CSSProperties, HTMLAttributes, ReactElement } from 'react';
+import * as React from 'react';
 import { createDevToolsPanel } from './core/devtools';
 
 /**
- * TanStack DevTools plugin interface
+ * Props for the embedded c15t panel used inside TanStack Devtools.
  */
-export interface DevToolsPlugin {
-	name: string;
-	label: string;
-	render: (container: HTMLElement) => () => void;
-}
-
-/**
- * Options for the c15t DevTools plugin
- */
-export interface C15tDevtoolsPluginOptions {
+export interface C15tTanStackDevtoolsPanelProps
+	extends HTMLAttributes<HTMLDivElement> {
 	/**
-	 * Namespace for the c15tStore on window
+	 * Namespace for the c15tStore on window.
 	 * @default 'c15tStore'
 	 */
 	namespace?: string;
 }
 
 /**
- * Creates a c15t plugin for TanStack DevTools
+ * Plugin configuration for React TanStack Devtools.
  */
-export function c15tDevtoolsPlugin(
+export interface TanStackDevtoolsPlugin {
+	id?: string;
+	name: string;
+	defaultOpen?: boolean;
+	render: ReactElement;
+}
+
+/**
+ * Options for the c15t TanStack Devtools plugin factory.
+ */
+export interface C15tDevtoolsPluginOptions
+	extends C15tTanStackDevtoolsPanelProps {
+	/**
+	 * Stable plugin identifier used by TanStack Devtools.
+	 * @default 'c15t'
+	 */
+	id?: string;
+
+	/**
+	 * Display name shown in the TanStack Devtools sidebar.
+	 * @default 'c15t'
+	 */
+	name?: string;
+
+	/**
+	 * Whether the c15t panel should be open on first load.
+	 * @default false
+	 */
+	defaultOpen?: boolean;
+}
+
+const embeddedPanelStyle: CSSProperties = {
+	height: '100%',
+	width: '100%',
+	minHeight: 0,
+};
+
+const EMBEDDED_PANEL_RELEASE_DELAY_MS = 60_000;
+
+interface SharedEmbeddedPanelEntry {
+	panel: ReturnType<typeof createDevToolsPanel>;
+	refCount: number;
+	releaseTimeout: ReturnType<typeof setTimeout> | null;
+}
+
+const sharedEmbeddedPanels = new Map<string, SharedEmbeddedPanelEntry>();
+
+function acquireEmbeddedPanel(namespace: string): SharedEmbeddedPanelEntry {
+	const existingPanel = sharedEmbeddedPanels.get(namespace);
+
+	if (existingPanel) {
+		if (existingPanel.releaseTimeout) {
+			clearTimeout(existingPanel.releaseTimeout);
+			existingPanel.releaseTimeout = null;
+		}
+		existingPanel.refCount += 1;
+		return existingPanel;
+	}
+
+	const panel = createDevToolsPanel({
+		namespace,
+		mode: 'embedded',
+	});
+	const entry: SharedEmbeddedPanelEntry = {
+		panel,
+		refCount: 1,
+		releaseTimeout: null,
+	};
+	sharedEmbeddedPanels.set(namespace, entry);
+	return entry;
+}
+
+function releaseEmbeddedPanel(namespace: string): void {
+	const entry = sharedEmbeddedPanels.get(namespace);
+
+	if (!entry) {
+		return;
+	}
+
+	entry.refCount = Math.max(0, entry.refCount - 1);
+
+	if (entry.refCount > 0 || entry.releaseTimeout) {
+		return;
+	}
+
+	entry.releaseTimeout = setTimeout(() => {
+		const currentEntry = sharedEmbeddedPanels.get(namespace);
+
+		if (!currentEntry || currentEntry.refCount > 0) {
+			return;
+		}
+
+		currentEntry.panel.destroy();
+		sharedEmbeddedPanels.delete(namespace);
+	}, EMBEDDED_PANEL_RELEASE_DELAY_MS);
+}
+
+/**
+ * React panel component for embedding c15t DevTools inside TanStack Devtools.
+ */
+export function C15tTanStackDevtoolsPanel({
+	namespace = 'c15tStore',
+	style,
+	...props
+}: C15tTanStackDevtoolsPanelProps): React.JSX.Element {
+	const containerRef = React.useRef<HTMLDivElement | null>(null);
+
+	React.useLayoutEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+
+		const entry = acquireEmbeddedPanel(namespace);
+		container.replaceChildren(entry.panel.element);
+
+		return () => {
+			if (entry.panel.element.parentElement === container) {
+				container.removeChild(entry.panel.element);
+			}
+			releaseEmbeddedPanel(namespace);
+		};
+	}, [namespace]);
+
+	return React.createElement('div', {
+		...props,
+		ref: containerRef,
+		style: {
+			...embeddedPanelStyle,
+			...style,
+		},
+	});
+}
+
+function createC15tDevtoolsPlugin(
 	options: C15tDevtoolsPluginOptions = {}
-): DevToolsPlugin {
-	const { namespace = 'c15tStore' } = options;
+): TanStackDevtoolsPlugin {
+	const {
+		namespace = 'c15tStore',
+		id = 'c15t',
+		name = 'c15t',
+		defaultOpen = false,
+		...panelProps
+	} = options;
 
 	return {
-		name: 'c15t',
-		label: 'Consent',
-		render: (container: HTMLElement) => {
-			const panel = createDevToolsPanel({
-				namespace,
-				mode: 'embedded',
-			});
-
-			container.appendChild(panel.element);
-
-			return () => {
-				panel.destroy();
-			};
-		},
+		id,
+		name,
+		defaultOpen,
+		render: React.createElement(C15tTanStackDevtoolsPanel, {
+			...panelProps,
+			namespace,
+		}),
 	};
 }
 
-// Re-export types that might be useful
+/**
+ * Creates a c15t plugin config for TanStack Devtools.
+ */
+export function c15tDevtools(
+	options: C15tDevtoolsPluginOptions = {}
+): TanStackDevtoolsPlugin {
+	return createC15tDevtoolsPlugin(options);
+}
+
+/**
+ * Backward-compatible alias for the TanStack Devtools plugin factory.
+ */
+export const c15tDevtoolsPlugin = c15tDevtools;
+
 export type { DevToolsPosition, DevToolsTab } from './core/state-manager';


### PR DESCRIPTION
## Overview

Fix the `@c15t/dev-tools/tanstack` integration so it uses TanStack Devtools' React plugin API, keeps the c15t store connected across plugin tab switches, and presents an embedded UI that fits TanStack's dark styling. This also adds a dedicated demo page for reproducing and validating the embedded plugin behavior.

## Related Issue

Fixes #765

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Replace the imperative TanStack adapter with a React plugin factory, expose `c15tDevtools()`, and keep `c15tDevtoolsPlugin` as a compatibility alias.
2. Reuse the embedded c15t panel across TanStack remounts, restyle embedded mode to match TanStack's dark palette, and add a `/tanstack-devtools` repro page plus docs/tests for the workflow.

### Technical Notes

The embedded panel now caches its `createDevToolsPanel()` instance by namespace and only destroys it after a delayed release, which avoids losing the underlying store connection when TanStack swaps plugin views. Embedded mode also uses a scoped token override so existing c15t panel components render with TanStack-like colors without changing the standalone DevTools theme.

## Testing

### Test Plan

- [x] Scenario 1: Verify the TanStack wrapper API and remount behavior

  ```ts
  bunx vitest run src/__tests__/core/tanstack.test.ts --config vitest.config.ts
  ```

  ✓ Expected: the plugin config is React-compatible, the alias is preserved, and the embedded panel is reused across remounts instead of being recreated immediately.

- [x] Scenario 2: Verify package types and the demo app build

  ```ts
  bun run check-types
  bunx turbo run build --filter=@c15t/dev-tools --filter=pigeon-post
  ```

  ✓ Expected: `@c15t/dev-tools` typechecks, the package builds, and the demo app including `/tanstack-devtools` compiles successfully.

### Edge Cases

- [x] Error handling: switching between TanStack plugins should no longer leave c15t stuck in a disconnected state until a full page reload.
- [x] Performance: the embedded panel is reused between tab switches instead of being torn down and rebuilt on each remount.
- [x] Security: no new privileged APIs or network behavior; changes stay within local devtools rendering and docs/demo code.

### Visual Changes

| Before | After |
|--------|-------|
| Embedded c15t controls used bright white surfaces on TanStack's dark panel and the custom tab UI could fall into a disconnected state after switching away and back. | Embedded c15t mode uses TanStack-aligned dark tokens, a flat button row for all tabs, and keeps the store connection stable across plugin switches. |

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
