### PR TITLE
Fix react-hooks + effect-cleanup errors flagged by react-doctor

### DIFF
--- a/packages/react/src/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/components/consent-banner/consent-banner.tsx
@@ -232,17 +232,19 @@ export const ConsentBanner: FC<ConsentBannerProps> = ({
 		layout ??
 		((banner.layout?.length ?? 0) > 0 ? banner.actionGroups : DEFAULT_LAYOUT);
 	const resolvedDirection = direction ?? banner.direction ?? 'row';
-	const activeGroups = resolvedLayout
-		.map((item) =>
-			Array.isArray(item)
-				? item.filter((action): action is PolicyUiAction =>
-						allowedActions.has(action)
-					)
-				: allowedActions.has(item)
-					? [item]
-					: []
-		)
-		.filter((group) => group.length > 0);
+	const activeGroups: PolicyUiAction[][] = [];
+	for (const item of resolvedLayout) {
+		const group = Array.isArray(item)
+			? item.filter((action): action is PolicyUiAction =>
+					allowedActions.has(action)
+				)
+			: allowedActions.has(item)
+				? [item]
+				: [];
+		if (group.length > 0) {
+			activeGroups.push(group);
+		}
+	}
 	const shouldFillActions = shouldFillPolicyActions({
 		uiProfile: banner.uiProfile,
 		actionGroups: activeGroups,

--- a/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
+++ b/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
@@ -199,8 +199,8 @@ export const IABConsentBanner: FC<IABConsentBannerProps> = ({
 							{descriptionText.split(partnersLinkText)[1]}
 						</p>
 						<ul className={styles.purposeList}>
-							{banner.displayItems.map((name, index) => (
-								<li key={index}>{name}</li>
+							{banner.displayItems.map((name) => (
+								<li key={name}>{name}</li>
 							))}
 							{banner.remainingCount > 0 && (
 								<li className={styles.purposeMore}>

--- a/packages/react/src/components/iab-consent-dialog/atoms/purpose-item.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/purpose-item.tsx
@@ -31,6 +31,9 @@ interface PurposeItemProps {
 	) => void;
 }
 
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+const EMPTY_PURPOSE_LEG_INT: Record<number, boolean> = Object.freeze({});
+
 export const PurposeItem: FC<PurposeItemProps> = ({
 	purpose,
 	isEnabled,
@@ -39,9 +42,9 @@ export const PurposeItem: FC<PurposeItemProps> = ({
 	onVendorToggle,
 	onVendorClick,
 	isLocked = false,
-	vendorLegitimateInterests = {},
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
-	purposeLegitimateInterests = {},
+	purposeLegitimateInterests = EMPTY_PURPOSE_LEG_INT,
 	onPurposeLegitimateInterestToggle,
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
@@ -255,8 +258,8 @@ export const PurposeItem: FC<PurposeItemProps> = ({
 							</PreferenceItem.Trigger>
 							<PreferenceItem.Content noStyle>
 								<ul className={styles.examplesList}>
-									{purpose.illustrations.map((illustration, index) => (
-										<li key={index}>{illustration}</li>
+									{purpose.illustrations.map((illustration) => (
+										<li key={illustration}>{illustration}</li>
 									))}
 								</ul>
 							</PreferenceItem.Content>

--- a/packages/react/src/components/iab-consent-dialog/atoms/root.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/root.tsx
@@ -98,15 +98,6 @@ const IABConsentDialogRoot: FC<IABConsentDialogRootProps> = ({
 		}
 	}, [isOpen, disableAnimation]);
 
-	// Don't render if not mounted or IAB is disabled
-	if (!isMounted || !iabState?.config.enabled) {
-		return null;
-	}
-
-	if (!isOpen && !isVisible) {
-		return null;
-	}
-
 	const themedStyle = useStyles('iabConsentDialog', {
 		baseClassName: cn(
 			styles.root,
@@ -118,6 +109,15 @@ const IABConsentDialogRoot: FC<IABConsentDialogRootProps> = ({
 		),
 	});
 	const domStyleProps = sanitizeDOMStyleProps(themedStyle);
+
+	// Don't render if not mounted or IAB is disabled
+	if (!isMounted || !iabState?.config.enabled) {
+		return null;
+	}
+
+	if (!isOpen && !isVisible) {
+		return null;
+	}
 
 	const dialogContent = (
 		<ConsentTrackingContext.Provider

--- a/packages/react/src/components/iab-consent-dialog/atoms/stack-item.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/stack-item.tsx
@@ -30,6 +30,9 @@ interface StackItemProps {
 	) => void;
 }
 
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+const EMPTY_PURPOSE_LEG_INT: Record<number, boolean> = Object.freeze({});
+
 export const StackItem: FC<StackItemProps> = ({
 	stack,
 	consents,
@@ -37,9 +40,9 @@ export const StackItem: FC<StackItemProps> = ({
 	vendorConsents,
 	onVendorToggle,
 	onVendorClick,
-	vendorLegitimateInterests = {},
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
-	purposeLegitimateInterests = {},
+	purposeLegitimateInterests = EMPTY_PURPOSE_LEG_INT,
 	onPurposeLegitimateInterestToggle,
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);

--- a/packages/react/src/components/iab-consent-dialog/atoms/tabs.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/tabs.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
-import {
-	forwardRef,
-	type HTMLAttributes,
-	type ReactNode,
-	useMemo,
-} from 'react';
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import * as Tabs from '~/components/shared/ui/tabs';
 import { useGVLData } from '../hooks/use-gvl-data';
 import { useIABTranslations } from '../use-iab-translations';
@@ -30,19 +25,11 @@ const IABConsentDialogTabs = forwardRef<
 		totalVendors,
 		isLoading,
 	} = useGVLData();
-	const purposeCount = useMemo(
-		() =>
-			purposes.length +
-			specialPurposes.length +
-			specialFeatures.length +
-			features.length,
-		[
-			features.length,
-			purposes.length,
-			specialFeatures.length,
-			specialPurposes.length,
-		]
-	);
+	const purposeCount =
+		purposes.length +
+		specialPurposes.length +
+		specialFeatures.length +
+		features.length;
 
 	return (
 		<Tabs.Root

--- a/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -40,6 +40,9 @@ interface VendorListProps {
 	) => void;
 }
 
+const EMPTY_CUSTOM_VENDORS: CustomVendor[] = [];
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+
 export const VendorList: FC<VendorListProps> = ({
 	vendorData,
 	purposes,
@@ -47,8 +50,8 @@ export const VendorList: FC<VendorListProps> = ({
 	onVendorToggle,
 	selectedVendorId,
 	onClearSelection,
-	customVendors = [],
-	vendorLegitimateInterests = {},
+	customVendors = EMPTY_CUSTOM_VENDORS,
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
 }) => {
 	const [searchTerm, setSearchTerm] = useState('');

--- a/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -159,14 +159,18 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return purposes
-			.filter((purpose) =>
-				purpose.vendors.some((v) => String(v.id) === String(vendorId))
-			)
-			.map((purpose) => ({
-				...purpose,
-				usesLegitimateInterest: vendor.legIntPurposes.includes(purpose.id),
-			}));
+		const result: (ProcessedPurpose & { usesLegitimateInterest: boolean })[] =
+			[];
+		const idStr = String(vendorId);
+		for (const purpose of purposes) {
+			if (purpose.vendors.some((v) => String(v.id) === idStr)) {
+				result.push({
+					...purpose,
+					usesLegitimateInterest: vendor.legIntPurposes.includes(purpose.id),
+				});
+			}
+		}
+		return result;
 	};
 
 	const getVendorSpecialPurposes = (vendorId: VendorId) => {
@@ -175,14 +179,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return vendor.specialPurposes
-			.map((id) => vendorData.specialPurposes[id])
-			.filter((sp): sp is NonNullable<typeof sp> => sp != null)
-			.map((sp) => ({
-				id: sp.id,
-				name: sp.name,
-				description: sp.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.specialPurposes) {
+			const sp = vendorData.specialPurposes[id];
+			if (sp != null) {
+				result.push({ id: sp.id, name: sp.name, description: sp.description });
+			}
+		}
+		return result;
 	};
 
 	const getVendorSpecialFeatures = (vendorId: VendorId) => {
@@ -191,14 +195,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return vendor.specialFeatures
-			.map((id) => vendorData.specialFeatures[id])
-			.filter((sf): sf is NonNullable<typeof sf> => sf != null)
-			.map((sf) => ({
-				id: sf.id,
-				name: sf.name,
-				description: sf.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.specialFeatures) {
+			const sf = vendorData.specialFeatures[id];
+			if (sf != null) {
+				result.push({ id: sf.id, name: sf.name, description: sf.description });
+			}
+		}
+		return result;
 	};
 
 	const getVendorFeatures = (vendorId: VendorId) => {
@@ -207,14 +211,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return (vendor.features || [])
-			.map((id) => vendorData.features[id])
-			.filter((f): f is NonNullable<typeof f> => f != null)
-			.map((f) => ({
-				id: f.id,
-				name: f.name,
-				description: f.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.features || []) {
+			const f = vendorData.features[id];
+			if (f != null) {
+				result.push({ id: f.id, name: f.name, description: f.description });
+			}
+		}
+		return result;
 	};
 
 	return (

--- a/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -112,17 +112,19 @@ export const VendorList: FC<VendorListProps> = ({
 	].sort((a, b) => a.name.localeCompare(b.name));
 
 	useEffect(() => {
-		if (selectedVendorId !== null) {
-			setExpandedVendors((prev) => new Set(prev).add(selectedVendorId));
-			setTimeout(() => {
-				const element = document.getElementById(
-					`vendor-${String(selectedVendorId)}`
-				);
-				if (element) {
-					element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-				}
-			}, 100);
+		if (selectedVendorId === null) {
+			return;
 		}
+		setExpandedVendors((prev) => new Set(prev).add(selectedVendorId));
+		const timer = setTimeout(() => {
+			const element = document.getElementById(
+				`vendor-${String(selectedVendorId)}`
+			);
+			if (element) {
+				element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+			}
+		}, 100);
+		return () => clearTimeout(timer);
 	}, [selectedVendorId]);
 
 	const filteredVendors =

--- a/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -405,8 +405,9 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 			);
 			if (unassignedInStack.length >= 2) {
 				// Get purposes for this stack (only unassigned ones)
+				const unassignedInStackSet = new Set(unassignedInStack);
 				const stackPurposes = otherPurposes.filter((p) =>
-					unassignedInStack.includes(p.id)
+					unassignedInStackSet.has(p.id)
 				);
 				processedStacks.push({
 					id: stackId,

--- a/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -251,108 +251,108 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 			isCustom: true,
 		});
 
-		// Process purposes
-		const processedPurposes: ProcessedPurpose[] = Object.entries(gvl.purposes)
-			.map(([id, purpose]) => {
-				// Get IAB vendors for this purpose (all vendors from GVL)
-				const iabVendorsForPurpose: ProcessedVendor[] = Object.entries(
-					gvl.vendors
-				)
-					.filter(([, vendor]) => {
-						return (
-							vendor.purposes?.includes(Number(id)) ||
-							vendor.legIntPurposes?.includes(Number(id))
-						);
-					})
-					.map(([vendorId, vendor]) => mapVendor(vendorId, vendor, Number(id)));
-
-				// Get custom vendors for this purpose
-				const customVendorsForPurpose: ProcessedVendor[] = customVendors
-					.filter((cv) => {
-						return (
-							cv.purposes?.includes(Number(id)) ||
-							cv.legIntPurposes?.includes(Number(id))
-						);
-					})
-					.map((cv) => mapCustomVendor(cv, Number(id)));
-
-				return {
-					id: Number(id),
+		// Process purposes — single-pass: build IAB/custom vendor lists, then
+		// only emit purposes that ended up with at least one vendor.
+		const processedPurposes: ProcessedPurpose[] = [];
+		for (const [id, purpose] of Object.entries(gvl.purposes)) {
+			const numId = Number(id);
+			const iabVendorsForPurpose: ProcessedVendor[] = [];
+			for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+				if (
+					vendor.purposes?.includes(numId) ||
+					vendor.legIntPurposes?.includes(numId)
+				) {
+					iabVendorsForPurpose.push(mapVendor(vendorId, vendor, numId));
+				}
+			}
+			const customVendorsForPurpose: ProcessedVendor[] = [];
+			for (const cv of customVendors) {
+				if (
+					cv.purposes?.includes(numId) ||
+					cv.legIntPurposes?.includes(numId)
+				) {
+					customVendorsForPurpose.push(mapCustomVendor(cv, numId));
+				}
+			}
+			const vendors = [...iabVendorsForPurpose, ...customVendorsForPurpose];
+			if (vendors.length > 0) {
+				processedPurposes.push({
+					id: numId,
 					name: purpose.name,
 					description: purpose.description,
 					descriptionLegal: purpose.descriptionLegal,
 					illustrations: purpose.illustrations || [],
-					vendors: [...iabVendorsForPurpose, ...customVendorsForPurpose],
-				};
-			})
-			.filter((purpose) => purpose.vendors.length > 0);
+					vendors,
+				});
+			}
+		}
 
 		// Process special purposes
-		const processedSpecialPurposes: ProcessedPurpose[] = Object.entries(
-			gvl.specialPurposes || {}
-		)
-			.map(([id, purpose]) => {
-				const vendorsForPurpose: ProcessedVendor[] = Object.entries(gvl.vendors)
-					.filter(([, vendor]) => {
-						return vendor.specialPurposes?.includes(Number(id));
-					})
-					.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-				return {
-					id: Number(id),
+		const processedSpecialPurposes: ProcessedPurpose[] = [];
+		for (const [id, purpose] of Object.entries(gvl.specialPurposes || {})) {
+			const numId = Number(id);
+			const vendorsForPurpose: ProcessedVendor[] = [];
+			for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+				if (vendor.specialPurposes?.includes(numId)) {
+					vendorsForPurpose.push(mapVendor(vendorId, vendor));
+				}
+			}
+			if (vendorsForPurpose.length > 0) {
+				processedSpecialPurposes.push({
+					id: numId,
 					name: purpose.name,
 					description: purpose.description,
 					descriptionLegal: purpose.descriptionLegal,
 					illustrations: purpose.illustrations || [],
 					vendors: vendorsForPurpose,
 					isSpecialPurpose: true,
-				};
-			})
-			.filter((sp) => sp.vendors.length > 0);
+				});
+			}
+		}
 
 		// Process special features
-		const processedSpecialFeatures: ProcessedSpecialFeature[] = Object.entries(
-			gvl.specialFeatures || {}
-		)
-			.map(([id, feature]) => {
-				const vendorsForFeature: ProcessedVendor[] = Object.entries(gvl.vendors)
-					.filter(([, vendor]) => {
-						return vendor.specialFeatures?.includes(Number(id));
-					})
-					.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-				return {
-					id: Number(id),
+		const processedSpecialFeatures: ProcessedSpecialFeature[] = [];
+		for (const [id, feature] of Object.entries(gvl.specialFeatures || {})) {
+			const numId = Number(id);
+			const vendorsForFeature: ProcessedVendor[] = [];
+			for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+				if (vendor.specialFeatures?.includes(numId)) {
+					vendorsForFeature.push(mapVendor(vendorId, vendor));
+				}
+			}
+			if (vendorsForFeature.length > 0) {
+				processedSpecialFeatures.push({
+					id: numId,
 					name: feature.name,
 					description: feature.description,
 					descriptionLegal: feature.descriptionLegal,
 					illustrations: feature.illustrations || [],
 					vendors: vendorsForFeature,
-				};
-			})
-			.filter((sf) => sf.vendors.length > 0);
+				});
+			}
+		}
 
 		// Process features (informational, no consent toggle)
-		const processedFeatures: ProcessedFeature[] = Object.entries(
-			gvl.features || {}
-		)
-			.map(([id, feature]) => {
-				const vendorsForFeature: ProcessedVendor[] = Object.entries(gvl.vendors)
-					.filter(([, vendor]) => {
-						return vendor.features?.includes(Number(id));
-					})
-					.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-				return {
-					id: Number(id),
+		const processedFeatures: ProcessedFeature[] = [];
+		for (const [id, feature] of Object.entries(gvl.features || {})) {
+			const numId = Number(id);
+			const vendorsForFeature: ProcessedVendor[] = [];
+			for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+				if (vendor.features?.includes(numId)) {
+					vendorsForFeature.push(mapVendor(vendorId, vendor));
+				}
+			}
+			if (vendorsForFeature.length > 0) {
+				processedFeatures.push({
+					id: numId,
 					name: feature.name,
 					description: feature.description,
 					descriptionLegal: feature.descriptionLegal,
 					illustrations: feature.illustrations || [],
 					vendors: vendorsForFeature,
-				};
-			})
-			.filter((f) => f.vendors.length > 0);
+				});
+			}
+		}
 
 		// Group purposes into stacks (Purpose 1 is always standalone per IAB TCF spec)
 		const STANDALONE_PURPOSE_ID = 1;

--- a/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -569,6 +569,7 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 		// Use double-RAF to ensure browser has laid out new content
 		let rafId1: number;
 		let rafId2: number;
+		let removeTransitionListener: (() => void) | null = null;
 
 		rafId1 = requestAnimationFrame(() => {
 			rafId2 = requestAnimationFrame(() => {
@@ -609,12 +610,15 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 				content.addEventListener('transitionend', handleTransitionEnd, {
 					once: true,
 				});
+				removeTransitionListener = () =>
+					content.removeEventListener('transitionend', handleTransitionEnd);
 			});
 		});
 
 		return () => {
 			cancelAnimationFrame(rafId1);
 			cancelAnimationFrame(rafId2);
+			removeTransitionListener?.();
 		};
 	}, [activeTab]);
 

--- a/packages/react/src/components/shared/ui/animated-collapse/animated-collapse.tsx
+++ b/packages/react/src/components/shared/ui/animated-collapse/animated-collapse.tsx
@@ -94,6 +94,7 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 	useLayoutEffect(() => {
 		const wrapper = wrapperRef.current;
 		const content = contentRef.current;
+		let removeTransitionListener: (() => void) | null = null;
 
 		// Check for reduced motion preference
 		const prefersReducedMotion = window.matchMedia(
@@ -158,9 +159,12 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 						});
 						setIsAnimating(false);
 						wrapper?.removeEventListener('transitionend', handleTransitionEnd);
+						removeTransitionListener = null;
 					};
 
 					wrapper?.addEventListener('transitionend', handleTransitionEnd);
+					removeTransitionListener = () =>
+						wrapper?.removeEventListener('transitionend', handleTransitionEnd);
 				});
 			});
 		} else {
@@ -204,9 +208,12 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 					setShouldRender(false);
 					setIsAnimating(false);
 					wrapper.removeEventListener('transitionend', handleTransitionEnd);
+					removeTransitionListener = null;
 				};
 
 				wrapper.addEventListener('transitionend', handleTransitionEnd);
+				removeTransitionListener = () =>
+					wrapper.removeEventListener('transitionend', handleTransitionEnd);
 			});
 		}
 
@@ -214,6 +221,7 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 			if (animationRef.current !== null) {
 				cancelAnimationFrame(animationRef.current);
 			}
+			removeTransitionListener?.();
 		};
 	}, [isOpen, duration, easing]);
 

--- a/packages/react/src/v3/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/v3/components/consent-banner/consent-banner.tsx
@@ -237,17 +237,17 @@ export const ConsentBanner: FC<ConsentBannerProps> = ({
 			layout ??
 			((banner.layout?.length ?? 0) > 0 ? banner.actionGroups : DEFAULT_LAYOUT);
 		const directionResolved = direction ?? banner.direction ?? 'row';
-		const activeGroups = layoutResolved
-			.map((item) =>
-				Array.isArray(item)
-					? item.filter((action): action is PolicyUiAction =>
-							allowed.has(action)
-						)
-					: allowed.has(item)
-						? [item]
-						: []
-			)
-			.filter((group) => group.length > 0);
+		const activeGroups: PolicyUiAction[][] = [];
+		for (const item of layoutResolved) {
+			const group = Array.isArray(item)
+				? item.filter((action): action is PolicyUiAction => allowed.has(action))
+				: allowed.has(item)
+					? [item]
+					: [];
+			if (group.length > 0) {
+				activeGroups.push(group);
+			}
+		}
 		return {
 			allowedActions: allowed,
 			resolvedLayout: layoutResolved,

--- a/packages/react/src/v3/components/iab-consent-banner/iab-consent-banner.tsx
+++ b/packages/react/src/v3/components/iab-consent-banner/iab-consent-banner.tsx
@@ -199,8 +199,8 @@ export const IABConsentBanner: FC<IABConsentBannerProps> = ({
 							{descriptionText.split(partnersLinkText)[1]}
 						</p>
 						<ul className={styles.purposeList}>
-							{banner.displayItems.map((name, index) => (
-								<li key={index}>{name}</li>
+							{banner.displayItems.map((name) => (
+								<li key={name}>{name}</li>
 							))}
 							{banner.remainingCount > 0 && (
 								<li className={styles.purposeMore}>

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/purpose-item.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/purpose-item.tsx
@@ -31,6 +31,9 @@ interface PurposeItemProps {
 	) => void;
 }
 
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+const EMPTY_PURPOSE_LEG_INT: Record<number, boolean> = Object.freeze({});
+
 export const PurposeItem: FC<PurposeItemProps> = ({
 	purpose,
 	isEnabled,
@@ -39,9 +42,9 @@ export const PurposeItem: FC<PurposeItemProps> = ({
 	onVendorToggle,
 	onVendorClick,
 	isLocked = false,
-	vendorLegitimateInterests = {},
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
-	purposeLegitimateInterests = {},
+	purposeLegitimateInterests = EMPTY_PURPOSE_LEG_INT,
 	onPurposeLegitimateInterestToggle,
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
@@ -255,8 +258,8 @@ export const PurposeItem: FC<PurposeItemProps> = ({
 							</PreferenceItem.Trigger>
 							<PreferenceItem.Content noStyle>
 								<ul className={styles.examplesList}>
-									{purpose.illustrations.map((illustration, index) => (
-										<li key={index}>{illustration}</li>
+									{purpose.illustrations.map((illustration) => (
+										<li key={illustration}>{illustration}</li>
 									))}
 								</ul>
 							</PreferenceItem.Content>

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/root.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/root.tsx
@@ -100,15 +100,6 @@ const IABConsentDialogRoot: FC<IABConsentDialogRootProps> = ({
 		}
 	}, [isOpen, disableAnimation]);
 
-	// Don't render if not mounted or IAB is disabled
-	if (!isMounted || !iabState?.config.enabled) {
-		return null;
-	}
-
-	if (!isOpen && !isVisible) {
-		return null;
-	}
-
 	const themedStyle = useStyles('iabConsentDialog', {
 		baseClassName: cn(
 			styles.root,
@@ -120,6 +111,15 @@ const IABConsentDialogRoot: FC<IABConsentDialogRootProps> = ({
 		),
 	});
 	const domStyleProps = sanitizeDOMStyleProps(themedStyle);
+
+	// Don't render if not mounted or IAB is disabled
+	if (!isMounted || !iabState?.config.enabled) {
+		return null;
+	}
+
+	if (!isOpen && !isVisible) {
+		return null;
+	}
 
 	const dialogContent = (
 		<ConsentTrackingContext.Provider

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/stack-item.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/stack-item.tsx
@@ -30,6 +30,9 @@ interface StackItemProps {
 	) => void;
 }
 
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+const EMPTY_PURPOSE_LEG_INT: Record<number, boolean> = Object.freeze({});
+
 export const StackItem: FC<StackItemProps> = ({
 	stack,
 	consents,
@@ -37,9 +40,9 @@ export const StackItem: FC<StackItemProps> = ({
 	vendorConsents,
 	onVendorToggle,
 	onVendorClick,
-	vendorLegitimateInterests = {},
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
-	purposeLegitimateInterests = {},
+	purposeLegitimateInterests = EMPTY_PURPOSE_LEG_INT,
 	onPurposeLegitimateInterestToggle,
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/tabs.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/tabs.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
-import {
-	forwardRef,
-	type HTMLAttributes,
-	type ReactNode,
-	useMemo,
-} from 'react';
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import * as Tabs from '~/v3/components/shared/ui/tabs';
 import { useGVLData } from '../hooks/use-gvl-data';
 import { useIABTranslations } from '../use-iab-translations';
@@ -30,19 +25,11 @@ const IABConsentDialogTabs = forwardRef<
 		totalVendors,
 		isLoading,
 	} = useGVLData();
-	const purposeCount = useMemo(
-		() =>
-			purposes.length +
-			specialPurposes.length +
-			specialFeatures.length +
-			features.length,
-		[
-			features.length,
-			purposes.length,
-			specialFeatures.length,
-			specialPurposes.length,
-		]
-	);
+	const purposeCount =
+		purposes.length +
+		specialPurposes.length +
+		specialFeatures.length +
+		features.length;
 
 	return (
 		<Tabs.Root

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -40,6 +40,9 @@ interface VendorListProps {
 	) => void;
 }
 
+const EMPTY_CUSTOM_VENDORS: CustomVendor[] = [];
+const EMPTY_VENDOR_LEG_INT: Record<string, boolean> = Object.freeze({});
+
 export const VendorList: FC<VendorListProps> = ({
 	vendorData,
 	purposes,
@@ -47,8 +50,8 @@ export const VendorList: FC<VendorListProps> = ({
 	onVendorToggle,
 	selectedVendorId,
 	onClearSelection,
-	customVendors = [],
-	vendorLegitimateInterests = {},
+	customVendors = EMPTY_CUSTOM_VENDORS,
+	vendorLegitimateInterests = EMPTY_VENDOR_LEG_INT,
 	onVendorLegitimateInterestToggle,
 }) => {
 	const [searchTerm, setSearchTerm] = useState('');

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -159,14 +159,18 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return purposes
-			.filter((purpose) =>
-				purpose.vendors.some((v) => String(v.id) === String(vendorId))
-			)
-			.map((purpose) => ({
-				...purpose,
-				usesLegitimateInterest: vendor.legIntPurposes.includes(purpose.id),
-			}));
+		const result: (ProcessedPurpose & { usesLegitimateInterest: boolean })[] =
+			[];
+		const idStr = String(vendorId);
+		for (const purpose of purposes) {
+			if (purpose.vendors.some((v) => String(v.id) === idStr)) {
+				result.push({
+					...purpose,
+					usesLegitimateInterest: vendor.legIntPurposes.includes(purpose.id),
+				});
+			}
+		}
+		return result;
 	};
 
 	const getVendorSpecialPurposes = (vendorId: VendorId) => {
@@ -175,14 +179,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return vendor.specialPurposes
-			.map((id) => vendorData.specialPurposes[id])
-			.filter((sp): sp is NonNullable<typeof sp> => sp != null)
-			.map((sp) => ({
-				id: sp.id,
-				name: sp.name,
-				description: sp.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.specialPurposes) {
+			const sp = vendorData.specialPurposes[id];
+			if (sp != null) {
+				result.push({ id: sp.id, name: sp.name, description: sp.description });
+			}
+		}
+		return result;
 	};
 
 	const getVendorSpecialFeatures = (vendorId: VendorId) => {
@@ -191,14 +195,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return vendor.specialFeatures
-			.map((id) => vendorData.specialFeatures[id])
-			.filter((sf): sf is NonNullable<typeof sf> => sf != null)
-			.map((sf) => ({
-				id: sf.id,
-				name: sf.name,
-				description: sf.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.specialFeatures) {
+			const sf = vendorData.specialFeatures[id];
+			if (sf != null) {
+				result.push({ id: sf.id, name: sf.name, description: sf.description });
+			}
+		}
+		return result;
 	};
 
 	const getVendorFeatures = (vendorId: VendorId) => {
@@ -207,14 +211,14 @@ export const VendorList: FC<VendorListProps> = ({
 			return [];
 		}
 
-		return (vendor.features || [])
-			.map((id) => vendorData.features[id])
-			.filter((f): f is NonNullable<typeof f> => f != null)
-			.map((f) => ({
-				id: f.id,
-				name: f.name,
-				description: f.description,
-			}));
+		const result: { id: number; name: string; description: string }[] = [];
+		for (const id of vendor.features || []) {
+			const f = vendorData.features[id];
+			if (f != null) {
+				result.push({ id: f.id, name: f.name, description: f.description });
+			}
+		}
+		return result;
 	};
 
 	return (

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -112,17 +112,19 @@ export const VendorList: FC<VendorListProps> = ({
 	].sort((a, b) => a.name.localeCompare(b.name));
 
 	useEffect(() => {
-		if (selectedVendorId !== null) {
-			setExpandedVendors((prev) => new Set(prev).add(selectedVendorId));
-			setTimeout(() => {
-				const element = document.getElementById(
-					`vendor-${String(selectedVendorId)}`
-				);
-				if (element) {
-					element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-				}
-			}, 100);
+		if (selectedVendorId === null) {
+			return;
 		}
+		setExpandedVendors((prev) => new Set(prev).add(selectedVendorId));
+		const timer = setTimeout(() => {
+			const element = document.getElementById(
+				`vendor-${String(selectedVendorId)}`
+			);
+			if (element) {
+				element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+			}
+		}, 100);
+		return () => clearTimeout(timer);
 	}, [selectedVendorId]);
 
 	const filteredVendors =

--- a/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -322,6 +322,7 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 		// Use double-RAF to ensure browser has laid out new content
 		let rafId1: number;
 		let rafId2: number;
+		let removeTransitionListener: (() => void) | null = null;
 
 		rafId1 = requestAnimationFrame(() => {
 			rafId2 = requestAnimationFrame(() => {
@@ -362,12 +363,15 @@ export const IABConsentDialog: FC<IABConsentDialogProps> = ({
 				content.addEventListener('transitionend', handleTransitionEnd, {
 					once: true,
 				});
+				removeTransitionListener = () =>
+					content.removeEventListener('transitionend', handleTransitionEnd);
 			});
 		});
 
 		return () => {
 			cancelAnimationFrame(rafId1);
 			cancelAnimationFrame(rafId2);
+			removeTransitionListener?.();
 		};
 	}, [activeTab]);
 

--- a/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -1040,8 +1040,9 @@ function computeProcessedGvl(
 			(pid) => !assignedPurposeIds.has(pid)
 		);
 		if (unassignedInStack.length >= 2) {
+			const unassignedInStackSet = new Set(unassignedInStack);
 			const stackPurposes = otherPurposes.filter((p) =>
-				unassignedInStack.includes(p.id)
+				unassignedInStackSet.has(p.id)
 			);
 			processedStacks.push({
 				id: stackId,

--- a/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -910,94 +910,102 @@ function computeProcessedGvl(
 		isCustom: true,
 	});
 
-	const processedPurposes: ProcessedPurpose[] = Object.entries(gvl.purposes)
-		.map(([id, purpose]) => {
-			const iabVendorsForPurpose: ProcessedVendor[] = Object.entries(
-				gvl.vendors
-			)
-				.filter(
-					([, vendor]) =>
-						vendor.purposes?.includes(Number(id)) ||
-						vendor.legIntPurposes?.includes(Number(id))
-				)
-				.map(([vendorId, vendor]) => mapVendor(vendorId, vendor, Number(id)));
-
-			const customVendorsForPurpose: ProcessedVendor[] = customVendors
-				.filter(
-					(cv) =>
-						cv.purposes?.includes(Number(id)) ||
-						cv.legIntPurposes?.includes(Number(id))
-				)
-				.map((cv) => mapCustomVendor(cv, Number(id)));
-
-			return {
-				id: Number(id),
+	// Single-pass: build IAB/custom vendor lists, then only emit purposes
+	// that ended up with at least one vendor.
+	const processedPurposes: ProcessedPurpose[] = [];
+	for (const [id, purpose] of Object.entries(gvl.purposes)) {
+		const numId = Number(id);
+		const iabVendorsForPurpose: ProcessedVendor[] = [];
+		for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+			if (
+				vendor.purposes?.includes(numId) ||
+				vendor.legIntPurposes?.includes(numId)
+			) {
+				iabVendorsForPurpose.push(mapVendor(vendorId, vendor, numId));
+			}
+		}
+		const customVendorsForPurpose: ProcessedVendor[] = [];
+		for (const cv of customVendors) {
+			if (cv.purposes?.includes(numId) || cv.legIntPurposes?.includes(numId)) {
+				customVendorsForPurpose.push(mapCustomVendor(cv, numId));
+			}
+		}
+		const vendors = [...iabVendorsForPurpose, ...customVendorsForPurpose];
+		if (vendors.length > 0) {
+			processedPurposes.push({
+				id: numId,
 				name: purpose.name,
 				description: purpose.description,
 				descriptionLegal: purpose.descriptionLegal,
 				illustrations: purpose.illustrations || [],
-				vendors: [...iabVendorsForPurpose, ...customVendorsForPurpose],
-			};
-		})
-		.filter((purpose) => purpose.vendors.length > 0);
+				vendors,
+			});
+		}
+	}
 
-	const processedSpecialPurposes: ProcessedPurpose[] = Object.entries(
-		gvl.specialPurposes || {}
-	)
-		.map(([id, purpose]) => {
-			const vendorsForPurpose: ProcessedVendor[] = Object.entries(gvl.vendors)
-				.filter(([, vendor]) => vendor.specialPurposes?.includes(Number(id)))
-				.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-			return {
-				id: Number(id),
+	const processedSpecialPurposes: ProcessedPurpose[] = [];
+	for (const [id, purpose] of Object.entries(gvl.specialPurposes || {})) {
+		const numId = Number(id);
+		const vendorsForPurpose: ProcessedVendor[] = [];
+		for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+			if (vendor.specialPurposes?.includes(numId)) {
+				vendorsForPurpose.push(mapVendor(vendorId, vendor));
+			}
+		}
+		if (vendorsForPurpose.length > 0) {
+			processedSpecialPurposes.push({
+				id: numId,
 				name: purpose.name,
 				description: purpose.description,
 				descriptionLegal: purpose.descriptionLegal,
 				illustrations: purpose.illustrations || [],
 				vendors: vendorsForPurpose,
 				isSpecialPurpose: true,
-			};
-		})
-		.filter((sp) => sp.vendors.length > 0);
+			});
+		}
+	}
 
-	const processedSpecialFeatures: ProcessedSpecialFeature[] = Object.entries(
-		gvl.specialFeatures || {}
-	)
-		.map(([id, feature]) => {
-			const vendorsForFeature: ProcessedVendor[] = Object.entries(gvl.vendors)
-				.filter(([, vendor]) => vendor.specialFeatures?.includes(Number(id)))
-				.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-			return {
-				id: Number(id),
+	const processedSpecialFeatures: ProcessedSpecialFeature[] = [];
+	for (const [id, feature] of Object.entries(gvl.specialFeatures || {})) {
+		const numId = Number(id);
+		const vendorsForFeature: ProcessedVendor[] = [];
+		for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+			if (vendor.specialFeatures?.includes(numId)) {
+				vendorsForFeature.push(mapVendor(vendorId, vendor));
+			}
+		}
+		if (vendorsForFeature.length > 0) {
+			processedSpecialFeatures.push({
+				id: numId,
 				name: feature.name,
 				description: feature.description,
 				descriptionLegal: feature.descriptionLegal,
 				illustrations: feature.illustrations || [],
 				vendors: vendorsForFeature,
-			};
-		})
-		.filter((sf) => sf.vendors.length > 0);
+			});
+		}
+	}
 
-	const processedFeatures: ProcessedFeature[] = Object.entries(
-		gvl.features || {}
-	)
-		.map(([id, feature]) => {
-			const vendorsForFeature: ProcessedVendor[] = Object.entries(gvl.vendors)
-				.filter(([, vendor]) => vendor.features?.includes(Number(id)))
-				.map(([vendorId, vendor]) => mapVendor(vendorId, vendor));
-
-			return {
-				id: Number(id),
+	const processedFeatures: ProcessedFeature[] = [];
+	for (const [id, feature] of Object.entries(gvl.features || {})) {
+		const numId = Number(id);
+		const vendorsForFeature: ProcessedVendor[] = [];
+		for (const [vendorId, vendor] of Object.entries(gvl.vendors)) {
+			if (vendor.features?.includes(numId)) {
+				vendorsForFeature.push(mapVendor(vendorId, vendor));
+			}
+		}
+		if (vendorsForFeature.length > 0) {
+			processedFeatures.push({
+				id: numId,
 				name: feature.name,
 				description: feature.description,
 				descriptionLegal: feature.descriptionLegal,
 				illustrations: feature.illustrations || [],
 				vendors: vendorsForFeature,
-			};
-		})
-		.filter((f) => f.vendors.length > 0);
+			});
+		}
+	}
 
 	// Group purposes into stacks (Purpose 1 is always standalone per IAB TCF spec)
 	const STANDALONE_PURPOSE_ID = 1;

--- a/packages/react/src/v3/components/shared/ui/animated-collapse/animated-collapse.tsx
+++ b/packages/react/src/v3/components/shared/ui/animated-collapse/animated-collapse.tsx
@@ -94,6 +94,7 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 	useLayoutEffect(() => {
 		const wrapper = wrapperRef.current;
 		const content = contentRef.current;
+		let removeTransitionListener: (() => void) | null = null;
 
 		// Check for reduced motion preference
 		const prefersReducedMotion = window.matchMedia(
@@ -158,9 +159,12 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 						});
 						setIsAnimating(false);
 						wrapper?.removeEventListener('transitionend', handleTransitionEnd);
+						removeTransitionListener = null;
 					};
 
 					wrapper?.addEventListener('transitionend', handleTransitionEnd);
+					removeTransitionListener = () =>
+						wrapper?.removeEventListener('transitionend', handleTransitionEnd);
 				});
 			});
 		} else {
@@ -204,9 +208,12 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 					setShouldRender(false);
 					setIsAnimating(false);
 					wrapper.removeEventListener('transitionend', handleTransitionEnd);
+					removeTransitionListener = null;
 				};
 
 				wrapper.addEventListener('transitionend', handleTransitionEnd);
+				removeTransitionListener = () =>
+					wrapper.removeEventListener('transitionend', handleTransitionEnd);
 			});
 		}
 
@@ -214,6 +221,7 @@ export const AnimatedCollapse: FC<AnimatedCollapseProps> = ({
 			if (animationRef.current !== null) {
 				cancelAnimationFrame(animationRef.current);
 			}
+			removeTransitionListener?.();
 		};
 	}, [isOpen, duration, easing]);
 

--- a/packages/react/src/v3/provider.tsx
+++ b/packages/react/src/v3/provider.tsx
@@ -484,9 +484,13 @@ function snapshotConsentsChanged(
 }
 
 function categoriesWithValue(snapshot: ConsentSnapshot, value: boolean) {
-	return Object.entries(snapshot.consents)
-		.filter(([, enabled]) => enabled === value)
-		.map(([category]) => category as AllConsentNames);
+	const result: AllConsentNames[] = [];
+	for (const [category, enabled] of Object.entries(snapshot.consents)) {
+		if (enabled === value) {
+			result.push(category as AllConsentNames);
+		}
+	}
+	return result;
 }
 
 function stringifyError(error: unknown): string {


### PR DESCRIPTION
## Summary

Fixes the eight ERROR-severity findings react-doctor flagged in `@c15t/react`, plus a small set of mechanical lint-hygiene cleanups in the IAB dialog hot paths. Three commits, applied to v2 and v3 trees in lock-step.

### What this is

- **`fix(react): rules-of-hooks + effect cleanup in IAB consent dialog`** — the load-bearing change. Eight latent bugs:
  - `useStyles` was called *after* two early `return null`s in `iab-consent-dialog/atoms/root.tsx` (v2 + v3). Hooks must run unconditionally; this could blow up if the early-return path was ever reached after the first non-null render.
  - `addEventListener('transitionend', …)` in `animated-collapse.tsx` (v2 + v3) had no matching `removeEventListener` in cleanup. Listeners leaked on every effect re-run and on unmount before the transition fired.
  - `setTimeout` for vendor scroll-into-view in `vendor-list.tsx` (v2 + v3) had no `clearTimeout` cleanup.
  - `addEventListener('transitionend', …, { once: true })` for the tab-switch height animation in `iab-consent-dialog.tsx` (v2 + v3): `{ once: true }` removes the listener after firing, but if the component unmounts first the listener still hangs on the DOM node. Added explicit cleanup for symmetry.

- **`perf(react): drop trivial useMemo, hoist empty defaults, set lookups`** — mechanical lint hygiene:
  - Drop a `useMemo` around four `.length` reads in `iab-consent-dialog/atoms/tabs.tsx`.
  - Convert `unassignedInStack.includes(p.id)` inside a `.filter()` over GVL purposes to a Set (was O(n*m) per stack, now O(n+m)).
  - Hoist default empty objects/arrays to module-level consts in `purpose-item.tsx`, `stack-item.tsx`, `vendor-list.tsx` so memoised children get a stable reference.
  - Replace `key={index}` in `iab-consent-banner.tsx` and `purpose-item.tsx` with the stable string the list iterates.

- **`perf(react): collapse .filter().map() chains into single-pass loops`** — same lint-hygiene category, but in `processGvlForDialog()` (the IAB dialog GVL pre-processor) and the `getVendor*` accessors in `vendor-list.tsx`. Both ran two passes per call; now one pass with conditional `push`.

### What this isn't

Honest framing: the second and third commits are theoretical perf wins flagged by lint, but **none of them moved any number we measure**. I rebuilt and re-ran `bun run bench:important-react -- --iterations 15 --warmup 2` against the canary baseline; banner-visibility and script-unblock medians were within noise (the v2-vs-v3 ratio is essentially identical before and after). That makes sense — the wins live in `processGvlForDialog` and the vendor-list accessors, neither of which the existing harness exercises (it mounts the banner, not the IAB dialog). Real perf wins from this sweep would come from the deferred architectural buckets (hydration flicker → `useSyncExternalStore`, `useReducer` for `IABConsentDialog`, effect-as-handler refactor) plus a bench scenario that opens the IAB dialog.

So treat this PR as a **correctness fix with some lint hygiene riding along**, not a perf PR. Reviewers may reasonably want to split it: the first commit is the one that actually fixes bugs.

### What I deliberately skipped

- **forwardRef deprecation (92 sites)** — peer dep range allows React 16.8 / 17 / 18, so forwardRef is still required for backward compat.
- **`react/no-danger`** in the theme `<style>` injection — the HTML is `themeCSS` from `generateThemeCSS()`, not user input. Intentional and safe.
- **3.2 batch DOM/CSS writes** in the tab-switch animation — flagged as 14 sites, but the code uses deliberate forced-reflow (`content.offsetHeight`) between writes. Batching via `cssText` would break the animation.
- **2.2 / 2.3** in `animated-collapse.tsx` — flagged states are read in early returns (just not in JSX), and `shouldRender` intentionally outlives the prop transition. False positives.
- **5.1 heading-has-content** — generic heading components in `preference-item.tsx` and `dialog.tsx` receive children via `{...rest}`; the lint heuristic doesn't see that.
- **5.2 / 5.3** test-only flags (barrel imports, sequential awaits) — tests don't ship in bundles.
- **3.6 SVG decimal precision** in `logo.tsx` — risky to touch on a brand mark for byte savings on a tiny file.
- **4.2 inline render functions** in `consent-banner.tsx` and `frame.tsx` — closure-heavy; cost-to-extract > the reconciliation benefit.

## Test plan

- [x] `bun tsc --noEmit -p packages/react/tsconfig.json` — clean
- [x] `bun biome lint` on touched files — no new hook-rule, effect-cleanup, or correctness violations introduced (pre-existing SVG-a11y / Cookie-Store warnings unchanged)
- [x] `src/hooks/__tests__/use-styles.test.tsx` — 4/4 pass
- [x] `bun run bench:important-react -- --iterations 15 --warmup 2 --script-counts 5,25` rebuilt vs baseline — no regression
- [ ] **Pre-existing:** `src/v3/components/iab-consent-dialog/__tests__/purposes-tab.test.tsx` fails 8/8 — verified this also fails on canary HEAD before any change in this PR (test setup missing `<ConsentProvider>` wrapper). Not introduced here.
- [ ] Manual dogfood: open the IAB dialog in an example app, click through tabs and accept/reject, confirm no console errors and animations still play.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event listener cleanup in animations to prevent memory leaks.
  * Improved React list reconciliation by using stable identifiers instead of array indices.

* **Performance**
  * Optimized component rendering by removing unnecessary memoization.
  * Reduced memory allocations through shared immutable default objects.

* **Refactor**
  * Refactored internal logic flow for improved code clarity and maintainability across consent dialog components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c15t/c15t/pull/802)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->