### PR TITLE
Fix Tailwind v3 CSS entrypoints

### DIFF
--- a/.changeset/fix-dialog-overlay-classname.md
+++ b/.changeset/fix-dialog-overlay-classname.md
@@ -1,0 +1,5 @@
+---
+"@c15t/react": patch
+---
+
+Allow `ConsentDialog.Overlay` to accept direct `className`, ref, and div props for headless `noStyle` usage, matching the banner overlay API.

--- a/.changeset/tw3-css-entrypoints.md
+++ b/.changeset/tw3-css-entrypoints.md
@@ -1,0 +1,9 @@
+---
+"@c15t/ui": patch
+"@c15t/react": patch
+"@c15t/nextjs": patch
+---
+
+Fix Tailwind CSS v3 stylesheet packaging so package resolvers that do not follow nested CSS imports still include the generated c15t component rules.
+
+Root `styles.tw3.css` and `iab/styles.tw3.css` proxy entrypoints are now published, and the React/Next.js Tailwind v3 dist stylesheets inline the generated UI CSS instead of forwarding through nested package imports.

--- a/benchmarks/core-benchmarks/src/run.ts
+++ b/benchmarks/core-benchmarks/src/run.ts
@@ -1,16 +1,18 @@
 #!/usr/bin/env bun
 import { join } from 'node:path';
