### PR TITLE
Rewrite scripts docs with clearer IA and lifecycle model

### DIFF
--- a/docs/frameworks/next/script-loader.mdx
+++ b/docs/frameworks/next/script-loader.mdx
@@ -1,13 +1,13 @@
 ---
 title: Script Loader
-description: Gate third-party scripts behind consent - load Google Analytics, Meta Pixel, and other tracking scripts only when users grant permission.
+description: Gate third-party scripts behind consent in Next.js — load Google Analytics, Meta Pixel, and other tracking scripts only when users grant permission.
 ---
 
 <import src="../../shared/react/guides/script-loader.mdx#intro" />
 
 ## Basic Usage
 
-Pass an array of scripts to `ConsentManagerProvider`. Built-in helpers from `@c15t/scripts` return plain `Script` objects, so they can sit beside app-specific scripts:
+Pass an array of scripts to `ConsentManagerProvider`. Built-in helpers from `@c15t/scripts` return plain `Script` objects, so they sit beside app-specific scripts:
 
 ```tsx
 import { type ReactNode } from 'react';
@@ -36,11 +36,11 @@ export function ConsentManager({ children }: { children: ReactNode }) {
 }
 ```
 
-In Next.js, put the provider in the client boundary that owns your consent UI. The script loader runs in the browser, so script definitions should be passed through the provider options rather than injected directly in Server Components.
+The script loader runs in the browser, so place the provider in the client boundary that owns your consent UI and pass scripts through the provider options instead of injecting them in Server Components.
 
 ## Recommended Structure
 
-Keep script setup close to your consent provider. For most apps, define the scripts once and pass them to the provider:
+Define your script list once and keep it next to the consent provider:
 
 ```tsx
 'use client';
@@ -70,35 +70,30 @@ export function ConsentProvider({ children }: { children: ReactNode }) {
 }
 ```
 
-Use environment variables or server-rendered configuration to choose IDs, but avoid rendering vendor scripts with `next/script` separately unless you are deliberately opting out of c15t's script lifecycle for that vendor.
+Use environment variables or server-rendered configuration to choose ids per environment, but avoid rendering vendor scripts with `next/script` separately — that bypasses c15t's lifecycle for that vendor.
 
 <import src="../../shared/react/guides/script-loader.mdx#script-types-to-advanced" />
 
 ## Dynamic Script Management
 
-Add, remove, or check scripts at runtime via `useConsentManager()`. This is useful for tenant-specific integrations, dashboard-only tools, or vendors that are configured after a user signs in.
+The shared guide above lists what the script-manager methods do. In Next.js they are exposed through `useConsentManager()`:
 
 ```tsx
 import { useConsentManager } from '@c15t/nextjs';
 
 function ScriptManager() {
-  const { setScripts, removeScript, isScriptLoaded, getLoadedScriptIds } = useConsentManager();
+  const {
+    setScripts,
+    removeScript,
+    isScriptLoaded,
+    getLoadedScriptIds,
+  } = useConsentManager();
 
-  // Add scripts dynamically
-  setScripts([{ id: 'dynamic', src: '...', category: 'measurement' }]);
-
-  // Remove a script
-  removeScript('dynamic');
-
-  // Check if a script is loaded
-  const loaded = isScriptLoaded('google-analytics');
-
-  // Get all loaded script IDs
-  const allLoaded = getLoadedScriptIds();
+  // ...
 }
 ```
 
-Register dynamic scripts from a client effect or event handler, not during render:
+Register dynamic scripts from a client effect or event handler — never directly in the render body — so React can run the call once per dependency change and tear it down on unmount:
 
 ```tsx
 'use client';
@@ -129,24 +124,23 @@ export function WorkspaceAnalytics({ workspaceId }: { workspaceId: string }) {
 }
 ```
 
-## Next.js And Renderable Integrations
+## Renderable Integrations
 
 Some integrations need a visible component, not just a script tag. Google Maps, YouTube, checkout widgets, and calendars all need consent gating plus component lifecycle.
 
-For those integrations:
+Split the problem into three layers:
 
-- keep the c15t script loader as the source of truth for shared SDK loading,
-- render a placeholder until consent is granted,
-- create the widget only on the client,
-- and avoid duplicating the same vendor through both `next/script` and c15t.
+1. Use the script loader as the source of truth for shared SDK loading.
+2. Render a placeholder until consent is granted.
+3. Create the widget instance only on the client and clean it up on unmount.
 
-If the integration is iframe-only, prefer iframe gating. If the integration needs an SDK, load the SDK once and let each component instance create and clean up its own widget.
+For iframe-only embeds, use the [iframe blocking](/docs/frameworks/next/iframe-blocking) pattern. For SDK-backed widgets, load the SDK once and let each component instance create and clean up its own widget. Avoid mixing `next/script` with c15t for the same vendor.
 
 ## App Router Notes
 
-- The provider and dynamic script management components must be client components.
-- Keep vendor IDs out of static examples when they differ per environment.
-- If a script must be available before a page becomes interactive, prefer a built-in helper that models denied consent defaults rather than adding a separate `next/script` tag.
+- The provider and any component that calls `useConsentManager()` must be client components.
+- Keep vendor ids out of static examples when they differ per environment — read them from `process.env.NEXT_PUBLIC_*` or runtime config.
+- If a script must be available before a page becomes interactive, prefer a built-in helper that models denied-consent defaults rather than adding a separate `next/script` tag.
 - If you use CSP nonces, pass the nonce through the `Script` object so c15t applies it to the generated script element.
 
 <import src="../../shared/react/guides/script-loader.mdx#api-reference" />

--- a/docs/frameworks/react/script-loader.mdx
+++ b/docs/frameworks/react/script-loader.mdx
@@ -1,13 +1,13 @@
 ---
 title: Script Loader
-description: Gate third-party scripts behind consent - load Google Analytics, Meta Pixel, and other tracking scripts only when users grant permission.
+description: Gate third-party scripts behind consent in React — load Google Analytics, Meta Pixel, and other tracking scripts only when users grant permission.
 ---
 
 <import src="../../shared/react/guides/script-loader.mdx#intro" />
 
 ## Basic Usage
 
-Pass an array of scripts to `ConsentManagerProvider`. Built-in helpers from `@c15t/scripts` return plain `Script` objects, so they can sit beside app-specific scripts:
+Pass an array of scripts to `ConsentManagerProvider`. Built-in helpers from `@c15t/scripts` return plain `Script` objects, so they sit beside app-specific scripts:
 
 ```tsx
 import { type ReactNode } from 'react';
@@ -36,11 +36,11 @@ export function ConsentManager({ children }: { children: ReactNode }) {
 }
 ```
 
-The provider registers those scripts when the consent runtime starts. From that point on, c15t owns the script lifecycle: it checks consent, injects eligible scripts, unloads scripts when consent is revoked, and runs consent-change callbacks for scripts that stay loaded.
+The provider registers those scripts when the consent runtime starts. From that point on, c15t owns the lifecycle: it checks consent, injects eligible scripts, unloads them when consent is revoked, and runs `onConsentChange` for scripts that stay loaded.
 
 ## Recommended Structure
 
-For React apps, keep script setup close to your consent provider:
+Define your script list once and keep it next to the consent provider so vendor setup stays declarative:
 
 ```tsx
 import { gtag } from '@c15t/scripts/google-tag';
@@ -66,35 +66,30 @@ export function ConsentProvider({ children }: { children: React.ReactNode }) {
 }
 ```
 
