### PR TITLE
Verify package artifacts before packing

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -120,7 +120,7 @@
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"knip": "knip",
 		"lint": "bun biome lint ./src",
-		"prepack": "bun run build",
+		"prepack": "bun ../../scripts/verify-package-artifacts.ts",
 		"start": "node dist/server.cjs",
 		"test": "bun prebuild && vitest run",
 		"test:watch": "bun prebuild && vitest"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
 		"dev": "sh -c 'bun prebuild && rslib build --no-dts --no-clean && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",
-		"prepack": "bun run build",
+		"prepack": "bun ../../scripts/verify-package-artifacts.ts",
 		"test": "bun prebuild && vitest run",
 		"test:watch": "bun prebuild && vitest"
 	},

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -92,7 +92,7 @@
 		"dev": "sh -c 'bun prebuild && rslib build --no-dts --no-clean && bun scripts/generate-distribution-css.ts && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",
-		"prepack": "bun run build",
+		"prepack": "bun ../../scripts/verify-package-artifacts.ts",
 		"test": "bun prebuild && vitest run --passWithNoTests",
 		"test:watch": "bun prebuild && vitest --passWithNoTests"
 	},

--- a/packages/node-sdk/rslib.config.ts
+++ b/packages/node-sdk/rslib.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 	source: {
 		entry: {
 			index: ['./src/index.ts'],
+			testing: ['./src/testing.ts'],
 		},
 	},
 	lib: [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,7 +70,7 @@
 		},
 		"./cookie-banner": {
 			"types": "./dist-types/components/consent-banner/index.d.ts",
-			"import": "./dist/components/consent-banner/index.js",
+			"import": "./client/components/consent-banner.js",
 			"require": "./dist/components/consent-banner/index.cjs"
 		},
 		"./components/consent-banner": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,20 +68,10 @@
 			"import": "./dist/headless.js",
 			"require": "./dist/headless.cjs"
 		},
-		"./preference-center": {
-			"types": "./dist-types/components/preference-center/index.d.ts",
-			"import": "./dist/components/preference-center/index.js",
-			"require": "./dist/components/preference-center/index.cjs"
-		},
-		"./preference-center-widget": {
-			"types": "./dist-types/components/preference-center-widget/index.d.ts",
-			"import": "./dist/components/preference-center-widget/index.js",
-			"require": "./dist/components/preference-center-widget/index.cjs"
-		},
 		"./cookie-banner": {
-			"types": "./dist-types/components/cookie-banner/index.d.ts",
-			"import": "./dist/components/cookie-banner/index.js",
-			"require": "./dist/components/cookie-banner/index.cjs"
+			"types": "./dist-types/components/consent-banner/index.d.ts",
+			"import": "./dist/components/consent-banner/index.js",
+			"require": "./dist/components/consent-banner/index.cjs"
 		},
 		"./components/consent-banner": {
 			"types": "./dist-types/components/consent-banner/index.d.ts",
@@ -123,21 +113,6 @@
 			"import": "./dist/hooks/index.js",
 			"require": "./dist/hooks/index.cjs"
 		},
-		"./context": {
-			"types": "./dist-types/context/index.d.ts",
-			"import": "./dist/context/index.js",
-			"require": "./dist/context/index.cjs"
-		},
-		"./types": {
-			"types": "./dist-types/types/index.d.ts",
-			"import": "./dist/types/index.js",
-			"require": "./dist/types/index.cjs"
-		},
-		"./utils": {
-			"types": "./dist-types/utils/index.d.ts",
-			"import": "./dist/utils/index.js",
-			"require": "./dist/utils/index.cjs"
-		},
 		".": {
 			"types": "./dist-types/index.d.ts",
 			"import": "./dist/index.js",
@@ -168,7 +143,7 @@
 		"dev": "sh -c 'bun prebuild && rslib build --no-dts --no-clean && bun scripts/generate-distribution-css.ts && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",
-		"prepack": "bun run build",
+		"prepack": "bun ../../scripts/verify-package-artifacts.ts",
 		"test": "bun prebuild && vitest run",
 		"test:watch": "bun prebuild && vitest"
 	},

--- a/scripts/check-publish-artifacts.ts
+++ b/scripts/check-publish-artifacts.ts
@@ -6,6 +6,12 @@ import {
 	checkPackedAgentDocs,
 	supportedAgentDocsPackages,
 } from './agent-docs/check-budgets';