+import { coreRuntimeBudgets } from '@c15t/benchmarking/budgets';
+import { coreFixtures } from '@c15t/benchmarking/fixtures';
 import {
 	BENCHMARK_SCHEMA_VERSION,
 	type BenchmarkResult,
-	coreFixtures,
-	coreRuntimeBudgets,
+} from '@c15t/benchmarking/schema';
+import {
 	getEnvironment,
 	safeBaseSha,
 	safeCommitSha,
 	summarizeMetric,
 	writeJson,
-} from '@c15t/benchmarking';
+} from '@c15t/benchmarking/utils';
 import {
 	type ConsentState,
 	configureConsentManager,

--- a/benchmarks/tw3-test/next.config.ts
+++ b/benchmarks/tw3-test/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from 'next';
 
-const config: NextConfig = {};
+const transpilePackages = [
+	'@c15t/benchmarking',
+	'@c15t/react',
+	'@c15t/nextjs',
+	'c15t',
+];
+
+const config: NextConfig = {
+	transpilePackages,
+};
 
 export default config;

--- a/benchmarks/tw3-test/next.config.ts
+++ b/benchmarks/tw3-test/next.config.ts
@@ -1,14 +1,5 @@
 import type { NextConfig } from 'next';
 
-const transpilePackages = [
-	'@c15t/benchmarking',
-	'@c15t/react',
-	'@c15t/nextjs',
-	'c15t',
-];
-
-const config: NextConfig = {
-	transpilePackages,
-};
+const config: NextConfig = {};
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"release": "bun run build && bun run check:publish-artifacts && bun scripts/resolve-workspace-deps.ts && changeset publish",
 		"release:canary": "bun run build && bun run check:publish-artifacts && bun scripts/resolve-workspace-deps.ts && changeset publish --tag canary",
 		"release:rc": "bun run build:libs && bun run check:publish-artifacts && bun scripts/resolve-workspace-deps.ts && changeset publish",
+		"repro:tw3-css": "bun scripts/repro-tw3-css-entrypoints.ts",
 		"setup:docs": "tsx scripts/setup-docs.ts",
 		"test": "turbo run test",
 		"vercel-build": "tsx scripts/setup-docs.ts --vercel",

--- a/packages/nextjs/iab/styles.tw3.css
+++ b/packages/nextjs/iab/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "../dist/iab/styles.tw3.css";

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -61,6 +61,7 @@
 		"dist-types",
 		"client",
 		"styles.css",
+		"styles.tw3.css",
 		"iab",
 		"src/styles.css",
 		"src/styles.tw3.css",

--- a/packages/nextjs/scripts/generate-distribution-css.ts
+++ b/packages/nextjs/scripts/generate-distribution-css.ts
@@ -98,7 +98,7 @@ for (const relativePath of inlinedFiles) {
 		' */',
 		'',
 	].join('\n');
-	Bun.write(targetPath, `${header}${sourceCss}`);
+	await Bun.write(targetPath, `${header}${sourceCss}`);
 }
 
 console.log(

--- a/packages/nextjs/scripts/generate-distribution-css.ts
+++ b/packages/nextjs/scripts/generate-distribution-css.ts
@@ -1,18 +1,15 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const packageRoot = join(import.meta.dirname, '..');
 const sourceRoot = join(packageRoot, 'src');
 const distRoot = join(packageRoot, 'dist');
+const uiDistRoot = join(packageRoot, '..', 'ui', 'dist');
 
-const files = [
-	'styles.css',
-	'styles.tw3.css',
-	'iab/styles.css',
-	'iab/styles.tw3.css',
-];
+const wrapperFiles = ['styles.css', 'iab/styles.css'];
+const inlinedFiles = ['styles.tw3.css', 'iab/styles.tw3.css'];
 
-for (const relativePath of files) {
+for (const relativePath of wrapperFiles) {
 	const sourcePath = join(sourceRoot, relativePath);
 	const targetPath = join(distRoot, relativePath);
 
@@ -24,6 +21,28 @@ for (const relativePath of files) {
 	copyFileSync(sourcePath, targetPath);
 }
 
+for (const relativePath of inlinedFiles) {
+	const sourcePath = join(uiDistRoot, relativePath);
+	const targetPath = join(distRoot, relativePath);
+
+	if (!existsSync(sourcePath)) {
+		throw new Error(`Missing UI CSS asset to inline: ${sourcePath}`);
+	}
+
+	mkdirSync(dirname(targetPath), { recursive: true });
+	const sourceCss = readFileSync(sourcePath, 'utf8');
+	const header = [
+		'/**',
+		' * @c15t/nextjs - Tailwind 3-compatible prebuilt component styles.',
+		' *',
+		' * This file inlines @c15t/ui CSS so bundlers that do not follow',
+		' * nested package CSS imports still include the complete stylesheet.',
+		' */',
+		'',
+	].join('\n');
+	Bun.write(targetPath, `${header}${sourceCss}`);
+}
+
 console.log(
-	'Copied wrapper CSS entrypoints into dist/styles.css, dist/styles.tw3.css, dist/iab/styles.css, and dist/iab/styles.tw3.css'
+	'Generated distribution CSS entrypoints in dist/styles.css, dist/styles.tw3.css, dist/iab/styles.css, and dist/iab/styles.tw3.css'
 );

--- a/packages/nextjs/scripts/generate-distribution-css.ts
+++ b/packages/nextjs/scripts/generate-distribution-css.ts
@@ -1,13 +1,75 @@
+import { spawnSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const packageRoot = join(import.meta.dirname, '..');
 const sourceRoot = join(packageRoot, 'src');
 const distRoot = join(packageRoot, 'dist');
-const uiDistRoot = join(packageRoot, '..', 'ui', 'dist');
+const uiPackageRoot = join(packageRoot, '..', 'ui');
+const uiDistRoot = join(uiPackageRoot, 'dist');
 
 const wrapperFiles = ['styles.css', 'iab/styles.css'];
 const inlinedFiles = ['styles.tw3.css', 'iab/styles.tw3.css'];
+
+let attemptedUiCssGeneration = false;
+
+function formatCommandOutput(label: string, output?: string | null) {
+	const trimmedOutput = output?.trim();
+	return trimmedOutput ? `\n${label}:\n${trimmedOutput}` : '';
+}
+
+function generateUiCssAssets(missingPath: string) {
+	if (attemptedUiCssGeneration) {
+		return;
+	}
+
+	attemptedUiCssGeneration = true;
+	console.log(
+		`Missing UI CSS asset ${missingPath}; generating @c15t/ui CSS entrypoints...`
+	);
+
+	const result = spawnSync('bun', ['scripts/generate-css-entrypoints.ts'], {
+		cwd: uiPackageRoot,
+		encoding: 'utf8',
+	});
+
+	if (result.error) {
+		throw new Error(
+			`Failed to start @c15t/ui CSS generator: ${result.error.message}`
+		);
+	}
+
+	if (result.status !== 0) {
+		const exitReason =
+			result.signal === null
+				? `exit code ${result.status}`
+				: `signal ${result.signal}`;
+
+		throw new Error(
+			`Failed to generate @c15t/ui CSS entrypoints with ${exitReason}.` +
+				formatCommandOutput('stdout', result.stdout) +
+				formatCommandOutput('stderr', result.stderr)
+		);
+	}
+}
+
+function getUiCssAsset(relativePath: string) {
+	const sourcePath = join(uiDistRoot, relativePath);
+
+	if (existsSync(sourcePath)) {
+		return sourcePath;
+	}
+
+	generateUiCssAssets(sourcePath);
+
+	if (existsSync(sourcePath)) {
+		return sourcePath;
+	}
+
+	throw new Error(
+		`@c15t/ui CSS generator completed but did not produce ${sourcePath}`
+	);
+}
 
 for (const relativePath of wrapperFiles) {
 	const sourcePath = join(sourceRoot, relativePath);
@@ -22,12 +84,8 @@ for (const relativePath of wrapperFiles) {
 }
 
 for (const relativePath of inlinedFiles) {
-	const sourcePath = join(uiDistRoot, relativePath);
+	const sourcePath = getUiCssAsset(relativePath);
 	const targetPath = join(distRoot, relativePath);
-
-	if (!existsSync(sourcePath)) {
-		throw new Error(`Missing UI CSS asset to inline: ${sourcePath}`);
-	}
 
 	mkdirSync(dirname(targetPath), { recursive: true });
 	const sourceCss = readFileSync(sourcePath, 'utf8');

--- a/packages/nextjs/styles.tw3.css
+++ b/packages/nextjs/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "./dist/styles.tw3.css";

--- a/packages/react/iab/styles.tw3.css
+++ b/packages/react/iab/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "../dist/iab/styles.tw3.css";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -140,6 +140,7 @@
 		"dist-types",
 		"client",
 		"styles.css",
+		"styles.tw3.css",
 		"iab",
 		"src/styles.tw3.css",
 		"src/iab/styles.tw3.css",

--- a/packages/react/scripts/generate-distribution-css.ts
+++ b/packages/react/scripts/generate-distribution-css.ts
@@ -98,7 +98,7 @@ for (const relativePath of inlinedFiles) {
 		' */',
 		'',
 	].join('\n');
-	Bun.write(targetPath, `${header}${sourceCss}`);
+	await Bun.write(targetPath, `${header}${sourceCss}`);
 }
 
 console.log(

--- a/packages/react/scripts/generate-distribution-css.ts
+++ b/packages/react/scripts/generate-distribution-css.ts
@@ -1,18 +1,15 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const packageRoot = join(import.meta.dirname, '..');
 const sourceRoot = join(packageRoot, 'src');
 const distRoot = join(packageRoot, 'dist');
+const uiDistRoot = join(packageRoot, '..', 'ui', 'dist');
 
-const files = [
-	'styles.css',
-	'styles.tw3.css',
-	'iab/styles.css',
-	'iab/styles.tw3.css',
-];
+const wrapperFiles = ['styles.css', 'iab/styles.css'];
+const inlinedFiles = ['styles.tw3.css', 'iab/styles.tw3.css'];
 
-for (const relativePath of files) {
+for (const relativePath of wrapperFiles) {
 	const sourcePath = join(sourceRoot, relativePath);
 	const targetPath = join(distRoot, relativePath);
 
@@ -24,6 +21,28 @@ for (const relativePath of files) {
 	copyFileSync(sourcePath, targetPath);
 }
 
+for (const relativePath of inlinedFiles) {
+	const sourcePath = join(uiDistRoot, relativePath);
+	const targetPath = join(distRoot, relativePath);
+
+	if (!existsSync(sourcePath)) {
+		throw new Error(`Missing UI CSS asset to inline: ${sourcePath}`);
+	}
+
+	mkdirSync(dirname(targetPath), { recursive: true });
+	const sourceCss = readFileSync(sourcePath, 'utf8');
+	const header = [
+		'/**',
+		' * @c15t/react - Tailwind 3-compatible prebuilt component styles.',
+		' *',
+		' * This file inlines @c15t/ui CSS so bundlers that do not follow',
+		' * nested package CSS imports still include the complete stylesheet.',
+		' */',
+		'',
+	].join('\n');
+	Bun.write(targetPath, `${header}${sourceCss}`);
+}
+
 console.log(
-	'Copied wrapper CSS entrypoints into dist/styles.css, dist/styles.tw3.css, dist/iab/styles.css, and dist/iab/styles.tw3.css'
+	'Generated distribution CSS entrypoints in dist/styles.css, dist/styles.tw3.css, dist/iab/styles.css, and dist/iab/styles.tw3.css'
 );

--- a/packages/react/scripts/generate-distribution-css.ts
+++ b/packages/react/scripts/generate-distribution-css.ts
@@ -1,13 +1,75 @@
+import { spawnSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const packageRoot = join(import.meta.dirname, '..');
 const sourceRoot = join(packageRoot, 'src');
 const distRoot = join(packageRoot, 'dist');
-const uiDistRoot = join(packageRoot, '..', 'ui', 'dist');
+const uiPackageRoot = join(packageRoot, '..', 'ui');
+const uiDistRoot = join(uiPackageRoot, 'dist');
 
 const wrapperFiles = ['styles.css', 'iab/styles.css'];
 const inlinedFiles = ['styles.tw3.css', 'iab/styles.tw3.css'];
+
+let attemptedUiCssGeneration = false;
+
+function formatCommandOutput(label: string, output?: string | null) {
+	const trimmedOutput = output?.trim();
+	return trimmedOutput ? `\n${label}:\n${trimmedOutput}` : '';
+}
+
+function generateUiCssAssets(missingPath: string) {
+	if (attemptedUiCssGeneration) {
+		return;
+	}
+
+	attemptedUiCssGeneration = true;
+	console.log(
+		`Missing UI CSS asset ${missingPath}; generating @c15t/ui CSS entrypoints...`
+	);
+
+	const result = spawnSync('bun', ['scripts/generate-css-entrypoints.ts'], {
+		cwd: uiPackageRoot,
+		encoding: 'utf8',
+	});
+
+	if (result.error) {
+		throw new Error(
+			`Failed to start @c15t/ui CSS generator: ${result.error.message}`
+		);
+	}
+
+	if (result.status !== 0) {
+		const exitReason =
+			result.signal === null
+				? `exit code ${result.status}`
+				: `signal ${result.signal}`;
+
+		throw new Error(
+			`Failed to generate @c15t/ui CSS entrypoints with ${exitReason}.` +
+				formatCommandOutput('stdout', result.stdout) +
+				formatCommandOutput('stderr', result.stderr)
+		);
+	}
+}
+
+function getUiCssAsset(relativePath: string) {
+	const sourcePath = join(uiDistRoot, relativePath);
+
+	if (existsSync(sourcePath)) {
+		return sourcePath;
+	}
+
+	generateUiCssAssets(sourcePath);
+
+	if (existsSync(sourcePath)) {
+		return sourcePath;
+	}
+
+	throw new Error(
+		`@c15t/ui CSS generator completed but did not produce ${sourcePath}`
+	);
+}
 
 for (const relativePath of wrapperFiles) {
 	const sourcePath = join(sourceRoot, relativePath);
@@ -22,12 +84,8 @@ for (const relativePath of wrapperFiles) {
 }
 
 for (const relativePath of inlinedFiles) {
-	const sourcePath = join(uiDistRoot, relativePath);
+	const sourcePath = getUiCssAsset(relativePath);
 	const targetPath = join(distRoot, relativePath);
-
-	if (!existsSync(sourcePath)) {
-		throw new Error(`Missing UI CSS asset to inline: ${sourcePath}`);
-	}
 
 	mkdirSync(dirname(targetPath), { recursive: true });
 	const sourceCss = readFileSync(sourcePath, 'utf8');

--- a/packages/react/src/components/__tests__/theme-regressions.test.tsx
+++ b/packages/react/src/components/__tests__/theme-regressions.test.tsx
@@ -1,5 +1,6 @@
 import type { ConsentStoreState } from 'c15t';
 import { defaultTranslationConfig } from 'c15t';
+import { createRef } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentDialogOverlay } from '~/components/consent-dialog/atoms/overlay';
@@ -163,6 +164,7 @@ describe('Theme regressions', () => {
 
 	test('allows direct className and inline style on ConsentDialog.Overlay', async () => {
 		const state = createMockState();
+		const overlayRef = createRef<HTMLDivElement>();
 
 		await render(
 			<GlobalThemeContext.Provider value={{ noStyle: false }}>
@@ -178,7 +180,10 @@ describe('Theme regressions', () => {
 					}}
 				>
 					<ConsentDialogOverlay
+						ref={overlayRef}
 						className="dialog-overlay-direct"
+						data-qa="overlay"
+						id="overlay-id"
 						noStyle
 						style={{ backgroundColor: 'rgb(7, 8, 9)' }}
 					/>
@@ -192,6 +197,9 @@ describe('Theme regressions', () => {
 			) as HTMLElement | null;
 
 			expect(overlay).toBeInTheDocument();
+			expect(overlayRef.current).toBe(overlay);
+			expect(overlay).toHaveAttribute('data-qa', 'overlay');
+			expect(overlay).toHaveAttribute('id', 'overlay-id');
 			expect(overlay?.className).toContain('dialog-overlay-direct');
 			expect(overlay).toHaveStyle({
 				backgroundColor: 'rgb(7, 8, 9)',

--- a/packages/react/src/components/__tests__/theme-regressions.test.tsx
+++ b/packages/react/src/components/__tests__/theme-regressions.test.tsx
@@ -1,9 +1,59 @@
+import type { ConsentStoreState } from 'c15t';
+import { defaultTranslationConfig } from 'c15t';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
+import { ConsentDialogOverlay } from '~/components/consent-dialog/atoms/overlay';
 import { ConsentWidgetAccordion } from '~/components/consent-widget/atoms/accordion';
 import { IABConsentBannerFooter } from '~/components/iab-consent-banner/atoms/footer';
 import { IABConsentBannerHeader } from '~/components/iab-consent-banner/atoms/header';
+import { ConsentStateContext } from '~/context/consent-manager-context';
 import { GlobalThemeContext } from '~/context/theme-context';
+
+function createMockState(
+	overrides: Partial<ConsentStoreState> = {}
+): ConsentStoreState {
+	return {
+		activeUI: 'dialog',
+		model: 'opt-in',
+		translationConfig: defaultTranslationConfig,
+		consents: {
+			necessary: true,
+			functionality: false,
+			experience: false,
+			marketing: false,
+			measurement: false,
+		},
+		selectedConsents: {
+			necessary: true,
+			functionality: false,
+			experience: false,
+			marketing: false,
+			measurement: false,
+		},
+		consentInfo: null,
+		consentCategories: [
+			'necessary',
+			'functionality',
+			'experience',
+			'marketing',
+			'measurement',
+		],
+		consentTypes: [],
+		policyCategories: null,
+		policyScopeMode: null,
+		policyBanner: {},
+		policyDialog: {},
+		saveConsents: vi.fn().mockResolvedValue(undefined),
+		setConsent: vi.fn(),
+		setSelectedConsent: vi.fn(),
+		setActiveUI: vi.fn(),
+		has: vi.fn(),
+		hasConsented: vi.fn(),
+		getDisplayedConsents: vi.fn(() => []),
+		subscribeToConsentChanges: vi.fn(() => () => undefined),
+		...overrides,
+	} as unknown as ConsentStoreState;
+}
 
 describe('Theme regressions', () => {
 	test('does not forward slot noStyle to the DOM', async () => {
@@ -107,6 +157,44 @@ describe('Theme regressions', () => {
 			expect(accordion).toHaveStyle({
 				backgroundColor: 'rgb(4, 5, 6)',
 				padding: '12px',
+			});
+		});
+	});
+
+	test('allows direct className and inline style on ConsentDialog.Overlay', async () => {
+		const state = createMockState();
+
+		await render(
+			<GlobalThemeContext.Provider value={{ noStyle: false }}>
+				<ConsentStateContext.Provider
+					value={{
+						state,
+						store: {
+							getState: () => state,
+							subscribe: () => () => undefined,
+							setState: () => undefined,
+						},
+						manager: null,
+					}}
+				>
+					<ConsentDialogOverlay
+						className="dialog-overlay-direct"
+						noStyle
+						style={{ backgroundColor: 'rgb(7, 8, 9)' }}
+					/>
+				</ConsentStateContext.Provider>
+			</GlobalThemeContext.Provider>
+		);
+
+		await vi.waitFor(() => {
+			const overlay = document.querySelector(
+				'[data-testid="consent-dialog-overlay"]'
+			) as HTMLElement | null;
+
+			expect(overlay).toBeInTheDocument();
+			expect(overlay?.className).toContain('dialog-overlay-direct');
+			expect(overlay).toHaveStyle({
+				backgroundColor: 'rgb(7, 8, 9)',
 			});
 		});
 	});

--- a/packages/react/src/components/consent-dialog/atoms/overlay.tsx
+++ b/packages/react/src/components/consent-dialog/atoms/overlay.tsx
@@ -5,7 +5,13 @@
  */
 
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
-import { type FC, type PropsWithChildren, useEffect, useState } from 'react';
+import {
+	type CSSProperties,
+	forwardRef,
+	type HTMLAttributes,
+	useEffect,
+	useState,
+} from 'react';
 import { useConsentManager } from '~/hooks/use-consent-manager';
 import { useStyles } from '~/hooks/use-styles';
 import { useTheme } from '~/hooks/use-theme';
@@ -23,25 +29,18 @@ import { cnExt as cn } from '~/utils/cn';
  * @public
  */
 
-/**
- * Props for the Overlay component.
- *
- * @remarks
- * Extends {@link PropsWithChildren} so that the overlay can optionally wrap
- * its compound components (e.g. `ConsentDialog.Card`). This resolves
- * TypeScript errors when consumers nest elements inside
- * `<ConsentDialog.Root>`.
- */
-export type OverlayProps = PropsWithChildren<{
+export interface OverlayProps
+	extends Omit<HTMLAttributes<HTMLDivElement>, 'style'> {
 	/**
 	 * Custom styles to override default overlay styling.
 	 *
 	 * @remarks
-	 * - Can be a string class name or an object with className and style properties
+	 * - Accepts normal React inline styles
+	 * - Also accepts the legacy string class name or object with className and style properties
 	 * - Styles are merged with theme styles and default styles
 	 * - Useful for customizing overlay appearance while maintaining functionality
 	 */
-	style?: ThemeValue;
+	style?: CSSProperties | ThemeValue;
 
 	/**
 	 * Disables default styling when true.
@@ -52,78 +51,86 @@ export type OverlayProps = PropsWithChildren<{
 	 * - Maintains functionality without visual opinions
 	 */
 	noStyle?: boolean;
-}>;
+}
 
-const ConsentDialogOverlay: FC<OverlayProps> = ({ noStyle, style }) => {
-	const { activeUI } = useConsentManager();
-	const {
-		disableAnimation,
-		noStyle: isThemeNoStyle,
-		scrollLock = true,
-	} = useTheme();
+const ConsentDialogOverlay = forwardRef<HTMLDivElement, OverlayProps>(
+	({ className, noStyle, style, ...props }, ref) => {
+		const { activeUI } = useConsentManager();
+		const { disableAnimation, noStyle: isThemeNoStyle } = useTheme();
 
-	const showDialog = activeUI === 'dialog';
-	const [isVisible, setIsVisible] = useState(false);
+		const showDialog = activeUI === 'dialog';
+		const [isVisible, setIsVisible] = useState(false);
 
-	// Handle animation visibility state
-	useEffect(() => {
-		if (showDialog) {
-			setIsVisible(true);
-		} else if (disableAnimation) {
-			setIsVisible(false);
-		} else {
-			const animationDurationMs = Number.parseInt(
-				getComputedStyle(document.documentElement).getPropertyValue(
-					'--consent-dialog-animation-duration'
-				) || '200',
-				10
-			);
-			const timer = setTimeout(() => {
+		// Handle animation visibility state
+		useEffect(() => {
+			if (showDialog) {
+				setIsVisible(true);
+			} else if (disableAnimation) {
 				setIsVisible(false);
-			}, animationDurationMs); // Match CSS animation duration
-			return () => clearTimeout(timer);
-		}
-	}, [showDialog, disableAnimation]);
-
-	// Get custom className from style prop
-	const customClassName = typeof style === 'string' ? style : style?.className;
-
-	// Apply theme styles
-	const theme = useStyles('consentDialogOverlay', {
-		baseClassName: !(isThemeNoStyle || noStyle) && styles.overlay,
-		className: customClassName,
-		noStyle: isThemeNoStyle || noStyle,
-	});
-
-	// Animations are handled with CSS classes
-	const shouldApplyAnimation =
-		!(isThemeNoStyle || noStyle) && !disableAnimation;
-
-	// Use conditional assignment instead of nested ternaries
-	let animationClass: string | undefined;
-	if (shouldApplyAnimation) {
-		animationClass = isVisible ? styles.overlayVisible : styles.overlayHidden;
-	} else {
-		animationClass = undefined;
-	}
-
-	// Combine theme className with animation class if needed
-	const finalClassName = cn(theme.className, animationClass);
-
-	return (
-		<div
-			role="presentation"
-			aria-hidden="true"
-			style={
-				typeof style === 'object' && 'style' in style
-					? { ...theme.style, ...style.style }
-					: theme.style
+			} else {
+				const animationDurationMs = Number.parseInt(
+					getComputedStyle(document.documentElement).getPropertyValue(
+						'--consent-dialog-animation-duration'
+					) || '200',
+					10
+				);
+				const timer = setTimeout(() => {
+					setIsVisible(false);
+				}, animationDurationMs); // Match CSS animation duration
+				return () => clearTimeout(timer);
 			}
-			className={finalClassName}
-			data-testid="consent-dialog-overlay"
-		/>
-	);
-};
+		}, [showDialog, disableAnimation]);
+
+		const legacyStyleClassName =
+			typeof style === 'string'
+				? style
+				: style && ('className' in style ? style.className : undefined);
+		const customClassName = cn(legacyStyleClassName, className);
+
+		const inlineStyle =
+			typeof style === 'object' && style !== null
+				? 'style' in style || 'className' in style
+					? style.style
+					: style
+				: undefined;
+
+		// Apply theme styles
+		const theme = useStyles('consentDialogOverlay', {
+			baseClassName: !(isThemeNoStyle || noStyle) && styles.overlay,
+			className: customClassName,
+			noStyle: isThemeNoStyle || noStyle,
+		});
+
+		// Animations are handled with CSS classes
+		const shouldApplyAnimation =
+			!(isThemeNoStyle || noStyle) && !disableAnimation;
+
+		// Use conditional assignment instead of nested ternaries
+		let animationClass: string | undefined;
+		if (shouldApplyAnimation) {
+			animationClass = isVisible ? styles.overlayVisible : styles.overlayHidden;
+		} else {
+			animationClass = undefined;
+		}
+
+		// Combine theme className with animation class if needed
+		const finalClassName = cn(theme.className, animationClass);
+
+		return (
+			<div
+				ref={ref}
+				{...props}
+				role="presentation"
+				aria-hidden="true"
+				style={{ ...theme.style, ...inlineStyle }}
+				className={finalClassName}
+				data-testid="consent-dialog-overlay"
+			/>
+		);
+	}
+);
+
+ConsentDialogOverlay.displayName = 'ConsentDialogOverlay';
 
 const Overlay = ConsentDialogOverlay;
 

--- a/packages/react/src/components/consent-dialog/atoms/overlay.tsx
+++ b/packages/react/src/components/consent-dialog/atoms/overlay.tsx
@@ -81,18 +81,23 @@ const ConsentDialogOverlay = forwardRef<HTMLDivElement, OverlayProps>(
 			}
 		}, [showDialog, disableAnimation]);
 
-		const legacyStyleClassName =
-			typeof style === 'string'
-				? style
-				: style && ('className' in style ? style.className : undefined);
+		let legacyStyleClassName: string | undefined;
+		if (typeof style === 'string') {
+			legacyStyleClassName = style;
+		} else if (style && 'className' in style) {
+			legacyStyleClassName = style.className;
+		}
+
 		const customClassName = cn(legacyStyleClassName, className);
 
-		const inlineStyle =
-			typeof style === 'object' && style !== null
-				? 'style' in style || 'className' in style
-					? style.style
-					: style
-				: undefined;
+		let inlineStyle: CSSProperties | undefined;
+		if (typeof style === 'object' && style !== null) {
+			if ('style' in style || 'className' in style) {
+				inlineStyle = style.style;
+			} else {
+				inlineStyle = style as CSSProperties;
+			}
+		}
 
 		// Apply theme styles
 		const theme = useStyles('consentDialogOverlay', {

--- a/packages/react/styles.tw3.css
+++ b/packages/react/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "./dist/styles.tw3.css";

--- a/packages/ui/iab/styles.tw3.css
+++ b/packages/ui/iab/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "../dist/iab/styles.tw3.css";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -86,6 +86,7 @@
 		"dist",
 		"dist-types",
 		"styles.css",
+		"styles.tw3.css",
 		"iab",
 		"src/primitives",
 		"src/styles",

--- a/packages/ui/styles.tw3.css
+++ b/packages/ui/styles.tw3.css
@@ -1,0 +1,1 @@
+@import "./dist/styles.tw3.css";

--- a/scripts/check-publish-artifacts.ts
+++ b/scripts/check-publish-artifacts.ts
@@ -45,7 +45,9 @@ const distBlockedPathPatterns: Array<{ reason: string; pattern: RegExp }> = [
 const requiredPackedFilesByPackage: Record<string, string[]> = {
 	'@c15t/ui': [
 		'styles.css',
+		'styles.tw3.css',
 		'iab/styles.css',
+		'iab/styles.tw3.css',
 		'dist/styles.css',
 		'dist/styles.tw3.css',
 		'dist/iab/styles.css',
@@ -53,22 +55,41 @@ const requiredPackedFilesByPackage: Record<string, string[]> = {
 	],
 	'@c15t/react': [
 		'styles.css',
+		'styles.tw3.css',
 		'iab/styles.css',
+		'iab/styles.tw3.css',
 		'dist/styles.css',
+		'dist/styles.tw3.css',
 		'dist/iab/styles.css',
+		'dist/iab/styles.tw3.css',
 		'src/styles.tw3.css',
 		'src/iab/styles.tw3.css',
 	],
 	'@c15t/nextjs': [
 		'styles.css',
+		'styles.tw3.css',
 		'iab/styles.css',
+		'iab/styles.tw3.css',
 		'dist/styles.css',
+		'dist/styles.tw3.css',
 		'dist/iab/styles.css',
+		'dist/iab/styles.tw3.css',
 		'src/styles.css',
 		'src/styles.tw3.css',
 		'src/iab/styles.css',
 		'src/iab/styles.tw3.css',
 	],
+};
+
+const styleEntrypointPackages = new Set([
+	'@c15t/ui',
+	'@c15t/react',
+	'@c15t/nextjs',
+]);
+
+const rootTw3ProxyContents: Record<string, string> = {
+	'styles.tw3.css': '@import "./dist/styles.tw3.css";',
+	'iab/styles.tw3.css': '@import "../dist/iab/styles.tw3.css";',
 };
 
 function readManifest(packageDir: string): PackageManifest {
@@ -302,6 +323,59 @@ function scanAgentDocsContent(packageDir: string): string[] {
 	return issues;
 }
 
+function scanStyleEntrypointsContent(
+	packageDir: string,
+	packageName: string,
+	packedFilePaths: Set<string>
+): Array<{ path: string; size: number; reason: string }> {
+	if (!styleEntrypointPackages.has(packageName)) {
+		return [];
+	}
+
+	const issues: Array<{ path: string; size: number; reason: string }> = [];
+
+	for (const [path, expectedContent] of Object.entries(rootTw3ProxyContents)) {
+		if (!packedFilePaths.has(path)) {
+			continue;
+		}
+
+		const filePath = join(packageDir, path);
+		const content = existsSync(filePath) ? readFileSync(filePath, 'utf8') : '';
+		if (content.trim() !== expectedContent) {
+			issues.push({
+				path,
+				size: content.length,
+				reason: 'Tailwind v3 root proxy must point at the dist entrypoint',
+			});
+		}
+	}
+
+	for (const path of ['dist/styles.tw3.css', 'dist/iab/styles.tw3.css']) {
+		if (!packedFilePaths.has(path)) {
+			continue;
+		}
+
+		const filePath = join(packageDir, path);
+		const content = existsSync(filePath) ? readFileSync(filePath, 'utf8') : '';
+		if (/^\s*@import\b/m.test(content)) {
+			issues.push({
+				path,
+				size: content.length,
+				reason: 'Tailwind v3 dist CSS must inline rules, not nested imports',
+			});
+		}
+		if (!content.includes('c15t-ui-')) {
+			issues.push({
+				path,
+				size: content.length,
+				reason: 'Tailwind v3 dist CSS must contain generated c15t UI rules',
+			});
+		}
+	}
+
+	return issues;
+}
+
 const packageDirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
 	.filter((entry) => entry.isDirectory())
 	.map((entry) => join(PACKAGES_DIR, entry.name))
@@ -348,6 +422,9 @@ for (const packageDir of packageDirs) {
 			});
 		}
 	}
+	blockedFiles.push(
+		...scanStyleEntrypointsContent(packageDir, packed.name, packedFilePaths)
+	);
 
 	if (blockedFiles.length > 0) {
 		offenders.push({

--- a/scripts/repro-tw3-css-entrypoints.ts
+++ b/scripts/repro-tw3-css-entrypoints.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = process.argv[2]
+	? resolve(process.argv[2])
+	: join(import.meta.dirname, '..');
+
+const stylePackages = [
+	{ name: '@c15t/ui', dir: 'packages/ui' },
+	{ name: '@c15t/react', dir: 'packages/react' },
+	{ name: '@c15t/nextjs', dir: 'packages/nextjs' },
+];
+
+const entries = ['styles.tw3.css', 'iab/styles.tw3.css'];
+
+function readRequiredFile(path: string): string {
+	if (!existsSync(path)) {
+		throw new Error(`Missing file: ${path}`);
+	}
+
+	return readFileSync(path, 'utf8');
+}
+
+function expectedProxy(entry: string): string {
+	return entry.startsWith('iab/')
+		? '@import "../dist/iab/styles.tw3.css";'
+		: '@import "./dist/styles.tw3.css";';
+}
+
+const failures: string[] = [];
+
+for (const stylePackage of stylePackages) {
+	const packageDir = join(ROOT, stylePackage.dir);
+
+	for (const entry of entries) {
+		const rootEntryPath = join(packageDir, entry);
+		const distEntryPath = join(packageDir, 'dist', entry);
+
+		try {
+			const rootEntry = readRequiredFile(rootEntryPath).trim();
+			const distEntry = readRequiredFile(distEntryPath);
+
+			if (rootEntry !== expectedProxy(entry)) {
+				failures.push(
+					`${stylePackage.name}/${entry} does not proxy to its dist entrypoint`
+				);
+			}
+
+			if (/^\s*@import\b/m.test(distEntry)) {
+				failures.push(
+					`${stylePackage.name}/dist/${entry} still contains a nested @import`
+				);
+			}
+
+			if (!distEntry.includes('c15t-ui-')) {
+				failures.push(
+					`${stylePackage.name}/dist/${entry} does not contain generated c15t UI rules`
+				);
+			}
+		} catch (error) {
+			failures.push(
+				`${stylePackage.name}/${entry}: ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
+		}
+	}
+}
+
+if (failures.length > 0) {
+	console.error('Tailwind v3 CSS entrypoint reproduction failed.');
+	for (const failure of failures) {
+		console.error(`- ${failure}`);
+	}
+	process.exit(1);
+}
+
+console.log(
+	'Tailwind v3 CSS entrypoint reproduction passed: root TW3 files resolve physically and dist TW3 files inline generated c15t UI rules.'
+);


### PR DESCRIPTION
## Overview
Fixes Tailwind CSS v3 stylesheet packaging so c15t component rules are present even when a resolver does not follow nested package CSS imports, and aligns `ConsentDialog.Overlay` with the banner overlay API for direct headless styling.

## Related Issue
Fixes #785

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Publish root Tailwind v3 stylesheet proxies for `@c15t/ui`, `@c15t/react`, and `@c15t/nextjs`, and inline generated UI CSS in React/Next.js TW3 dist files.
2. Add a TW3 reproduction script plus publish-artifact checks that fail if dist TW3 CSS uses nested imports or lacks `c15t-ui-*` rules.
3. Allow `ConsentDialog.Overlay` to accept direct `className`, refs, inline styles, and div props, with regression coverage.

### Technical Notes
The TW3 repro was run against `origin/main` and failed there because root TW3 files were missing, then passed on this branch.

## Testing

### Test Plan
- [x] Tailwind v3 entrypoint repro

  ```sh
  bun run repro:tw3-css
  ```

  ✓ Expected: root TW3 files resolve physically and dist TW3 files inline c15t UI rules

- [x] Publish artifact guard

  ```sh
  bun scripts/check-publish-artifacts.ts
  ```

  ✓ Expected: all public package publish artifacts pass

- [x] React overlay regression

  ```sh
  bun run --filter @c15t/react test -- theme-regressions
  ```

  ✓ Expected: focused theme regression tests pass

### Edge Cases
- [x] Error handling: publish guard fails when TW3 dist CSS contains nested imports or no generated UI rules
- [x] Performance: no runtime impact, packaging-only CSS generation changes
- [x] Security: no security-sensitive code paths changed

### Visual Changes
None

## Checklist

### Required
- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ConsentDialog.Overlay accepts className, ref, and standard div attributes in headless noStyle mode.
  * Tailwind CSS v3 support: TW3 stylesheet entrypoints and inlined TW3 distribution CSS published for UI, React, and Next.js.

* **Tests**
  * Added regression test verifying overlay forwards ref, className, attributes, and inline style.

* **Chores**
  * Added generation/verification scripts, publish checks, and a workspace repro script to enforce TW3 entrypoint requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->