-This keeps vendor setup declarative and avoids scattering script definitions across components. If an integration is truly route-specific or tenant-specific, use dynamic script management instead.
+If an integration is route-specific or tenant-specific, use [dynamic script management](#dynamic-script-management) instead of conditionally building this list per render.
 
 <import src="../../shared/react/guides/script-loader.mdx#script-types-to-advanced" />
 
 ## Dynamic Script Management
 
-Add, remove, or check scripts at runtime via `useConsentManager()`. This is useful for feature-flagged vendors, tenant-level integrations, or tools that only exist on a subset of pages.
+The shared guide above lists what the script-manager methods do. In React they are exposed through `useConsentManager()`:
 
 ```tsx
 import { useConsentManager } from '@c15t/react';
 
 function ScriptManager() {
-  const { setScripts, removeScript, isScriptLoaded, getLoadedScriptIds } = useConsentManager();
+  const {
+    setScripts,
+    removeScript,
+    isScriptLoaded,
+    getLoadedScriptIds,
+  } = useConsentManager();
 
-  // Add scripts dynamically
-  setScripts([{ id: 'dynamic', src: '...', category: 'measurement' }]);
-
-  // Remove a script
-  removeScript('dynamic');
-
-  // Check if a script is loaded
-  const loaded = isScriptLoaded('google-analytics');
-
-  // Get all loaded script IDs
-  const allLoaded = getLoadedScriptIds();
+  // ...
 }
 ```
 
-Avoid calling `setScripts()` unconditionally during render. Add dynamic scripts from an effect, event handler, or initialization path that only runs when the script should be registered.
+Register dynamic scripts from an effect or event handler — never directly in the render body. Effects guarantee the call runs once per dependency change and gives you a tear-down path:
 
 ```tsx
 import { useEffect } from 'react';
@@ -104,16 +99,18 @@ export function TenantAnalytics({ siteId }: { siteId: string }) {
   const { setScripts, removeScript } = useConsentManager();
 
   useEffect(() => {
+    const scriptId = `tenant-analytics-${siteId}`;
+
     setScripts([
       {
-        id: `tenant-analytics-${siteId}`,
+        id: scriptId,
         src: `https://cdn.example.com/${siteId}.js`,
         category: 'measurement',
       },
     ]);
 
     return () => {
-      removeScript(`tenant-analytics-${siteId}`);
+      removeScript(scriptId);
     };
   }, [siteId, setScripts, removeScript]);
 
