### PR TITLE
docs: update IAB certification guidance

### DIFF
--- a/docs/frameworks/next/iab/consent-banner.mdx
+++ b/docs/frameworks/next/iab/consent-banner.mdx
@@ -21,7 +21,7 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
         backendURL: '/api/c15t',
         iab: iab({
           vendors: [1, 2, 10, 25],
-          // cmpId is automatically provided by the backend when using consent.io.
+          // cmpId is automatically provided by the backend when using Inth.
           // Only set this if you have your own CMP registration.
           // cmpId: 123,
         }),

--- a/docs/frameworks/next/iab/consent-dialog.mdx
+++ b/docs/frameworks/next/iab/consent-dialog.mdx
@@ -23,7 +23,7 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
         backendURL: '/api/c15t',
         iab: iab({
           vendors: [1, 2, 10, 25],
-          // cmpId is automatically provided by the backend when using consent.io.
+          // cmpId is automatically provided by the backend when using Inth.
           // Only set this if you have your own CMP registration.
           // cmpId: 123,
         }),

--- a/docs/frameworks/react/iab/consent-banner.mdx
+++ b/docs/frameworks/react/iab/consent-banner.mdx
@@ -21,7 +21,7 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
         backendURL: 'https://your-instance.c15t.dev',
         iab: iab({
           vendors: [1, 2, 10, 25],
-          // cmpId is automatically provided by the backend when using consent.io.
+          // cmpId is automatically provided by the backend when using Inth.
           // Only set this if you have your own CMP registration.
           // cmpId: 123,
         }),

--- a/docs/frameworks/react/iab/consent-dialog.mdx
+++ b/docs/frameworks/react/iab/consent-dialog.mdx
@@ -23,7 +23,7 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
         backendURL: 'https://your-instance.c15t.dev',
         iab: iab({
           vendors: [1, 2, 10, 25],
-          // cmpId is automatically provided by the backend when using consent.io.
+          // cmpId is automatically provided by the backend when using Inth.
           // Only set this if you have your own CMP registration.
           // cmpId: 123,
         }),

