### PR TITLE
chore: remove Playwright artifact

### DIFF
--- a/.playwright-mcp/console-2026-05-02T00-09-49-563Z.log
+++ b/.playwright-mcp/console-2026-05-02T00-09-49-563Z.log
@@ -1,7 +1,0 @@
-[     476ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     477ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     478ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     479ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     483ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     484ms] [VERBOSE] Rendering was performed in a subtree hidden by content-visibility. @ http://127.0.0.1:4136/sb-manager/runtime.js:12798
-[     726ms] [WARNING] The 'ariaLabel' prop on 'PopoverProvider' will become mandatory in Storybook 11. Provide a concise, accessible label describing the popover's purpose. @ http://127.0.0.1:4136/sb-manager/globals-runtime.js:5810


### PR DESCRIPTION
## Summary
- remove an accidental Playwright MCP console log committed with the consent widget footer slot fix

## Notes
- The consent widget footer fix commit is already present on `origin/main`, which is why the original PR create command had no diff.
- This PR only removes the generated log artifact.

## Tests
- not run; generated log removal only
