### PR TITLE
refine policy category scope handling

### DIFF
--- a/.changeset/refined-policy-scope.md
+++ b/.changeset/refined-policy-scope.md
@@ -1,0 +1,6 @@
+---
+"@c15t/backend": patch
+"c15t": patch
+---
+
+Refine policy category scope handling.

--- a/.changeset/refined-policy-scope.md
+++ b/.changeset/refined-policy-scope.md
@@ -1,5 +1,6 @@
 ---
 "@c15t/backend": patch
+"@c15t/schema": patch
 "c15t": patch
 ---
 

--- a/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
@@ -27,6 +27,7 @@ const outputDir =
 const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
 const initPrefix = `${BASE_URL}/api/bench-consent/init`;
+const expectedServerShutdownCodes = new Set([0, 137, 143]);
 
 const scenarios = [
 	{ name: 'client', path: '/client' },
@@ -262,6 +263,7 @@ async function run() {
 		logs += String(chunk);
 	});
 
+	let serverFailure: Error | null = null;
 	try {
 		await waitForServer();
 		const browser = await chromium.launch({ headless: true });
@@ -422,9 +424,16 @@ async function run() {
 		if (!server.killed) {
 			server.kill('SIGKILL');
 		}
-		if (server.exitCode && server.exitCode !== 0) {
-			throw new Error(logs || 'Next.js browser bench server failed');
+		if (
+			server.exitCode != null &&
+			!expectedServerShutdownCodes.has(server.exitCode)
+		) {
+			serverFailure = new Error(logs || 'Next.js browser bench server failed');
 		}
+	}
+
+	if (serverFailure) {
+		throw serverFailure;
 	}
 }
 

--- a/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
@@ -28,6 +28,7 @@ const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
 const initPrefix = `${BASE_URL}/api/bench-consent/init`;
 const expectedServerShutdownCodes = new Set([0, 137, 143]);
+const expectedServerShutdownSignals = new Set(['SIGTERM', 'SIGKILL']);
 
 const scenarios = [
 	{ name: 'client', path: '/client' },
@@ -428,7 +429,17 @@ async function run() {
 			server.exitCode != null &&
 			!expectedServerShutdownCodes.has(server.exitCode)
 		) {
-			serverFailure = new Error(logs || 'Next.js browser bench server failed');
+			serverFailure = new Error(
+				`${logs || 'Next.js browser bench server failed'}\nUnexpected server exit code: ${server.exitCode}`
+			);
+		} else if (
+			server.exitCode == null &&
+			server.signalCode != null &&
+			!expectedServerShutdownSignals.has(server.signalCode)
+		) {
+			serverFailure = new Error(
+				`${logs || 'Next.js browser bench server failed'}\nUnexpected server signal: ${server.signalCode}`
+			);
 		}
 	}
 

--- a/benchmarks/react-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/react-browser-bench/scripts/run-bench.ts
@@ -25,6 +25,7 @@ const outputDir =
 	process.env.BENCH_OUTPUT_DIR ?? '.benchmarks/browser-runtime/react';
 const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
+const expectedServerShutdownCodes = new Set([0, 137, 143]);
 
 const scenarios = [
 	{ name: 'full-ui', path: '/full-ui' },
@@ -255,6 +256,7 @@ async function run() {
 		logs += String(chunk);
 	});
 
+	let serverFailure: Error | null = null;
 	try {
 		await waitForServer();
 		const browser = await chromium.launch({ headless: true });
@@ -419,9 +421,16 @@ async function run() {
 		if (!server.killed) {
 			server.kill('SIGKILL');
 		}
-		if (server.exitCode && server.exitCode !== 0) {
-			throw new Error(logs || 'React browser bench server failed');
+		if (
+			server.exitCode != null &&
+			!expectedServerShutdownCodes.has(server.exitCode)
+		) {
+			serverFailure = new Error(logs || 'React browser bench server failed');
 		}
+	}
+
+	if (serverFailure) {
+		throw serverFailure;
 	}
 }
 

--- a/benchmarks/react-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/react-browser-bench/scripts/run-bench.ts
@@ -26,6 +26,7 @@ const outputDir =
 const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
 const expectedServerShutdownCodes = new Set([0, 137, 143]);
+const expectedServerShutdownSignals = new Set(['SIGTERM', 'SIGKILL']);
 
 const scenarios = [
 	{ name: 'full-ui', path: '/full-ui' },
@@ -425,7 +426,17 @@ async function run() {
 			server.exitCode != null &&
 			!expectedServerShutdownCodes.has(server.exitCode)
 		) {
-			serverFailure = new Error(logs || 'React browser bench server failed');
+			serverFailure = new Error(
+				`${logs || 'React browser bench server failed'}\nUnexpected server exit code: ${server.exitCode}`
+			);
+		} else if (
+			server.exitCode == null &&
+			server.signalCode != null &&
+			!expectedServerShutdownSignals.has(server.signalCode)
+		) {
+			serverFailure = new Error(
+				`${logs || 'React browser bench server failed'}\nUnexpected server signal: ${server.signalCode}`
+			);
 		}
 	}
 

--- a/benchmarks/script-lifecycle-bench/scripts/run-bench.ts
+++ b/benchmarks/script-lifecycle-bench/scripts/run-bench.ts
@@ -30,6 +30,7 @@ const outputDir =
 const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
 const expectedServerShutdownCodes = new Set([0, 137, 143]);
+const expectedServerShutdownSignals = new Set(['SIGTERM', 'SIGKILL']);
 
 interface SerializableScriptBenchState {
 	scenario: string;
@@ -369,7 +370,17 @@ async function run() {
 			server.exitCode != null &&
 			!expectedServerShutdownCodes.has(server.exitCode)
 		) {
-			serverFailure = new Error(logs || 'Script lifecycle bench server failed');
+			serverFailure = new Error(
+				`${logs || 'Script lifecycle bench server failed'}\nUnexpected server exit code: ${server.exitCode}`
+			);
+		} else if (
+			server.exitCode == null &&
+			server.signalCode != null &&
+			!expectedServerShutdownSignals.has(server.signalCode)
+		) {
+			serverFailure = new Error(
+				`${logs || 'Script lifecycle bench server failed'}\nUnexpected server signal: ${server.signalCode}`
+			);
 		}
 	}
 

--- a/benchmarks/script-lifecycle-bench/scripts/run-bench.ts
+++ b/benchmarks/script-lifecycle-bench/scripts/run-bench.ts
@@ -29,6 +29,7 @@ const outputDir =
 	process.env.BENCH_OUTPUT_DIR ?? '.benchmarks/script-lifecycle';
 const iterations = Number(process.env.BENCH_ITERATIONS ?? '7');
 const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? '1');
+const expectedServerShutdownCodes = new Set([0, 137, 143]);
 
 interface SerializableScriptBenchState {
 	scenario: string;
@@ -264,6 +265,7 @@ async function run() {
 		logs += String(chunk);
 	});
 
+	let serverFailure: Error | null = null;
 	try {
 		await waitForServer();
 		const browser = await chromium.launch({ headless: true });
@@ -363,9 +365,16 @@ async function run() {
 		if (!server.killed) {
 			server.kill('SIGKILL');
 		}
-		if (server.exitCode && server.exitCode !== 0) {
-			throw new Error(logs || 'Script lifecycle bench server failed');
+		if (
+			server.exitCode != null &&
+			!expectedServerShutdownCodes.has(server.exitCode)
+		) {
+			serverFailure = new Error(logs || 'Script lifecycle bench server failed');
 		}
+	}
+
+	if (serverFailure) {
+		throw serverFailure;
 	}
 }
 

--- a/packages/backend/src/handlers/init/policy.test.ts
+++ b/packages/backend/src/handlers/init/policy.test.ts
@@ -137,7 +137,7 @@ describe('resolvePolicyDecision', () => {
 		expect(result?.policy.consent?.scopeMode).toBe('strict');
 	});
 
-	it('filters preselected categories to the configured policy scope', async () => {
+	it('filters preselected categories to the configured policy scope in strict mode', async () => {
 		const result = await resolvePolicyDecision({
 			policies: [
 				{
@@ -145,6 +145,7 @@ describe('resolvePolicyDecision', () => {
 					match: { countries: ['GB'] },
 					consent: {
 						model: 'opt-in',
+						scopeMode: 'strict',
 						categories: ['necessary', 'functionality'],
 						preselectedCategories: ['functionality', 'marketing'],
 					},
@@ -161,6 +162,30 @@ describe('resolvePolicyDecision', () => {
 		]);
 		expect(result?.policy.consent?.preselectedCategories).toEqual([
 			'functionality',
+		]);
+	});
+
+	it('keeps preselected categories outside policy categories in permissive mode', async () => {
+		const result = await resolvePolicyDecision({
+			policies: [
+				{
+					id: 'policy_uk',
+					match: { countries: ['GB'] },
+					consent: {
+						model: 'opt-in',
+						scopeMode: 'permissive',
+						categories: ['necessary'],
+						preselectedCategories: ['marketing'],
+					},
+				},
+			],
+			countryCode: 'GB',
+			regionCode: null,
+			jurisdiction: 'UK_GDPR',
+		});
+
+		expect(result?.policy.consent?.preselectedCategories).toEqual([
+			'marketing',
 		]);
 	});
 

--- a/packages/backend/src/handlers/subject/post.handler.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.test.ts
@@ -423,6 +423,58 @@ describe('postSubjectHandler policy purpose enforcement', () => {
 		expect(db.transaction).not.toHaveBeenCalled();
 	});
 
+	it('allows necessary preferences in strict scope even when omitted from policy categories', async () => {
+		vi.mocked(resolvePolicyDecision).mockResolvedValue({
+			policy: {
+				id: 'policy_restrictive',
+				model: 'opt-in',
+				consent: { scopeMode: 'strict', categories: ['measurement'] },
+			},
+			matchedBy: 'country',
+			fingerprint: 'a'.repeat(64),
+		});
+
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		registry.findOrCreateConsentPurposeByCode = vi
+			.fn()
+			.mockImplementation(async (code: string) => ({ id: `purpose_${code}` }));
+		const mockCtx = createMockContext(db, registry);
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			preferences: {
+				necessary: true,
+				measurement: true,
+			},
+		});
+
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+
+		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledWith(
+			'necessary'
+		);
+		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledWith(
+			'measurement'
+		);
+		expect(db.__tx.create).toHaveBeenCalledWith(
+			'consent',
+			expect.objectContaining({
+				purposeIds: {
+					json: ['purpose_necessary', 'purpose_measurement'],
+				},
+			})
+		);
+		expect(mockCtx.getJsonData()).toEqual(
+			expect.objectContaining({
+				appliedPreferences: {
+					necessary: true,
+					measurement: true,
+				},
+			})
+		);
+	});
+
 	it('passes top-level iabEnabled into write-time policy resolution', async () => {
 		const db = createMockDb(null);
 		const registry = createMockRegistry();

--- a/packages/backend/src/handlers/subject/post.handler.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.test.ts
@@ -588,7 +588,7 @@ describe('postSubjectHandler policy purpose enforcement', () => {
 		expect(db.transaction).not.toHaveBeenCalled();
 	});
 
-	it('ignores out-of-scope categories when scopeMode is permissive', async () => {
+	it('persists out-of-scope categories when scopeMode is permissive', async () => {
 		vi.mocked(resolvePolicyDecision).mockResolvedValue({
 			policy: {
 				id: 'policy_unmanaged',
@@ -616,9 +616,12 @@ describe('postSubjectHandler policy purpose enforcement', () => {
 		// @ts-expect-error - simplified test context
 		await expect(postSubjectHandler(mockCtx)).resolves.toBeDefined();
 
-		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledTimes(1);
+		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledTimes(2);
 		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledWith(
 			'measurement'
+		);
+		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledWith(
+			'marketing'
 		);
 		expect(db.transaction).toHaveBeenCalled();
 		expect(
@@ -629,7 +632,54 @@ describe('postSubjectHandler policy purpose enforcement', () => {
 			).appliedPreferences
 		).toEqual({
 			measurement: true,
+			marketing: true,
 		});
+	});
+
+	it('returns submitted preferences for necessary-only permissive policies', async () => {
+		vi.mocked(resolvePolicyDecision).mockResolvedValue({
+			policy: {
+				id: 'europe_opt_in',
+				model: 'opt-in',
+				consent: { scopeMode: 'permissive', categories: ['necessary'] },
+			},
+			matchedBy: 'country',
+			fingerprint: 'e'.repeat(64),
+		});
+
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		registry.findOrCreateConsentPurposeByCode = vi
+			.fn()
+			.mockImplementation(async (code: string) => ({ id: `pur_${code}` }));
+		const mockCtx = createMockContext(db, registry);
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			type: 'cookie_banner',
+			preferences: {
+				necessary: true,
+				measurement: true,
+				marketing: true,
+			},
+			consentAction: 'all',
+			uiSource: 'banner',
+		});
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).resolves.toBeDefined();
+
+		expect(registry.findOrCreateConsentPurposeByCode).toHaveBeenCalledTimes(3);
+		expect(mockCtx.getJsonData()).toEqual(
+			expect.objectContaining({
+				type: 'cookie_banner',
+				appliedPreferences: {
+					necessary: true,
+					measurement: true,
+					marketing: true,
+				},
+				uiSource: 'banner',
+			})
+		);
 	});
 
 	it('allows all purposes when policy uses wildcard scope', async () => {

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -540,11 +540,15 @@ export const postSubjectHandler = async (c: Context) => {
 				allowedCategories.length > 0 &&
 				!hasWildcardCategoryScope
 			) {
+				const strictAllowedCategories = new Set([
+					'necessary',
+					...allowedCategories,
+				]);
 				const disallowed = appliedPreferenceEntries
 					.map(([purpose]) => purpose)
-					.filter((purpose) => !allowedCategories.includes(purpose));
+					.filter((purpose) => !strictAllowedCategories.has(purpose));
 				filteredAppliedPreferenceEntries = appliedPreferenceEntries.filter(
-					([purpose]) => allowedCategories.includes(purpose)
+					([purpose]) => strictAllowedCategories.has(purpose)
 				);
 				if (disallowed.length > 0) {
 					throw new HTTPException(400, {

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -535,6 +535,7 @@ export const postSubjectHandler = async (c: Context) => {
 			let filteredAppliedPreferenceEntries = appliedPreferenceEntries;
 
 			if (
+				effectiveScopeMode === 'strict' &&
 				allowedCategories &&
 				allowedCategories.length > 0 &&
 				!hasWildcardCategoryScope
@@ -545,7 +546,7 @@ export const postSubjectHandler = async (c: Context) => {
 				filteredAppliedPreferenceEntries = appliedPreferenceEntries.filter(
 					([purpose]) => allowedCategories.includes(purpose)
 				);
-				if (disallowed.length > 0 && effectiveScopeMode === 'strict') {
+				if (disallowed.length > 0) {
 					throw new HTTPException(400, {
 						message: 'Preferences include categories not allowed by policy',
 						cause: { code: 'PURPOSE_NOT_ALLOWED', disallowed },

--- a/packages/core/src/__tests__/store-script-loader.test.ts
+++ b/packages/core/src/__tests__/store-script-loader.test.ts
@@ -100,10 +100,6 @@ describe('Store Script Loader Integration', () => {
 
 		// Mock MutationObserver as a constructor class
 		global.MutationObserver = class MutationObserver {
-			constructor(_callback: MutationCallback) {
-				// Mock implementation
-			}
-
 			observe = vi.fn();
 			disconnect = vi.fn();
 			takeRecords = vi.fn().mockReturnValue([]);
@@ -294,7 +290,7 @@ describe('Store Script Loader Integration', () => {
 			expect(loadedIds).not.toContain('marketing-script');
 		});
 
-		it('should load out-of-policy category scripts as permissive', () => {
+		it('should respect denied out-of-policy category scripts in permissive scope', () => {
 			const store = createTestStore({
 				necessary: true,
 				marketing: false,
@@ -311,8 +307,8 @@ describe('Store Script Loader Integration', () => {
 			store.getState().setScripts([scripts[1]]);
 
 			expect(store.getState().consentCategories).toContain('marketing');
-			expect(store.getState().isScriptLoaded('marketing-script')).toBe(true);
-			expect(store.getState().loadedScripts['marketing-script']).toBe(true);
+			expect(store.getState().isScriptLoaded('marketing-script')).toBe(false);
+			expect(store.getState().loadedScripts['marketing-script']).not.toBe(true);
 		});
 	});
 

--- a/packages/core/src/__tests__/store-script-loader.test.ts
+++ b/packages/core/src/__tests__/store-script-loader.test.ts
@@ -310,6 +310,7 @@ describe('Store Script Loader Integration', () => {
 
 			store.getState().setScripts([scripts[1]]);
 
+			expect(store.getState().consentCategories).toContain('marketing');
 			expect(store.getState().isScriptLoaded('marketing-script')).toBe(true);
 			expect(store.getState().loadedScripts['marketing-script']).toBe(true);
 		});

--- a/packages/core/src/libs/__tests__/has.test.ts
+++ b/packages/core/src/libs/__tests__/has.test.ts
@@ -330,7 +330,7 @@ describe('has - Consent Condition Evaluation', () => {
 	});
 
 	describe('Policy-Aware Options', () => {
-		it('should treat out-of-scope categories as granted in permissive mode', () => {
+		it('should respect out-of-scope category choices in permissive mode', () => {
 			const consents: ConsentState = {
 				necessary: true,
 				measurement: false,
@@ -344,6 +344,16 @@ describe('has - Consent Condition Evaluation', () => {
 					policyCategories: ['necessary', 'measurement'],
 					policyScopeMode: 'permissive',
 				})
+			).toBe(false);
+			expect(
+				has(
+					'experience',
+					{ ...consents, experience: true },
+					{
+						policyCategories: ['necessary', 'measurement'],
+						policyScopeMode: 'permissive',
+					}
+				)
 			).toBe(true);
 			expect(
 				has('measurement', consents, {

--- a/packages/core/src/libs/__tests__/policy.test.ts
+++ b/packages/core/src/libs/__tests__/policy.test.ts
@@ -288,7 +288,7 @@ describe('applyPolicyScopeForRuntimeGating', () => {
 	it('returns unchanged consents when no allowlist is provided', () => {
 		const consents = {
 			necessary: true,
-			functionality: false,
+			functionality: true,
 			experience: false,
 			marketing: false,
 			measurement: true,
@@ -299,10 +299,10 @@ describe('applyPolicyScopeForRuntimeGating', () => {
 		);
 	});
 
-	it('treats out-of-policy categories as granted for runtime gating', () => {
+	it('respects out-of-policy category choices in permissive mode', () => {
 		const consents = {
 			necessary: true,
-			functionality: false,
+			functionality: true,
 			experience: false,
 			marketing: false,
 			measurement: true,
@@ -317,8 +317,8 @@ describe('applyPolicyScopeForRuntimeGating', () => {
 		).toEqual({
 			necessary: true,
 			functionality: true,
-			experience: true,
-			marketing: true,
+			experience: false,
+			marketing: false,
 			measurement: true,
 		});
 	});

--- a/packages/core/src/libs/__tests__/policy.test.ts
+++ b/packages/core/src/libs/__tests__/policy.test.ts
@@ -4,6 +4,7 @@ import {
 	applyPolicyScopeForRuntimeGating,
 	filterConsentCategoriesByPolicy,
 	getEffectivePolicy,
+	shouldEnforcePolicyCategoryScope,
 	stripDisallowedPreferenceKeys,
 	validateUIAgainstPolicy,
 } from '../policy';
@@ -265,6 +266,19 @@ describe('filterConsentCategoriesByPolicy', () => {
 				['*']
 			)
 		).toEqual(['necessary', 'measurement', 'experience', 'marketing']);
+	});
+});
+
+describe('shouldEnforcePolicyCategoryScope', () => {
+	it('only enforces category scope for strict non-wildcard policies', () => {
+		expect(shouldEnforcePolicyCategoryScope(['necessary'], 'strict')).toBe(
+			true
+		);
+		expect(shouldEnforcePolicyCategoryScope(['necessary'], 'permissive')).toBe(
+			false
+		);
+		expect(shouldEnforcePolicyCategoryScope(['*'], 'strict')).toBe(false);
+		expect(shouldEnforcePolicyCategoryScope(undefined, 'strict')).toBe(false);
 	});
 });
 

--- a/packages/core/src/libs/__tests__/policy.test.ts
+++ b/packages/core/src/libs/__tests__/policy.test.ts
@@ -278,6 +278,8 @@ describe('shouldEnforcePolicyCategoryScope', () => {
 			false
 		);
 		expect(shouldEnforcePolicyCategoryScope(['*'], 'strict')).toBe(false);
+		expect(shouldEnforcePolicyCategoryScope(null, 'strict')).toBe(false);
+		expect(shouldEnforcePolicyCategoryScope([], 'strict')).toBe(false);
 		expect(shouldEnforcePolicyCategoryScope(undefined, 'strict')).toBe(false);
 	});
 });

--- a/packages/core/src/libs/__tests__/save-consents.test.ts
+++ b/packages/core/src/libs/__tests__/save-consents.test.ts
@@ -895,6 +895,7 @@ describe('saveConsents', () => {
 				lastBannerFetchData: {
 					policy: {
 						consent: {
+							scopeMode: 'strict',
 							categories: ['necessary', 'measurement', 'marketing'],
 						},
 					},
@@ -934,6 +935,95 @@ describe('saveConsents', () => {
 						measurement: true,
 						marketing: true,
 					},
+				}),
+			});
+		});
+
+		it('should keep configured preferences for permissive policy scope', async () => {
+			mockGet = vi.fn().mockReturnValue({
+				callbacks: {
+					onConsentSet: vi.fn(),
+					onError: vi.fn(),
+				},
+				consentCategories: ['necessary', 'measurement', 'marketing'],
+				updateScripts: updateScriptsMock,
+				updateIframeConsents: updateIframeConsentsMock,
+				updateNetworkBlockerConsents: updateNetworkBlockerConsentsMock,
+				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					experience: false,
+					marketing: false,
+				},
+				selectedConsents: {
+					necessary: true,
+					functionality: false,
+					measurement: true,
+					experience: false,
+					marketing: true,
+				},
+				consentTypes: [
+					{
+						name: 'necessary',
+						defaultValue: true,
+						description: 'Necessary cookies',
+						disabled: true,
+						display: true,
+						gdprType: 1,
+					},
+					{
+						name: 'measurement',
+						defaultValue: false,
+						description: 'Measurement cookies',
+						disabled: false,
+						display: true,
+						gdprType: 4,
+					},
+					{
+						name: 'marketing',
+						defaultValue: false,
+						description: 'Marketing cookies',
+						disabled: false,
+						display: true,
+						gdprType: 5,
+					},
+				],
+				reloadOnConsentRevoked: false,
+				consentInfo: null,
+				lastBannerFetchData: {
+					policy: {
+						consent: {
+							scopeMode: 'permissive',
+							categories: ['necessary'],
+						},
+					},
+				},
+			});
+
+			await saveConsents({
+				manager: mockManager,
+				type: 'custom',
+				get: mockGet,
+				set: mockSet,
+			});
+
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					consents: expect.objectContaining({
+						necessary: true,
+						measurement: true,
+						marketing: true,
+					}),
+				})
+			);
+			expect(mockManager.setConsent).toHaveBeenCalledWith({
+				body: expect.objectContaining({
+					preferences: expect.objectContaining({
+						necessary: true,
+						measurement: true,
+						marketing: true,
+					}),
 				}),
 			});
 		});

--- a/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
+++ b/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
@@ -349,13 +349,14 @@ describe('updateStore - policy purpose/category restrictions', () => {
 		vi.clearAllMocks();
 	});
 
-	it('treats out-of-policy categories as out-of-scope (hidden and false)', async () => {
+	it('treats strict out-of-policy categories as out-of-scope (hidden and false)', async () => {
 		const data = createMockConsentBannerResponse({
 			jurisdiction: 'GDPR',
 			policy: {
 				id: 'policy_jp_restricted',
 				model: 'opt-in',
 				consent: {
+					scopeMode: 'strict',
 					categories: ['necessary', 'measurement'],
 				},
 			},
@@ -419,6 +420,57 @@ describe('updateStore - policy purpose/category restrictions', () => {
 		);
 	});
 
+	it('keeps configured categories visible for permissive policy scope', async () => {
+		const data = createMockConsentBannerResponse({
+			jurisdiction: 'GDPR',
+			policy: {
+				id: 'policy_eu_permissive',
+				model: 'opt-in',
+				consent: {
+					scopeMode: 'permissive',
+					categories: ['necessary'],
+				},
+			},
+		});
+		const mockState = createMockStoreState({
+			iab: null,
+			consentCategories: ['necessary', 'measurement', 'marketing'],
+			consents: {
+				necessary: true,
+				measurement: false,
+				marketing: false,
+				functionality: false,
+				experience: false,
+			},
+			selectedConsents: {
+				necessary: true,
+				measurement: false,
+				marketing: false,
+				functionality: false,
+				experience: false,
+			},
+		});
+		const mockGet = vi.fn().mockReturnValue(mockState);
+		const mockSet = vi.fn();
+
+		await updateStore(
+			data,
+			{
+				get: mockGet,
+				set: mockSet,
+				manager: {} as InitConsentManagerConfig['manager'],
+				initialTranslationConfig: undefined,
+			},
+			true
+		);
+
+		expect(mockSet).toHaveBeenCalledWith(
+			expect.not.objectContaining({
+				consentCategories: expect.any(Array),
+			})
+		);
+	});
+
 	it('does not restrict categories when policy purpose scope is wildcard', async () => {
 		const data = createMockConsentBannerResponse({
 			jurisdiction: 'GDPR',
@@ -462,6 +514,7 @@ describe('updateStore - policy purpose/category restrictions', () => {
 				id: 'policy_uk',
 				model: 'opt-in',
 				consent: {
+					scopeMode: 'strict',
 					categories: ['necessary', 'functionality', 'measurement'],
 					preselectedCategories: ['functionality', 'marketing'],
 				},

--- a/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
+++ b/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
@@ -464,8 +464,8 @@ describe('updateStore - policy purpose/category restrictions', () => {
 			true
 		);
 
-		expect(mockSet).toHaveBeenCalledWith(
-			expect.not.objectContaining({
+		expect(mockSet).not.toHaveBeenCalledWith(
+			expect.objectContaining({
 				consentCategories: expect.any(Array),
 			})
 		);

--- a/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
+++ b/packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts
@@ -572,6 +572,63 @@ describe('updateStore - policy purpose/category restrictions', () => {
 		);
 	});
 
+	it('preselects out-of-policy configured categories in permissive scope', async () => {
+		const data = createMockConsentBannerResponse({
+			jurisdiction: 'GDPR',
+			policy: {
+				id: 'policy_eu_permissive',
+				model: 'opt-in',
+				consent: {
+					scopeMode: 'permissive',
+					categories: ['necessary'],
+					preselectedCategories: ['marketing', 'measurement'],
+				},
+			},
+		});
+		const mockState = createMockStoreState({
+			iab: null,
+			consentInfo: null,
+			consentCategories: ['necessary', 'marketing'],
+			consents: {
+				necessary: true,
+				functionality: false,
+				experience: false,
+				marketing: false,
+				measurement: false,
+			},
+			selectedConsents: {
+				necessary: true,
+				functionality: false,
+				experience: false,
+				marketing: false,
+				measurement: false,
+			},
+		});
+		const mockGet = vi.fn().mockReturnValue(mockState);
+		const mockSet = vi.fn();
+
+		await updateStore(
+			data,
+			{
+				get: mockGet,
+				set: mockSet,
+				manager: {} as InitConsentManagerConfig['manager'],
+				initialTranslationConfig: undefined,
+			},
+			true
+		);
+
+		expect(mockSet).toHaveBeenCalledWith(
+			expect.objectContaining({
+				selectedConsents: expect.objectContaining({
+					necessary: true,
+					marketing: true,
+					measurement: false,
+				}),
+			})
+		);
+	});
+
 	it('stores policy UI action order/layout hints from init response', async () => {
 		const data = createMockConsentBannerResponse({
 			jurisdiction: 'CCPA',

--- a/packages/core/src/libs/init-consent-manager/store-updater.ts
+++ b/packages/core/src/libs/init-consent-manager/store-updater.ts
@@ -180,10 +180,6 @@ function buildStoreUpdate(
 	// Apply policy-driven purpose/category restrictions for strict non-wildcard
 	// scope. Permissive policies keep configured/script-derived categories visible.
 	const policyCategories = data.policy?.consent?.categories;
-	const hasPolicyCategoryList =
-		Array.isArray(policyCategories) &&
-		policyCategories.length > 0 &&
-		!policyCategories.includes('*');
 	const hasStrictPolicyCategoryAllowlist = shouldEnforcePolicyCategoryScope(
 		policyCategories,
 		data.policy?.consent?.scopeMode ?? null
@@ -212,9 +208,11 @@ function buildStoreUpdate(
 		Array.isArray(preselectedCategories) &&
 		preselectedCategories.length > 0;
 	if (shouldApplyPreselectedCategories) {
-		const preselectedScope = hasPolicyCategoryList
-			? filterConsentCategoriesByPolicy(allConsentNames, policyCategories)
-			: allConsentNames;
+		const displayedConsentNames =
+			update.consentCategories ?? get().consentCategories;
+		const preselectedScope = hasStrictPolicyCategoryAllowlist
+			? filterConsentCategoriesByPolicy(displayedConsentNames, policyCategories)
+			: displayedConsentNames;
 		const allowedPreselectedCategories = filterConsentCategoriesByPolicy(
 			preselectedScope,
 			preselectedCategories

--- a/packages/core/src/libs/init-consent-manager/store-updater.ts
+++ b/packages/core/src/libs/init-consent-manager/store-updater.ts
@@ -19,6 +19,7 @@ import { hasGlobalPrivacyControlSignal } from '../global-privacy-control';
 import {
 	applyPolicyPurposeAllowlist,
 	filterConsentCategoriesByPolicy,
+	shouldEnforcePolicyCategoryScope,
 } from '../policy';
 import type { ConsentBannerResponse, InitConsentManagerConfig } from './types';
 
@@ -176,15 +177,18 @@ function buildStoreUpdate(
 		update.selectedConsents = autoGrantedConsents;
 	}
 
-	// Apply policy-driven purpose/category restrictions for non-wildcard scope.
-	// Out-of-policy categories are treated as out-of-scope (hidden + forced false),
-	// not as granted consent.
+	// Apply policy-driven purpose/category restrictions for strict non-wildcard
+	// scope. Permissive policies keep configured/script-derived categories visible.
 	const policyCategories = data.policy?.consent?.categories;
-	const hasPolicyCategoryAllowlist =
+	const hasPolicyCategoryList =
 		Array.isArray(policyCategories) &&
 		policyCategories.length > 0 &&
 		!policyCategories.includes('*');
-	if (hasPolicyCategoryAllowlist) {
+	const hasStrictPolicyCategoryAllowlist = shouldEnforcePolicyCategoryScope(
+		policyCategories,
+		data.policy?.consent?.scopeMode ?? null
+	);
+	if (hasStrictPolicyCategoryAllowlist) {
 		const uniqueAllowedCategories = filterConsentCategoriesByPolicy(
 			allConsentNames,
 			policyCategories
@@ -208,7 +212,7 @@ function buildStoreUpdate(
 		Array.isArray(preselectedCategories) &&
 		preselectedCategories.length > 0;
 	if (shouldApplyPreselectedCategories) {
-		const preselectedScope = hasPolicyCategoryAllowlist
+		const preselectedScope = hasPolicyCategoryList
 			? filterConsentCategoriesByPolicy(allConsentNames, policyCategories)
 			: allConsentNames;
 		const allowedPreselectedCategories = filterConsentCategoriesByPolicy(

--- a/packages/core/src/libs/policy.ts
+++ b/packages/core/src/libs/policy.ts
@@ -156,41 +156,16 @@ export function shouldEnforcePolicyCategoryScope(
 /**
  * Applies policy scope to runtime gating behavior.
  *
- * Out-of-policy categories are treated as permissive by c15t runtime and are
- * therefore granted for gating decisions (scripts/iframes load normally).
+ * Runtime gating should always respect the current consent state. Policy scope
+ * is enforced when categories are discovered, rendered, and saved rather than
+ * by overriding user choices here.
  */
 export function applyPolicyScopeForRuntimeGating(
 	consents: ConsentState,
-	allowedPurposeIds?: string[] | null,
-	scopeMode: 'strict' | 'permissive' | null = 'permissive'
+	_allowedPurposeIds?: string[] | null,
+	_scopeMode: 'strict' | 'permissive' | null = 'permissive'
 ): ConsentState {
-	if (scopeMode === 'strict') {
-		return consents;
-	}
-
-	if (
-		!allowedPurposeIds ||
-		allowedPurposeIds.length === 0 ||
-		allowedPurposeIds.includes('*')
-	) {
-		return consents;
-	}
-
-	const allowedCategories = new Set<AllConsentNames>([
-		'necessary',
-		...allowedPurposeIds.filter(isConsentCategory),
-	]);
-	const next = { ...consents };
-
-	for (const category of allConsentNames) {
-		if (!allowedCategories.has(category)) {
-			next[category] = true;
-		}
-	}
-
-	next.necessary = true;
-
-	return next;
+	return consents;
 }
 
 /**

--- a/packages/core/src/libs/policy.ts
+++ b/packages/core/src/libs/policy.ts
@@ -139,6 +139,21 @@ export function filterConsentCategoriesByPolicy(
 }
 
 /**
+ * Returns whether policy category scope should be enforced as a hard allowlist.
+ */
+export function shouldEnforcePolicyCategoryScope(
+	allowedPurposeIds?: string[] | null,
+	scopeMode: 'strict' | 'permissive' | null = 'permissive'
+): boolean {
+	return (
+		scopeMode === 'strict' &&
+		Array.isArray(allowedPurposeIds) &&
+		allowedPurposeIds.length > 0 &&
+		!allowedPurposeIds.includes('*')
+	);
+}
+
+/**
  * Applies policy scope to runtime gating behavior.
  *
  * Out-of-policy categories are treated as permissive by c15t runtime and are

--- a/packages/core/src/libs/policy.ts
+++ b/packages/core/src/libs/policy.ts
@@ -154,11 +154,9 @@ export function shouldEnforcePolicyCategoryScope(
 }
 
 /**
- * Applies policy scope to runtime gating behavior.
- *
- * Runtime gating should always respect the current consent state. Policy scope
- * is enforced when categories are discovered, rendered, and saved rather than
- * by overriding user choices here.
+ * @deprecated No-op retained for API compatibility. Runtime gating respects
+ * the current consent state directly; policy scope is enforced at category
+ * discovery, render, and save time instead.
  */
 export function applyPolicyScopeForRuntimeGating(
 	consents: ConsentState,

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -13,6 +13,7 @@ import { generateSubjectId } from './generate-subject-id';
 import {
 	applyPolicyPurposeAllowlist,
 	getEffectivePolicy,
+	shouldEnforcePolicyCategoryScope,
 	stripDisallowedPreferenceKeys,
 } from './policy';
 import { sanitizeSubjectIdentifiers } from './sanitize-subject-identifiers';
@@ -185,16 +186,18 @@ export async function saveConsents({
 		}
 	}
 
-	const policyCategories =
-		getEffectivePolicy(lastBannerFetchData)?.consent?.categories;
-	const effectiveConsents = applyPolicyPurposeAllowlist(
-		newConsents,
-		policyCategories
+	const effectivePolicy = getEffectivePolicy(lastBannerFetchData);
+	const policyCategories = effectivePolicy?.consent?.categories;
+	const shouldEnforcePolicyScope = shouldEnforcePolicyCategoryScope(
+		policyCategories,
+		effectivePolicy?.consent?.scopeMode ?? null
 	);
-	const requestPreferences = stripDisallowedPreferenceKeys(
-		effectiveConsents,
-		policyCategories
-	);
+	const effectiveConsents = shouldEnforcePolicyScope
+		? applyPolicyPurposeAllowlist(newConsents, policyCategories)
+		: newConsents;
+	const requestPreferences = shouldEnforcePolicyScope
+		? stripDisallowedPreferenceKeys(effectiveConsents, policyCategories)
+		: effectiveConsents;
 	const didChange = haveConsentsChanged(
 		previousConsents,
 		effectiveConsents,

--- a/packages/core/src/libs/script-loader/__tests__/store.test.ts
+++ b/packages/core/src/libs/script-loader/__tests__/store.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ConsentStoreState } from '../../../store/type';
-import type { AllConsentNames } from '../../../types/consent-types';
 import { clearAllScripts, loadScripts, updateScripts } from '../core';
 import { createScriptManager } from '../store';
 import type { Script } from '../types';
@@ -223,7 +222,7 @@ describe('Script Manager Store Integration', () => {
 			expect(document.head.appendChild).toHaveBeenCalledTimes(1);
 		});
 
-		it('should apply permissive policy scope before reloading', () => {
+		it('should respect denied out-of-policy categories before reloading', () => {
 			mockState.scripts = [...scripts];
 			mockState.consents = {
 				...sampleConsents,
@@ -239,9 +238,9 @@ describe('Script Manager Store Integration', () => {
 
 			const result = scriptManager.reloadScript('marketing-script');
 
-			expect(result).toBe(true);
-			expect(document.createElement).toHaveBeenCalledTimes(1);
-			expect(document.head.appendChild).toHaveBeenCalledTimes(1);
+			expect(result).toBe(false);
+			expect(document.createElement).not.toHaveBeenCalled();
+			expect(document.head.appendChild).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/core/src/store/__tests__/consent-store.test.ts
+++ b/packages/core/src/store/__tests__/consent-store.test.ts
@@ -8,7 +8,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConsentManagerStore } from '..';
 import { STORAGE_KEY_V2 } from '../initial-state';
-import type { ConsentStoreState, StoreOptions } from '../type';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock Setup
@@ -844,7 +843,7 @@ describe('Consent Store', () => {
 			expect(store.getState().has(condition)).toBe(true);
 		});
 
-		it('should treat out-of-policy categories as granted in has()', () => {
+		it('should respect out-of-policy category choices in has()', () => {
 			const store = createConsentManagerStore(mockManager);
 
 			store.setState({
@@ -852,14 +851,14 @@ describe('Consent Store', () => {
 				policyScopeMode: 'permissive',
 				consents: {
 					necessary: true,
-					marketing: false,
+					marketing: true,
 					measurement: true,
 					functionality: false,
 					experience: false,
 				},
 			});
 
-			expect(store.getState().has('experience')).toBe(true);
+			expect(store.getState().has('experience')).toBe(false);
 			expect(store.getState().has('marketing')).toBe(true);
 			expect(store.getState().has('measurement')).toBe(true);
 		});
@@ -1175,7 +1174,7 @@ describe('Consent Store', () => {
 			const storeCustom = createConsentManagerStore(mockManager, {
 				reloadOnConsentRevoked: false,
 			});
-			// Note: reloadOnConsentRevoked might be in initial state, check actual behavior
+			expect(storeCustom.getState().reloadOnConsentRevoked).toBe(false);
 		});
 
 		it('should apply model configuration', () => {

--- a/packages/core/src/store/__tests__/consent-store.test.ts
+++ b/packages/core/src/store/__tests__/consent-store.test.ts
@@ -466,6 +466,7 @@ describe('Consent Store', () => {
 
 			store.setState({
 				policyCategories: ['necessary', 'measurement'],
+				policyScopeMode: 'strict',
 			});
 
 			store
@@ -489,6 +490,7 @@ describe('Consent Store', () => {
 			store.setState({
 				consentCategories: ['necessary', 'measurement'],
 				policyCategories: ['necessary', 'measurement'],
+				policyScopeMode: 'strict',
 			});
 
 			store.getState().updateConsentCategories(['experience', 'marketing']);
@@ -1132,10 +1134,11 @@ describe('Consent Store', () => {
 			expect(store.getState().consentCategories).toContain('measurement');
 		});
 
-		it('should not add out-of-policy script categories to consentCategories', () => {
+		it('should not add out-of-policy script categories to consentCategories in strict scope mode', () => {
 			const store = createConsentManagerStore(mockManager);
 			store.setState({
 				policyCategories: ['necessary', 'measurement'],
+				policyScopeMode: 'strict',
 				consentCategories: ['necessary', 'measurement'],
 			});
 

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -299,7 +299,7 @@ export const createConsentManagerStore = (
 						policyScopeMode
 					)
 						? filterConsentCategoriesByPolicy(types, policyCategories)
-						: types,
+						: Array.from(new Set(types)),
 				};
 			}),
 		setCallback: (name, callback) => {

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -24,7 +24,10 @@ import type { IABConfig } from '../libs/iab-tcf/types';
 import { createIframeManager } from '../libs/iframe-blocker/store';
 import { initConsentManager } from '../libs/init-consent-manager';
 import { createNetworkBlockerManager } from '../libs/network-blocker/store';
-import { filterConsentCategoriesByPolicy } from '../libs/policy';
+import {
+	filterConsentCategoriesByPolicy,
+	shouldEnforcePolicyCategoryScope,
+} from '../libs/policy';
 import { sanitizeSubjectIdentifiers } from '../libs/sanitize-subject-identifiers';
 import { saveConsents } from '../libs/save-consents';
 import { createScriptManager } from '../libs/script-loader';
@@ -288,11 +291,16 @@ export const createConsentManagerStore = (
 			});
 		},
 		setConsentCategories: (types) =>
-			set({
-				consentCategories: filterConsentCategoriesByPolicy(
-					types,
-					get().policyCategories
-				),
+			set(() => {
+				const { policyCategories, policyScopeMode } = get();
+				return {
+					consentCategories: shouldEnforcePolicyCategoryScope(
+						policyCategories,
+						policyScopeMode
+					)
+						? filterConsentCategoriesByPolicy(types, policyCategories)
+						: types,
+				};
 			}),
 		setCallback: (name, callback) => {
 			const currentState = get();
@@ -396,10 +404,16 @@ export const createConsentManagerStore = (
 				...get().consentCategories,
 				...newCategories,
 			]);
-			const allCategories = filterConsentCategoriesByPolicy(
-				Array.from(allCategoriesSet),
-				get().policyCategories
-			);
+			const { policyCategories, policyScopeMode } = get();
+			const allCategories = shouldEnforcePolicyCategoryScope(
+				policyCategories,
+				policyScopeMode
+			)
+				? filterConsentCategoriesByPolicy(
+						Array.from(allCategoriesSet),
+						policyCategories
+					)
+				: Array.from(allCategoriesSet);
 			set({ consentCategories: allCategories });
 		},
 

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -293,13 +293,19 @@ export const createConsentManagerStore = (
 		setConsentCategories: (types) =>
 			set(() => {
 				const { policyCategories, policyScopeMode } = get();
+				if (
+					shouldEnforcePolicyCategoryScope(policyCategories, policyScopeMode)
+				) {
+					return {
+						consentCategories: filterConsentCategoriesByPolicy(
+							types,
+							policyCategories
+						),
+					};
+				}
+
 				return {
-					consentCategories: shouldEnforcePolicyCategoryScope(
-						policyCategories,
-						policyScopeMode
-					)
-						? filterConsentCategoriesByPolicy(types, policyCategories)
-						: Array.from(new Set(types)),
+					consentCategories: Array.from(new Set(types)),
 				};
 			}),
 		setCallback: (name, callback) => {
@@ -400,21 +406,27 @@ export const createConsentManagerStore = (
 		},
 
 		updateConsentCategories: (newCategories: AllConsentNames[]) => {
+			const {
+				consentCategories: currentConsentCategories,
+				policyCategories,
+				policyScopeMode,
+			} = get();
 			const allCategoriesSet = new Set<AllConsentNames>([
-				...get().consentCategories,
+				...currentConsentCategories,
 				...newCategories,
 			]);
-			const { policyCategories, policyScopeMode } = get();
-			const allCategories = shouldEnforcePolicyCategoryScope(
-				policyCategories,
-				policyScopeMode
-			)
-				? filterConsentCategoriesByPolicy(
-						Array.from(allCategoriesSet),
-						policyCategories
-					)
-				: Array.from(allCategoriesSet);
-			set({ consentCategories: allCategories });
+			let consentCategories: AllConsentNames[];
+
+			if (shouldEnforcePolicyCategoryScope(policyCategories, policyScopeMode)) {
+				consentCategories = filterConsentCategoriesByPolicy(
+					Array.from(allCategoriesSet),
+					policyCategories
+				);
+			} else {
+				consentCategories = Array.from(allCategoriesSet);
+			}
+
+			set({ consentCategories });
 		},
 
 		identifyUser: async (user: User) => {

--- a/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
@@ -187,7 +187,7 @@ describe('useConsentManager', () => {
 			),
 		});
 
-		expect(result.current.has('experience')).toBe(true);
+		expect(result.current.has('experience')).toBe(false);
 		expect(result.current.has('measurement')).toBe(false);
 	});
 });

--- a/packages/schema/src/shared/policy-runtime.test.ts
+++ b/packages/schema/src/shared/policy-runtime.test.ts
@@ -113,6 +113,50 @@ describe('resolvePolicyDecision', () => {
 		expect(first?.fingerprint).toMatch(/^[a-f0-9]{64}$/);
 	});
 
+	it('filters preselected categories only when policy scope is strict', async () => {
+		const strict = await resolvePolicyDecision({
+			policies: [
+				{
+					id: 'strict_policy',
+					match: policyMatchers.countries(['GB']),
+					consent: {
+						model: 'opt-in',
+						scopeMode: 'strict',
+						categories: ['necessary', 'functionality'],
+						preselectedCategories: ['functionality', 'marketing'],
+					},
+				},
+			],
+			countryCode: 'GB',
+			regionCode: null,
+			jurisdiction: 'UK_GDPR',
+		});
+		const permissive = await resolvePolicyDecision({
+			policies: [
+				{
+					id: 'permissive_policy',
+					match: policyMatchers.countries(['GB']),
+					consent: {
+						model: 'opt-in',
+						scopeMode: 'permissive',
+						categories: ['necessary'],
+						preselectedCategories: ['marketing'],
+					},
+				},
+			],
+			countryCode: 'GB',
+			regionCode: null,
+			jurisdiction: 'UK_GDPR',
+		});
+
+		expect(strict?.policy.consent?.preselectedCategories).toEqual([
+			'functionality',
+		]);
+		expect(permissive?.policy.consent?.preselectedCategories).toEqual([
+			'marketing',
+		]);
+	});
+
 	it('creates the same policy fingerprint across all hash strategies', async () => {
 		Object.defineProperty(globalThis, 'crypto', {
 			value: webcrypto,

--- a/packages/schema/src/shared/policy-runtime.ts
+++ b/packages/schema/src/shared/policy-runtime.ts
@@ -407,7 +407,12 @@ function normalizePreselectedCategories(
 	}
 
 	const categories = normalizeCategories(policy);
-	if (!categories || categories.length === 0 || categories.includes('*')) {
+	if (
+		normalizeScopeMode(policy) !== 'strict' ||
+		!categories ||
+		categories.length === 0 ||
+		categories.includes('*')
+	) {
 		return dedupeTrimmedStrings(preselectedCategories);
 	}
 


### PR DESCRIPTION
## Summary

Refines policy category scope handling across the client runtime and backend consent writes.

## Details

- Keeps configured and script-derived categories available when policy scope is permissive.
- Preserves strict scope behavior for policy category enforcement.
- Adds coverage for client category display, consent saving, script category registration, and backend applied preferences.

## Validation

- `bun biome check .changeset/refined-policy-scope.md packages/backend/src/handlers/subject/post.handler.test.ts packages/backend/src/handlers/subject/post.handler.ts packages/core/src/__tests__/store-script-loader.test.ts packages/core/src/libs/__tests__/policy.test.ts packages/core/src/libs/__tests__/save-consents.test.ts packages/core/src/libs/init-consent-manager/__tests__/store-updater.test.ts packages/core/src/libs/init-consent-manager/store-updater.ts packages/core/src/libs/policy.ts packages/core/src/libs/save-consents.ts packages/core/src/store/index.ts`
- `bun vitest run src/libs/__tests__/policy.test.ts src/libs/init-consent-manager/__tests__/store-updater.test.ts src/libs/__tests__/save-consents.test.ts src/__tests__/store-script-loader.test.ts`
- `bun vitest run src/handlers/subject/post.handler.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consent processing now correctly enforces strict vs permissive policy scope: strict mode restricts out-of-policy categories; permissive mode preserves submitted preferences (including out-of-scope values).

* **Tests**
  * Added/updated tests for strict/permissive scope, preselection, persistence, and script/category handling to validate runtime and store behavior.

* **Other**
  * Store/save flows now respect policy-scope decisions consistently; benchmarking scripts tolerate additional expected server shutdown codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->