--- a/docs/self-host/guides/iab-tcf.mdx
+++ b/docs/self-host/guides/iab-tcf.mdx
@@ -7,16 +7,16 @@ The c15t backend optionally supports [IAB TCF v2.3](https://iabeurope.eu/transpa
 
 ## CMP Registration
 
-[inth.com](https://inth.com) is pending validation as an IAB Europe-registered CMP for c15t. Once approved, when using inth.com as your hosted backend, the CMP ID will be automatically provided to clients — no additional configuration needed.
+[Inth](https://inth.com), c15t's hosted platform, is IAB TCF certified. If you use Inth instead of self-hosting, the CMP ID is automatically provided to clients — no additional configuration needed.
 
-If you self-host and have your own CMP registration with IAB Europe, configure your CMP ID via `iab.cmpId`. This value is returned to clients in the `/init` response so they use the correct CMP identity in TC Strings.
+If you self-host, you need your own CMP registration with IAB Europe and must configure your CMP ID via `iab.cmpId`. Registering your own CMP may also involve IAB Europe fees, so check IAB Europe's current CMP registration terms and pricing before choosing this route. This value is returned to clients in the `/init` response so they use the correct CMP identity in TC Strings.
 
 <Callout type="warn">
   A valid (non-zero) CMP ID is required for IAB TCF compliance. If neither the backend nor the client provides a CMP ID, IAB initialization will fail with an error.
 </Callout>
 
 <Callout type="warn">
-  If you heavily customize or build your own IAB banner or dialog (rather than using the default `IABConsentBanner` and `IABConsentDialog` components provided by c15t), you cannot use inth.com's CMP ID. You must register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and configure your CMP ID via `iab.cmpId`.
+  If you heavily customize or build your own IAB banner or dialog instead of using the default `IABConsentBanner` and `IABConsentDialog` components provided by c15t, you cannot use Inth's CMP ID. You must register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and configure your CMP ID via `iab.cmpId`.
 </Callout>
 
 ## Enable IAB
@@ -28,7 +28,7 @@ export const c15t = c15tInstance({
   // ...
   iab: {
     enabled: true,
-    cmpId: 10,                  // your registered CMP ID (inth.com provides this automatically)
+    cmpId: 10,                  // your registered CMP ID (only set this when self-hosting or using your own CMP)
     vendorIds: [755, 52, 69],   // only include vendors you use
   },
 });

--- a/docs/self-host/guides/iab-tcf.mdx
+++ b/docs/self-host/guides/iab-tcf.mdx
@@ -9,7 +9,7 @@ The c15t backend optionally supports [IAB TCF v2.3](https://iabeurope.eu/transpa
 
 [Inth](https://inth.com), c15t's hosted platform, is IAB TCF certified. If you use Inth instead of self-hosting, the CMP ID is automatically provided to clients — no additional configuration needed.
 
-If you self-host, you need your own CMP registration with IAB Europe and must configure your CMP ID via `iab.cmpId`. Registering your own CMP may also involve IAB Europe fees, so check IAB Europe's current CMP registration terms and pricing before choosing this route. This value is returned to clients in the `/init` response so they use the correct CMP identity in TC Strings.
+If you self-host, you need your own CMP registration with IAB Europe and must configure your CMP ID via `iab.cmpId`. Registering your own CMP may also involve IAB Europe fees, so check IAB Europe's current CMP registration terms and pricing before choosing this route. The backend returns this value in the `/init` response so clients use the correct CMP identity in TC Strings.
 
 <Callout type="warn">
   A valid (non-zero) CMP ID is required for IAB TCF compliance. If neither the backend nor the client provides a CMP ID, IAB initialization will fail with an error.
@@ -28,13 +28,13 @@ export const c15t = c15tInstance({
   // ...
   iab: {
     enabled: true,
-    cmpId: 10,                  // your registered CMP ID (only set this when self-hosting or using your own CMP)
+    cmpId: Number('<YOUR_CMP_ID>'), // replace with your registered CMP ID
     vendorIds: [755, 52, 69],   // only include vendors you use
   },
 });
 ```
 
-The backend fetches the GVL from `https://gvl.inth.com` by default and caches it. The `/init` endpoint returns the filtered GVL and your CMP ID to the frontend.
+The backend fetches the GVL from `https://gvl.inth.com` by default and caches it. The `/init` endpoint returns the filtered GVL and your CMP ID to the frontend, so use the same `iab.cmpId` pattern in every self-hosted configuration.
 
 ## Custom GVL Endpoint
 
@@ -43,6 +43,7 @@ Point to your own GVL mirror:
 ```ts
 iab: {
   enabled: true,
+  cmpId: Number('<YOUR_CMP_ID>'), // replace with your registered CMP ID
   endpoint: 'https://your-gvl-mirror.com',
   vendorIds: [755, 52, 69],
 },
@@ -58,6 +59,7 @@ import gvlDe from './gvl/de.json';
 
 iab: {
   enabled: true,
+  cmpId: Number('<YOUR_CMP_ID>'), // replace with your registered CMP ID
   bundled: {
     en: gvlEn,
     de: gvlDe,
@@ -76,6 +78,7 @@ Add your own vendors alongside IAB-registered ones:
 ```ts
 iab: {
   enabled: true,
+  cmpId: Number('<YOUR_CMP_ID>'), // replace with your registered CMP ID
   vendorIds: [755],
   customVendors: [
     {

--- a/docs/shared/react/iab/consent-banner.mdx
+++ b/docs/shared/react/iab/consent-banner.mdx
@@ -1,8 +1,8 @@
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="intro">
-  <Callout type="error">
-    c15t is **not yet IAB certified**. The IAB TCF components are under active development and should **not be used in production**. APIs and behavior may change before certification is achieved.
+  <Callout type="info">
+    c15t's IAB TCF support can be used in production. Use [Inth](https://inth.com) for a hosted, IAB TCF-certified CMP setup with a managed CMP ID, or register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and configure your own CMP ID.
   </Callout>
 
   `IABConsentBanner` is a pre-built consent banner that follows the [IAB Transparency & Consent Framework (TCF) 2.3](https://iabeurope.eu/tcf-2-0/) specification. It renders when the consent model is set to `'iab'` and includes required disclosures like partner count, purpose summaries, and legitimate interest notices.

--- a/docs/shared/react/iab/consent-dialog.mdx
+++ b/docs/shared/react/iab/consent-dialog.mdx
@@ -1,8 +1,8 @@
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="intro">
-  <Callout type="error">
-    c15t is **not yet IAB certified**. The IAB TCF components are under active development and should **not be used in production**. APIs and behavior may change before certification is achieved.
+  <Callout type="info">
+    c15t's IAB TCF support can be used in production. Use [Inth](https://inth.com) for a hosted, IAB TCF-certified CMP setup with a managed CMP ID, or register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and configure your own CMP ID.
   </Callout>
 
   `IABConsentDialog` is an IAB TCF 2.3 compliant consent dialog that provides a tabbed interface for managing purpose consent and vendor preferences. It includes purpose grouping via stacks, individual purpose/vendor toggles, special purpose and feature disclosures, and legitimate interest handling.

--- a/docs/shared/react/iab/overview.mdx
+++ b/docs/shared/react/iab/overview.mdx
@@ -14,12 +14,12 @@
 
   ## CMP Registration
 
-  [inth.com](https://inth.com) is pending validation as an IAB Europe-registered CMP for c15t. Once approved, when you use inth.com as your backend, the correct CMP ID will be automatically provided to your client via the `/init` endpoint — no client-side configuration needed.
+  [Inth](https://inth.com), c15t's hosted platform, is IAB TCF certified. When you use Inth as your backend with c15t's prebuilt IAB UI, the correct CMP ID is automatically provided to your client via the `/init` endpoint — no client-side configuration needed.
 
-  If you self-host the c15t backend and have your own CMP registration with IAB Europe, you can configure your CMP ID on the backend via `advanced.iab.cmpId` or on the client via the `iab.cmpId` option. A valid (non-zero) CMP ID is required for IAB TCF compliance.
+  If you self-host the c15t backend or want to operate as your own CMP, register your own CMP with IAB Europe and configure your CMP ID on the backend via `advanced.iab.cmpId` or on the client via the `iab.cmpId` option. Registering your own CMP may also involve IAB Europe fees, so check IAB Europe's current CMP registration terms and pricing before choosing this route. A valid (non-zero) CMP ID is required for IAB TCF compliance.
 
   <Callout type="warn">
-    If you heavily customize or build your own IAB banner or dialog (rather than using the default `IABConsentBanner` and `IABConsentDialog` components), you cannot use inth.com's CMP ID. You must register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and use your own CMP ID.
+    If you heavily customize or build your own IAB banner or dialog instead of using the default `IABConsentBanner` and `IABConsentDialog` components, you cannot use Inth's CMP ID. You must register your own CMP with [IAB Europe](https://iabeurope.eu/tcf-2-0/) and use your own CMP ID.
   </Callout>
 
   ## How c15t Implements TCF
@@ -42,7 +42,7 @@
 
   | Option | Type | Description |
   |--------|------|-------------|
-  | `cmpId` | `number` | CMP ID registered with IAB Europe. Automatically provided by the backend when using inth.com. Only set this if you have your own CMP registration. |
+  | `cmpId` | `number` | CMP ID registered with IAB Europe. Automatically provided by the backend when using Inth with the prebuilt IAB UI. Only set this if you have your own CMP registration. |
   | `vendors` | `number[]` | IAB vendor IDs that your site works with |
   | `customVendors` | `NonIABVendor[]` | Custom vendors not in the IAB registry |
 

--- a/docs/shared/react/iab/use-gvl-data.mdx
+++ b/docs/shared/react/iab/use-gvl-data.mdx
@@ -1,8 +1,8 @@
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="content">
-  <Callout type="error">
-    c15t is **not yet IAB certified**. The IAB TCF components are under active development and should **not be used in production**. APIs and behavior may change before certification is achieved.
+  <Callout type="warn">
+    c15t's IAB TCF support can be used in production through [Inth](https://inth.com) or with your own registered CMP ID. `useGVLData()` is different: it remains an internal hook and is not part of the supported public API.
   </Callout>
 
   `useGVLData()` currently powers the built-in `IABConsentDialog`, but it is **not part of the public package surface**.


### PR DESCRIPTION
## Overview
This updates the IAB TCF docs to match the current production guidance.
It replaces outdated warnings about c15t not being certified with accurate guidance for using Inth as the certified hosted CMP path or registering your own CMP and CMP ID for self-managed setups.
It also adds a note that registering your own CMP may involve IAB Europe fees and aligns the React and Next examples with Inth terminology.

## Related Issue
Fixes #767

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Updated the shared IAB overview, banner, dialog, and `useGVLData()` docs plus the self-host IAB guide to describe the certified Inth path and the bring-your-own CMP path accurately.
2. Replaced stale `consent.io` references in the React and Next IAB examples with `Inth` so the examples match the supported hosted path.

### Technical Notes
This is a docs-only change. No runtime behavior or public API changed.

## Testing
### Test Plan
- [x] Scenario 1: Check the updated wording in the touched docs

  ```bash
  rg -n "not yet IAB certified|should not be used in production|pending validation|provided by the backend when using consent.io" docs
  ```

  ✓ Expected: No outdated certification wording remains in `docs/`

- [x] Scenario 2: Review the PR diff against `main`

  ```bash
  git diff origin/main...
  ```

  ✓ Expected: The diff is limited to the nine IAB docs files and consistently describes Inth as the hosted certified path plus the self-managed CMP path

### Edge Cases
- [x] Error handling: `useGVLData()` still clearly warns that it is internal-only even though production IAB support is now documented as available
- [x] Performance: No runtime or build impact beyond doc content changes
- [x] Security: No security impact; this only corrects guidance and terminology

## Checklist

### Required

- [x] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated IAB TCF documentation to reflect production-ready support via Inth (IAB certified hosted solution) or user-registered CMP ID with IAB Europe.
  * Clarified CMP ID configuration requirements and registration guidance for both hosted and self-hosted setups.
  * Updated code examples and best practices for IAB TCF integration across all framework guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->