+import type { PackageManifest } from './manifest-utils';
+import {
+	collectManifestTargets,
+	readManifest,
+	wildcardToRegExp,
+} from './manifest-utils';
 
 type PackedFile = {
 	path: string;
@@ -16,21 +22,6 @@ type PackResult = {
 	name: string;
 	version: string;
 	files: PackedFile[];
-};
-
-type PackageManifest = {
-	name?: string;
-	private?: boolean;
-	main?: string;
-	module?: string;
-	types?: string;
-	bin?: string | Record<string, string>;
-	exports?: unknown;
-};
-
-type ManifestTarget = {
-	source: string;
-	target: string;
 };
 
 const ROOT = process.cwd();
@@ -101,86 +92,6 @@ const rootTw3ProxyContents: Record<string, string> = {
 	'styles.tw3.css': '@import "./dist/styles.tw3.css";',
 	'iab/styles.tw3.css': '@import "../dist/iab/styles.tw3.css";',
 };
-
-function readManifest(packageDir: string): PackageManifest {
-	return JSON.parse(
-		readFileSync(join(packageDir, 'package.json'), 'utf8')
-	) as PackageManifest;
-}
-
-function normalizePackagePath(target: string): string | null {
-	if (target.startsWith('/') || target.includes('://')) {
-		return null;
-	}
-
-	return target.replace(/^\.\//, '').replaceAll('\\', '/');
-}
-
-function collectExportTargets(
-	value: unknown,
-	targets: ManifestTarget[],
-	source: string
-) {
-	if (typeof value === 'string') {
-		const normalized = normalizePackagePath(value);
-		if (normalized) {
-			targets.push({ source, target: normalized });
-		}
-		return;
-	}
-
-	if (Array.isArray(value)) {
-		for (const item of value) {
-			collectExportTargets(item, targets, source);
-		}
-		return;
-	}
-
-	if (value && typeof value === 'object') {
-		for (const [key, item] of Object.entries(value)) {
-			collectExportTargets(item, targets, `${source}[${JSON.stringify(key)}]`);
-		}
-	}
-}
-
-function collectManifestTargets(manifest: PackageManifest): ManifestTarget[] {
-	const targets: ManifestTarget[] = [];
-
-	for (const key of ['main', 'module', 'types'] as const) {
-		const value = manifest[key];
-		if (typeof value !== 'string') {
-			continue;
-		}
-
-		const normalized = normalizePackagePath(value);
-		if (normalized) {
-			targets.push({ source: key, target: normalized });
-		}
-	}
-
-	if (typeof manifest.bin === 'string') {
-		const normalized = normalizePackagePath(manifest.bin);
-		if (normalized) {
-			targets.push({ source: 'bin', target: normalized });
-		}
-	} else if (manifest.bin && typeof manifest.bin === 'object') {
-		for (const [name, value] of Object.entries(manifest.bin)) {
-			const normalized = normalizePackagePath(value);
-			if (normalized) {
-				targets.push({ source: `bin.${name}`, target: normalized });
-			}
-		}
-	}
-
-	collectExportTargets(manifest.exports, targets, 'exports');
-
-	return targets;
-}
-
-function wildcardToRegExp(pattern: string): RegExp {
-	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
-	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
-}
 
 function scanPackedManifestTargets(
 	manifest: PackageManifest,

--- a/scripts/check-publish-artifacts.ts
+++ b/scripts/check-publish-artifacts.ts
@@ -21,6 +21,16 @@ type PackResult = {
 type PackageManifest = {
 	name?: string;
 	private?: boolean;
+	main?: string;
+	module?: string;
+	types?: string;
+	bin?: string | Record<string, string>;
+	exports?: unknown;
+};
+
+type ManifestTarget = {
+	source: string;
+	target: string;
 };
 
 const ROOT = process.cwd();
@@ -96,6 +106,102 @@ function readManifest(packageDir: string): PackageManifest {
 	return JSON.parse(
 		readFileSync(join(packageDir, 'package.json'), 'utf8')
 	) as PackageManifest;
+}
+
+function normalizePackagePath(target: string): string | null {
+	if (!(target.startsWith('./') || target.startsWith('../'))) {
+		return null;
+	}
+
+	return target.replace(/^\.\//, '').replaceAll('\\', '/');
+}
+
+function collectExportTargets(
+	value: unknown,
+	targets: ManifestTarget[],
+	source: string
+) {
+	if (typeof value === 'string') {
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source, target: normalized });
+		}
+		return;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectExportTargets(item, targets, source);
+		}
+		return;
+	}
+
+	if (value && typeof value === 'object') {
+		for (const [key, item] of Object.entries(value)) {
+			collectExportTargets(item, targets, `${source}[${JSON.stringify(key)}]`);
+		}
+	}
+}
+
+function collectManifestTargets(manifest: PackageManifest): ManifestTarget[] {
+	const targets: ManifestTarget[] = [];
+
+	for (const key of ['main', 'module', 'types'] as const) {
+		const value = manifest[key];
+		if (typeof value !== 'string') {
+			continue;
+		}
+
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source: key, target: normalized });
+		}
+	}
+
+	if (typeof manifest.bin === 'string') {
+		const normalized = normalizePackagePath(manifest.bin);
+		if (normalized) {
+			targets.push({ source: 'bin', target: normalized });
+		}
+	} else if (manifest.bin && typeof manifest.bin === 'object') {
+		for (const [name, value] of Object.entries(manifest.bin)) {
+			const normalized = normalizePackagePath(value);
+			if (normalized) {
+				targets.push({ source: `bin.${name}`, target: normalized });
+			}
+		}
+	}
+
+	collectExportTargets(manifest.exports, targets, 'exports');
+
+	return targets;
+}
+
+function wildcardToRegExp(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
+}
+
+function scanPackedManifestTargets(
+	manifest: PackageManifest,
+	packedFilePaths: Set<string>
+): Array<{ path: string; size: number; reason: string }> {
+	const packedFiles = [...packedFilePaths];
+
+	return collectManifestTargets(manifest)
+		.filter(({ target }) => {
+			if (target.includes('*')) {
+				const pattern = wildcardToRegExp(target);
+				return !packedFiles.some((filePath) => pattern.test(filePath));
+			}
+
+			return !packedFilePaths.has(target);
+		})
+		.map(({ source, target }) => ({
+			path: target,
+			size: 0,
+			reason: `manifest target missing from packed files (${source})`,
+		}));
 }
 
 function runPack(packageDir: string): PackResult {
@@ -422,6 +528,7 @@ for (const packageDir of packageDirs) {
 			});
 		}
 	}