@@ -123,15 +120,14 @@ export function TenantAnalytics({ siteId }: { siteId: string }) {
 
 ## Renderable Integrations
 
-Some vendors need a React render surface as well as a script. Examples include maps, video players, calendars, and checkout widgets.
+Some vendors need a render surface as well as a script — maps, video players, calendars, and checkout widgets all fall in this bucket.
 
-For those cases, split the problem:
+Split the problem into three layers:
 
-- use the script loader to gate and load the shared SDK,
-- use React state to render a placeholder until consent is granted,
-- create the widget only after the SDK is ready,
-- and clean up widget instances on unmount.
+1. Use the script loader to gate and load the shared SDK once.
+2. Use React state (or a custom hook) to render a placeholder until consent is granted.
+3. Create the widget instance only after the SDK is ready and clean it up on unmount.
 
-For iframe-only embeds, prefer iframe gating instead of loading a JavaScript SDK just to hide an iframe. For SDK-backed widgets, treat the SDK as a singleton and each rendered component as its own instance.
+For iframe-only embeds, use the [iframe blocking](/docs/frameworks/react/iframe-blocking) pattern instead of loading a JavaScript SDK to hide an iframe. For SDK-backed widgets, treat the SDK as a singleton and each rendered component as its own instance.
 
 <import src="../../shared/react/guides/script-loader.mdx#api-reference" />

--- a/docs/integrations/databuddy.mdx
+++ b/docs/integrations/databuddy.mdx
@@ -8,6 +8,12 @@ icon: databuddy
 
 The Databuddy script automatically respects consent preferences by toggling tracking on and off based on the user's consent state.
 
+## How c15t loads it
+
+- **Category:** `measurement` (Analytics)
+- **Loads when:** [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load) — runs on page start regardless of consent state
+- **On consent change:** c15t toggles `window.databuddy.options.disabled` so tracking turns on or off without removing the script
+
 ## Script Implementation
 
 <Steps>
@@ -15,7 +21,7 @@ The Databuddy script automatically respects consent preferences by toggling trac
     ### Adding the Databuddy script to c15t
 
     <Callout type="info">
-      See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+      Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
     </Callout>
 
     ```ts
@@ -124,7 +130,7 @@ databuddy({
 
 ### DatabuddyConsentOptions
 
-<AutoTypeTable path="./packages/scripts/src/databuddy.ts" name="DatabuddyConsentOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/analytics/databuddy.ts" name="DatabuddyConsentOptions" />
 
 ### Script
 

--- a/docs/integrations/google-tag-manager.mdx
+++ b/docs/integrations/google-tag-manager.mdx
@@ -8,13 +8,19 @@ icon: google-tag-manager
 
 Google Tag Manager (GTM) is Google's tag management system that lets you deploy and manage marketing tags, analytics scripts, and conversion pixels without modifying your codebase. Instead of hardcoding multiple scripts, you configure them through GTM's web interface.
 
-c15t automatically injects the GTM script into your page and syncs consent state with GTM using Consent Mode v2. By default, c15t loads GTM regardless of consent because GTM manages its own internal consent state and only fires tags when appropriate consent is granted.
+c15t automatically injects the GTM script into your page and syncs consent state with GTM using Consent Mode v2. GTM manages its own internal consent state and only fires tags when appropriate consent is granted, which means it can safely load before consent is collected.
 
 This prevents GTM-managed scripts from loading without proper consent while giving you centralized control over your marketing stack.
 
 <Callout type="info">
   Use GTM if your team manages many tags centrally in the GTM UI. Use `gtag.js` if you only need GA4/Google Ads directly in code. Don't run both for the same destination unless intentional, or you may duplicate events.
 </Callout>
+
+## How c15t loads it
+
+- **Category:** `necessary` (Tag Managers)
+- **Loads when:** [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load) — runs on page start with Consent Mode v2 defaults set to denied
+- **On consent change:** c15t pushes a Consent Mode v2 `update` to the data layer; GTM-managed tags re-evaluate against the new state
 
 ## Implementation
 
@@ -61,7 +67,7 @@ This prevents GTM-managed scripts from loading without proper consent while givi
     After creating your container, you can set up c15t with Google Tag Manager. All you need to do is copy and paste your container ID & begins with "GTM-".
 
     <Callout type="info">
-      See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+      Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
     </Callout>
 
     ```ts
@@ -86,7 +92,7 @@ This prevents GTM-managed scripts from loading without proper consent while givi
 
 ### GoogleTagManagerOptions
 
-<AutoTypeTable path="./packages/scripts/src/google-tag-manager.ts" name="GoogleTagManagerOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/tag-managers/google-tag-manager.ts" name="GoogleTagManagerOptions" />
 
 ### Script
 

--- a/docs/integrations/google-tag.mdx
+++ b/docs/integrations/google-tag.mdx
@@ -19,10 +19,16 @@ c15t initializes Google Tag with Consent Mode v2 defaults set to denied and auto
 - Use `category: 'measurement'` for analytics-only tracking (GA4 events)
 - Use `category: 'marketing'` for advertising and conversion tracking (Google Ads)
 
+## How c15t loads it
+
+- **Category:** configurable — `measurement` (default) or `marketing` (Analytics)
+- **Loads when:** [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load) — runs on page start regardless of consent state, with Consent Mode v2 defaults set to denied
+- **On consent change:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t pushes a Consent Mode v2 `update` to gtag instead of removing the script
+
 ## Adding GA4 + Google Ads to c15t
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -38,7 +44,7 @@ gtag({
 
 ### GtagOptions
 
-<AutoTypeTable path="./packages/scripts/src/google-tag.ts" name="GtagOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/analytics/google-tag.ts" name="GtagOptions" />
 
 ### Script
 

--- a/docs/integrations/linkedin-insights.mdx
+++ b/docs/integrations/linkedin-insights.mdx
@@ -6,12 +6,18 @@ lastModified: 2025-09-24
 icon: linkedin
 ---
 
-LinkedIn Insights Tag is LinkedIn's conversion tracking and audience matching tool for LinkedIn advertising campaigns. It tracks website actions, measures ad performance, builds matched audiences for retargeting, and provides demographic insights about your visitors. By default, c15t loads this script based on `marketing` consent.
+LinkedIn Insights Tag is LinkedIn's conversion tracking and audience matching tool for LinkedIn advertising campaigns. It tracks website actions, measures ad performance, builds matched audiences for retargeting, and provides demographic insights about your visitors.
+
+## How c15t loads it
+
+- **Category:** `marketing` (Ads & Pixels)
+- **Loads when:** marketing consent is granted
+- **On revocation:** unloaded — c15t removes the script element from the DOM
 
 ## Adding the LinkedIn Insights Tag to c15t
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -26,7 +32,7 @@ linkedinInsights({
 
 ### LinkedInInsightsOptions
 
-<AutoTypeTable path="./packages/scripts/src/linkedin-insights.ts" name="LinkedInInsightsOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.ts" name="LinkedInInsightsOptions" />
 
 ### Script
 

--- a/docs/integrations/meta-pixel.mdx
+++ b/docs/integrations/meta-pixel.mdx
@@ -6,14 +6,18 @@ lastModified: 2025-09-24
 icon: meta
 ---
 
-Meta Pixel (formerly Facebook Pixel) is Meta's conversion tracking and audience targeting tool for Facebook and Instagram advertising. It tracks user actions, measures ad effectiveness, builds custom audiences, and optimizes ad delivery. By default, c15t loads this script based on `marketing` consent.
+Meta Pixel (formerly Facebook Pixel) is Meta's conversion tracking and audience targeting tool for Facebook and Instagram advertising. It tracks user actions, measures ad effectiveness, builds custom audiences, and optimizes ad delivery.
 
-This script persists after consent is revoked because it has built-in consent management. When consent changes, c15t updates Meta's internal consent state rather than removing the script entirely.
+## How c15t loads it
+
+- **Category:** `marketing` (Ads & Pixels)
+- **Loads when:** marketing consent is granted
+- **On revocation:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t calls `fbq('consent', 'revoke')` so Meta stops tracking without removing the script
 
 ## Adding the Meta Pixel to c15t
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -40,7 +44,7 @@ metaPixelEvent('Purchase', { value: 10.0, currency: 'USD' });
 
 ### MetaPixelOptions
 
-<AutoTypeTable path="./packages/scripts/src/meta-pixel.ts" name="MetaPixelOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts" name="MetaPixelOptions" />
 
 ### Script
 
@@ -48,4 +52,4 @@ metaPixelEvent('Purchase', { value: 10.0, currency: 'USD' });
 
 ### StandardEventParams
 
-<AutoTypeTable path="./packages/scripts/src/meta-pixel.ts" name="StandardEventParams" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts" name="StandardEventParams" />

--- a/docs/integrations/meta.json
+++ b/docs/integrations/meta.json
@@ -9,17 +9,17 @@
 	"pages": [
 		"overview",
 		"building-integrations",
-		"--- Tag Management ---",
-		"google-tag-manager",
+		"--- Analytics ---",
 		"google-tag",
-		"--- Measurement ---",
 		"databuddy",
 		"posthog",
-		"--- Advertising & Conversion Tracking ---",
+		"--- Ads & Pixels ---",
 		"meta-pixel",
 		"tiktok-pixel",
 		"linkedin-insights",
 		"microsoft-uet",
-		"x-pixel"
+		"x-pixel",
+		"--- Tag Managers ---",
+		"google-tag-manager"
 	]
 }

--- a/docs/integrations/microsoft-uet.mdx
+++ b/docs/integrations/microsoft-uet.mdx
@@ -6,16 +6,22 @@ lastModified: 2025-09-24
 icon: microsoft
 ---
 
-Microsoft UET (Universal Event Tracking) is Microsoft's conversion tracking tag for Microsoft Advertising. It tracks user actions, measures campaign effectiveness, and enables remarketing campaigns. By default, c15t loads this script based on `marketing` consent.
+Microsoft UET (Universal Event Tracking) is Microsoft's conversion tracking tag for Microsoft Advertising. It tracks user actions, measures campaign effectiveness, and enables remarketing campaigns.
 
 <Callout type="note">
   UET can also load Microsoft Clarity (if enabled in your UET tag settings). Since Clarity is an analytics tool, we recommend loading it separately with `measurement` consent instead.
 </Callout>
 
+## How c15t loads it
+
+- **Category:** `marketing` (Ads & Pixels)
+- **Loads when:** marketing consent is granted
+- **On revocation:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t pushes the new consent state to `uetq` so UET stops tracking without removing the script
+
 ## Adding Microsoft UET to c15t
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -30,7 +36,7 @@ microsoftUet({
 
 ### MicrosoftUetOptions
 
-<AutoTypeTable path="./packages/scripts/src/microsoft-uet.ts" name="MicrosoftUetOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.ts" name="MicrosoftUetOptions" />
 
 ### Script
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -1,54 +1,55 @@
 ---
 title: Integrations
-description: "Many of your tools may require consent to be given before they can be used. This is especially true for analytics and marketing tools. \nc15t has various ways to integrate with your tools, depending on the tool you are using."
-lastModified: 2026-04-10
+description: "Browse built-in `@c15t/scripts` integrations by category, or learn when to drop down to a plain `Script` or a manifest-backed helper."
+lastModified: 2026-05-10
 
 ---
 
-c15t supports two integration styles:
-
-- use a prebuilt helper from `@c15t/scripts`,
-- build a one-off `Script` for app-specific code,
-- or build a reusable manifest-backed helper when the vendor setup needs structure.
-
-If you are building something reusable or contributing to `@c15t/scripts`, start with the [custom integration guide](/docs/integrations/building-integrations).
+c15t ships prebuilt helpers in [`@c15t/scripts`](https://www.npmjs.com/package/@c15t/scripts) for the third-party tools developers integrate most often. Every helper returns a regular `Script` object, so it works anywhere the c15t [script loader](/docs/frameworks/javascript/script-loader) accepts scripts.
 
 <Callout type="info">
-  The prebuilt helpers return regular `Script` objects, so they work anywhere the c15t script loader accepts scripts. They are the recommended starting point because they encode vendor boot order, default consent behavior, and common lifecycle callbacks.
+  Built-in helpers encode vendor boot order, consent updates, and common defaults for you. Prefer them over hand-rolled snippets whenever c15t already supports the vendor.
 </Callout>
 
-## Choose an Integration Type
+## Choose An Integration Style
 
-Use a **prebuilt helper** when c15t ships the vendor already. Use a **plain `Script`** when the code is unique to your app and the vendor snippet is small. Use a **manifest-backed helper** when the integration needs queues, stubs, ordered setup phases, or a vendor consent API.
+Most apps mix more than one style. Pick the smallest one that keeps consent behavior obvious.
 
-For visible embeds such as video players, maps, calendars, and checkout widgets, split the problem: gate the script or iframe with c15t, then render the UI only when consent and readiness allow it.
+| Style | Use when |
+|---|---|
+| **Built-in helper** from `@c15t/scripts` | The vendor is listed below — start here. |
+| **Plain `Script`** | One-off app code with simple load and callback behavior. |
+| **Manifest-backed helper** | Reusable vendor integration with structured setup phases, queues, stubs, or a vendor consent API. |
+| **Iframe / renderable integration** | Vendor exposes an iframe or React component, not just a script tag. |
+
+Setup is the same shape in every framework: import the helper, call it with vendor options, and pass the result to the consent runtime through your provider's `scripts` option. See the framework guides for end-to-end snippets — [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), [Next.js](/docs/frameworks/next/script-loader).
 
 ## Analytics
 
 Analytics integrations usually require `measurement` consent. Some vendors can run in a consent-aware or cookieless mode; others should stay fully blocked until measurement consent is granted.
 
 <Cards className="my-10 grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3 @container not-prose grid gap-4">
-  <Card variant="interactive" title="GA4 + Google Ads (gtag.js)" description="Send data to Google Analytics 4 and Google Ads with automatic Consent Mode v2 support." icon={<Icon name="google-analytics" />} href="/docs/integrations/google-tag" />
+  <Card variant="interactive" title="Google Tag (gtag.js)" description="Send data to Google Analytics 4 and Google Ads with automatic Consent Mode v2 support." icon={<Icon name="google-analytics" />} href="/docs/integrations/google-tag" />
 
   <Card variant="interactive" title="Databuddy" description="Privacy-focused analytics with automatic consent management and cookieless tracking support." icon={<Icon name="databuddy" />} href="/docs/integrations/databuddy" />
 
   <Card variant="interactive" title="PostHog" description="Open-source product analytics with cookieless tracking that works even without consent." icon={<Icon name="posthog" />} href="/docs/integrations/posthog" />
 </Cards>
 
-## Ads And Pixels
+## Ads & Pixels
 
-Advertising pixels usually require `marketing` consent. Many of them need startup stubs so events can be queued safely before the remote SDK loads.
+Advertising pixels usually require `marketing` consent. Many of them need startup stubs so events can be queued safely before the remote SDK loads — built-in helpers handle this for you.
 
 <Cards className="my-10 grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3 @container not-prose grid gap-4">
   <Card variant="interactive" title="Meta Pixel" description="Track conversions and build audiences for Facebook and Instagram advertising campaigns." icon={<Icon name="meta" />} href="/docs/integrations/meta-pixel" />
 
   <Card variant="interactive" title="TikTok Pixel" description="Measure ad performance and build audiences for TikTok advertising campaigns." icon={<Icon name="tiktok" />} href="/docs/integrations/tiktok-pixel" />
 
-  <Card variant="interactive" title="LinkedIn Insights" description="Track conversions and build matched audiences for LinkedIn advertising campaigns." icon={<Icon name="linkedin" />} href="/docs/integrations/linkedin-insights" />
+  <Card variant="interactive" title="LinkedIn Insight Tag" description="Track conversions and build matched audiences for LinkedIn advertising campaigns." icon={<Icon name="linkedin" />} href="/docs/integrations/linkedin-insights" />
 
   <Card variant="interactive" title="Microsoft UET" description="Track conversions and measure performance for Microsoft Advertising." icon={<Icon name="microsoft" />} href="/docs/integrations/microsoft-uet" />
 
-  <Card variant="interactive" title="X Pixel" description="Measure ad performance and build audiences for advertising campaigns on X (Twitter)." icon={<Icon name="x" />} href="/docs/integrations/x-pixel" />
+  <Card variant="interactive" title="X (Twitter) Pixel" description="Measure ad performance and build audiences for advertising campaigns on X (Twitter)." icon={<Icon name="x" />} href="/docs/integrations/x-pixel" />
 </Cards>
 
 ## Tag Managers
@@ -61,104 +62,18 @@ Tag managers can load other scripts, so they deserve extra care. Prefer vendor c
 
 ## Build Your Own
 
-Use the custom integration guide when the vendor is not listed yet, or when you need to turn an app-specific script into a reusable package-level helper.
+If c15t does not ship the vendor you need, drop down a level:
+
+- build a one-off `Script` directly in your app for simple cases,
+- build a reusable manifest-backed helper for shared or package-level integrations,
+- or combine the script loader with iframe gating for visible media and widget integrations.
 
 <Cards className="my-10 grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3 @container not-prose grid gap-4">
   <Card variant="interactive" title="Build a Custom Integration" description="Learn when to use a raw Script, when to use a manifest, and how to debug and test custom integrations." icon={<Icon name="guide" />} href="/docs/integrations/building-integrations" />
 </Cards>
 
-## General Pattern
+## Where To Next
 
-Every integration provides a script configuration function. Pass it to your framework's setup:
-
-<Tabs items={['JavaScript', 'React', 'Next.js']}>
-  <Tab value="JavaScript">
-    ```ts
-    import { getOrCreateConsentRuntime } from 'c15t';
-    import { yourScript } from '@c15t/scripts/your-script';
-
-    getOrCreateConsentRuntime({
-      mode: 'hosted',
-      scripts: [
-        yourScript({ /* options */ }),
-      ],
-    });
-    ```
-  </Tab>
-
-  <Tab value="React">
-    ```tsx
-    import { yourScript } from '@c15t/scripts/your-script';
-    import { ConsentManagerProvider } from '@c15t/react';
-
-    export function App({ children }: { children: React.ReactNode }) {
-      return (
-        <ConsentManagerProvider
-          options={{
-            scripts: [
-              yourScript({ /* options */ }),
-            ],
-          }}
-        >
-          {children}
-        </ConsentManagerProvider>
-      );
-    }
-    ```
-  </Tab>
-
-  <Tab value="Next.js">
-    ```tsx
-    import { yourScript } from '@c15t/scripts/your-script';
-    import { ConsentManagerProvider } from '@c15t/nextjs';
-
-    export function App({ children }: { children: React.ReactNode }) {
-      return (
-        <ConsentManagerProvider
-          options={{
-            scripts: [
-              yourScript({ /* options */ }),
-            ],
-          }}
-        >
-          {children}
-        </ConsentManagerProvider>
-      );
-    }
-    ```
-  </Tab>
-</Tabs>
-
-## Script Loader
-
-Many marketing and analytics tools are commonly loaded using a script tag, such as Google Tag Manager (GTM), Google Tag (gtag.js), Meta Pixel and TikTok Pixel.
-
-c15t's script loader allows you to easily integrate your tools that require consent with c15t. The prebuilt integrations in `@c15t/scripts` are the recommended starting point, and the custom integration guide explains how to build your own when you need something more specialized.
-
-- [JavaScript](/docs/frameworks/javascript/script-loader)
-- [React](/docs/frameworks/react/script-loader)
-- [Next.js](/docs/frameworks/next/script-loader)
-
-## Building Your Own
-
-If you need a vendor we do not ship yet:
-
-- build a one-off `Script` directly in your app for simple cases,
-- build a reusable manifest-backed helper for shared or package-level integrations,
-- or combine the script loader with iframe/embed gating for visible media and widget integrations.
-
-Read the [custom integration guide](/docs/integrations/building-integrations) for the manifest phases, structured step model, testing checklist, and devtools debugging flow.
-
-## has() method
-
-The `has()` method allows you to check if the user has given consent for a specific purpose. You can learn more about the `has()` method [here](/docs/frameworks/javascript/store/checking-consent).
-
-```ts
-
-
-const hasAnalytics = has('measurement');
-
-if (hasAnalytics) {
-  myAnalyticsLibrary.track('checkout_completed');
-}
-```
+- Read the script loader guide for your framework: [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), [Next.js](/docs/frameworks/next/script-loader).
+- See the [iframe blocking](/docs/frameworks/react/iframe-blocking) pattern for visible embeds (YouTube, maps, calendars).
+- Use [`has()`](/docs/frameworks/javascript/store/checking-consent) to conditionally run app code based on consent state.

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -15,15 +15,15 @@ c15t exposes two integration patterns for PostHog. Pick the one that matches how
 
 ## PostHog SDK Implementation
 
-This is the recommended approach if you're using the Posthog JS SDK, this is commonly used in React projects.
+This is the recommended approach if you're using the PostHog JS SDK; it's commonly used in React projects.
 
 ### Adding the PostHog SDK to c15t
 
 <Steps>
   <Step>
-    ### Initialize Posthog
+    ### Initialize PostHog
 
-    When you initialize posthog make sure to set `cookieless_mode` to `on_reject`.
+    When you initialize PostHog make sure to set `cookieless_mode` to `on_reject`.
 
     ```ts
     posthog.init("phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", {
@@ -85,7 +85,7 @@ This is the recommended approach if you're using the Posthog JS SDK, this is com
 
 ## PostHog Script Implementation
 
-If you want to load posthog via a script tag it's recommended to use this approach.
+If you want to load PostHog via a script tag, it's recommended to use this approach.
 
 ### How c15t loads it
 

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -95,19 +95,18 @@ If you want to load posthog via a script tag it's recommended to use this approa
 
 <Steps>
   <Step>
-    ### Initialize Posthog
+    ### Configure cookieless mode
 
-    This script does not load the Posthog script, it only syncs the consent state with Posthog via the Posthog JS SDK.
+    The c15t helper loads PostHog's bootstrap script, calls `posthog.init()` for you using the `initOptions` you pass, and then synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
 
-    This is due to Posthog's use of cookieless tracking. However, you need to set `cookieless_mode` to `on_reject` when initializing Posthog.
+    Because PostHog supports cookieless tracking, set `cookieless_mode: 'on_reject'` in `initOptions` so PostHog keeps collecting data without cookies until measurement consent is granted:
 
     ```ts
-    posthog.init("phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", {
-      api_host: "https://eu.i.posthog.com",
-      defaults: "2025-05-24",
+    const initOptions = {
+      api_host: 'https://eu.i.posthog.com',
       // PostHog will not set any cookies until the user has given consent
-      cookieless_mode: 'on_reject'
-    })
+      cookieless_mode: 'on_reject',
+    };
     ```
   </Step>
 
@@ -130,6 +129,7 @@ If you want to load posthog via a script tag it's recommended to use this approa
         ui_host: 'https://eu.i.posthog.com',
         autocapture: false,
         person_profiles: 'identified_only',
+        cookieless_mode: 'on_reject',
       }
     })
     ```

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -8,6 +8,11 @@ icon: posthog
 
 PostHog is an open-source product analytics platform that helps you understand user behavior, track events, and analyze product usage. Unlike traditional analytics tools, PostHog supports both cookieless and cookie-based tracking. This means you can sync c15t with PostHog and continue collecting analytics even when users haven't given consent—PostHog simply operates in cookieless mode until consent is granted.
 
+c15t exposes two integration patterns for PostHog. Pick the one that matches how you already load the SDK:
+
+- **PostHog SDK** — your app loads `posthog-js` itself; c15t only synchronizes consent. Recommended for most React apps.
+- **PostHog Script** — c15t loads PostHog's array bootstrap as a managed `Script`.
+
 ## PostHog SDK Implementation
 
 This is the recommended approach if you're using the Posthog JS SDK, this is commonly used in React projects.
@@ -37,7 +42,7 @@ This is the recommended approach if you're using the Posthog JS SDK, this is com
     The recommended PostHog SDK approach uses two phases: run one initial sync after c15t has finished resolving consent, then subscribe to future real preference changes with `subscribeToConsentChanges()`.
 
     <Callout type="info">
-      See the [integration overview](/docs/integrations) for how to wrap this in your framework (React or Next.js). Pass the `callbacks` option to your `ConsentManagerProvider` the same way you would pass `scripts`.
+      To wrap this in your framework, pass the `callbacks` option to your `ConsentManagerProvider` the same way you would pass `scripts` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
     </Callout>
 
     ```ts
@@ -82,7 +87,11 @@ This is the recommended approach if you're using the Posthog JS SDK, this is com
 
 If you want to load posthog via a script tag it's recommended to use this approach.
 
-By default c15t will always load the script regardless of consent. This is because the script has built-in functionality to opt into and out of tracking based on consent.
+### How c15t loads it
+
+- **Category:** `measurement` (Analytics)
+- **Loads when:** [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load) — runs on page start regardless of consent state
+- **On consent change:** c15t calls `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()` so the script stays loaded but only captures after consent is granted
 
 <Steps>
   <Step>
@@ -106,7 +115,7 @@ By default c15t will always load the script regardless of consent. This is becau
     ### Adding the script to c15t
 
     <Callout type="info">
-      See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+      Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
     </Callout>
 
     ```ts
@@ -131,7 +140,7 @@ By default c15t will always load the script regardless of consent. This is becau
 
 ### PosthogConsentOptions
 
-<AutoTypeTable path="./packages/scripts/src/posthog.ts" name="PosthogConsentOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/analytics/posthog.ts" name="PosthogConsentOptions" />
 
 ### Script
 

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -47,7 +47,7 @@ This is the recommended approach if you're using the Posthog JS SDK, this is com
 
     ```ts
     import { getOrCreateConsentRuntime } from 'c15t';
-    import { posthog } from 'posthog-js';
+    import posthog from 'posthog-js';
 
     function syncPostHogMeasurementConsent(hasMeasurementConsent: boolean) {
       if (hasMeasurementConsent) {

--- a/docs/integrations/tiktok-pixel.mdx
+++ b/docs/integrations/tiktok-pixel.mdx
@@ -6,16 +6,20 @@ lastModified: 2025-09-24
 icon: tiktok
 ---
 
-TikTok Pixel is TikTok's conversion tracking and audience targeting tool. It measures ad effectiveness, tracks user actions, and helps optimize your TikTok advertising campaigns. By default, c15t loads this script based on `marketing` consent.
+TikTok Pixel is TikTok's conversion tracking and audience targeting tool. It measures ad effectiveness, tracks user actions, and helps optimize your TikTok advertising campaigns.
 
-This script persists after consent is revoked because it has built-in consent management. When consent changes, c15t updates TikTok's internal consent state rather than removing the script entirely.
+## How c15t loads it
+
+- **Category:** `marketing` (Ads & Pixels)
+- **Loads when:** marketing consent is granted
+- **On revocation:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t pushes the new consent state to `ttq` so TikTok stops tracking without removing the script
 
 ## Implementation
 
 ### Adding the script to c15t
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -30,7 +34,7 @@ tiktokPixel({
 
 ### TikTokPixelOptions
 
-<AutoTypeTable path="./packages/scripts/src/tiktok-pixel.ts" name="TikTokPixelOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.ts" name="TikTokPixelOptions" />
 
 ### Script
 

--- a/docs/integrations/x-pixel.mdx
+++ b/docs/integrations/x-pixel.mdx
@@ -6,12 +6,18 @@ lastModified: 2025-09-24
 icon: x
 ---
 
-X Pixel (formerly Twitter Pixel) is X's conversion tracking and audience building tool. It helps you measure ad performance, retarget website visitors, and optimize campaigns on the X platform. By default, c15t loads this script based on `marketing` consent.
+X Pixel (formerly Twitter Pixel) is X's conversion tracking and audience building tool. It helps you measure ad performance, retarget website visitors, and optimize campaigns on the X platform.
+
+## How c15t loads it
+
+- **Category:** `marketing` (Ads & Pixels)
+- **Loads when:** marketing consent is granted
+- **On revocation:** unloaded — c15t removes the script element from the DOM
 
 ## Implementation
 
 <Callout type="info">
-  See the [integration overview](/docs/integrations) for how to pass scripts to your framework (JavaScript, React, or Next.js).
+  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -36,7 +42,7 @@ xPixelEvent('tw-xxxx-xxxx', { value: 10.00, currency: 'USD' });
 
 ### XPixelOptions
 
-<AutoTypeTable path="./packages/scripts/src/x-pixel.ts" name="XPixelOptions" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts" name="XPixelOptions" />
 
 ### Script
 
@@ -44,8 +50,8 @@ xPixelEvent('tw-xxxx-xxxx', { value: 10.00, currency: 'USD' });
 
 ### XPixelEvent
 
-<AutoTypeTable path="./packages/scripts/src/x-pixel.ts" name="XPixelEvent" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts" name="XPixelEvent" />
 
 ### XPixelContent
 
-<AutoTypeTable path="./packages/scripts/src/x-pixel.ts" name="XPixelContent" />
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts" name="XPixelContent" />

--- a/docs/shared/react/guides/script-loader.mdx
+++ b/docs/shared/react/guides/script-loader.mdx
@@ -1,54 +1,54 @@
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="intro">
-  The script loader manages third-party JavaScript based on consent state. You declare scripts in the provider's `scripts` option, and c15t decides when each script should load, stay loaded, unload, or receive a consent update.
+  The script loader manages third-party JavaScript based on consent state. You declare scripts in your provider's `scripts` option, and c15t decides when each script should load, stay loaded, unload, or receive a consent update.
 
-  Use it for analytics, pixels, tag managers, product analytics, and other vendor snippets that should not run until the right consent condition is satisfied. Prebuilt helpers live in `@c15t/scripts`; custom scripts can be declared directly when the vendor is specific to your app.
+  Use it for analytics, pixels, tag managers, product analytics, and other vendor snippets that should not run until the right consent condition is satisfied. Prebuilt helpers live in [`@c15t/scripts`](/docs/integrations/overview); custom scripts can be declared directly when the vendor is specific to your app.
 
   <PackageCommandTabs mode="install" command="@c15t/scripts" />
 
   <Callout type="info">
-    Start with the [integrations overview](/docs/integrations/overview) before writing your own script. The built-in helpers encode vendor boot order, consent updates, and common defaults for you.
+    Start with the [integrations overview](/docs/integrations/overview) before writing your own script. Built-in helpers encode vendor boot order, consent updates, and common defaults so you do not have to.
   </Callout>
 
   <Callout type="note">
-    If you need a vendor c15t does not ship yet, see the [custom integration guide](/docs/integrations/building-integrations). It explains when to use a one-off `Script` object and when to build a reusable manifest-backed helper.
+    If you need a vendor c15t does not ship yet, see the [custom integration guide](/docs/integrations/building-integrations). It explains when a one-off `Script` is enough and when to build a reusable manifest-backed helper.
   </Callout>
 
   <Callout type="info">
-    The script loader handles JavaScript tags and callback lifecycles. For iframe-only embeds, use the iframe blocking pattern. For UI components such as maps or video players, combine consent state with a component-level placeholder or a dedicated renderable integration.
+    The script loader handles JavaScript tags and callback lifecycles. For iframe-only embeds, use the [iframe blocking](/docs/frameworks/react/iframe-blocking) pattern. For UI components such as maps or video players, combine consent state with a component-level placeholder or a dedicated renderable integration.
   </Callout>
 </section>
 
 <section id="script-types-to-advanced">
+  ## Mental Model
+
+  Every script you register has the same lifecycle. c15t evaluates each script against the current consent state, then drives it through a small number of states:
+
+  1. **Pending** — registered but waiting for consent. Nothing is in the DOM yet.
+  2. **Loaded** — consent matched, c15t injected the script (or ran callbacks for callback-only scripts).
+  3. **Updated** — already loaded, consent state changed, `onConsentChange` ran so the SDK can react.
+  4. **Unloaded** — consent was revoked. c15t removed the script element unless you opted into persistence.
+
+  Four lifecycle callbacks let you hook into transitions: `onBeforeLoad`, `onLoad`, `onConsentChange`, and `onError`. Two flags — [`alwaysLoad`](#always-load) and [`persistAfterConsentRevoked`](#persist-after-revocation) — change how c15t treats consent boundaries. Everything else (DOM placement, ad-block evasion, dynamic management) is a refinement on top of this core model.
+
   ## Choose the Right Approach
 
-  Most projects use more than one integration style. Pick the smallest one that keeps consent behavior clear:
+  Most projects mix more than one style. Pick the smallest one that keeps consent behavior obvious:
 
-  - Use a built-in helper from `@c15t/scripts` when c15t already supports the vendor.
-  - Use a plain `Script` for one-off app code with simple load and callback behavior.
-  - Use a manifest-backed helper for reusable vendor integrations with setup phases, queues, stubs, or consent APIs.
-  - Use iframe/embed gating when the third party loads through an iframe rather than a script tag.
-  - Use a renderable integration pattern when the script backs a React/Next component, such as a map or video player.
-
-  ## How Loading Works
-
-  c15t evaluates each script against the current consent state. If the script has consent, c15t injects it into the page and tracks it as loaded. If consent is later revoked, c15t unloads the script unless the script is configured to persist and receive consent updates instead.
-
-  A typical lifecycle looks like this:
-
-  1. c15t checks the script's `category` condition.
-  2. `onBeforeLoad` runs before the script tag is added.
-  3. The script tag is appended to the configured target.
-  4. `onLoad` runs when the browser loads the script.
-  5. `onConsentChange` runs for loaded scripts when consent changes.
-  6. `onError` runs if the script fails to load.
+  | Style | Use when |
+  |---|---|
+  | **Built-in helper** from `@c15t/scripts` | c15t already ships the vendor. See the [integrations overview](/docs/integrations/overview). |
+  | **Plain `Script`** | One-off app code with simple load and callback behavior. |
+  | **Callback-only `Script`** | Another package already loaded the SDK; c15t only synchronizes consent. |
+  | **Manifest-backed helper** | Reusable vendor integration with structured setup phases, queues, stubs, or a vendor consent API. |
+  | **Iframe / renderable integration** | Vendor exposes an iframe or React component, not just a `<script>` tag. |
 
   ## Script Types
 
   ### Standard Scripts
 
-  Standard scripts load an external JavaScript file via a `<script>` tag. Use this for most analytics and pixel SDKs:
+  Standard scripts load an external JavaScript file via a `<script>` tag. This is the default for most analytics and pixel SDKs:
 
   ```tsx
   {
@@ -77,7 +77,7 @@
 
   ### Callback-Only Scripts
 
-  Callback-only scripts do not inject a script tag. They run lifecycle callbacks when consent allows them to. Use this when another package has already loaded the library and c15t only needs to synchronize consent:
+  Callback-only scripts do not inject a script tag. They run lifecycle callbacks when consent allows them to. Use this when another package has already loaded the SDK and c15t only needs to drive consent:
 
   ```tsx
   {
@@ -101,7 +101,7 @@
 
   ### Manifest-Backed Helpers
 
-  Built-in integrations in `@c15t/scripts` are manifest-backed. A manifest describes vendor setup as structured steps, then c15t compiles it into a `Script`. This keeps queue setup, script URLs, consent signaling, and post-load work consistent across apps.
+  Built-in integrations in `@c15t/scripts` are manifest-backed. A manifest describes vendor setup as structured phases, then c15t compiles it into a `Script`. Manifests keep queue stubs, script URLs, consent signaling, and post-load work consistent across apps and they are safe to ship from a server.
 
   Use a manifest-backed helper when:
 
@@ -110,11 +110,43 @@
   - the vendor exposes a consent API,
   - or you plan to contribute the integration back to c15t.
 
+  Read the [custom integration guide](/docs/integrations/building-integrations) for the manifest contract, phases, and testing checklist.
+
   ### Iframe And Renderable Integrations
 
   Some vendors are not just script tags. YouTube embeds, maps, calendars, and checkout widgets often need a visible component, a placeholder, or an iframe.
 
-  For iframe-only embeds, gate the iframe source until consent is granted. For SDK-backed UI, use the script loader for the shared SDK and render the component only when consent and SDK readiness agree.
+  - For iframe-only embeds, gate the iframe `src` with the [iframe blocking](/docs/frameworks/react/iframe-blocking) pattern instead of loading a script just to hide an iframe.
+  - For SDK-backed UI, use the script loader for the shared SDK and render the component only when consent and SDK readiness agree.
+
+  ## Lifecycle Callbacks
+
+  Every script supports four callbacks. Each receives a `ScriptCallbackInfo` payload (id, element, hasConsent, consents):
+
+  - `onBeforeLoad` — runs before the script tag is injected. Create globals, queues, or vendor stubs here.
+  - `onLoad` — runs after the browser loads the script. Call vendor `init()` APIs here.
+  - `onConsentChange` — runs for loaded scripts when consent changes. Forward the new consent state to the vendor SDK.
+  - `onError` — runs when the script fails to load. Record diagnostics or render a fallback.
+
+  ```tsx
+  {
+    id: 'analytics',
+    src: 'https://analytics.example.com/v2.js',
+    category: 'measurement',
+    onBeforeLoad: ({ id }) => {
+      window.analyticsQueue = window.analyticsQueue || [];
+    },
+    onLoad: () => {
+      window.analytics.init('my-key');
+    },
+    onError: ({ error }) => {
+      console.error('Failed to load analytics:', error);
+    },
+    onConsentChange: ({ hasConsent }) => {
+      window.analytics.setConsent(hasConsent);
+    },
+  }
+  ```
 
   ## Consent Conditions
 
@@ -131,57 +163,32 @@
   { category: { or: ['measurement', 'marketing'] } }
   ```
 
-  ## Script Callbacks
+  Consent categories use the same names as the rest of c15t (`necessary`, `functionality`, `experience`, `measurement`, `marketing`).
 
-  Every script supports four lifecycle callbacks:
-
-  - `onBeforeLoad`: runs before the script tag is injected. Use it to create globals, queues, or config objects.
-  - `onLoad`: runs after the browser loads the script. Use it to call vendor initialization APIs.
-  - `onError`: runs when the script fails to load. Use it to record diagnostics or show a fallback.
-  - `onConsentChange`: runs for loaded scripts when consent changes. Use it to call vendor consent APIs.
-
-  ```tsx
-  {
-    id: 'analytics',
-    src: 'https://analytics.example.com/v2.js',
-    category: 'measurement',
-    onBeforeLoad: ({ id }) => {
-      console.log(`Loading script: ${id}`);
-    },
-    onLoad: ({ element }) => {
-      window.analytics.init('my-key');
-    },
-    onError: ({ error }) => {
-      console.error('Failed to load analytics:', error);
-    },
-    onConsentChange: ({ hasConsent, consents }) => {
-      window.analytics.setConsent(hasConsent);
-    },
-  }
-  ```
-
-  ## Advanced Options
+  ## Persistence Options
 
   ### Always Load
 
-  `alwaysLoad` loads the script regardless of whether its category is currently granted. Use it only when the vendor must be present early and has a reliable consent API of its own, such as Google Tag Manager with Consent Mode.
+  `alwaysLoad` loads the script regardless of whether its category is currently granted. Use it only when the vendor must be present early **and** has a reliable consent API of its own — Google Tag Manager with Consent Mode is the canonical example.
 
   ```tsx
   {
     id: 'google-tag-manager',
     src: 'https://www.googletagmanager.com/gtm.js?id=GTM-XXXX',
     category: 'measurement',
-    alwaysLoad: true, // Loads regardless of consent state
+    alwaysLoad: true,
   }
   ```
 
+  When `alwaysLoad` is on, `onConsentChange` becomes mandatory: it is how the loaded SDK learns about every transition.
+
   <Callout type="warning">
-    `alwaysLoad` shifts responsibility to the vendor integration. Make sure the script receives denied consent defaults before it can track.
+    `alwaysLoad` shifts compliance responsibility to the vendor integration. Make sure the script receives denied-by-default consent signals before it can track.
   </Callout>
 
   ### Persist After Revocation
 
-  `persistAfterConsentRevoked` keeps the script in the page after consent is revoked. Use it only when the vendor exposes a runtime consent toggle. Otherwise, unloading is safer.
+  `persistAfterConsentRevoked` keeps a script in the page after consent is revoked instead of unloading it. Use it only when the vendor exposes a runtime consent toggle — otherwise unloading is safer because removing the element guarantees the SDK stops.
 
   ```tsx
   {
@@ -189,59 +196,61 @@
     src: 'https://errors.example.com/track.js',
     category: 'measurement',
     persistAfterConsentRevoked: true,
+    onConsentChange: ({ hasConsent }) => {
+      window.ErrorTracker.setConsent(hasConsent);
+    },
   }
   ```
 
-  When this is enabled, `onConsentChange` becomes important because it is how the already-loaded SDK learns about the new consent state.
+  As with `alwaysLoad`, `onConsentChange` is how the persisted SDK learns about consent updates.
 
-  ### Script Placement
+  ### `alwaysLoad` vs `persistAfterConsentRevoked`
 
-  Control where in the DOM the script is injected:
+  These two flags answer different questions. Use this table to keep them straight:
+
+  | Question | `alwaysLoad` | `persistAfterConsentRevoked` |
+  |---|---|---|
+  | Loads before consent is granted? | Yes | No (waits for consent like a normal script) |
+  | Stays loaded after consent is revoked? | Yes | Yes |
+  | Requires a vendor consent API? | Yes | Yes |
+
+  ## DOM Placement
+
+  Control where the script is injected and whether the element id is anonymized:
 
   ```tsx
   {
     id: 'widget',
     src: 'https://widget.example.com/embed.js',
     category: 'experience',
-    target: 'body', // 'head' (default) or 'body'
+    target: 'body',     // 'head' (default) or 'body'
+    anonymizeId: true,  // default: true, hides the c15t script id from ad blockers
+    nonce: 'abc123',    // optional CSP nonce
   }
   ```
 
-  ### Ad Blocker Evasion
-
-  Script element IDs are anonymized by default to avoid simple ad blocker pattern matching:
-
-  ```tsx
-  {
-    id: 'analytics',
-    src: '...',
-    category: 'measurement',
-    anonymizeId: true, // default: true
-  }
-  ```
-
-  Set `anonymizeId: false` only when another script or test needs a stable DOM ID.
+  Set `anonymizeId: false` only when another script or test needs a stable DOM id. Pass `nonce` when your CSP requires it; c15t applies it directly to the generated `<script>` element.
 
   ## Dynamic Management
 
-  Framework packages expose script manager methods through `useConsentManager()`. Use them when integrations are not known at initial render, such as tenant-specific tools or feature-flagged scripts.
+  Framework packages expose script-manager methods so integrations can be added, removed, or inspected at runtime. Use this for tenant-specific tools, feature-flagged scripts, or vendors that are configured after sign-in:
 
-  - `setScripts()` adds script definitions and immediately evaluates them against consent.
-  - `removeScript()` removes a definition and unloads its element if needed.
-  - `isScriptLoaded()` checks whether c15t has loaded a script.
-  - `getLoadedScriptIds()` returns all currently loaded script IDs.
+  - `setScripts(scripts)` — registers script definitions and immediately evaluates them against consent.
+  - `removeScript(id)` — removes a definition and unloads its element if needed.
+  - `isScriptLoaded(id)` — returns whether c15t has loaded a script.
+  - `getLoadedScriptIds()` — returns every currently loaded script id.
 
-  Dynamic scripts should still use stable IDs. If the same vendor is added repeatedly with different IDs, c15t treats them as different scripts.
+  Dynamic scripts should still use stable ids. If the same vendor is added repeatedly with different ids, c15t treats each call as a new script.
 
   ## Debugging Checklist
 
-  If a script does not behave as expected:
+  When a script does not behave as expected:
 
-  1. Confirm the script's `category` matches the consent you granted.
+  1. Confirm the script's `category` matches the consent that has been granted.
   2. Check whether the script is `alwaysLoad` or consent-gated.
-  3. Check whether the browser blocked the request.
-  4. Confirm `onBeforeLoad` creates any globals before the vendor code reads them.
-  5. Confirm `onConsentChange` updates persisted scripts when consent changes.
+  3. Confirm `onBeforeLoad` creates any globals before the vendor code reads them.
+  4. Confirm `onConsentChange` updates persisted or always-loaded scripts when consent changes.
+  5. Check whether the browser or an ad blocker blocked the request.
   6. Use c15t devtools to inspect script lifecycle events when available.
 </section>
 


### PR DESCRIPTION
## Summary

Implements [#836](https://github.com/c15t/c15t/issues/836) — the docs leg of Tranche 1 in the [scripts roadmap](https://github.com/c15t/c15t/issues/833). Now that the identity registry from [#844](https://github.com/c15t/c15t/pull/844) gives us canonical categories, this PR rewires the script-loader docs around them and around an explicit lifecycle mental model.

## Shared script-loader guide (`docs/shared/react/guides/script-loader.mdx`)

Rewritten around a four-state lifecycle (Pending → Loaded → Updated → Unloaded) so the rest of the page reads as refinements on a single idea instead of nine flat sections. Section IDs (`#intro`, `#script-types-to-advanced`, `#api-reference`) preserved so the framework imports keep working.

- Lead with **Mental Model** + a **Choose the Right Approach** decision matrix.
- Promote **Lifecycle Callbacks** to a top-level section.
- Split **Persistence Options** so `alwaysLoad` and `persistAfterConsentRevoked` are clearly distinguished, with a comparison table.
- Tighten **DOM Placement** (`target`, `anonymizeId`, `nonce` in one block).
- Clearer cross-links to iframe blocking and the custom integration guide.

## Framework pages (React + Next.js)

- Both pages share structure now: Basic Usage → Recommended Structure → shared lifecycle import → Dynamic Script Management → Renderable Integrations → API Reference.
- Dynamic management section drops the prose duplicated by the shared guide and focuses on framework-specific bits (the hook + effect pattern).
- Next.js page keeps App Router notes and cross-links to `next/iframe-blocking`.

## Integrations overview (`docs/integrations/overview.mdx`)

Restructured around the canonical registry categories from #844 (`Analytics` → `Ads & Pixels` → `Tag Managers`). Removed boilerplate that fought the script-loader pages: the General Pattern framework tabs, the embedded basic-usage snippet, and the unrelated \`has()\` section. Sidebar order in `meta.json` updated to match.

## Per-integration page pass

The vendor reorg in #844 broke every `AutoTypeTable` path on the integration pages — fixed across all 9 pages.

Each integration page now opens with a consistent **How c15t loads it** block stating its category, when it loads, and what happens on revocation, with anchor links into the shared guide's `#always-load` and `#persist-after-revocation` sections:

| Integration | Category | Behavior |
|---|---|---|
| Google Tag (gtag.js) | `measurement` / `marketing` | `alwaysLoad` + persists, Consent Mode v2 |
| Google Tag Manager | `necessary` | `alwaysLoad`, Consent Mode v2 update |
| Databuddy | `measurement` | `alwaysLoad`, toggles `disabled` flag |
| PostHog (Script mode) | `measurement` | `alwaysLoad`, `opt_in_capturing` / `opt_out_capturing` |
| Meta Pixel | `marketing` | consent-gated, persists, `fbq('consent', 'revoke')` |
| TikTok Pixel | `marketing` | consent-gated, persists, `ttq` consent |
| Microsoft UET | `marketing` | consent-gated, persists, `uetq` consent |
| LinkedIn Insights | `marketing` | consent-gated, **unloaded** on revoke |
| X Pixel | `marketing` | consent-gated, **unloaded** on revoke |

The "See the integration overview" callouts now point directly at the JS / React / Next.js script-loader guides instead of bouncing through the overview, which no longer documents framework setup.

## Stats

14 files changed · +258 / −291 (denser despite the new per-page block, because the overview rewrite cut more than the per-page additions).

## Test plan

- [x] `bun run lint:docs` clean — every file marked written, no warnings.
- [x] All `AutoTypeTable` paths point at existing files (`packages/scripts/src/vendors/<category>/<vendor>.ts`).
- [x] All shared-guide imports (`#intro`, `#script-types-to-advanced`, `#api-reference`) still resolve.
- [ ] Visual review on Vercel preview — sidebar grouping, anchor links, table rendering.
- [ ] Confirm `AutoTypeTable` renders the right type for every integration page.

Closes #836

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined guidance for gating third‑party scripts behind consent across JavaScript, React, and Next.js
  * Clarified provider/client-boundary, hook usage, dynamic script registration, and app-router client-component requirements
  * Added a structured three‑layer pattern for renderable integrations, iframe guidance, and widget lifecycle/cleanup
  * Revised many integration pages and navigation; clarified load/unload and consent‑sync behaviors, examples, and debugging guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c15t/c15t/pull/845)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->