### PR TITLE
fix: Tailwind import order with Fumadocs presets

### DIFF
--- a/.changeset/five-snails-obey.md
+++ b/.changeset/five-snails-obey.md
@@ -1,0 +1,5 @@
+---
+'@c15t/cli': patch
+---
+
+Place Tailwind v4 c15t stylesheet imports at the end of the top-level import block so preset styles like Fumadocs do not override c15t theme tokens.

--- a/docs/frameworks/next/styling/tailwind.mdx
+++ b/docs/frameworks/next/styling/tailwind.mdx
@@ -5,6 +5,24 @@ description: Use Tailwind CSS utility classes to style consent components via th
 
 <import src="../../../shared/react/styling/tailwind.mdx#intro-and-setup" />
 
+## Troubleshooting: Fumadocs Overrides c15t Styles
+
+If c15t components render partially unstyled or lose their theme tokens inside a Fumadocs site, check the order of the imports in `app/globals.css`.
+
+**Cause:** Fumadocs preset imports can load after c15t and override the tokens and layer output that c15t components depend on.
+
+**Fix:** Keep `@c15t/nextjs/styles.css` at the end of the top-level `@import` block:
+
+```css title="app/globals.css"
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "fumadocs-ui/css/shadcn.css";
+@import "fumadocs-ui/css/preset.css";
+@import "@c15t/nextjs/styles.css";
+```
+
+If you use other preset or docs-site stylesheets, apply the same rule: load them first, then import c15t last in the top-level import block.
+
 ## Using Tailwind with Slots
 
 Apply Tailwind classes via the theme's `slots` object:

--- a/docs/shared/react/styling/stylesheet-entrypoint.mdx
+++ b/docs/shared/react/styling/stylesheet-entrypoint.mdx
@@ -1,3 +1,5 @@
 <section id="why-global-css">
   Keeping the c15t stylesheet in your global CSS entrypoint makes layer and cascade order explicit. JS/TSX side-effect imports can load in a different order across framework and Tailwind tooling, which makes style regressions harder to debug.
+
+  With Tailwind v4, keep c15t at the end of the top-level `@import` block so Fumadocs, `tw-animate-css`, and other preset imports do not override c15t theme tokens.
 </section>

--- a/docs/shared/react/styling/tailwind.mdx
+++ b/docs/shared/react/styling/tailwind.mdx
@@ -19,15 +19,17 @@
 
   ### Tailwind v4
 
-  Tailwind v4 automatically scans your source files. Import Tailwind normally, then place the c15t stylesheet immediately after it. c15t component styles join Tailwind's `components` layer automatically, so no extra c15t-specific layer declaration is needed:
+  Tailwind v4 automatically scans your source files. Import Tailwind normally, then keep the c15t stylesheet last in the top-level `@import` block so Fumadocs, `tw-animate-css`, or other preset styles load first. c15t component styles join Tailwind's `components` layer automatically, so no extra c15t-specific layer declaration is needed:
 
   ```css title="src/index.css"
   @import "tailwindcss";
+  @import "tw-animate-css";
   @import "@c15t/react/styles.css";
   ```
 
   ```css title="app/globals.css"
   @import "tailwindcss";
+  @import "tw-animate-css";
   @import "@c15t/nextjs/styles.css";
   ```
 

--- a/packages/cli/src/commands/generate/templates/css.test.ts
+++ b/packages/cli/src/commands/generate/templates/css.test.ts
@@ -55,7 +55,7 @@ describe('updateAppStylesheetImports', () => {
 		);
 	});
 
