### PR TITLE
Fix CORS wildcard domain matching

### DIFF
--- a/.changeset/fix-cors-wildcard-domains.md
+++ b/.changeset/fix-cors-wildcard-domains.md
@@ -1,0 +1,5 @@
+---
+"@c15t/backend": patch
+---
+
+Fix CORS trusted origin matching for wildcard subdomains and www variants.

--- a/.changeset/fix-cors-wildcard-domains.md
+++ b/.changeset/fix-cors-wildcard-domains.md
@@ -2,4 +2,6 @@
 "@c15t/backend": patch
 ---
 
+# Fix CORS trusted origin matching
+
 Fix CORS trusted origin matching for wildcard subdomains and www variants.

--- a/packages/backend/src/middleware/cors/cors.test.ts
+++ b/packages/backend/src/middleware/cors/cors.test.ts
@@ -58,6 +58,45 @@ describe('createCORSOptions (unit)', () => {
 		});
 	});
 
+	describe('wildcard subdomains', () => {
+		it('allows apex, www, and wildcard subdomains when apex and wildcard are configured', async () => {
+			const config = createCORSOptions([
+				'https://example.com',
+				'https://*.example.com',
+			]);
+
+			expect(await callOrigin(config.origin, 'https://example.com')).toBe(
+				'https://example.com'
+			);
+			expect(await callOrigin(config.origin, 'https://www.example.com')).toBe(
+				'https://www.example.com'
+			);
+			expect(await callOrigin(config.origin, 'https://app.example.com')).toBe(
+				'https://app.example.com'
+			);
+		});
+
+		it('does not allow apex domains from wildcard-only configuration', async () => {
+			const config = createCORSOptions(['https://*.example.com']);
+
+			expect(await callOrigin(config.origin, 'https://example.com')).toBeNull();
+			expect(await callOrigin(config.origin, 'https://app.example.com')).toBe(
+				'https://app.example.com'
+			);
+		});
+
+		it('rejects similar domains that are not subdomains', async () => {
+			const config = createCORSOptions(['https://*.example.com']);
+
+			expect(
+				await callOrigin(config.origin, 'https://badexample.com')
+			).toBeNull();
+			expect(
+				await callOrigin(config.origin, 'https://example.com.evil.com')
+			).toBeNull();
+		});
+	});
+
 	describe('specific origins', () => {
 		it('allows trusted origin and rejects untrusted', async () => {
 			const config = createCORSOptions(['http://localhost:3002']);

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -4,6 +4,8 @@
  * @packageDocumentation
  */
 
+import { matchesWildcard } from './matches-wildcard';
+
 /**
  * CORS configuration options compatible with Hono's cors middleware
  */
@@ -102,19 +104,6 @@ function expandWithWWW(origins: string[]): string[] {
 		}
 	}
 	return Array.from(expanded);
-}
-
-/**
- * Checks if a normalized origin matches a normalized wildcard pattern.
- *
- * @param origin - Normalized request origin
- * @param wildcardPattern - Normalized wildcard pattern (e.g. *.example.com)
- * @returns true if the origin is a subdomain of the wildcard pattern
- */
-function matchesWildcard(origin: string, wildcardPattern: string): boolean {
-	const wildcardDomain = wildcardPattern.slice(2);
-
-	return origin !== wildcardDomain && origin.endsWith(`.${wildcardDomain}`);
 }
 
 /**

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -105,6 +105,19 @@ function expandWithWWW(origins: string[]): string[] {
 }
 
 /**
+ * Checks if a normalized origin matches a normalized wildcard pattern.
+ *
+ * @param origin - Normalized request origin
+ * @param wildcardPattern - Normalized wildcard pattern (e.g. *.example.com)
+ * @returns true if the origin is a subdomain of the wildcard pattern
+ */
+function matchesWildcard(origin: string, wildcardPattern: string): boolean {
+	const wildcardDomain = wildcardPattern.slice(2);
+
+	return origin !== wildcardDomain && origin.endsWith(`.${wildcardDomain}`);
+}
+
+/**
  * Creates CORS options configuration for Hono's cors middleware
  *
  * @param trustedOrigins - Array of allowed origin patterns or single string. Can include wildcards ('*').
@@ -172,6 +185,9 @@ export function createCORSOptions(
 						normalizedOrigin === '[::1]' ||
 						normalizedOrigin.startsWith('[::1]:')
 					);
+				}
+				if (normalizedTrusted.startsWith('*.')) {
+					return matchesWildcard(normalizedOrigin, normalizedTrusted);
 				}
 				return normalizedTrusted === normalizedOrigin;
 			});

--- a/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
@@ -88,6 +88,15 @@ describe('CORS utilities', () => {
 			expect(isOriginTrusted('https://EXAMPLE.COM', trustedDomains)).toBe(true);
 		});
 
+		it('should allow www and non-www exact domain variants', () => {
+			expect(isOriginTrusted('https://www.example.com', ['example.com'])).toBe(
+				true
+			);
+			expect(isOriginTrusted('https://example.com', ['www.example.com'])).toBe(
+				true
+			);
+		});
+
 		it('should handle subdomain levels with wildcards', () => {
 			const trustedDomains = ['*.example.com'];
 			expect(isOriginTrusted('https://a.b.example.com', trustedDomains)).toBe(

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -19,6 +19,9 @@ import type { Logger } from '@c15t/logger';
 export const STRIP_REGEX =
 	/^(?:https?:\/\/)|^(?:wss?:\/\/)|(?:\/+$)|(?::\d+$)/g;
 
+/** Regular expression to match www prefix in domain names */
+const WWW_REGEX = /^www\./;
+
 /**
  * Checks if a domain matches a wildcard pattern
  *
@@ -117,9 +120,11 @@ export function isOriginTrusted(
 				return matchesWildcard(originHostname, strippedDomain, logger);
 			}
 
-			const isMatch = originHostname === strippedDomain;
+			const normalizedOriginHostname = originHostname.replace(WWW_REGEX, '');
+			const normalizedDomain = strippedDomain.replace(WWW_REGEX, '');
+			const isMatch = normalizedOriginHostname === normalizedDomain;
 			logger?.debug(
-				`Exact match result: ${isMatch} ${originHostname} === ${strippedDomain}`
+				`Exact match result: ${isMatch} ${normalizedOriginHostname} === ${normalizedDomain}`
 			);
 			return isMatch;
 		});

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Logger } from '@c15t/logger';
+import { matchesWildcard } from './matches-wildcard';
 
 /**
  * Regular expression to strip protocol, trailing slashes, and port numbers from URLs
@@ -21,35 +22,6 @@ export const STRIP_REGEX =
 
 /** Regular expression to match www prefix in domain names */
 const WWW_REGEX = /^www\./;
-
-/**
- * Checks if a domain matches a wildcard pattern
- *
- * @param hostname - The hostname to check
- * @param wildcardPattern - The wildcard pattern (e.g. *.example.com)
- * @param logger - Optional logger for debugging
- * @returns true if the hostname matches the wildcard pattern
- *
- * @internal
- */
-function matchesWildcard(
-	hostname: string,
-	wildcardPattern: string,
-	logger?: Logger
-): boolean {
-	const wildcardDomain = wildcardPattern.slice(2); // Remove *. prefix
-
-	// Ensure the hostname is not the base domain and ends with .wildcardDomain
-	// This prevents matching domains like 'foobar-my-site.com' against '*.my-site.com'
-	const isValid =
-		hostname !== wildcardDomain && hostname.endsWith(`.${wildcardDomain}`);
-
-	logger?.debug(
-		`Wildcard match result: ${isValid} ${hostname} ends with .${wildcardDomain}`
-	);
-
-	return isValid;
-}
 
 /**
  * Validates if a given origin matches any of the trusted domain patterns
@@ -117,7 +89,11 @@ export function isOriginTrusted(
 			logger?.debug(`Checking against stripped domain: ${strippedDomain}`);
 
 			if (strippedDomain.startsWith('*.')) {
-				return matchesWildcard(originHostname, strippedDomain, logger);
+				const isMatch = matchesWildcard(originHostname, strippedDomain);
+				logger?.debug(
+					`Wildcard match result: ${isMatch} ${originHostname} matches ${strippedDomain}`
+				);
+				return isMatch;
 			}
 
 			const normalizedOriginHostname = originHostname.replace(WWW_REGEX, '');

--- a/packages/backend/src/middleware/cors/matches-wildcard.ts
+++ b/packages/backend/src/middleware/cors/matches-wildcard.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared wildcard matching utilities for CORS origin checks.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Checks if an origin matches a wildcard domain pattern.
+ *
+ * @param origin - Hostname or normalized origin to check
+ * @param wildcardPattern - Wildcard pattern (e.g. *.example.com)
+ * @returns true if the origin is a subdomain of the wildcard pattern
+ */
+export function matchesWildcard(
+	origin: string,
+	wildcardPattern: string
+): boolean {
+	const wildcardDomain = wildcardPattern.slice(2);
+
+	return origin !== wildcardDomain && origin.endsWith(`.${wildcardDomain}`);
+}


### PR DESCRIPTION
## Overview
Fixes CORS origin matching so `*.example.com` entries allow real subdomains like `app.example.com` while `example.com` continues to cover the apex and `www` variant. The root cause was that `createCORSOptions()` normalized wildcard entries but compared them with exact string equality, so wildcard subdomains were rejected. The shared origin validator now also treats exact `www` and non-`www` variants consistently with the documented CORS behavior.

## Related Issue
Fixes #787

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. Added wildcard subdomain matching to the Hono CORS options path.
2. Added exact-domain `www` equivalence to the shared origin validator.
3. Added regression tests for apex, `www`, wildcard subdomains, wildcard-only apex rejection, and similar-domain rejection.

### Technical Notes
Wildcard entries remain subdomain-only, so `*.example.com` does not implicitly allow `example.com`; deployments should configure both when they need both.

## Testing

### Test Plan
- [x] Wildcard and apex config allows apex, `www`, and subdomains.

  ```ts
  trustedOrigins: ['https://example.com', 'https://*.example.com']
  ```

  ✓ Expected: `https://example.com`, `https://www.example.com`, and `https://app.example.com` are allowed.

- [x] Wildcard-only config does not allow the apex.

  ```ts
  trustedOrigins: ['https://*.example.com']
  ```

  ✓ Expected: `https://app.example.com` is allowed and `https://example.com` is rejected.

### Edge Cases
- [x] Error handling: invalid origins still return `null`/false.
- [x] Performance: matching stays as simple normalized string checks.
- [x] Security: similar domains such as `badexample.com` and `example.com.evil.com` are rejected.

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CORS trusted origin matching to correctly handle wildcard subdomains (e.g., *.example.com) and www variants.
  * Strengthened origin validation to reject lookalike or malicious domains that do not match configured patterns.

* **Tests**
  * Added unit tests covering wildcard and exact-origin scenarios to ensure consistent CORS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->