+	blockedFiles.push(...scanPackedManifestTargets(manifest, packedFilePaths));
 	blockedFiles.push(
 		...scanStyleEntrypointsContent(packageDir, packed.name, packedFilePaths)
 	);

--- a/scripts/check-publish-artifacts.ts
+++ b/scripts/check-publish-artifacts.ts
@@ -109,7 +109,7 @@ function readManifest(packageDir: string): PackageManifest {
 }
 
 function normalizePackagePath(target: string): string | null {
-	if (!(target.startsWith('./') || target.startsWith('../'))) {
+	if (target.startsWith('/') || target.includes('://')) {
 		return null;
 	}
 

--- a/scripts/manifest-utils.ts
+++ b/scripts/manifest-utils.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join, posix as pathPosix } from 'node:path';
 
-export type PackageManifest = {
+export interface PackageManifest {
 	name?: string;
 	private?: boolean;
 	main?: string;
@@ -9,12 +9,12 @@ export type PackageManifest = {
 	types?: string;
 	bin?: string | Record<string, string>;
 	exports?: unknown;
-};
+}
 
-export type ManifestTarget = {
+export interface ManifestTarget {
 	source: string;
 	target: string;
-};
+}
 
 const MAX_WILDCARD_PATTERN_LENGTH = 256;
 
@@ -53,7 +53,7 @@ export function collectExportTargets(
 	value: unknown,
 	targets: ManifestTarget[],
 	source: string
-) {
+): void {
 	if (typeof value === 'string') {
 		const normalized = normalizePackagePath(value);
 		if (normalized) {

--- a/scripts/manifest-utils.ts
+++ b/scripts/manifest-utils.ts
@@ -16,6 +16,8 @@ export type ManifestTarget = {
 	target: string;
 };
 
+const MAX_WILDCARD_PATTERN_LENGTH = 256;
+
 export function readManifest(packageDir: string): PackageManifest {
 	return JSON.parse(
 		readFileSync(join(packageDir, 'package.json'), 'utf8')
@@ -111,6 +113,12 @@ export function collectManifestTargets(
 }
 
 export function wildcardToRegExp(pattern: string): RegExp {
+	if (pattern.length > MAX_WILDCARD_PATTERN_LENGTH) {
+		throw new Error(
+			`Manifest wildcard target is too long (${pattern.length} characters; max ${MAX_WILDCARD_PATTERN_LENGTH}).`
+		);
+	}
+
 	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
 	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
 }

--- a/scripts/manifest-utils.ts
+++ b/scripts/manifest-utils.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs';
+import { join, posix as pathPosix } from 'node:path';
+
+export type PackageManifest = {
+	name?: string;
+	private?: boolean;
+	main?: string;
+	module?: string;
+	types?: string;
+	bin?: string | Record<string, string>;
+	exports?: unknown;
+};
+
+export type ManifestTarget = {
+	source: string;
+	target: string;
+};
+
+export function readManifest(packageDir: string): PackageManifest {
+	return JSON.parse(
+		readFileSync(join(packageDir, 'package.json'), 'utf8')
+	) as PackageManifest;
+}
+
+export function normalizePackagePath(target: string): string | null {
+	const slashNormalized = target.replaceAll('\\', '/');
+
+	if (
+		slashNormalized.startsWith('/') ||
+		/^[A-Za-z]:\//.test(slashNormalized) ||
+		slashNormalized.includes('://')
+	) {
+		return null;
+	}
+
+	const normalized = pathPosix.normalize(slashNormalized.replace(/^\.\//, ''));
+
+	if (
+		normalized === '.' ||
+		normalized === '..' ||
+		normalized.startsWith('../') ||
+		normalized.includes('/../')
+	) {
+		return null;
+	}
+
+	return normalized;
+}
+
+export function collectExportTargets(
+	value: unknown,
+	targets: ManifestTarget[],
+	source: string
+) {
+	if (typeof value === 'string') {
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source, target: normalized });
+		}
+		return;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectExportTargets(item, targets, source);
+		}
+		return;
+	}
+
+	if (value && typeof value === 'object') {
+		for (const [key, item] of Object.entries(value)) {
+			collectExportTargets(item, targets, `${source}[${JSON.stringify(key)}]`);
+		}
+	}
+}
+
+export function collectManifestTargets(
+	manifest: PackageManifest
+): ManifestTarget[] {
+	const targets: ManifestTarget[] = [];
+
+	for (const key of ['main', 'module', 'types'] as const) {
+		const value = manifest[key];
+		if (typeof value !== 'string') {
+			continue;
+		}
+
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source: key, target: normalized });
+		}
+	}
+
+	if (typeof manifest.bin === 'string') {
+		const normalized = normalizePackagePath(manifest.bin);
+		if (normalized) {
+			targets.push({ source: 'bin', target: normalized });
+		}
+	} else if (manifest.bin && typeof manifest.bin === 'object') {
+		for (const [name, value] of Object.entries(manifest.bin)) {
+			const normalized = normalizePackagePath(value);
+			if (normalized) {
+				targets.push({ source: `bin.${name}`, target: normalized });
+			}
+		}
+	}
+
+	collectExportTargets(manifest.exports, targets, 'exports');
+
+	return targets;
+}
+
+export function wildcardToRegExp(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
+}

--- a/scripts/verify-package-artifacts.ts
+++ b/scripts/verify-package-artifacts.ts
@@ -1,111 +1,13 @@
 #!/usr/bin/env bun
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-
-type PackageManifest = {
-	name?: string;
-	main?: string;
-	module?: string;
-	types?: string;
-	bin?: string | Record<string, string>;
-	exports?: unknown;
-};
-
-type ManifestTarget = {
-	source: string;
-	target: string;
-};
-
-function readManifest(packageDir: string): PackageManifest {
-	return JSON.parse(
-		readFileSync(join(packageDir, 'package.json'), 'utf8')
-	) as PackageManifest;
-}
-
-function normalizePackagePath(target: string): string | null {
-	const normalized = target.replaceAll('\\', '/');
-
-	if (
-		normalized.startsWith('/') ||
-		/^[A-Za-z]:\//.test(normalized) ||
-		normalized.includes('://') ||
-		normalized === '..' ||
-		normalized.startsWith('../') ||
-		normalized.endsWith('/..') ||
-		normalized.includes('/../')
-	) {
-		return null;
-	}
-
-	return normalized.replace(/^\.\//, '');
-}
-
-function collectExportTargets(
-	value: unknown,
-	targets: ManifestTarget[],
-	source: string
-) {
-	if (typeof value === 'string') {
-		const normalized = normalizePackagePath(value);
-		if (normalized) {
-			targets.push({ source, target: normalized });
-		}
-		return;
-	}
-
-	if (Array.isArray(value)) {
-		for (const item of value) {
-			collectExportTargets(item, targets, source);
-		}
-		return;
-	}
-
-	if (value && typeof value === 'object') {
-		for (const [key, item] of Object.entries(value)) {
-			collectExportTargets(item, targets, `${source}[${JSON.stringify(key)}]`);
-		}
-	}
-}
-
-function collectManifestTargets(manifest: PackageManifest): ManifestTarget[] {
-	const targets: ManifestTarget[] = [];
-
-	for (const key of ['main', 'module', 'types'] as const) {
-		const value = manifest[key];
-		if (typeof value !== 'string') {
-			continue;
-		}
-
-		const normalized = normalizePackagePath(value);
-		if (normalized) {
-			targets.push({ source: key, target: normalized });
-		}
-	}
-
-	if (typeof manifest.bin === 'string') {
-		const normalized = normalizePackagePath(manifest.bin);
-		if (normalized) {
-			targets.push({ source: 'bin', target: normalized });
-		}
-	} else if (manifest.bin && typeof manifest.bin === 'object') {
-		for (const [name, value] of Object.entries(manifest.bin)) {
-			const normalized = normalizePackagePath(value);
-			if (normalized) {
-				targets.push({ source: `bin.${name}`, target: normalized });
-			}
-		}
-	}
-
-	collectExportTargets(manifest.exports, targets, 'exports');
-
-	return targets;
-}
-
-function wildcardToRegExp(pattern: string): RegExp {
-	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
-	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
-}
+import type { ManifestTarget } from './manifest-utils';
+import {
+	collectManifestTargets,
+	readManifest,
+	wildcardToRegExp,
+} from './manifest-utils';
 
 function collectPackageFiles(dir: string, prefix = ''): string[] {
 	const result: string[] = [];

--- a/scripts/verify-package-artifacts.ts
+++ b/scripts/verify-package-artifacts.ts
@@ -24,11 +24,21 @@ function readManifest(packageDir: string): PackageManifest {
 }
 
 function normalizePackagePath(target: string): string | null {
-	if (!(target.startsWith('./') || target.startsWith('../'))) {
+	const normalized = target.replaceAll('\\', '/');
+
+	if (
+		normalized.startsWith('/') ||
+		/^[A-Za-z]:\//.test(normalized) ||
+		normalized.includes('://') ||
+		normalized === '..' ||
+		normalized.startsWith('../') ||
+		normalized.endsWith('/..') ||
+		normalized.includes('/../')
+	) {
 		return null;
 	}
 
-	return target.replace(/^\.\//, '').replaceAll('\\', '/');
+	return normalized.replace(/^\.\//, '');
 }
 
 function collectExportTargets(

--- a/scripts/verify-package-artifacts.ts
+++ b/scripts/verify-package-artifacts.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type PackageManifest = {
+	name?: string;
+	main?: string;
+	module?: string;
+	types?: string;
+	bin?: string | Record<string, string>;
+	exports?: unknown;
+};
+
+type ManifestTarget = {
+	source: string;
+	target: string;
+};
+
+function readManifest(packageDir: string): PackageManifest {
+	return JSON.parse(
+		readFileSync(join(packageDir, 'package.json'), 'utf8')
+	) as PackageManifest;
+}
+
+function normalizePackagePath(target: string): string | null {
+	if (!(target.startsWith('./') || target.startsWith('../'))) {
+		return null;
+	}
+
+	return target.replace(/^\.\//, '').replaceAll('\\', '/');
+}
+
+function collectExportTargets(
+	value: unknown,
+	targets: ManifestTarget[],
+	source: string
+) {
+	if (typeof value === 'string') {
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source, target: normalized });
+		}
+		return;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectExportTargets(item, targets, source);
+		}
+		return;
+	}
+
+	if (value && typeof value === 'object') {
+		for (const [key, item] of Object.entries(value)) {
+			collectExportTargets(item, targets, `${source}[${JSON.stringify(key)}]`);
+		}
+	}
+}
+
+function collectManifestTargets(manifest: PackageManifest): ManifestTarget[] {
+	const targets: ManifestTarget[] = [];
+
+	for (const key of ['main', 'module', 'types'] as const) {
+		const value = manifest[key];
+		if (typeof value !== 'string') {
+			continue;
+		}
+
+		const normalized = normalizePackagePath(value);
+		if (normalized) {
+			targets.push({ source: key, target: normalized });
+		}
+	}
+
+	if (typeof manifest.bin === 'string') {
+		const normalized = normalizePackagePath(manifest.bin);
+		if (normalized) {
+			targets.push({ source: 'bin', target: normalized });
+		}
+	} else if (manifest.bin && typeof manifest.bin === 'object') {
+		for (const [name, value] of Object.entries(manifest.bin)) {
+			const normalized = normalizePackagePath(value);
+			if (normalized) {
+				targets.push({ source: `bin.${name}`, target: normalized });
+			}
+		}
+	}
+
+	collectExportTargets(manifest.exports, targets, 'exports');
+
+	return targets;
+}
+
+function wildcardToRegExp(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`^${escaped.replaceAll('*', '.+')}$`);
+}
+
+function collectPackageFiles(dir: string, prefix = ''): string[] {
+	const result: string[] = [];
+
+	for (const entry of readdirSync(join(dir, prefix), { withFileTypes: true })) {
+		if (
+			entry.isDirectory() &&
+			(entry.name === 'node_modules' ||
+				entry.name === '.turbo' ||
+				entry.name === '.git')
+		) {
+			continue;
+		}
+
+		const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) {
+			result.push(...collectPackageFiles(dir, relativePath));
+		} else if (entry.isFile()) {
+			result.push(relativePath);
+		}
+	}
+
+	return result;
+}
+
+function getMissingTargets(
+	packageDir: string,
+	targets: ManifestTarget[]
+): ManifestTarget[] {
+	const packageFiles = collectPackageFiles(packageDir);
+
+	return targets.filter(({ target }) => {
+		if (target.includes('*')) {
+			const pattern = wildcardToRegExp(target);
+			return !packageFiles.some((filePath) => pattern.test(filePath));
+		}
+
+		return !existsSync(join(packageDir, target));
+	});
+}
+
+const packageDir = process.cwd();
+const manifest = readManifest(packageDir);
+const targets = collectManifestTargets(manifest);
+const missingTargets = getMissingTargets(packageDir, targets);
+
+if (missingTargets.length === 0) {
+	console.log(
+		`Package artifacts verified for ${manifest.name ?? packageDir}. Checked ${targets.length} manifest targets.`
+	);
+	process.exit(0);
+}
+
+console.error(
+	`Package artifact verification failed for ${manifest.name ?? packageDir}.`
+);
+console.error('Run `bun run build` before packing or publishing this package.');
+console.error('\nMissing manifest targets:');
+for (const { source, target } of missingTargets) {
+	console.error(`- ${source}: ${target}`);
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary
- Add a package artifact verification script that checks `main`, `module`, `types`, `bin`, and `exports` targets before publish/pack flows run.
- Switch `prepack` in backend, core, nextjs, and react packages to run the new verification script instead of rebuilding during pack.
- Extend the node SDK build config to emit the `testing` entrypoint and tighten the publish artifact checks to catch missing manifest targets.

## Testing
- Not run (not requested).
- Verified the changed `prepack` scripts point to `scripts/verify-package-artifacts.ts`.
- Verified the new script walks package contents and fails when manifest targets are missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a repository-level package artifact verification step to the pre-publish flow for multiple packages.
  * Consolidated React package exports: removed several subpath exports and redirected cookie-banner to the consent-banner implementation.
  * Added a new testing entry point to the Node SDK build configuration.
* **New Features**
  * Added a CLI verification tool and manifest utilities that validate package manifest targets (including exports and wildcard patterns) before packing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->