-	it('inserts the Tailwind v4 stylesheet immediately after tailwindcss', async () => {
+	it('inserts the Tailwind v4 stylesheet at the end of the import block', async () => {
 		const { root } = await createProject({
 			'app/layout.tsx': [
 				"import './globals.css';",
@@ -67,6 +67,7 @@ describe('updateAppStylesheetImports', () => {
 			'app/globals.css': [
 				'@import "tailwindcss";',
 				'@import "tw-animate-css";',
+				'@import "fumadocs-ui/css/preset.css";',
 				'',
 				':root { color: #111827; }',
 			].join('\n'),
@@ -82,7 +83,7 @@ describe('updateAppStylesheetImports', () => {
 
 		expect(result.updated).toBe(true);
 		expect(content).toContain(
-			'@import "tailwindcss";\n@import "@c15t/nextjs/styles.css";\n@import "tw-animate-css";'
+			'@import "tailwindcss";\n@import "tw-animate-css";\n@import "fumadocs-ui/css/preset.css";\n@import "@c15t/nextjs/styles.css";'
 		);
 	});
 

--- a/packages/cli/src/commands/shared/stylesheets.ts
+++ b/packages/cli/src/commands/shared/stylesheets.ts
@@ -164,7 +164,7 @@ function findTailwindV4InsertionLineIndex(
 			/^\/\*.*\*\/\s*$/.test(trimmed) ||
 			/^\/\/.*\s*$/.test(trimmed) ||
 			/^\/\*.*\s*$/.test(trimmed) ||
-			/^\*\/\s*$/.test(trimmed);
+			/^\*(?:\/|$|\s(?!\{).*)$/.test(trimmed);
 
 		if (trimmed === '' || isStandaloneCommentLine) {
 			continue;

--- a/packages/cli/src/commands/shared/stylesheets.ts
+++ b/packages/cli/src/commands/shared/stylesheets.ts
@@ -22,7 +22,7 @@ const CSS_ENTRYPOINT_CANDIDATES = [
 const LOCAL_CSS_IMPORT_RE =
 	/^\s*import(?:\s+[^'"]+\s+from\s+)?['"]([^'"]+\.css)['"];\s*$/gm;
 
-const CSS_IMPORT_RE = /^\s*@import\b.+;\s*$/;
+const CSS_IMPORT_RE = /^\s*@import\b.+;\s*(?:(?:\/\*.*\*\/|\/\/.*)\s*)?$/;
 const TAILWIND_V4_IMPORT_RE = /^\s*@import\s+['"]tailwindcss['"];\s*$/;
 const TAILWIND_COMPONENTS_RE = /^\s*@tailwind\s+components\s*;\s*$/;
 const TAILWIND_UTILITIES_RE = /^\s*@tailwind\s+utilities\s*;\s*$/;
@@ -160,8 +160,13 @@ function findTailwindV4InsertionLineIndex(
 	for (let index = tailwindImportIndex + 1; index < lines.length; index += 1) {
 		const line = lines[index];
 		const trimmed = line?.trim() ?? '';
+		const isStandaloneCommentLine =
+			/^\/\*.*\*\/\s*$/.test(trimmed) ||
+			/^\/\/.*\s*$/.test(trimmed) ||
+			/^\/\*.*\s*$/.test(trimmed) ||
+			/^\*\/\s*$/.test(trimmed);
 
-		if (trimmed === '') {
+		if (trimmed === '' || isStandaloneCommentLine) {
 			continue;
 		}
 

--- a/packages/cli/src/commands/shared/stylesheets.ts
+++ b/packages/cli/src/commands/shared/stylesheets.ts
@@ -22,6 +22,7 @@ const CSS_ENTRYPOINT_CANDIDATES = [
 const LOCAL_CSS_IMPORT_RE =
 	/^\s*import(?:\s+[^'"]+\s+from\s+)?['"]([^'"]+\.css)['"];\s*$/gm;
 
+const CSS_IMPORT_RE = /^\s*@import\b.+;\s*$/;
 const TAILWIND_V4_IMPORT_RE = /^\s*@import\s+['"]tailwindcss['"];\s*$/;
 const TAILWIND_COMPONENTS_RE = /^\s*@tailwind\s+components\s*;\s*$/;
 const TAILWIND_UTILITIES_RE = /^\s*@tailwind\s+utilities\s*;\s*$/;
@@ -150,6 +151,31 @@ function findTopInsertionLineIndex(lines: string[]): number {
 	return index;
 }
 
+function findTailwindV4InsertionLineIndex(
+	lines: string[],
+	tailwindImportIndex: number
+): number {
+	let lastImportIndex = tailwindImportIndex;
+
+	for (let index = tailwindImportIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		const trimmed = line?.trim() ?? '';
+
+		if (trimmed === '') {
+			continue;
+		}
+
+		if (CSS_IMPORT_RE.test(line ?? '')) {
+			lastImportIndex = index;
+			continue;
+		}
+
+		break;
+	}
+
+	return lastImportIndex + 1;
+}
+
 function insertImportsIntoCssContent(
 	content: string,
 	desiredImports: string[],
@@ -189,7 +215,10 @@ function insertImportsIntoCssContent(
 			TAILWIND_V4_IMPORT_RE.test(line)
 		);
 		if (tailwindImportIndex >= 0) {
-			insertionIndex = tailwindImportIndex + 1;
+			insertionIndex = findTailwindV4InsertionLineIndex(
+				filteredLines,
+				tailwindImportIndex
+			);
 		}
 	}
 


### PR DESCRIPTION
## Overview
c15t styles could be inserted too early in Tailwind v4 apps, which let later preset imports like Fumadocs override c15t theme tokens.
This updates the CLI stylesheet insertion logic to place c15t at the end of the top-level import block and adds matching guidance in the styling docs.
This is better because users no longer need to hand-reorder imports after generation, and the docs now call out the Fumadocs failure mode explicitly.

## Related Issue
N/A

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [x] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details
### Key Changes
1. Changed Tailwind v4 stylesheet insertion to keep `@c15t/nextjs/styles.css` and `@c15t/react/styles.css` after other top-level `@import` presets such as `tw-animate-css` and Fumadocs.
2. Added shared Tailwind guidance plus a Next.js troubleshooting section with the exact `app/globals.css` import order.
3. Added a changeset for `@c15t/cli` and updated the focused CLI test coverage.

### Technical Notes
Tailwind v3 behavior is unchanged: c15t still inserts after `@tailwind components;` and before `@tailwind utilities;`.

## Testing
### Test Plan
- [x] Scenario 1: CLI stylesheet insertion keeps c15t last in a Tailwind v4 import block

  ```ts
  bun vitest run packages/cli/src/commands/generate/templates/css.test.ts
  ```

  ✓ Expected: generated CSS keeps preset imports first and `@c15t/nextjs/styles.css` last

- [x] Scenario 2: codemod flow still updates stylesheet imports correctly

  ```ts
  bun vitest run packages/cli/src/commands/codemods/add-stylesheet-imports.test.ts
  ```
  
  ✓ Expected: codemod tests pass and Tailwind v3 behavior remains unchanged

### Edge Cases
- [x] Error handling: existing insertion logic still falls back cleanly when Tailwind imports are absent
- [x] Performance: no meaningful runtime impact; this only changes generated import placement
- [x] Security: no security-sensitive behavior changed

## Checklist
### Required
- [ ] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting and clarified Tailwind v4 guidance: ensure c15t stylesheet is imported last so preset/docs-site styles don’t override c15t theme tokens.

* **Improvements**
  * Updated CLI behavior to insert the c15t stylesheet after other preset imports for Tailwind v4 setups.

* **Tests**
  * Adjusted tests to reflect the updated Tailwind v4 import ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->