### PR TITLE
Refactor vendor script helpers

### DIFF
--- a/docs/integrations/linkedin-insights.mdx
+++ b/docs/integrations/linkedin-insights.mdx
@@ -1,23 +1,37 @@
 ---
 title: LinkedIn Insights
 description: Track conversions and build matched audiences for LinkedIn advertising campaigns.
-lastModified: 2025-09-24
+lastModified: 2026-05-11
 
 icon: linkedin
 ---
 
-LinkedIn Insights Tag is LinkedIn's conversion tracking and audience matching tool for LinkedIn advertising campaigns. It tracks website actions, measures ad performance, builds matched audiences for retargeting, and provides demographic insights about your visitors.
+LinkedIn Insight Tag is LinkedIn's conversion tracking and audience matching tool for LinkedIn advertising campaigns. It tracks website actions, measures ad performance, builds website retargeting audiences, and provides aggregate audience insights about visitors from LinkedIn member accounts.
+
+## Official LinkedIn documentation
+
+- [Add the LinkedIn Insight Tag to your website](https://www.linkedin.com/help/lms/answer/a418880)
+- [LinkedIn Insight Tag overview](https://www.linkedin.com/help/lms/answer/a489169)
+- [LinkedIn Insight Tag FAQs](https://www.linkedin.com/help/lms/answer/a427660)
+- [Insight Tag source status](https://www.linkedin.com/help/lms/answer/a488323)
+- [Compatible tag management systems](https://www.linkedin.com/help/lms/answer/a422760)
+- [LinkedIn Ads Agreement](https://www.linkedin.com/legal/sas-terms)
 
 ## How c15t loads it
 
 - **Category:** `marketing` (Ads & Pixels)
 - **Loads when:** marketing consent is granted
-- **On revocation:** unloaded — c15t removes the script element from the DOM
+- **Default install:** c15t sets the LinkedIn partner ID globals, seeds the `lintrk` queue, and loads LinkedIn's `insight.min.js`
+- **On revocation:** unloaded - c15t removes the script element from the DOM
 
-## Adding the LinkedIn Insights Tag to c15t
+<Callout type="warning">
+  LinkedIn says the Insight Tag should not be installed on pages that collect or contain Sensitive Data, including certain consumer health or financial pages. If your app has those pages, only include this script on eligible routes and confirm the placement with your legal team.
+</Callout>
+
+## Adding the LinkedIn Insight Tag to c15t
 
 <Callout type="info">
-  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
+  Pass the result to your `ConsentManagerProvider` - see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -28,9 +42,21 @@ linkedinInsights({
 })
 ```
 
+Use the LinkedIn Insight Tag partner ID as `id`. You can find it in Campaign Manager under **Data** -> **Signals manager** -> **Insight Tag**.
+
+c15t intentionally does not add LinkedIn's `<noscript>` image pixel fallback. The integration is consent-gated JavaScript, so the script only loads after `marketing` consent is granted.
+
+## Verifying the tag
+
+LinkedIn validates the tag after an associated domain or URL receives traffic. Source status can take a few minutes and up to 24 hours to update after the first page load:
+
+- **Active:** signal received in the past seven days
+- **No recent activity:** no signal for more than seven days
+- **Unverified:** no signal received yet
+
 ## Tracking events in your app
 
-c15t gates the LinkedIn Insight Tag from loading until `marketing` consent is granted. Page tracking is automatic once the script loads, but if you fire custom conversions through `window.lintrk(...)`, those calls are **not** automatically gated — `window.lintrk` does not exist before consent is granted, and is removed again if consent is revoked.
+c15t gates the LinkedIn Insight Tag from loading until `marketing` consent is granted. Page tracking is automatic once the script loads, but if you fire custom conversions through `window.lintrk(...)`, those calls are **not** automatically gated - `window.lintrk` does not exist before consent is granted, and is removed again if consent is revoked.
 
 Guard custom conversion calls by checking consent state:
 

--- a/docs/integrations/meta-pixel.mdx
+++ b/docs/integrations/meta-pixel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Meta Pixel
 description: Track conversions and build audiences for Facebook and Instagram advertising campaigns.
-lastModified: 2025-09-24
+lastModified: 2026-05-11
 
 icon: meta
 ---
@@ -12,6 +12,7 @@ Meta Pixel (formerly Facebook Pixel) is Meta's conversion tracking and audience 
 
 - **Category:** `marketing` (Ads & Pixels)
 - **Loads when:** marketing consent is granted
+- **Default install:** c15t queues `fbq('consent', 'grant')`, `fbq('init', pixelId)`, `fbq('track', 'PageView')`, then loads Meta's `fbevents.js`
 - **On revocation:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t calls `fbq('consent', 'revoke')` so Meta stops tracking without removing the script
 
 ## Adding the Meta Pixel to c15t
@@ -28,16 +29,104 @@ metaPixel({
 })
 ```
 
-## metaPixelEvent
+Meta recommends installing the base pixel on every page you want to measure. c15t injects scripts into the document head by default, which matches Meta's recommendation to load the pixel early.
 
-You can use the `metaPixelEvent` function to track events. This is a wrapper around the `fbq` function that the Meta Pixel script uses.
+## Setup options
 
-To learn more about Meta Pixel's standard events, see the [Meta Pixel documentation](https://developers.facebook.com/docs/meta-pixel/reference).
+Use the default setup when you want Meta's standard `PageView` event to fire as soon as the pixel loads after marketing consent.
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+});
+```
+
+For single page applications, disable the automatic `PageView` and track route changes yourself.
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+  trackPageView: false,
+});
+```
+
+You can pass optional init data as the third argument to `fbq('init', ...)`.
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+  initOptions: {
+    external_id: 'customer-123',
+  },
+});
+```
+
+## Tracking conversions
+
+Use `metaPixelEvent` to track Meta standard events. It is a typed wrapper around `fbq('track', ...)`.
+
+Meta documents standard event tracking in its [conversion tracking guide](https://developers.facebook.com/docs/meta-pixel/implementation/conversion-tracking) and [Marketing API pixel examples](https://developers.facebook.com/docs/meta-pixel/implementation/marketing-api).
 
 ```ts
 import { metaPixelEvent } from '@c15t/scripts/meta-pixel';
 
-metaPixelEvent('Purchase', { value: 10.0, currency: 'USD' });
+metaPixelEvent('Lead', {
+  value: 40,
+  currency: 'USD',
+});
+
+metaPixelEvent('AddToCart', {
+  content_ids: ['SKU-123'],
+  content_type: 'product',
+  value: 49.99,
+  currency: 'USD',
+});
+
+metaPixelEvent(
+  'Purchase',
+  {
+    contents: [
+      { id: 'SKU-123', quantity: 2 },
+      { id: 'SKU-456', quantity: 1 },
+    ],
+    content_type: 'product',
+    value: 149.97,
+    currency: 'USD',
+  },
+  'browser-event-123'
+);
+```
+
+The optional third argument can be an event ID string or an options object. c15t forwards string IDs as `{ eventID: '...' }`, which is the browser-side format used for Conversions API deduplication.
+
+```ts
+metaPixelEvent(
+  'Purchase',
+  { value: 149.97, currency: 'USD' },
+  { eventID: 'browser-event-123' }
+);
+```
+
+## Custom events
+
+Use `metaPixelCustomEvent` when Meta's standard events do not fit the action you are measuring. Meta custom event names must be strings and cannot exceed 50 characters.
+
+```ts
+import { metaPixelCustomEvent } from '@c15t/scripts/meta-pixel';
+
+metaPixelCustomEvent('ShareDiscount', {
+  promotion: 'share_discount_10%',
+});
+```
+
+Custom events can also use an event ID for Conversions API deduplication.
+
+```ts
+metaPixelCustomEvent(
+  'ShareDiscount',
+  { promotion: 'share_discount_10%' },
+  'browser-event-456'
+);
 ```
 
 ## Tracking events in your app
@@ -68,11 +157,152 @@ function PurchaseButton() {
 }
 ```
 
+## SPA route changes
+
+Meta's [SPA guidance](https://developers.facebook.com/docs/facebook-pixel/implementation/tag_spa) recommends tracking meaningful URL changes from your router. Disable the install-time `PageView`, then emit page views after navigation while marketing consent is granted.
+
+```tsx
+import { useConsentManager } from '@c15t/react';
+import { metaPixelEvent } from '@c15t/scripts/meta-pixel';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
+
+function MetaRouteTracking() {
+  const { has } = useConsentManager();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (has('marketing')) {
+      metaPixelEvent('PageView');
+    }
+  }, [has, location.pathname, location.search]);
+
+  return null;
+}
+```
+
+## Consent and privacy
+
+Meta's GDPR guidance documents `fbq('consent', 'revoke')` and `fbq('consent', 'grant')`. c15t handles those calls for you after the script has loaded once:
+
+- Before marketing consent, c15t does not load Meta Pixel.
+- When marketing consent is granted, c15t loads Meta Pixel and calls `fbq('consent', 'grant')`.
+- When marketing consent is revoked later, c15t keeps the script in place and calls `fbq('consent', 'revoke')`.
+
+For US state privacy rules, Meta supports [Data Processing Options](https://developers.facebook.com/docs/meta-pixel/implementation/data-processing-options). Pass `dataProcessingOptions` to queue `fbq('dataProcessingOptions', ...)` before `fbq('init', ...)`.
+
+Let Meta geolocate Limited Data Use:
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+  dataProcessingOptions: {
+    options: ['LDU'],
+    country: 0,
+    state: 0,
+  },
+});
+```
+
+Enable Limited Data Use for California:
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+  dataProcessingOptions: {
+    options: ['LDU'],
+    country: 1,
+    state: 1000,
+  },
+});
+```
+
+Explicitly disable Limited Data Use:
+
+```ts
+metaPixel({
+  pixelId: '123456789012345',
+  dataProcessingOptions: {
+    options: [],
+  },
+});
+```
+
+## Catalog and collaborative ads
+
+For Advantage+ catalog ads, Meta requires `ViewContent`, `AddToCart`, and `Purchase` events to include either `content_ids` or `contents`. IDs must match your product catalog. See Meta's [Advantage+ catalog ads guide](https://developers.facebook.com/docs/meta-pixel/get-started/advantage-catalog-ads).
+
+```ts
+metaPixelEvent('ViewContent', {
+  content_ids: ['SKU-123'],
+  content_type: 'product',
+  value: 49.99,
+  currency: 'USD',
+});
+```
+
+For collaborative ads, Meta requires `content_type: 'product'`; `AddToCart` and `Purchase` also require `contents`, `currency`, and `value`. See Meta's [collaborative ads pixel guide](https://developers.facebook.com/docs/meta-pixel/implementation/pixel-for-collaborative-ads).
+
+```ts
+metaPixelEvent('AddToCart', {
+  contents: [{ id: 'SKU-123', quantity: 2 }],
+  content_type: 'product',
+  value: 99.98,
+  currency: 'USD',
+});
+```
+
+## Movies
+
+Meta's [movies pixel guide](https://developers.facebook.com/docs/meta-pixel/implementation/pixel-for-movies) uses the standard events `ViewContent`, `InitiateCheckout`, `Purchase`, and `PageView` with movie-specific parameters such as `movieref`.
+
+```ts
+metaPixelEvent('InitiateCheckout', {
+  content_ids: ['movie-1|theater-1|2026-05-11T19:30:00-07:00'],
+  movieref: 'fb_movies',
+  num_items: 2,
+});
+```
+
+## Multiple pixels
+
+Meta's [multiple pixel guidance](https://developers.facebook.com/docs/facebook-pixel/implementation/accurate_event_tracking) warns that `fbq('track', ...)` and `fbq('trackCustom', ...)` fire for every initialized pixel ID. If another integration or tag manager initializes more than one pixel, use the single-pixel helpers to prevent overfiring.
+
+```ts
+import {
+  metaPixelSingleCustomEvent,
+  metaPixelSingleEvent,
+} from '@c15t/scripts/meta-pixel';
+
+metaPixelSingleEvent('PIXEL-A', 'Purchase', {
+  value: 149.97,
+  currency: 'USD',
+});
+
+metaPixelSingleCustomEvent('PIXEL-B', 'Step4', {
+  funnel: 'checkout',
+});
+```
+
+## Custom audiences and sharing
+
+Meta custom audiences are configured in Events Manager after standard events, custom events, or custom conversions are being received. The c15t integration sends the browser events; audience rules are managed in Meta. See Meta's [custom audiences guide](https://developers.facebook.com/docs/facebook-pixel/implementation/custom-audiences).
+
+Pixel sharing between businesses or agencies is also managed through Meta Business Manager or the Business Management APIs, not through the browser script. See Meta's [pixel sharing guide](https://developers.facebook.com/docs/marketing-api/business-asset-management/guides/business-pixel-sharing).
+
 ## Types
 
 ### MetaPixelOptions
 
 <AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts" name="MetaPixelOptions" />
+
+### MetaPixelDataProcessingOptions
+
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts" name="MetaPixelDataProcessingOptions" />
+
+### MetaPixelEventOptions
+
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts" name="MetaPixelEventOptions" />
 
 ### Script
 

--- a/docs/integrations/meta-pixel.mdx
+++ b/docs/integrations/meta-pixel.mdx
@@ -41,7 +41,7 @@ metaPixel({
 });
 ```
 
-For single page applications, disable the automatic `PageView` and track route changes yourself.
+For single-page applications, disable the automatic `PageView` and track route changes yourself.
 
 ```ts
 metaPixel({

--- a/docs/integrations/microsoft-uet.mdx
+++ b/docs/integrations/microsoft-uet.mdx
@@ -1,27 +1,42 @@
 ---
 title: Microsoft UET
 description: Track conversions and measure performance for Microsoft Advertising and Bing Ads.
-lastModified: 2025-09-24
+lastModified: 2026-05-11
 
 icon: microsoft
 ---
 
-Microsoft UET (Universal Event Tracking) is Microsoft's conversion tracking tag for Microsoft Advertising. It tracks user actions, measures campaign effectiveness, and enables remarketing campaigns.
+Microsoft UET (Universal Event Tracking) is Microsoft's conversion tracking tag
+for Microsoft Advertising. It tracks user actions, measures campaign
+effectiveness, and enables remarketing campaigns.
+
+## Official Microsoft documentation
+
+- [Universal Event Tracking](https://learn.microsoft.com/en-us/advertising/guides/universal-event-tracking?view=bingads-13)
+- [UET tag data object](https://learn.microsoft.com/en-us/advertising/campaign-management-service/uettag?view=bingads-13)
+- [FAQ: Universal Event Tracking](https://help.ads.microsoft.com/#apex/3/en/53056/2)
+- [FAQ: Remarketing](https://help.ads.microsoft.com/#apex/3/en/56727/1)
 
 <Callout type="note">
-  UET can also load Microsoft Clarity (if enabled in your UET tag settings). Since Clarity is an analytics tool, we recommend loading it separately with `measurement` consent instead.
+  UET can also load Microsoft Clarity (if enabled in your UET tag settings). Since
+  Clarity is an analytics tool, we recommend loading it separately with
+  `measurement` consent instead.
 </Callout>
 
 ## How c15t loads it
 
 - **Category:** `marketing` (Ads & Pixels)
-- **Loads when:** marketing consent is granted
-- **On revocation:** [persists](/docs/frameworks/react/script-loader#persist-after-revocation) — c15t pushes the new consent state to `uetq` so UET stops tracking without removing the script
+- **Loads when:** immediately, with Microsoft consent mode enabled
+- **Default consent:** c15t pushes `ad_storage: 'denied'` before loading UET unless marketing consent is already granted
+- **On grant/revocation:** c15t pushes the new consent state to `uetq` so UET can switch between granted and denied mode without removing the script
 
 ## Adding Microsoft UET to c15t
 
 <Callout type="info">
-  Pass the result to your `ConsentManagerProvider` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
+  Pass the result to your `ConsentManagerProvider` — see the
+  [JavaScript](/docs/frameworks/javascript/script-loader),
+  [React](/docs/frameworks/react/script-loader), or
+  [Next.js](/docs/frameworks/next/script-loader) script loader guide.
 </Callout>
 
 ```ts
@@ -32,11 +47,21 @@ microsoftUet({
 })
 ```
 
+Use the UET tag ID as `id`. Microsoft recommends creating one UET tag and
+adding it across your site; that tag can then support conversion goals and
+remarketing lists.
+
 ## Tracking events in your app
 
-c15t gates the Microsoft UET script from loading until `marketing` consent is granted. After consent is granted the script stays in the DOM, and c15t pushes the new consent state to `uetq` if consent is later revoked.
+c15t loads Microsoft UET in consent mode, so `window.uetq` is created before
+consent is granted. Your own event calls are **not** automatically gated. Guard
+them if you only want to send custom conversion events after marketing consent
+is granted.
 
-This means `window.uetq` is only defined after the user has granted marketing consent at least once. Before that, unguarded calls throw. After that, calls are safe — UET's own consent state suppresses tracking when revoked.
+Microsoft's custom event syntax uses
+`window.uetq.push('event', action, parameters)`. Conversion goals can match page
+visits and custom events, and event payloads can include revenue fields such as
+`revenue_value` and `currency`.
 
 ```tsx
 import { useConsentManager } from '@c15t/react';
@@ -44,7 +69,10 @@ import { useConsentManager } from '@c15t/react';
 function trackPurchase() {
   const { has } = useConsentManager();
   if (has('marketing')) {
-    window.uetq?.push('event', 'purchase', { revenue_value: 10, currency: 'USD' });
+    window.uetq?.push('event', 'purchase', {
+      revenue_value: 10,
+      currency: 'USD',
+    });
   }
 }
 ```

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -161,6 +161,10 @@ The behavior depends on which pattern you chose:
 - **SDK Implementation** — your app loaded `posthog-js` itself, so `posthog.capture(...)` is available once your SDK setup has run. c15t calls `opt_in_capturing()` / `opt_out_capturing()` for you. Pending events before c15t syncs consent may be dropped; after denial, PostHog captures cookieless events.
 - **Script Implementation** — the c15t helper uses `alwaysLoad: true`, so `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events.
 
+<Callout type="warning">
+  PostHog may start a new session when a user moves between cookieless and cookie-based capture. This can split pre-consent and post-consent activity into separate sessions, which may inflate session counts or affect funnels around the consent boundary. Treat this as a PostHog analytics limitation, not a c15t consent sync issue.
+</Callout>
+
 ```ts
 posthog.capture('signup');
 ```

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -162,7 +162,7 @@ The behavior depends on which pattern you chose:
 - **Script Implementation** — the c15t helper uses `alwaysLoad: true`, so `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events.
 
 <Callout type="warning">
-  PostHog may start a new session when a user moves between cookieless and cookie-based capture. This can split pre-consent and post-consent activity into separate sessions, which may inflate session counts or affect funnels around the consent boundary. Treat this as a PostHog analytics limitation, not a c15t consent sync issue.
+  PostHog may start a new session when a user moves between cookieless and cookie-based capture. This can split pre-consent and post-consent activity into separate sessions, which may inflate session counts or affect funnels around the consent boundary. Treat this as a PostHog analytics limitation, not a c15t consent sync issue. See the upstream [PostHog session continuity issue](https://github.com/PostHog/posthog-js/issues/3130).
 </Callout>
 
 ```ts

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -1,12 +1,12 @@
 ---
 title: PostHog
 description: PostHog is an open-source product analytics platform for tracking user behavior, session replays, feature flags, and A/B testing. It supports cookieless tracking, allowing analytics to continue even without cookie consent.
-lastModified: 2026-04-08
+lastModified: 2026-05-11
 
 icon: posthog
 ---
 
-PostHog is an open-source product analytics platform that helps you understand user behavior, track events, and analyze product usage. Unlike traditional analytics tools, PostHog supports both cookieless and cookie-based tracking. This means you can sync c15t with PostHog and continue collecting analytics even when users haven't given consent—PostHog simply operates in cookieless mode until consent is granted.
+PostHog is an open-source product analytics platform that helps you understand user behavior, track events, and analyze product usage. Unlike traditional analytics tools, PostHog supports both cookieless and cookie-based tracking. This means you can sync c15t with PostHog and, when your PostHog project is configured for cookieless tracking, continue collecting privacy-preserving analytics after a user rejects measurement consent.
 
 c15t exposes two integration patterns for PostHog. Pick the one that matches how you already load the SDK:
 
@@ -21,18 +21,24 @@ This is the recommended approach if you're using the PostHog JS SDK; it's common
 
 <Steps>
   <Step>
+    ### Enable cookieless tracking in PostHog
+
+    Before using `cookieless_mode`, enable **Cookieless server hash mode** in your PostHog project under **Project Settings** > **Web analytics**. PostHog ignores cookieless events unless this project setting is enabled.
+  </Step>
+
+  <Step>
     ### Initialize PostHog
 
-    When you initialize PostHog make sure to set `cookieless_mode` to `on_reject`.
+    When you initialize PostHog, set `cookieless_mode` to `on_reject`. This keeps PostHog from writing cookies or local/session storage until the user grants measurement consent. If the user rejects measurement consent, c15t calls `opt_out_capturing()` and PostHog switches to cookieless capture.
 
     ```ts
     posthog.init("phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", {
       api_host: "https://eu.i.posthog.com",
-      defaults: "2025-05-24",
+      defaults: "2026-01-30",
       cookieless_mode: 'on_reject'
     })
 
-    posthog.opt_out_capturing() // Avoids accidental tracking without consent till c15t has loaded
+    posthog.opt_out_capturing() // Avoids cookie-based capture until c15t syncs consent
     ```
   </Step>
 
@@ -40,6 +46,8 @@ This is the recommended approach if you're using the PostHog JS SDK; it's common
     ### Sync settled consent once, then subscribe to real changes
 
     The recommended PostHog SDK approach uses two phases: run one initial sync after c15t has finished resolving consent, then subscribe to future real preference changes with `subscribeToConsentChanges()`.
+
+    With `cookieless_mode: 'on_reject'`, denied measurement consent does not mean "no events." It means PostHog records cookieless events without browser persistence. If your product needs denied consent to stop all PostHog event capture, do not use cookieless mode; load or call PostHog only after consent is granted.
 
     <Callout type="info">
       To wrap this in your framework, pass the `callbacks` option to your `ConsentManagerProvider` the same way you would pass `scripts` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
@@ -91,23 +99,31 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
 
 - **Category:** `measurement` (Analytics)
 - **Loads when:** [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load) — runs on page start regardless of consent state
-- **On consent change:** c15t calls `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()` so the script stays loaded but only captures after consent is granted
+- **On consent change:** c15t calls `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()` so the script stays loaded while PostHog switches between cookie-based and cookieless capture
 
 <Steps>
   <Step>
     ### Configure cookieless mode
 
-    The c15t helper loads PostHog's bootstrap script, calls `posthog.init()` for you using the `initOptions` you pass, and then synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
+    The c15t helper loads PostHog's bootstrap script, calls `posthog.init()` for you, and then synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
 
-    Because PostHog supports cookieless tracking, set `cookieless_mode: 'on_reject'` in `initOptions` so PostHog keeps collecting data without cookies until measurement consent is granted:
+    The helper includes these PostHog init defaults:
 
     ```ts
     const initOptions = {
       api_host: 'https://eu.i.posthog.com',
-      // PostHog will not set any cookies until the user has given consent
+      defaults: '2026-01-30',
       cookieless_mode: 'on_reject',
     };
     ```
+
+    You can still override any of these through `initOptions`. Keep `cookieless_mode: 'on_reject'` when you want PostHog to use cookieless capture after a consent rejection.
+  </Step>
+
+  <Step>
+    ### Enable cookieless tracking in PostHog
+
+    Enable **Cookieless server hash mode** in your PostHog project under **Project Settings** > **Web analytics**. This is required by PostHog before cookieless events are accepted.
   </Step>
 
   <Step>
@@ -125,11 +141,9 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
       apiHost: 'https://eu.i.posthog.com',
       scriptUrl: 'https://eu-assets.i.posthog.com/static/array.js',
       initOptions: {
-        api_host: 'https://eu.i.posthog.com',
         ui_host: 'https://eu.i.posthog.com',
         autocapture: false,
         person_profiles: 'identified_only',
-        cookieless_mode: 'on_reject',
       }
     })
     ```
@@ -140,14 +154,18 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
 
 The behavior depends on which pattern you chose:
 
-- **SDK Implementation** — your app loaded `posthog-js` itself, so `posthog.capture(...)` is always available. c15t calls `opt_in_capturing()` / `opt_out_capturing()` for you, so PostHog's own consent state suppresses capture when measurement is denied. Calls are safe at any time.
-- **Script Implementation** — the c15t helper uses `alwaysLoad: true`, so `window.posthog` is always defined. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Calls to `posthog.capture(...)` are safe — they will simply be no-ops while consent is denied.
+- **SDK Implementation** — your app loaded `posthog-js` itself, so `posthog.capture(...)` is available once your SDK setup has run. c15t calls `opt_in_capturing()` / `opt_out_capturing()` for you. Pending events before c15t syncs consent may be dropped; after denial, PostHog captures cookieless events.
+- **Script Implementation** — the c15t helper uses `alwaysLoad: true`, so `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events.
 
 ```ts
 posthog.capture('signup');
 ```
 
-You do not need to guard these calls with `useConsentManager().has('measurement')`, but doing so is fine if you prefer the explicit check.
+You do not need to guard these calls with `useConsentManager().has('measurement')` when cookieless measurement after rejection is acceptable. Add your own guard if denied consent should mean no PostHog event capture at all.
+
+## GDPR notes
+
+PostHog's GDPR guidance recommends using PostHog Cloud EU for robust GDPR compliance, configuring consent clearly, and limiting what personal data is collected. Cookieless mode helps avoid browser persistence when measurement consent is rejected, but it does not replace your own legal basis, consent language, data minimization, IP capture settings, or right-to-be-forgotten process.
 
 ## Types
 

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -49,6 +49,10 @@ This is the recommended approach if you're using the PostHog JS SDK; it's common
 
     With `cookieless_mode: 'on_reject'`, denied measurement consent does not mean "no events." It means PostHog records cookieless events without browser persistence. If your product needs denied consent to stop all PostHog event capture, do not use cookieless mode; load or call PostHog only after consent is granted.
 
+    <Callout type="warning">
+      Do not use `posthog.has_opted_in_capturing()` or `posthog.has_opted_out_capturing()` to decide whether to show your banner. In recent PostHog versions, `has_opted_in_capturing()` can return `true` when consent is still pending. Use c15t's consent store as the source of truth, or use PostHog's `get_explicit_consent_status()` when you specifically need PostHog's stored consent state.
+    </Callout>
+
     <Callout type="info">
       To wrap this in your framework, pass the `callbacks` option to your `ConsentManagerProvider` the same way you would pass `scripts` — see the [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), or [Next.js](/docs/frameworks/next/script-loader) script loader guide.
     </Callout>

--- a/docs/integrations/reddit-pixel.mdx
+++ b/docs/integrations/reddit-pixel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reddit Pixel
 description: Track conversions and build retargeting audiences for Reddit advertising campaigns.
-lastModified: 2026-05-10
+lastModified: 2026-05-11
 
 icon: reddit
 ---
@@ -12,7 +12,10 @@ Reddit Pixel is Reddit's conversion tracking tool for ads and remarketing. It se
 
 - **Category:** `marketing` (Ads & Pixels)
 - **Loads when:** marketing consent is granted
-- **On revocation:** unloaded - c15t removes the script from the DOM, so later `rdt(...)` calls from app code need guarding until consent is granted again.
+- **On revocation:** retained in the DOM so c15t can call Reddit's
+  first-party-cookie controls. c15t calls `rdt('disableFirstPartyCookies')`
+  when marketing consent is denied and `rdt('enableFirstPartyCookies')` when
+  it is granted again.
 
 ## Adding Reddit Pixel to c15t
 
@@ -37,6 +40,70 @@ redditPixel({
 })
 ```
 
+## Consent and privacy
+
+c15t keeps Reddit Pixel behind `marketing` consent. Before marketing consent,
+the Reddit script is not loaded. After marketing consent is granted, c15t loads
+the script and queues the Reddit `init` call.
+
+For stricter first-party-cookie behavior, disable Reddit first-party cookies
+during initialization:
+
+```ts
+redditPixel({
+  pixelId: 't2_abcdef',
+  disableFirstPartyCookies: true,
+})
+```
+
+You can also pass Reddit's initialization options directly:
+
+```ts
+redditPixel({
+  pixelId: 't2_abcdef',
+  initOptions: {
+    optOut: true,
+    disableFirstPartyCookies: true,
+  },
+})
+```
+
+Reddit supports a Limited Data Use flag through data processing fields. Use the
+values required by your policy and jurisdiction:
+
+```ts
+redditPixel({
+  pixelId: 't2_abcdef',
+  initOptions: {
+    dpm: ['LDU'],
+    dpcc: 'US',
+    dprc: 'CA',
+  },
+})
+```
+
+Reddit can also receive attribution matching signals such as `email`,
+`phoneNumber`, `externalId`, `aaid`, and `idfa`. Only pass those fields after
+you have the right consent or legal basis for your use case:
+
+```ts
+redditPixel({
+  pixelId: 't2_abcdef',
+  initOptions: {
+    email: 'person@example.com',
+    externalId: 'customer-123',
+    aam: {
+      email: false,
+      phone_number: false,
+    },
+  },
+})
+```
+
+See Reddit's docs for [Limited Data Use](https://business.reddithelp.com/s/article/Limited-Data-Use),
+[event metadata](https://business.reddithelp.com/s/article/about-event-metadata),
+and [event deduplication](https://business.reddithelp.com/s/article/event-deduplication).
+
 ## Tracking events in your app
 
 c15t gates the Reddit Pixel script from loading until `marketing` consent is granted. Your application code that calls Reddit's runtime API (`window.rdt(...)`) is **not** automatically gated - `window.rdt` does not exist until the script is loaded, so unguarded calls before consent throw.
@@ -46,13 +113,18 @@ Guard event calls by checking consent state. From React:
 ```tsx
 import { useCallback } from 'react';
 import { useConsentManager } from '@c15t/react';
+import { redditPixelEvent } from '@c15t/scripts/reddit-pixel';
 
 function CheckoutExample() {
   const { has } = useConsentManager();
 
   const trackPurchase = useCallback(() => {
     if (has('marketing')) {
-      window.rdt?.('track', 'Purchase', { currency: 'USD', value: 99 });
+      redditPixelEvent('Purchase', {
+        currency: 'USD',
+        value: 99,
+        conversionId: 'order-123',
+      });
     }
   }, [has]);
 
@@ -68,15 +140,31 @@ import { getOrCreateConsentRuntime } from 'c15t';
 const { consentStore } = getOrCreateConsentRuntime();
 
 if (consentStore.getState().has('marketing')) {
-  window.rdt?.('track', 'Purchase', { currency: 'USD', value: 99 });
+  window.rdt?.('track', 'Purchase', {
+    currency: 'USD',
+    value: 99,
+    conversionId: 'order-123',
+  });
 }
 ```
+
+When you use Reddit Pixel and Conversions API together, send the same
+`conversionId` in the browser event and the server event so Reddit can
+deduplicate them.
 
 ## Types
 
 ### RedditPixelOptions
 
 <AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts" name="RedditPixelOptions" />
+
+### RedditPixelInitOptions
+
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts" name="RedditPixelInitOptions" />
+
+### RedditPixelEventMetadata
+
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts" name="RedditPixelEventMetadata" />
 
 ### Script
 

--- a/docs/integrations/snapchat-pixel.mdx
+++ b/docs/integrations/snapchat-pixel.mdx
@@ -44,18 +44,25 @@ snapchatPixel({
 
 c15t gates the Snapchat Pixel script from loading until `marketing` consent is granted. Your application code that calls Snapchat's runtime API (`window.snaptr(...)`) is **not** automatically gated - `window.snaptr` does not exist until the script is loaded, so unguarded calls before consent throw.
 
-Guard event calls by checking consent state. From React:
+Use `snapchatPixelEvent()` for typed standard and custom event tracking. Guard
+event calls by checking consent state. From React:
 
 ```tsx
 import { useCallback } from 'react';
 import { useConsentManager } from '@c15t/react';
+import { snapchatPixelEvent } from '@c15t/scripts/snapchat-pixel';
 
 function CheckoutExample() {
   const { has } = useConsentManager();
 
   const trackPurchase = useCallback(() => {
     if (has('marketing')) {
-      window.snaptr?.('track', 'PURCHASE', { currency: 'USD', price: 99 });
+      snapchatPixelEvent('PURCHASE', {
+        price: 99,
+        currency: 'USD',
+        transaction_id: 'order-123',
+        client_dedup_id: 'event-123',
+      });
     }
   }, [has]);
 
@@ -67,11 +74,12 @@ From plain JavaScript:
 
 ```ts
 import { getOrCreateConsentRuntime } from 'c15t';
+import { snapchatPixelEvent } from '@c15t/scripts/snapchat-pixel';
 
 const { consentStore } = getOrCreateConsentRuntime();
 
 if (consentStore.getState().has('marketing')) {
-  window.snaptr?.('track', 'PURCHASE', { currency: 'USD', price: 99 });
+  snapchatPixelEvent('PURCHASE', { price: 99, currency: 'USD' });
 }
 ```
 
@@ -80,6 +88,10 @@ if (consentStore.getState().has('marketing')) {
 ### SnapchatPixelOptions
 
 <AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts" name="SnapchatPixelOptions" />
+
+### SnapchatPixelEventProperties
+
+<AutoTypeTable path="./packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts" name="SnapchatPixelEventProperties" />
 
 ### Script
 

--- a/docs/integrations/x-pixel.mdx
+++ b/docs/integrations/x-pixel.mdx
@@ -8,6 +8,10 @@ icon: x
 
 X Pixel (formerly Twitter Pixel) is X's conversion tracking and audience building tool. It helps you measure ad performance, retarget website visitors, and optimize campaigns on the X platform.
 
+## Official X documentation
+
+- [Conversion tracking for websites (X Ads Help)](https://business.x.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites)
+
 ## How c15t loads it
 
 - **Category:** `marketing` (Ads & Pixels)
@@ -24,7 +28,7 @@ X Pixel (formerly Twitter Pixel) is X's conversion tracking and audience buildin
 import { xPixel } from '@c15t/scripts/x-pixel';
 
 xPixel({
-  id: '123456789012345',
+  pixelId: '123456789012345',
 })
 ```
 

--- a/packages/scripts/src/__tests__/helpers.ts
+++ b/packages/scripts/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import type { ConsentState, ScriptCallbackInfo } from 'c15t';
+import type { ConsentState, Script, ScriptCallbackInfo } from 'c15t';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 import {
 	type BuiltInScriptIntegrationKey,
@@ -92,6 +92,22 @@ export function createCallbackInfo(
 		consents: deniedConsentState,
 		...overrides,
 	};
+}
+
+export type LifecycleCallbackOverrides = Partial<
+	Omit<ScriptCallbackInfo, 'id'>
+>;
+
+export function runOnBeforeLoad(
+	script: Pick<Script, 'id' | 'onBeforeLoad'>,
+	overrides: LifecycleCallbackOverrides = {}
+): void {
+	script.onBeforeLoad?.(
+		createCallbackInfo({
+			id: script.id,
+			...overrides,
+		})
+	);
 }
 
 /**
@@ -197,6 +213,33 @@ export function expectScriptMatchesIntegration(
  */
 export function toArgumentsArray(value: unknown): unknown[] {
 	return Array.prototype.slice.call(value);
+}
+
+export function expectGoogleConsentDefault(entry: unknown): void {
+	expect(toArgumentsArray(entry)).toEqual([
+		'consent',
+		'default',
+		{
+			security_storage: 'granted',
+			functionality_storage: 'denied',
+			analytics_storage: 'denied',
+			ad_storage: 'denied',
+			ad_user_data: 'denied',
+			ad_personalization: 'denied',
+			personalization_storage: 'denied',
+		},
+	]);
+}
+
+export function expectStubCommandQueue(
+	stub: unknown,
+	queueKey: string,
+	commands: unknown[][]
+): void {
+	const queueOwner = stub as Record<string, unknown> | undefined;
+	expect(queueOwner?.[queueKey]).toEqual(
+		commands.map((command) => toArgumentsArray(command))
+	);
 }
 
 function setupMockBrowser() {

--- a/packages/scripts/src/registry.test.ts
+++ b/packages/scripts/src/registry.test.ts
@@ -277,7 +277,7 @@ const helperParityCases = {
 	microsoftUet: {
 		script: microsoftUet({ id: 'uet-123' }),
 		expected: {
-			alwaysLoad: undefined,
+			alwaysLoad: true,
 			persistAfterConsentRevoked: true,
 			src: '//bat.bing.com/bat.js',
 		},

--- a/packages/scripts/src/registry.test.ts
+++ b/packages/scripts/src/registry.test.ts
@@ -254,7 +254,7 @@ const helperParityCases = {
 		script: redditPixel({ pixelId: 't2_abcdef' }),
 		expected: {
 			alwaysLoad: undefined,
-			persistAfterConsentRevoked: undefined,
+			persistAfterConsentRevoked: true,
 			src: 'https://www.redditstatic.com/ads/pixel.js',
 		},
 	},

--- a/packages/scripts/src/vendors/_shared/attributes.test.ts
+++ b/packages/scripts/src/vendors/_shared/attributes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { booleanDataAttribute, listDataAttribute } from './attributes';
+
+describe('vendor attribute helpers', () => {
+	describe('booleanDataAttribute', () => {
+		it('omits undefined values', () => {
+			expect(booleanDataAttribute(undefined)).toBeUndefined();
+		});
+
+		it('serializes booleans as data attribute strings', () => {
+			expect(booleanDataAttribute(true)).toBe('true');
+			expect(booleanDataAttribute(false)).toBe('false');
+		});
+	});
+
+	describe('listDataAttribute', () => {
+		it('omits undefined values', () => {
+			expect(listDataAttribute(undefined)).toBeUndefined();
+		});
+
+		it('passes through strings', () => {
+			expect(listDataAttribute('example.com')).toBe('example.com');
+		});
+
+		it('joins arrays with commas', () => {
+			expect(listDataAttribute(['example.com', 'www.example.com'])).toBe(
+				'example.com,www.example.com'
+			);
+		});
+	});
+});

--- a/packages/scripts/src/vendors/_shared/attributes.ts
+++ b/packages/scripts/src/vendors/_shared/attributes.ts
@@ -5,6 +5,13 @@
  * @param value - Optional boolean value from a vendor option.
  * @returns `'true'` or `'false'` when a boolean is provided, otherwise
  * `undefined` so the manifest compiler can omit the attribute.
+ *
+ * @example
+ * ```ts
+ * booleanDataAttribute(true); // 'true'
+ * booleanDataAttribute(false); // 'false'
+ * booleanDataAttribute(undefined); // undefined
+ * ```
  */
 export function booleanDataAttribute(
 	value: boolean | undefined
@@ -27,6 +34,13 @@ export function booleanDataAttribute(
  * @param value - Optional string value or string list from a vendor option.
  * @returns The original string, a comma-joined array, or `undefined` so the
  * manifest compiler can omit the attribute.
+ *
+ * @example
+ * ```ts
+ * listDataAttribute('example.com'); // 'example.com'
+ * listDataAttribute(['a.com', 'b.com']); // 'a.com,b.com'
+ * listDataAttribute(undefined); // undefined
+ * ```
  */
 export function listDataAttribute(
 	value: string[] | string | undefined

--- a/packages/scripts/src/vendors/_shared/attributes.ts
+++ b/packages/scripts/src/vendors/_shared/attributes.ts
@@ -1,0 +1,43 @@
+/**
+ * Converts an optional boolean into a string suitable for a script `data-*`
+ * attribute.
+ *
+ * @param value - Optional boolean value from a vendor option.
+ * @returns `'true'` or `'false'` when a boolean is provided, otherwise
+ * `undefined` so the manifest compiler can omit the attribute.
+ */
+export function booleanDataAttribute(
+	value: boolean | undefined
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (value) {
+		return 'true';
+	}
+
+	return 'false';
+}
+
+/**
+ * Converts a string or string list into a comma-separated script `data-*`
+ * attribute value.
+ *
+ * @param value - Optional string value or string list from a vendor option.
+ * @returns The original string, a comma-joined array, or `undefined` so the
+ * manifest compiler can omit the attribute.
+ */
+export function listDataAttribute(
+	value: string[] | string | undefined
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	if (Array.isArray(value)) {
+		return value.join(',');
+	}
+
+	return value;
+}

--- a/packages/scripts/src/vendors/_shared/google-consent.test.ts
+++ b/packages/scripts/src/vendors/_shared/google-consent.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+	GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+	withOptionalConsentMapping,
+} from './google-consent';
+
+describe('google consent helpers', () => {
+	it('exposes the shared Consent Mode v2 mapping', () => {
+		expect(GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING).toEqual({
+			necessary: ['security_storage'],
+			functionality: ['functionality_storage'],
+			measurement: ['analytics_storage'],
+			marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+			experience: ['personalization_storage'],
+		});
+	});
+
+	it('returns the original manifest when no override is provided', () => {
+		const manifest = {
+			vendor: 'gtag',
+			consentMapping: GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+		};
+
+		expect(withOptionalConsentMapping(manifest, undefined)).toBe(manifest);
+	});
+
+	it('returns a manifest with an override mapping when provided', () => {
+		const manifest = {
+			vendor: 'gtag',
+			consentMapping: GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+		};
+		const consentMapping = {
+			measurement: ['analytics_storage'],
+		};
+
+		expect(withOptionalConsentMapping(manifest, consentMapping)).toEqual({
+			vendor: 'gtag',
+			consentMapping,
+		});
+	});
+});

--- a/packages/scripts/src/vendors/_shared/google-consent.ts
+++ b/packages/scripts/src/vendors/_shared/google-consent.ts
@@ -4,6 +4,13 @@
  * @remarks
  * Shared by direct gtag.js and Google Tag Manager integrations so both emit the
  * same Google storage consent defaults unless a caller provides an override.
+ *
+ * @example
+ * ```ts
+ * const manifest = {
+ * 	consentMapping: GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+ * };
+ * ```
  */
 export const GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING: Record<string, string[]> =
 	{
@@ -23,6 +30,25 @@ export const GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING: Record<string, string[]> =
  * categories to Google consent types.
  * @returns The original manifest when no override is provided, or a shallow
  * copy with the override mapping when one is provided.
+ *
+ * @example
+ * ```ts
+ * const customMapping: Record<string, string[]> = {
+ * 	marketing: ['ad_storage'],
+ * };
+ * const mapped = withOptionalConsentMapping<TManifest>(
+ * 	manifest,
+ * 	customMapping
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * const unchanged = withOptionalConsentMapping<TManifest>(
+ * 	manifest,
+ * 	undefined
+ * );
+ * ```
  */
 export function withOptionalConsentMapping<
 	TManifest extends {

--- a/packages/scripts/src/vendors/_shared/google-consent.ts
+++ b/packages/scripts/src/vendors/_shared/google-consent.ts
@@ -1,0 +1,43 @@
+/**
+ * Default c15t consent category mapping for Google Consent Mode v2.
+ *
+ * @remarks
+ * Shared by direct gtag.js and Google Tag Manager integrations so both emit the
+ * same Google storage consent defaults unless a caller provides an override.
+ */
+export const GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING: Record<string, string[]> =
+	{
+		necessary: ['security_storage'],
+		functionality: ['functionality_storage'],
+		measurement: ['analytics_storage'],
+		marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
+		experience: ['personalization_storage'],
+	};
+
+/**
+ * Applies an optional Google consent mapping override to a manifest.
+ *
+ * @param manifest - Vendor manifest that already contains the default consent
+ * mapping.
+ * @param consentMapping - Optional caller-provided mapping from c15t consent
+ * categories to Google consent types.
+ * @returns The original manifest when no override is provided, or a shallow
+ * copy with the override mapping when one is provided.
+ */
+export function withOptionalConsentMapping<
+	TManifest extends {
+		consentMapping?: Record<string, string[]>;
+	},
+>(
+	manifest: TManifest,
+	consentMapping: Record<string, string[]> | undefined
+): TManifest {
+	if (consentMapping === undefined) {
+		return manifest;
+	}
+
+	return {
+		...manifest,
+		consentMapping,
+	};
+}

--- a/packages/scripts/src/vendors/_shared/install-builders.test.ts
+++ b/packages/scripts/src/vendors/_shared/install-builders.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildQueuePixelInstall } from './install-builders';
+
+describe('vendor install builders', () => {
+	it('builds an init call followed by a script load', () => {
+		expect(
+			buildQueuePixelInstall({
+				global: 'rdt',
+				initArgs: ['init', '{{pixelId}}'],
+			})
+		).toEqual([
+			{
+				type: 'callGlobal',
+				global: 'rdt',
+				args: ['init', '{{pixelId}}'],
+			},
+			{
+				type: 'loadScript',
+				src: '{{scriptUrl}}',
+				async: true,
+			},
+		]);
+	});
+
+	it('adds an optional tracking call before loading the script', () => {
+		expect(
+			buildQueuePixelInstall({
+				global: 'snaptr',
+				initArgs: ['init', '{{pixelId}}'],
+				trackStep: {
+					args: ['track', 'PAGE_VIEW'],
+				},
+			})
+		).toEqual([
+			{
+				type: 'callGlobal',
+				global: 'snaptr',
+				args: ['init', '{{pixelId}}'],
+			},
+			{
+				type: 'callGlobal',
+				global: 'snaptr',
+				args: ['track', 'PAGE_VIEW'],
+			},
+			{
+				type: 'loadScript',
+				src: '{{scriptUrl}}',
+				async: true,
+			},
+		]);
+	});
+
+	it('supports a custom script placeholder', () => {
+		expect(
+			buildQueuePixelInstall({
+				global: 'pixel',
+				initArgs: ['init'],
+				scriptPlaceholder: '{{loaderUrl}}',
+			})
+		).toContainEqual({
+			type: 'loadScript',
+			src: '{{loaderUrl}}',
+			async: true,
+		});
+	});
+});

--- a/packages/scripts/src/vendors/_shared/install-builders.ts
+++ b/packages/scripts/src/vendors/_shared/install-builders.ts
@@ -1,0 +1,61 @@
+import type { VendorManifest } from '../../types';
+
+/**
+ * Optional tracking call inserted between the vendor init call and script load.
+ */
+interface QueuePixelInstallStep {
+	/** Arguments passed to the vendor queue function. */
+	args: unknown[];
+}
+
+/**
+ * Options for building the common pixel install sequence.
+ */
+export interface BuildQueuePixelInstallOptions {
+	/** Global queue function to call, for example `rdt` or `snaptr`. */
+	global: string;
+	/** Arguments for the required initialization call. */
+	initArgs: unknown[];
+	/** Optional tracking command queued immediately after initialization. */
+	trackStep?: QueuePixelInstallStep;
+	/** Manifest interpolation token used for the final loader script URL. */
+	scriptPlaceholder?: string;
+}
+
+/**
+ * Builds the common queue-pixel install sequence used by advertising pixels.
+ *
+ * @param options - Queue pixel install options.
+ * @returns Manifest install steps containing the required init call, an
+ * optional tracking call, and an async `loadScript` step.
+ */
+export function buildQueuePixelInstall({
+	global,
+	initArgs,
+	trackStep,
+	scriptPlaceholder = '{{scriptUrl}}',
+}: BuildQueuePixelInstallOptions): VendorManifest['install'] {
+	const install: VendorManifest['install'] = [
+		{
+			type: 'callGlobal',
+			global,
+			args: initArgs,
+		},
+	];
+
+	if (trackStep !== undefined) {
+		install.push({
+			type: 'callGlobal',
+			global,
+			args: trackStep.args,
+		});
+	}
+
+	install.push({
+		type: 'loadScript',
+		src: scriptPlaceholder,
+		async: true,
+	});
+
+	return install;
+}

--- a/packages/scripts/src/vendors/_shared/script-url.test.ts
+++ b/packages/scripts/src/vendors/_shared/script-url.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { joinUrlPath, resolveScriptUrl, trimToUndefined } from './script-url';
+
+describe('vendor script URL helpers', () => {
+	describe('trimToUndefined', () => {
+		it('returns undefined for missing and blank values', () => {
+			expect(trimToUndefined(undefined)).toBeUndefined();
+			expect(trimToUndefined('')).toBeUndefined();
+			expect(trimToUndefined('   ')).toBeUndefined();
+		});
+
+		it('returns trimmed non-empty values', () => {
+			expect(trimToUndefined('  https://cdn.example.com/script.js  ')).toBe(
+				'https://cdn.example.com/script.js'
+			);
+		});
+	});
+
+	describe('resolveScriptUrl', () => {
+		it('uses the fallback when no override is provided', () => {
+			expect(
+				resolveScriptUrl(undefined, 'https://cdn.example.com/default.js')
+			).toBe('https://cdn.example.com/default.js');
+		});
+
+		it('uses the override when provided', () => {
+			expect(
+				resolveScriptUrl(
+					'https://cdn.example.com/custom.js',
+					'https://cdn.example.com/default.js'
+				)
+			).toBe('https://cdn.example.com/custom.js');
+		});
+	});
+
+	describe('joinUrlPath', () => {
+		it('joins base URLs and paths with one slash', () => {
+			expect(
+				joinUrlPath('https://analytics.example.com///', '/script.js')
+			).toBe('https://analytics.example.com/script.js');
+		});
+	});
+});

--- a/packages/scripts/src/vendors/_shared/script-url.ts
+++ b/packages/scripts/src/vendors/_shared/script-url.ts
@@ -5,6 +5,13 @@
  * @param value - Optional string value, usually a user-provided override.
  * @returns The trimmed string when it contains non-whitespace characters,
  * otherwise `undefined`.
+ *
+ * @example
+ * ```ts
+ * trimToUndefined('  https://cdn.example.com  '); // 'https://cdn.example.com'
+ * trimToUndefined('   '); // undefined
+ * trimToUndefined(undefined); // undefined
+ * ```
  */
 export function trimToUndefined(value: string | undefined): string | undefined {
 	if (value === undefined) {
@@ -30,6 +37,21 @@ export function trimToUndefined(value: string | undefined): string | undefined {
  * This helper intentionally does not trim or validate the override. Use
  * `trimToUndefined` before calling this helper when blank string overrides
  * should fall back to the vendor default.
+ *
+ * @example
+ * ```ts
+ * resolveScriptUrl(undefined, 'https://cdn.example.com/default.js');
+ * // 'https://cdn.example.com/default.js'
+ * ```
+ *
+ * @example
+ * ```ts
+ * resolveScriptUrl(
+ * 	'https://custom.com/script.js',
+ * 	'https://cdn.example.com/default.js'
+ * );
+ * // 'https://custom.com/script.js'
+ * ```
  */
 export function resolveScriptUrl(
 	override: string | undefined,
@@ -48,6 +70,15 @@ export function resolveScriptUrl(
  * @param base - Base URL or origin. Trailing slashes are removed before joining.
  * @param path - Path segment. Leading slashes are removed before joining.
  * @returns A slash-joined URL string.
+ *
+ * @example
+ * ```ts
+ * joinUrlPath('https://example.com///', '///script.js');
+ * // 'https://example.com/script.js'
+ *
+ * joinUrlPath('https://example.com', 'script.js');
+ * // 'https://example.com/script.js'
+ * ```
  */
 export function joinUrlPath(base: string, path: string): string {
 	return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;

--- a/packages/scripts/src/vendors/_shared/script-url.ts
+++ b/packages/scripts/src/vendors/_shared/script-url.ts
@@ -1,0 +1,54 @@
+/**
+ * Trims an optional string and treats empty or whitespace-only values as
+ * missing.
+ *
+ * @param value - Optional string value, usually a user-provided override.
+ * @returns The trimmed string when it contains non-whitespace characters,
+ * otherwise `undefined`.
+ */
+export function trimToUndefined(value: string | undefined): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	if (trimmed.length === 0) {
+		return undefined;
+	}
+
+	return trimmed;
+}
+
+/**
+ * Resolves a script URL from an optional override and a required fallback.
+ *
+ * @param override - Explicit script URL supplied by the integration caller.
+ * @param fallback - Default vendor script URL.
+ * @returns `override` when it is defined, otherwise `fallback`.
+ *
+ * @remarks
+ * This helper intentionally does not trim or validate the override. Use
+ * `trimToUndefined` before calling this helper when blank string overrides
+ * should fall back to the vendor default.
+ */
+export function resolveScriptUrl(
+	override: string | undefined,
+	fallback: string
+): string {
+	if (override !== undefined) {
+		return override;
+	}
+
+	return fallback;
+}
+
+/**
+ * Joins a base URL and path with exactly one slash between them.
+ *
+ * @param base - Base URL or origin. Trailing slashes are removed before joining.
+ * @param path - Path segment. Leading slashes are removed before joining.
+ * @returns A slash-joined URL string.
+ */
+export function joinUrlPath(base: string, path: string): string {
+	return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}

--- a/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+	expectScriptMatchesIntegration,
+	getTestGlobal,
+	runOnBeforeLoad,
+	setupScriptHelperTest,
+} from '../../__tests__/helpers';
+import { linkedinInsights } from './linkedin-insights';
+
+describe('linkedinInsights', () => {
+	setupScriptHelperTest();
+
+	it('matches registry metadata with default loader URL', () => {
+		const script = linkedinInsights({ id: '987654' });
+
+		expectScriptMatchesIntegration('linkedinInsights', script, {
+			alwaysLoad: undefined,
+			persistAfterConsentRevoked: undefined,
+			src: 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
+		});
+	});
+
+	it('sets LinkedIn globals and initializes lintrk queue', () => {
+		const globalRef = getTestGlobal();
+		const script = linkedinInsights({ id: '987654' });
+
+		runOnBeforeLoad(script);
+
+		expect(globalRef._linkedin_partner_id).toBe('987654');
+		expect(globalRef._linkedin_data_partner_ids).toEqual(['987654']);
+
+		const lintrk = globalRef.lintrk as
+			| (((...args: unknown[]) => void) & { q?: unknown[][] })
+			| undefined;
+		expect(typeof lintrk).toBe('function');
+		expect(lintrk?.q).toEqual([]);
+
+		lintrk?.('track', { conversion_id: 'abc123' });
+		expect(lintrk?.q).toEqual([['track', { conversion_id: 'abc123' }]]);
+	});
+
+	it('supports overriding the loader URL', () => {
+		const script = linkedinInsights({
+			id: '987654',
+			scriptSrc: 'https://cdn.example.com/insight.min.js',
+		});
+
+		expect(script.src).toBe('https://cdn.example.com/insight.min.js');
+	});
+});

--- a/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
 	expectScriptMatchesIntegration,
+	expectStubCommandQueue,
 	getTestGlobal,
 	runOnBeforeLoad,
 	setupScriptHelperTest,
 } from '../../__tests__/helpers';
 import { linkedinInsights } from './linkedin-insights';
+
+type LintrkStub =
+	| (((...args: unknown[]) => void) & {
+			q?: unknown[][];
+	  })
+	| undefined;
 
 describe('linkedinInsights', () => {
 	setupScriptHelperTest();
@@ -29,14 +36,27 @@ describe('linkedinInsights', () => {
 		expect(globalRef._linkedin_partner_id).toBe('987654');
 		expect(globalRef._linkedin_data_partner_ids).toEqual(['987654']);
 
-		const lintrk = globalRef.lintrk as
-			| (((...args: unknown[]) => void) & { q?: unknown[][] })
-			| undefined;
+		const lintrk = globalRef.lintrk as LintrkStub;
 		expect(typeof lintrk).toBe('function');
-		expect(lintrk?.q).toEqual([]);
+		expectStubCommandQueue(lintrk, 'q', []);
 
 		lintrk?.('track', { conversion_id: 'abc123' });
-		expect(lintrk?.q).toEqual([['track', { conversion_id: 'abc123' }]]);
+		expectStubCommandQueue(lintrk, 'q', [
+			['track', { conversion_id: 'abc123' }],
+		]);
+	});
+
+	it('preserves existing data partner IDs while appending the partner ID', () => {
+		const globalRef = getTestGlobal();
+		globalRef._linkedin_data_partner_ids = ['existing'];
+		const script = linkedinInsights({ id: '987654' });
+
+		runOnBeforeLoad(script);
+
+		expect(globalRef._linkedin_data_partner_ids).toEqual([
+			'existing',
+			'987654',
+		]);
 	});
 
 	it('supports overriding the loader URL', () => {

--- a/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.ts
@@ -2,10 +2,20 @@ import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 
-// Extended Window interface to include linkedin insights specific properties
+export interface LinkedInInsightsConversionEvent {
+	conversion_id: string | number;
+	[key: string]: unknown;
+}
+
+type LinkedInInsightsFunction = {
+	(command: 'track', event: LinkedInInsightsConversionEvent): void;
+	(command: string, ...args: unknown[]): void;
+};
+
+// Extended Window interface to include LinkedIn Insight Tag specific properties.
 declare global {
 	interface Window {
-		lintrk: ((...args: unknown[]) => void) & { q?: unknown[][] };
+		lintrk: LinkedInInsightsFunction & { q?: unknown[][] };
 		_linkedin_partner_id?: string;
 		_linkedin_data_partner_ids?: string[];
 		ORIBILI?: {
@@ -17,9 +27,9 @@ declare global {
 }
 
 /**
- * LinkedIn Insights vendor manifest.
+ * LinkedIn Insight Tag vendor manifest.
  *
- * Sets up the LinkedIn partner ID globals and loads the insights script
+ * Sets up the LinkedIn partner ID globals and loads the Insight Tag script
  * via structured startup steps.
  */
 export const linkedinInsightsManifest = {
@@ -63,20 +73,24 @@ export const linkedinInsightsManifest = {
 
 export interface LinkedInInsightsOptions {
 	/**
-	 * Your LinkedIn Insights ID
+	 * Your LinkedIn Insight Tag partner ID.
+	 *
+	 * LinkedIn shows this in Campaign Manager under Data -> Signals manager ->
+	 * Insight Tag.
+	 *
 	 * @example `123456789012345`
 	 */
 	id: string;
 
-	/** LinkedIn Insights loader URL. */
+	/** LinkedIn Insight Tag loader URL. */
 	scriptSrc?: string;
 }
 
 /**
- * LinkedIn Insights Script
+ * LinkedIn Insight Tag script.
  *
- * @param options - The options for the LinkedIn Insights script
- * @returns The LinkedIn Insights script configuration
+ * @param options - The options for the LinkedIn Insight Tag script.
+ * @returns The LinkedIn Insight Tag script configuration.
  *
  * @example
  * ```ts
@@ -85,7 +99,7 @@ export interface LinkedInInsightsOptions {
  * });
  * ```
  *
- * @see {@link https://business.linkedin.com/marketing-solutions/ad-libraries/insights} LinkedIn Insights documentation
+ * @see {@link https://www.linkedin.com/help/lms/answer/a418880} Add the LinkedIn Insight Tag to your website
  */
 export function linkedinInsights({
 	id,

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
@@ -6,7 +6,13 @@ import {
 	getTestGlobal,
 	setupScriptHelperTest,
 } from '../../__tests__/helpers';
-import { metaPixel, metaPixelEvent } from './meta-pixel';
+import {
+	metaPixel,
+	metaPixelCustomEvent,
+	metaPixelEvent,
+	metaPixelSingleCustomEvent,
+	metaPixelSingleEvent,
+} from './meta-pixel';
 
 describe('metaPixel', () => {
 	setupScriptHelperTest();
@@ -38,6 +44,71 @@ describe('metaPixel', () => {
 		expect(globalRef._fbq).toBe(fbq);
 		expectStubCommandQueue(fbq, 'queue', [
 			['consent', 'grant'],
+			['init', '123456'],
+			['track', 'PageView'],
+		]);
+	});
+
+	it('supports init options and disabling the default PageView', () => {
+		const globalRef = getTestGlobal();
+		const script = metaPixel({
+			pixelId: '123456',
+			initOptions: { external_id: 'customer-123' },
+			trackPageView: false,
+		});
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+
+		const fbq = globalRef.fbq as
+			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
+			| undefined;
+		expectStubCommandQueue(fbq, 'queue', [
+			['consent', 'grant'],
+			['init', '123456', { external_id: 'customer-123' }],
+		]);
+	});
+
+	it('queues data processing options before pixel init', () => {
+		const globalRef = getTestGlobal();
+		const script = metaPixel({
+			pixelId: '123456',
+			dataProcessingOptions: {
+				options: ['LDU'],
+				country: 1,
+				state: 1000,
+			},
+		});
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+
+		const fbq = globalRef.fbq as
+			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
+			| undefined;
+		expectStubCommandQueue(fbq, 'queue', [
+			['consent', 'grant'],
+			['dataProcessingOptions', ['LDU'], 1, 1000],
+			['init', '123456'],
+			['track', 'PageView'],
+		]);
+	});
+
+	it('supports explicitly disabling limited data use', () => {
+		const globalRef = getTestGlobal();
+		const script = metaPixel({
+			pixelId: '123456',
+			dataProcessingOptions: {
+				options: [],
+			},
+		});
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+
+		const fbq = globalRef.fbq as
+			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
+			| undefined;
+		expectStubCommandQueue(fbq, 'queue', [
+			['consent', 'grant'],
+			['dataProcessingOptions', []],
 			['init', '123456'],
 			['track', 'PageView'],
 		]);
@@ -104,6 +175,98 @@ describe('metaPixelEvent', () => {
 				currency: 'USD',
 			},
 			undefined
+		);
+	});
+
+	it('forwards event IDs using Meta event options', () => {
+		const globalRef = getTestGlobal();
+		const fbq = vi.fn();
+		globalRef.fbq = fbq;
+
+		metaPixelEvent(
+			'Purchase',
+			{
+				value: 10,
+				currency: 'USD',
+			},
+			'event-123'
+		);
+
+		expect(fbq).toHaveBeenCalledWith(
+			'track',
+			'Purchase',
+			{
+				value: 10,
+				currency: 'USD',
+			},
+			{ eventID: 'event-123' }
+		);
+	});
+
+	it('forwards custom event payloads to fbq', () => {
+		const globalRef = getTestGlobal();
+		const fbq = vi.fn();
+		globalRef.fbq = fbq;
+
+		metaPixelCustomEvent(
+			'ShareDiscount',
+			{ promotion: 'share_discount_10%' },
+			{ eventID: 'event-456' }
+		);
+
+		expect(fbq).toHaveBeenCalledWith(
+			'trackCustom',
+			'ShareDiscount',
+			{ promotion: 'share_discount_10%' },
+			{ eventID: 'event-456' }
+		);
+	});
+
+	it('supports tracking a standard event for a single pixel', () => {
+		const globalRef = getTestGlobal();
+		const fbq = vi.fn();
+		globalRef.fbq = fbq;
+
+		metaPixelSingleEvent(
+			'pixel-a',
+			'Lead',
+			{
+				value: 40,
+				currency: 'USD',
+			},
+			'event-789'
+		);
+
+		expect(fbq).toHaveBeenCalledWith(
+			'trackSingle',
+			'pixel-a',
+			'Lead',
+			{
+				value: 40,
+				currency: 'USD',
+			},
+			{ eventID: 'event-789' }
+		);
+	});
+
+	it('supports tracking a custom event for a single pixel', () => {
+		const globalRef = getTestGlobal();
+		const fbq = vi.fn();
+		globalRef.fbq = fbq;
+
+		metaPixelSingleCustomEvent(
+			'pixel-b',
+			'Step4',
+			{ funnel: 'checkout' },
+			'event-abc'
+		);
+
+		expect(fbq).toHaveBeenCalledWith(
+			'trackSingleCustom',
+			'pixel-b',
+			'Step4',
+			{ funnel: 'checkout' },
+			{ eventID: 'event-abc' }
 		);
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createCallbackInfo,
+	expectScriptMatchesIntegration,
+	expectStubCommandQueue,
+	getTestGlobal,
+	setupScriptHelperTest,
+} from '../../__tests__/helpers';
+import { metaPixel, metaPixelEvent } from './meta-pixel';
+
+describe('metaPixel', () => {
+	setupScriptHelperTest();
+
+	it('matches registry metadata with default loader URL', () => {
+		const script = metaPixel({ pixelId: '123456' });
+
+		expectScriptMatchesIntegration('metaPixel', script, {
+			alwaysLoad: undefined,
+			persistAfterConsentRevoked: true,
+			src: 'https://connect.facebook.net/en_US/fbevents.js',
+		});
+	});
+
+	it('seeds fbq queue with consent grant, init, and PageView', () => {
+		const globalRef = getTestGlobal();
+		const script = metaPixel({ pixelId: '123456' });
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+
+		const fbq = globalRef.fbq as
+			| (((...args: unknown[]) => void) & {
+					queue?: unknown[][];
+					version?: string;
+			  })
+			| undefined;
+
+		expect(fbq?.version).toBe('2.0');
+		expect(globalRef._fbq).toBe(fbq);
+		expectStubCommandQueue(fbq, 'queue', [
+			['consent', 'grant'],
+			['init', '123456'],
+			['track', 'PageView'],
+		]);
+	});
+
+	it('maps consent changes to fbq consent calls', () => {
+		const globalRef = getTestGlobal();
+		const script = metaPixel({ pixelId: '123456' });
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+			})
+		);
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: false,
+			})
+		);
+
+		const fbq = globalRef.fbq as
+			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
+			| undefined;
+		expectStubCommandQueue(fbq, 'queue', [
+			['consent', 'grant'],
+			['init', '123456'],
+			['track', 'PageView'],
+			['consent', 'grant'],
+			['consent', 'revoke'],
+		]);
+	});
+
+	it('supports overriding the loader URL', () => {
+		const script = metaPixel({
+			pixelId: '123456',
+			scriptSrc: 'https://cdn.example.com/fbevents.js',
+		});
+
+		expect(script.src).toBe('https://cdn.example.com/fbevents.js');
+	});
+});
+
+describe('metaPixelEvent', () => {
+	setupScriptHelperTest();
+
+	it('forwards event payload to fbq', () => {
+		const globalRef = getTestGlobal();
+		const fbq = vi.fn();
+		globalRef.fbq = fbq;
+
+		metaPixelEvent('Purchase', {
+			value: 10,
+			currency: 'USD',
+		});
+
+		expect(fbq).toHaveBeenCalledWith('track', 'Purchase', {
+			value: 10,
+			currency: 'USD',
+		}, undefined);
+	});
+});

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.test.ts
@@ -96,9 +96,14 @@ describe('metaPixelEvent', () => {
 			currency: 'USD',
 		});
 
-		expect(fbq).toHaveBeenCalledWith('track', 'Purchase', {
-			value: 10,
-			currency: 'USD',
-		}, undefined);
+		expect(fbq).toHaveBeenCalledWith(
+			'track',
+			'Purchase',
+			{
+				value: 10,
+				currency: 'USD',
+			},
+			undefined
+		);
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { buildQueuePixelInstall } from '../_shared/install-builders';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 /**
  * Represents the `contents` array object property.
@@ -22,6 +24,7 @@ export interface FbqBaseEventParams {
 	content_type?: 'product' | 'product_group';
 	contents?: FbqContent[];
 	currency?: string;
+	delivery_category?: 'in_store' | 'curbside' | 'home_delivery';
 	num_items?: number;
 	predicted_ltv?: number;
 	search_string?: string;
@@ -29,69 +32,80 @@ export interface FbqBaseEventParams {
 	value?: number;
 }
 
-type AddPaymentInfoParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'contents' | 'currency' | 'value'
->;
-type AddToCartParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'content_type' | 'contents' | 'currency' | 'value'
->;
-type AddToWishlistParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'contents' | 'currency' | 'value'
->;
-type CompleteRegistrationParams = Pick<
-	FbqBaseEventParams,
-	'currency' | 'value' | 'status'
->;
-type InitiateCheckoutParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'contents' | 'currency' | 'num_items' | 'value'
->;
-type LeadParams = Pick<FbqBaseEventParams, 'currency' | 'value'>;
+export type FbqCustomParams = Record<string, unknown>;
+type WithCustomParams<TParams> = TParams & FbqCustomParams;
 
-type SearchParams = Pick<
-	FbqBaseEventParams,
-	| 'content_ids'
-	| 'content_type'
-	| 'contents'
-	| 'currency'
-	| 'search_string'
-	| 'value'
+type AddPaymentInfoParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'content_ids' | 'contents' | 'currency' | 'value'>
 >;
-type StartTrialParams = Pick<
-	FbqBaseEventParams,
-	'currency' | 'predicted_ltv' | 'value'
+type AddToCartParams = WithCustomParams<
+	Pick<
+		FbqBaseEventParams,
+		'content_ids' | 'content_type' | 'contents' | 'currency' | 'value'
+	>
 >;
-type SubscribeParams = Pick<
-	FbqBaseEventParams,
-	'currency' | 'predicted_ltv' | 'value'
+type AddToWishlistParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'content_ids' | 'contents' | 'currency' | 'value'>
 >;
-type ViewContentParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'content_type' | 'contents' | 'currency' | 'value'
+type CompleteRegistrationParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'currency' | 'value' | 'status'>
+>;
+type InitiateCheckoutParams = WithCustomParams<
+	Pick<
+		FbqBaseEventParams,
+		'content_ids' | 'contents' | 'currency' | 'num_items' | 'value'
+	>
+>;
+type LeadParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'currency' | 'value'>
+>;
+type PageViewParams = FbqCustomParams;
+
+type SearchParams = WithCustomParams<
+	Pick<
+		FbqBaseEventParams,
+		| 'content_ids'
+		| 'content_type'
+		| 'contents'
+		| 'currency'
+		| 'search_string'
+		| 'value'
+	>
+>;
+type StartTrialParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'currency' | 'predicted_ltv' | 'value'>
+>;
+type SubscribeParams = WithCustomParams<
+	Pick<FbqBaseEventParams, 'currency' | 'predicted_ltv' | 'value'>
+>;
+type ViewContentParams = WithCustomParams<
+	Pick<
+		FbqBaseEventParams,
+		'content_ids' | 'content_type' | 'contents' | 'currency' | 'value'
+	>
 >;
 
 /**
  * The 'Purchase' event has required properties.
  * We use TypeScript's utility types to enforce this.
  */
-type PurchaseParams = Pick<
-	FbqBaseEventParams,
-	'content_ids' | 'content_type' | 'contents' | 'num_items'
-> &
-	Required<Pick<FbqBaseEventParams, 'currency' | 'value'>>;
+type PurchaseParams = WithCustomParams<
+	Pick<
+		FbqBaseEventParams,
+		'content_ids' | 'content_type' | 'contents' | 'num_items'
+	> &
+		Required<Pick<FbqBaseEventParams, 'currency' | 'value'>>
+>;
 
 /**
  * Events with no specific properties listed can accept any of the base parameters.
  */
-type ContactParams = FbqBaseEventParams;
-type CustomizeProductParams = FbqBaseEventParams;
-type DonateParams = FbqBaseEventParams;
-type FindLocationParams = FbqBaseEventParams;
-type ScheduleParams = FbqBaseEventParams;
-type SubmitApplicationParams = FbqBaseEventParams;
+type ContactParams = WithCustomParams<FbqBaseEventParams>;
+type CustomizeProductParams = WithCustomParams<FbqBaseEventParams>;
+type DonateParams = WithCustomParams<FbqBaseEventParams>;
+type FindLocationParams = WithCustomParams<FbqBaseEventParams>;
+type ScheduleParams = WithCustomParams<FbqBaseEventParams>;
+type SubmitApplicationParams = WithCustomParams<FbqBaseEventParams>;
 
 /**
  * A mapping of Standard Event names to their corresponding parameter types.
@@ -108,6 +122,7 @@ export interface StandardEventParams {
 	FindLocation: FindLocationParams;
 	InitiateCheckout: InitiateCheckoutParams;
 	Lead: LeadParams;
+	PageView: PageViewParams;
 	Purchase: PurchaseParams;
 	Schedule: ScheduleParams;
 	Search: SearchParams;
@@ -119,16 +134,77 @@ export interface StandardEventParams {
 
 export type StandardEventName = keyof StandardEventParams;
 
+export interface MetaPixelEventOptions {
+	/**
+	 * Event ID used to deduplicate browser events against Conversions API events.
+	 *
+	 * @see https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events
+	 */
+	eventID?: string;
+	[key: string]: unknown;
+}
+
+export interface MetaPixelDataProcessingOptions {
+	/**
+	 * Data processing flags sent to Meta before `init`.
+	 *
+	 * Use `['LDU']` to enable Limited Data Use, or `[]` to explicitly disable it.
+	 */
+	options: 'LDU'[] | [];
+
+	/**
+	 * Meta country code. Use `0` to let Meta geolocate the event or `1` for USA.
+	 */
+	country?: number;
+
+	/**
+	 * Meta state code. Use `0` to let Meta geolocate the event.
+	 *
+	 * @example `1000` for California
+	 */
+	state?: number;
+}
+
 // Extended Window interface to include meta pixel specific properties
 declare global {
 	interface Window {
 		fbq: {
-			(command: 'init', pixelId: string): void;
+			(
+				command: 'dataProcessingOptions',
+				options: MetaPixelDataProcessingOptions['options'],
+				country?: number,
+				state?: number
+			): void;
+			(
+				command: 'init',
+				pixelId: string,
+				options?: Record<string, unknown>
+			): void;
 			(
 				command: 'track',
 				eventName: StandardEventName,
 				params?: StandardEventParams[StandardEventName],
-				eventId?: string
+				options?: MetaPixelEventOptions
+			): void;
+			(
+				command: 'trackCustom',
+				eventName: string,
+				params?: FbqCustomParams,
+				options?: MetaPixelEventOptions
+			): void;
+			(
+				command: 'trackSingle',
+				pixelId: string,
+				eventName: StandardEventName,
+				params?: StandardEventParams[StandardEventName],
+				options?: MetaPixelEventOptions
+			): void;
+			(
+				command: 'trackSingleCustom',
+				pixelId: string,
+				eventName: string,
+				params?: FbqCustomParams,
+				options?: MetaPixelEventOptions
 			): void;
 			(command: 'consent', action: 'grant' | 'revoke'): void;
 			(...args: unknown[]): void;
@@ -210,6 +286,24 @@ export interface MetaPixelOptions {
 	 */
 	pixelId: string;
 
+	/** Optional payload passed as the third argument to `fbq('init', ...)`. */
+	initOptions?: Record<string, unknown>;
+
+	/**
+	 * Queue the default `PageView` event during setup.
+	 *
+	 * @default true
+	 */
+	trackPageView?: boolean;
+
+	/**
+	 * Optional Meta data processing options, such as Limited Data Use.
+	 *
+	 * When provided, c15t queues `fbq('dataProcessingOptions', ...)` before
+	 * `fbq('init', ...)`.
+	 */
+	dataProcessingOptions?: MetaPixelDataProcessingOptions;
+
 	/** Meta Pixel loader URL. */
 	scriptSrc?: string;
 }
@@ -232,13 +326,111 @@ export interface MetaPixelOptions {
  *
  * @see {@link https://developers.facebook.com/docs/meta-pixel/get-started} Meta Pixel documentation
  */
-export function metaPixel({ pixelId, scriptSrc }: MetaPixelOptions): Script {
-	const resolved = resolveManifest(metaPixelManifest, {
+export function metaPixel({
+	pixelId,
+	initOptions,
+	trackPageView = true,
+	dataProcessingOptions,
+	scriptSrc,
+}: MetaPixelOptions): Script {
+	const install = buildMetaPixelInstall({
+		hasInitOptions: initOptions !== undefined,
+		trackPageView,
+		dataProcessingOptions,
+	});
+
+	const manifest = {
+		...metaPixelManifest,
+		install,
+	} as const satisfies VendorManifest;
+
+	const resolved = resolveManifest(manifest, {
 		pixelId,
-		scriptSrc: scriptSrc ?? 'https://connect.facebook.net/en_US/fbevents.js',
+		initOptions,
+		scriptSrc: resolveScriptUrl(
+			scriptSrc,
+			'https://connect.facebook.net/en_US/fbevents.js'
+		),
 	});
 
 	return resolved;
+}
+
+function buildMetaPixelInstall({
+	hasInitOptions,
+	trackPageView,
+	dataProcessingOptions,
+}: {
+	hasInitOptions: boolean;
+	trackPageView: boolean;
+	dataProcessingOptions?: MetaPixelDataProcessingOptions;
+}): VendorManifest['install'] {
+	const initArgs: unknown[] = ['init', '{{pixelId}}'];
+
+	if (hasInitOptions) {
+		initArgs.push('{{initOptions}}');
+	}
+
+	const install = buildQueuePixelInstall({
+		global: 'fbq',
+		initArgs,
+		trackStep: getMetaPixelPageViewStep(trackPageView),
+		scriptPlaceholder: '{{scriptSrc}}',
+	});
+
+	if (dataProcessingOptions !== undefined) {
+		install.unshift({
+			type: 'callGlobal',
+			global: 'fbq',
+			args: getMetaPixelDataProcessingArgs(dataProcessingOptions),
+		});
+	}
+
+	install.unshift({
+		type: 'callGlobal',
+		global: 'fbq',
+		args: ['consent', 'grant'],
+	});
+
+	return install;
+}
+
+function getMetaPixelDataProcessingArgs({
+	options,
+	country,
+	state,
+}: MetaPixelDataProcessingOptions): unknown[] {
+	const args: unknown[] = ['dataProcessingOptions', options];
+
+	if (country !== undefined || state !== undefined) {
+		args.push(country ?? 0, state ?? 0);
+	}
+
+	return args;
+}
+
+function getMetaPixelPageViewStep(
+	trackPageView: boolean
+): { args: unknown[] } | undefined {
+	if (trackPageView) {
+		return {
+			args: ['track', 'PageView'],
+		};
+	}
+
+	return undefined;
+}
+
+function resolveMetaPixelEventOptions(
+	eventOptions?: MetaPixelEventOptions | string
+): MetaPixelEventOptions | undefined {
+	if (typeof eventOptions === 'string') {
+		return {
+			eventID: eventOptions,
+		};
+	}
+
+	return eventOptions;
 }
 
 /**
@@ -259,5 +451,67 @@ export function metaPixel({ pixelId, scriptSrc }: MetaPixelOptions): Script {
 export const metaPixelEvent = <TEventName extends StandardEventName>(
 	eventName: TEventName,
 	params?: StandardEventParams[TEventName],
-	eventId?: string
-) => window.fbq('track', eventName, params, eventId);
+	eventOptions?: MetaPixelEventOptions | string
+) =>
+	window.fbq(
+		'track',
+		eventName,
+		params,
+		resolveMetaPixelEventOptions(eventOptions)
+	);
+
+/**
+ * Tracks a Meta Pixel custom event with optional custom parameters.
+ *
+ * @param eventName - The custom event name to track
+ * @param params - Optional custom parameters to track
+ * @param eventOptions - Optional event options, including Conversions API eventID
+ */
+export const metaPixelCustomEvent = (
+	eventName: string,
+	params?: FbqCustomParams,
+	eventOptions?: MetaPixelEventOptions | string
+) =>
+	window.fbq(
+		'trackCustom',
+		eventName,
+		params,
+		resolveMetaPixelEventOptions(eventOptions)
+	);
+
+/**
+ * Tracks a standard event for a single Meta Pixel ID.
+ *
+ * Use this when multiple Meta Pixels are initialized on the same page and the
+ * event should not fire for every initialized pixel.
+ */
+export const metaPixelSingleEvent = <TEventName extends StandardEventName>(
+	pixelId: string,
+	eventName: TEventName,
+	params?: StandardEventParams[TEventName],
+	eventOptions?: MetaPixelEventOptions | string
+) =>
+	window.fbq(
+		'trackSingle',
+		pixelId,
+		eventName,
+		params,
+		resolveMetaPixelEventOptions(eventOptions)
+	);
+
+/**
+ * Tracks a custom event for a single Meta Pixel ID.
+ */
+export const metaPixelSingleCustomEvent = (
+	pixelId: string,
+	eventName: string,
+	params?: FbqCustomParams,
+	eventOptions?: MetaPixelEventOptions | string
+) =>
+	window.fbq(
+		'trackSingleCustom',
+		pixelId,
+		eventName,
+		params,
+		resolveMetaPixelEventOptions(eventOptions)
+	);

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
@@ -434,16 +434,19 @@ function resolveMetaPixelEventOptions(
 }
 
 /**
- * Meta Pixel Event
- * This is a wrapper around the `fbq` function that the Meta Pixel script uses.
+ * Tracks a Meta Pixel standard event.
  *
- * @param eventName - The event name to track
- * @param params - Optional parameters to track
- * @param eventId - Optional event ID to track (If using Conversion API)
+ * This is a wrapper around `fbq('track', ...)`.
  *
- * @usage
+ * @template TEventName - The Meta `StandardEventName` being tracked.
+ * @param eventName - The `StandardEventName` to track.
+ * @param params - Optional `StandardEventParams[TEventName]` payload.
+ * @param eventOptions - Optional `MetaPixelEventOptions` or event ID string.
+ * @returns `void`; calls `window.fbq`.
+ *
+ * @example
  * ```ts
- * metaPixelEvent('Purchase', { value: 10.0, currency: 'USD' });
+ * metaPixelEvent('Purchase', { value: 10.0, currency: 'USD' }, 'event-123');
  * ```
  *
  * @see {@link https://developers.facebook.com/docs/meta-pixel/reference} Meta Pixel documentation
@@ -484,6 +487,23 @@ export const metaPixelCustomEvent = (
  *
  * Use this when multiple Meta Pixels are initialized on the same page and the
  * event should not fire for every initialized pixel.
+ *
+ * @template TEventName - The Meta `StandardEventName` being tracked.
+ * @param pixelId - Meta Pixel ID that should receive the event.
+ * @param eventName - The `StandardEventName` to track.
+ * @param params - Optional `StandardEventParams[TEventName]` payload.
+ * @param eventOptions - Optional `MetaPixelEventOptions` or event ID string.
+ * @returns `void`; calls `window.fbq`.
+ *
+ * @example
+ * ```ts
+ * metaPixelSingleEvent(
+ * 	'123456',
+ * 	'Purchase',
+ * 	{ value: 9.99, currency: 'USD' },
+ * 	'event-123'
+ * );
+ * ```
  */
 export const metaPixelSingleEvent = <TEventName extends StandardEventName>(
 	pixelId: string,
@@ -501,6 +521,20 @@ export const metaPixelSingleEvent = <TEventName extends StandardEventName>(
 
 /**
  * Tracks a custom event for a single Meta Pixel ID.
+ *
+ * Use this when multiple Meta Pixels are initialized on the same page and the
+ * custom event should not fire for every initialized pixel.
+ *
+ * @param pixelId - Meta Pixel ID that should receive the custom event.
+ * @param eventName - Custom event name to track.
+ * @param params - Optional `FbqCustomParams` payload.
+ * @param eventOptions - Optional `MetaPixelEventOptions` or event ID string.
+ * @returns `void`; calls `window.fbq`.
+ *
+ * @example
+ * ```ts
+ * metaPixelSingleCustomEvent('123456', 'MyCustomEvent', { foo: 'bar' });
+ * ```
  */
 export const metaPixelSingleCustomEvent = (
 	pixelId: string,

--- a/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
@@ -14,13 +14,49 @@ describe('microsoftUet', () => {
 		const script = microsoftUet({ id: 'uet-123' });
 
 		expectScriptMatchesIntegration('microsoftUet', script, {
-			alwaysLoad: undefined,
+			alwaysLoad: true,
 			persistAfterConsentRevoked: true,
 			src: '//bat.bing.com/bat.js',
 		});
 	});
 
-	it('boots queue and sends page + default consent on load', () => {
+	it('boots queue and sends granted default consent before load', () => {
+		const globalRef = getTestGlobal();
+		const script = microsoftUet({ id: 'uet-123' });
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+			})
+		);
+
+		expect(globalRef.uetq).toEqual([
+			'consent',
+			'default',
+			{ ad_storage: 'granted' },
+		]);
+	});
+
+	it('boots queue and sends denied default consent before load', () => {
+		const globalRef = getTestGlobal();
+		const script = microsoftUet({ id: 'uet-123' });
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: false,
+			})
+		);
+
+		expect(globalRef.uetq).toEqual([
+			'consent',
+			'default',
+			{ ad_storage: 'denied' },
+		]);
+	});
+
+	it('constructs UET and sends page load after script load', () => {
 		const globalRef = getTestGlobal();
 		const script = microsoftUet({ id: 'uet-123' });
 
@@ -52,12 +88,9 @@ describe('microsoftUet', () => {
 		expect(instance.options).toEqual({
 			ti: 'uet-123',
 			enableAutoSpaTracking: true,
-			q: [],
+			q: ['consent', 'default', { ad_storage: 'denied' }],
 		});
-		expect(instance.pushCalls).toEqual([
-			['pageLoad'],
-			['consent', 'default', { ad_storage: 'granted' }],
-		]);
+		expect(instance.pushCalls).toEqual([['pageLoad']]);
 
 		delete globalRef.UET;
 	});

--- a/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
@@ -75,7 +75,12 @@ describe('microsoftUet', () => {
 
 		globalRef.UET = UetMock;
 
-		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: false,
+			})
+		);
 		script.onLoad?.(
 			createCallbackInfo({
 				id: script.id,

--- a/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createCallbackInfo,
+	expectScriptMatchesIntegration,
+	getTestGlobal,
+	setupScriptHelperTest,
+} from '../../__tests__/helpers';
+import { microsoftUet } from './microsoft-uet';
+
+describe('microsoftUet', () => {
+	setupScriptHelperTest();
+
+	it('matches registry metadata with default loader URL', () => {
+		const script = microsoftUet({ id: 'uet-123' });
+
+		expectScriptMatchesIntegration('microsoftUet', script, {
+			alwaysLoad: undefined,
+			persistAfterConsentRevoked: true,
+			src: '//bat.bing.com/bat.js',
+		});
+	});
+
+	it('boots queue and sends page + default consent on load', () => {
+		const globalRef = getTestGlobal();
+		const script = microsoftUet({ id: 'uet-123' });
+
+		class UetMock {
+			options: Record<string, unknown>;
+			pushCalls: unknown[][] = [];
+
+			constructor(options: Record<string, unknown>) {
+				this.options = options;
+			}
+
+			push(...args: unknown[]) {
+				this.pushCalls.push(args);
+			}
+		}
+
+		globalRef.UET = UetMock;
+
+		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		script.onLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+			})
+		);
+
+		const instance = globalRef.uetq as UetMock;
+		expect(instance).toBeInstanceOf(UetMock);
+		expect(instance.options).toEqual({
+			ti: 'uet-123',
+			enableAutoSpaTracking: true,
+			q: [],
+		});
+		expect(instance.pushCalls).toEqual([
+			['pageLoad'],
+			['consent', 'default', { ad_storage: 'granted' }],
+		]);
+
+		delete globalRef.UET;
+	});
+
+	it('maps consent changes to UET consent updates', () => {
+		const globalRef = getTestGlobal();
+		const script = microsoftUet({ id: 'uet-123' });
+
+		const pushCalls: unknown[][] = [];
+		globalRef.uetq = {
+			push: (...args: unknown[]) => {
+				pushCalls.push(args);
+			},
+		};
+
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+			})
+		);
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: false,
+			})
+		);
+
+		expect(pushCalls).toEqual([
+			['consent', 'update', { ad_storage: 'granted' }],
+			['consent', 'update', { ad_storage: 'denied' }],
+		]);
+	});
+
+	it('supports overriding the loader URL', () => {
+		const script = microsoftUet({
+			id: 'uet-123',
+			scriptSrc: 'https://cdn.example.com/bat.js',
+		});
+
+		expect(script.src).toBe('https://cdn.example.com/bat.js');
+	});
+});

--- a/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.ts
@@ -12,13 +12,14 @@ declare global {
 /**
  * Microsoft UET vendor manifest.
  *
- * Uses structured startup steps and manages consent via the UET push API:
- * `window.uetq.push('consent', 'default'|'update', { ad_storage: 'granted'|'denied' })`
+ * Loads in consent mode and manages consent via the UET push API:
+ * `window.uetq.push('consent', 'default'|'update', consentState)`.
  */
 export const microsoftUetManifest = {
 	...vendorManifestContract,
 	vendor: 'microsoft-uet',
 	category: 'marketing',
+	alwaysLoad: true,
 	persistAfterConsentRevoked: true,
 	bootstrap: [
 		{
@@ -26,6 +27,22 @@ export const microsoftUetManifest = {
 			name: 'uetq',
 			value: [],
 			ifUndefined: true,
+		},
+	],
+	onBeforeLoadGranted: [
+		{
+			type: 'callGlobal',
+			global: 'uetq',
+			method: 'push',
+			args: ['consent', 'default', { ad_storage: 'granted' }],
+		},
+	],
+	onBeforeLoadDenied: [
+		{
+			type: 'callGlobal',
+			global: 'uetq',
+			method: 'push',
+			args: ['consent', 'default', { ad_storage: 'denied' }],
 		},
 	],
 	install: [
@@ -53,12 +70,6 @@ export const microsoftUetManifest = {
 			global: 'uetq',
 			method: 'push',
 			args: ['pageLoad'],
-		},
-		{
-			type: 'callGlobal',
-			global: 'uetq',
-			method: 'push',
-			args: ['consent', 'default', { ad_storage: 'granted' }],
 		},
 	],
 	onConsentGranted: [
@@ -92,7 +103,8 @@ export interface MicrosoftUetOptions {
 
 /**
  * Microsoft UET Script
- * This script is persistent after consent is revoked because it has built-in functionality to opt into and out of tracking based on consent, which allows us to not need to load the script again when consent is revoked.
+ * This script loads in consent mode and stays persistent because UET can opt
+ * into and out of tracking based on consent.
  *
  * @param options - The options for the Microsoft UET script
  * @returns The Microsoft UET script configuration

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
@@ -8,6 +8,12 @@ import {
 } from '../../__tests__/helpers';
 import { redditPixel } from './reddit-pixel';
 
+type RdtStub =
+	| (((...args: unknown[]) => void) & {
+			callQueue?: unknown[][];
+	  })
+	| undefined;
+
 describe('redditPixel', () => {
 	setupScriptHelperTest();
 
@@ -27,11 +33,7 @@ describe('redditPixel', () => {
 
 		runOnBeforeLoad(script);
 
-		const stub = globalRef.rdt as
-			| (((...args: unknown[]) => void) & {
-					callQueue?: unknown[][];
-			  })
-			| undefined;
+		const stub = globalRef.rdt as RdtStub;
 		expect(typeof stub).toBe('function');
 		expectStubCommandQueue(stub, 'callQueue', [
 			['init', 't2_abcdef'],
@@ -50,11 +52,7 @@ describe('redditPixel', () => {
 		expect(script.src).toBe('https://cdn.example.com/reddit-pixel.js');
 		runOnBeforeLoad(script);
 
-		const stub = globalRef.rdt as
-			| (((...args: unknown[]) => void) & {
-					callQueue?: unknown[][];
-			  })
-			| undefined;
+		const stub = globalRef.rdt as RdtStub;
 		expectStubCommandQueue(stub, 'callQueue', [['init', 't2_abcdef']]);
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+	createCallbackInfo,
 	expectScriptMatchesIntegration,
 	expectStubCommandQueue,
 	getTestGlobal,
 	runOnBeforeLoad,
 	setupScriptHelperTest,
 } from '../../__tests__/helpers';
-import { redditPixel } from './reddit-pixel';
+import { redditPixel, redditPixelEvent } from './reddit-pixel';
 
 type RdtStub =
 	| (((...args: unknown[]) => void) & {
@@ -22,7 +23,7 @@ describe('redditPixel', () => {
 
 		expectScriptMatchesIntegration('redditPixel', script, {
 			alwaysLoad: undefined,
-			persistAfterConsentRevoked: undefined,
+			persistAfterConsentRevoked: true,
 			src: 'https://www.redditstatic.com/ads/pixel.js',
 		});
 	});
@@ -54,5 +55,125 @@ describe('redditPixel', () => {
 
 		const stub = globalRef.rdt as RdtStub;
 		expectStubCommandQueue(stub, 'callQueue', [['init', 't2_abcdef']]);
+	});
+
+	it('passes privacy and matching options to pixel init', () => {
+		const globalRef = getTestGlobal();
+		const script = redditPixel({
+			pixelId: 't2_abcdef',
+			disableFirstPartyCookies: true,
+			initOptions: {
+				optOut: true,
+				email: 'person@example.com',
+				externalId: 'customer-123',
+				aam: {
+					email: false,
+					phone_number: false,
+				},
+				dpm: ['LDU'],
+				dpcc: 'US',
+				dprc: 'CA',
+				partner: 'c15t',
+				partner_version: '2.0.0',
+			},
+		});
+
+		runOnBeforeLoad(script);
+
+		const stub = globalRef.rdt as RdtStub;
+		expectStubCommandQueue(stub, 'callQueue', [
+			[
+				'init',
+				't2_abcdef',
+				{
+					optOut: true,
+					email: 'person@example.com',
+					externalId: 'customer-123',
+					aam: {
+						email: false,
+						phone_number: false,
+					},
+					dpm: ['LDU'],
+					dpcc: 'US',
+					dprc: 'CA',
+					partner: 'c15t',
+					partner_version: '2.0.0',
+					disableFirstPartyCookies: true,
+				},
+			],
+			['track', 'PageVisit'],
+		]);
+	});
+
+	it('queues first-party cookie controls on consent changes', () => {
+		const globalRef = getTestGlobal();
+		const script = redditPixel({ pixelId: 't2_abcdef' });
+
+		runOnBeforeLoad(script);
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: false,
+			})
+		);
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: false,
+					marketing: true,
+					experience: false,
+				},
+			})
+		);
+
+		const stub = globalRef.rdt as RdtStub;
+		expectStubCommandQueue(stub, 'callQueue', [
+			['init', 't2_abcdef'],
+			['track', 'PageVisit'],
+			['disableFirstPartyCookies'],
+			['enableFirstPartyCookies'],
+		]);
+	});
+});
+
+describe('redditPixelEvent', () => {
+	setupScriptHelperTest();
+
+	it('forwards metadata and conversion IDs to rdt', () => {
+		const globalRef = getTestGlobal();
+		const rdt = vi.fn();
+		globalRef.rdt = rdt;
+
+		redditPixelEvent('Purchase', {
+			value: 99,
+			currency: 'USD',
+			conversionId: 'conversion-123',
+			products: [
+				{
+					id: 'sku-123',
+					name: 'Example product',
+					quantity: 1,
+					itemPrice: 99,
+				},
+			],
+		});
+
+		expect(rdt).toHaveBeenCalledWith('track', 'Purchase', {
+			value: 99,
+			currency: 'USD',
+			conversionId: 'conversion-123',
+			products: [
+				{
+					id: 'sku-123',
+					name: 'Example product',
+					quantity: 1,
+					itemPrice: 99,
+				},
+			],
+		});
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
-	createCallbackInfo,
 	expectScriptMatchesIntegration,
+	expectStubCommandQueue,
 	getTestGlobal,
+	runOnBeforeLoad,
 	setupScriptHelperTest,
-	toArgumentsArray,
 } from '../../__tests__/helpers';
 import { redditPixel } from './reddit-pixel';
 
@@ -25,7 +25,7 @@ describe('redditPixel', () => {
 		const globalRef = getTestGlobal();
 		const script = redditPixel({ pixelId: 't2_abcdef' });
 
-		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		runOnBeforeLoad(script);
 
 		const stub = globalRef.rdt as
 			| (((...args: unknown[]) => void) & {
@@ -33,9 +33,9 @@ describe('redditPixel', () => {
 			  })
 			| undefined;
 		expect(typeof stub).toBe('function');
-		expect(stub?.callQueue).toEqual([
-			toArgumentsArray(['init', 't2_abcdef']),
-			toArgumentsArray(['track', 'PageVisit']),
+		expectStubCommandQueue(stub, 'callQueue', [
+			['init', 't2_abcdef'],
+			['track', 'PageVisit'],
 		]);
 	});
 
@@ -48,13 +48,13 @@ describe('redditPixel', () => {
 		});
 
 		expect(script.src).toBe('https://cdn.example.com/reddit-pixel.js');
-		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		runOnBeforeLoad(script);
 
 		const stub = globalRef.rdt as
 			| (((...args: unknown[]) => void) & {
 					callQueue?: unknown[][];
 			  })
 			| undefined;
-		expect(stub?.callQueue).toEqual([toArgumentsArray(['init', 't2_abcdef'])]);
+		expectStubCommandQueue(stub, 'callQueue', [['init', 't2_abcdef']]);
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
@@ -4,6 +4,11 @@ import { type VendorManifest, vendorManifestContract } from '../../types';
 import { buildQueuePixelInstall } from '../_shared/install-builders';
 import { resolveScriptUrl } from '../_shared/script-url';
 
+/**
+ * Reddit Pixel standard conversion event names.
+ *
+ * @see {@link https://business.reddithelp.com/s/article/supported-conversion-events | Reddit supported conversion events}
+ */
 export type RedditPixelEventName =
 	| 'PageVisit'
 	| 'ViewContent'
@@ -14,12 +19,139 @@ export type RedditPixelEventName =
 	| 'Lead'
 	| 'SignUp';
 
+/**
+ * Controls Reddit Pixel automatic advanced matching signals.
+ *
+ * @see {@link https://business.reddithelp.com/s/article/reddit-pixel | Reddit Pixel setup}
+ */
+export interface RedditPixelAdvancedMatchingOptions {
+	/** Automatically scan page content for email addresses. */
+	email?: boolean;
+
+	/** Automatically scan page content for phone numbers. */
+	phone_number?: boolean;
+}
+
+/**
+ * Reddit Pixel initialization options.
+ *
+ * @see {@link https://business.reddithelp.com/s/article/reddit-pixel | Reddit Pixel setup}
+ * @see {@link https://business.reddithelp.com/s/article/Limited-Data-Use | Reddit Limited Data Use}
+ */
+export interface RedditPixelInitOptions {
+	/**
+	 * Opt the user out of Reddit Pixel tracking.
+	 *
+	 * Reddit sends this as `opt_out=1` on pixel requests.
+	 */
+	optOut?: boolean;
+
+	/**
+	 * Disable Reddit first-party cookies during initialization.
+	 */
+	disableFirstPartyCookies?: boolean;
+
+	/** Email address or SHA-256 email hash for attribution matching. */
+	email?: string;
+
+	/** Phone number or SHA-256 phone hash for attribution matching. */
+	phoneNumber?: string;
+
+	/** External user identifier or SHA-256 hash for attribution matching. */
+	externalId?: string;
+
+	/** Android Advertising ID or SHA-256 hash. */
+	aaid?: string;
+
+	/** iOS Identifier for Advertisers or SHA-256 hash. */
+	idfa?: string;
+
+	/** Automatic advanced matching controls. */
+	aam?: RedditPixelAdvancedMatchingOptions;
+
+	/**
+	 * Data processing mode, including Reddit Limited Data Use values.
+	 *
+	 * @see {@link https://business.reddithelp.com/s/article/Limited-Data-Use | Reddit Limited Data Use}
+	 */
+	dpm?: string | string[];
+
+	/**
+	 * Data processing country code.
+	 *
+	 * @see {@link https://business.reddithelp.com/s/article/Limited-Data-Use | Reddit Limited Data Use}
+	 */
+	dpcc?: string;
+
+	/**
+	 * Data processing region code.
+	 *
+	 * @see {@link https://business.reddithelp.com/s/article/Limited-Data-Use | Reddit Limited Data Use}
+	 */
+	dprc?: string;
+
+	/** Integration partner name. */
+	partner?: string;
+
+	/** Integration partner version. */
+	partner_version?: string;
+
+	/** Source integration name reported to Reddit. */
+	integration?: 'reddit' | 'gtm' | (string & {});
+
+	/** Enable Reddit Pixel debug logging. */
+	debug?: boolean;
+
+	/**
+	 * Send monetary `value` metadata as `valueDecimal`.
+	 *
+	 * @default true
+	 */
+	useDecimalCurrencyValues?: boolean;
+
+	[key: string]: unknown;
+}
+
+/**
+ * Metadata supported by Reddit Pixel conversion events.
+ *
+ * @see {@link https://business.reddithelp.com/s/article/about-event-metadata | Reddit event metadata}
+ * @see {@link https://business.reddithelp.com/s/article/manual-conversion-events-with-the-reddit-pixel | Reddit manual conversion events}
+ */
+export interface RedditPixelEventMetadata {
+	itemCount?: number | string;
+	value?: number | string;
+	valueDecimal?: number | string;
+	currency?: string;
+	transactionId?: string;
+	customEventName?: string;
+	products?:
+		| string
+		| Array<{
+				id?: string | number;
+				name?: string;
+				category?: string;
+				quantity?: number | string;
+				itemPrice?: number | string;
+		  }>;
+	/**
+	 * Conversion ID used to deduplicate Pixel events against Conversions API
+	 * events.
+	 *
+	 * @see {@link https://business.reddithelp.com/s/article/event-deduplication | Reddit event deduplication}
+	 */
+	conversionId?: string;
+	[key: string]: unknown;
+}
+
 type RedditPixelFunction = {
-	(command: 'init', pixelId: string): void;
+	(command: 'init', pixelId: string, options?: RedditPixelInitOptions): void;
+	(command: 'enableFirstPartyCookies'): void;
+	(command: 'disableFirstPartyCookies'): void;
 	(
 		command: 'track',
 		eventName: RedditPixelEventName | (string & {}),
-		properties?: Record<string, unknown>
+		properties?: RedditPixelEventMetadata
 	): void;
 	(command: string, ...args: unknown[]): void;
 };
@@ -28,7 +160,7 @@ declare global {
 	interface Window {
 		rdt: RedditPixelFunction & {
 			callQueue?: unknown[][];
-			sendEvent?: (rdt: Window['rdt'], args: unknown[]) => void;
+			sendEvent?: (...args: unknown[]) => void;
 		};
 	}
 }
@@ -43,6 +175,7 @@ export const redditPixelManifest = {
 	...vendorManifestContract,
 	vendor: 'reddit-pixel',
 	category: 'marketing',
+	persistAfterConsentRevoked: true,
 	bootstrap: [
 		{
 			type: 'defineStubFunction',
@@ -72,6 +205,20 @@ export const redditPixelManifest = {
 			async: true,
 		},
 	],
+	onConsentGranted: [
+		{
+			type: 'callGlobal',
+			global: 'rdt',
+			args: ['enableFirstPartyCookies'],
+		},
+	],
+	onConsentDenied: [
+		{
+			type: 'callGlobal',
+			global: 'rdt',
+			args: ['disableFirstPartyCookies'],
+		},
+	],
 } as const satisfies VendorManifest;
 
 export interface RedditPixelOptions {
@@ -87,6 +234,18 @@ export interface RedditPixelOptions {
 	 */
 	trackPageVisit?: boolean;
 
+	/**
+	 * Optional payload passed as the third argument to `rdt('init', ...)`.
+	 */
+	initOptions?: RedditPixelInitOptions;
+
+	/**
+	 * Disable Reddit first-party cookies during setup.
+	 *
+	 * This is merged into `initOptions.disableFirstPartyCookies`.
+	 */
+	disableFirstPartyCookies?: boolean;
+
 	/** Reddit Pixel loader URL. */
 	scriptUrl?: string;
 }
@@ -100,6 +259,8 @@ export interface RedditPixelOptions {
 export function redditPixel({
 	pixelId,
 	trackPageVisit = true,
+	initOptions,
+	disableFirstPartyCookies,
 	scriptUrl,
 }: RedditPixelOptions): Script {
 	let trackStep: { args: unknown[] } | undefined;
@@ -110,9 +271,18 @@ export function redditPixel({
 		};
 	}
 
+	const resolvedInitOptions = getRedditPixelInitOptions({
+		initOptions,
+		disableFirstPartyCookies,
+	});
+	const initArgs: unknown[] = ['init', '{{pixelId}}'];
+	if (resolvedInitOptions !== undefined) {
+		initArgs.push('{{initOptions}}');
+	}
+
 	const install = buildQueuePixelInstall({
 		global: 'rdt',
-		initArgs: ['init', '{{pixelId}}'],
+		initArgs,
 		trackStep,
 	});
 
@@ -123,9 +293,39 @@ export function redditPixel({
 
 	return resolveManifest(manifest, {
 		pixelId,
+		initOptions: resolvedInitOptions,
 		scriptUrl: resolveScriptUrl(
 			scriptUrl,
 			'https://www.redditstatic.com/ads/pixel.js'
 		),
 	});
 }
+
+function getRedditPixelInitOptions({
+	initOptions,
+	disableFirstPartyCookies,
+}: {
+	initOptions?: RedditPixelInitOptions;
+	disableFirstPartyCookies?: boolean;
+}): RedditPixelInitOptions | undefined {
+	if (disableFirstPartyCookies === undefined) {
+		return initOptions;
+	}
+
+	return {
+		...initOptions,
+		disableFirstPartyCookies,
+	};
+}
+
+/**
+ * Tracks a Reddit Pixel event.
+ *
+ * @param eventName - Reddit standard event name or a custom event name.
+ * @param metadata - Optional event metadata, including `conversionId` for
+ * Pixel plus Conversions API deduplication.
+ */
+export const redditPixelEvent = (
+	eventName: RedditPixelEventName | (string & {}),
+	metadata?: RedditPixelEventMetadata
+) => window.rdt('track', eventName, metadata);

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { buildQueuePixelInstall } from '../_shared/install-builders';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 export type RedditPixelEventName =
 	| 'PageVisit'
@@ -100,26 +102,18 @@ export function redditPixel({
 	trackPageVisit = true,
 	scriptUrl,
 }: RedditPixelOptions): Script {
-	const install: VendorManifest['install'] = [
-		{
-			type: 'callGlobal',
-			global: 'rdt',
-			args: ['init', '{{pixelId}}'],
-		},
-	];
+	let trackStep: { args: unknown[] } | undefined;
 
 	if (trackPageVisit) {
-		install.push({
-			type: 'callGlobal',
-			global: 'rdt',
+		trackStep = {
 			args: ['track', 'PageVisit'],
-		});
+		};
 	}
 
-	install.push({
-		type: 'loadScript',
-		src: '{{scriptUrl}}',
-		async: true,
+	const install = buildQueuePixelInstall({
+		global: 'rdt',
+		initArgs: ['init', '{{pixelId}}'],
+		trackStep,
 	});
 
 	const manifest = {
@@ -129,6 +123,9 @@ export function redditPixel({
 
 	return resolveManifest(manifest, {
 		pixelId,
-		scriptUrl: scriptUrl ?? 'https://www.redditstatic.com/ads/pixel.js',
+		scriptUrl: resolveScriptUrl(
+			scriptUrl,
+			'https://www.redditstatic.com/ads/pixel.js'
+		),
 	});
 }

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	expectScriptMatchesIntegration,
 	expectStubCommandQueue,
@@ -6,7 +6,12 @@ import {
 	runOnBeforeLoad,
 	setupScriptHelperTest,
 } from '../../__tests__/helpers';
-import { snapchatPixel } from './snapchat-pixel';
+import { resolveManifest } from '../../resolve';
+import {
+	snapchatPixel,
+	snapchatPixelEvent,
+	snapchatPixelManifest,
+} from './snapchat-pixel';
 
 type SnaptrStub =
 	| (((...args: unknown[]) => void) & {
@@ -59,5 +64,49 @@ describe('snapchatPixel', () => {
 		expectStubCommandQueue(stub, 'queue', [
 			['init', '123456789012345', { user_email: 'hello@example.com' }],
 		]);
+	});
+
+	it('keeps the exported manifest resolvable without init options', () => {
+		const globalRef = getTestGlobal();
+		const script = resolveManifest(snapchatPixelManifest, {
+			pixelId: '123456789012345',
+			scriptUrl: 'https://sc-static.net/scevent.min.js',
+		});
+
+		runOnBeforeLoad(script);
+
+		const stub = globalRef.snaptr as SnaptrStub;
+		expectStubCommandQueue(stub, 'queue', [
+			['init', '123456789012345'],
+			['track', 'PAGE_VIEW'],
+		]);
+	});
+});
+
+describe('snapchatPixelEvent', () => {
+	setupScriptHelperTest();
+
+	it('forwards purchase metadata and deduplication IDs to snaptr', () => {
+		const globalRef = getTestGlobal();
+		const snaptr = vi.fn();
+		globalRef.snaptr = snaptr;
+
+		snapchatPixelEvent('PURCHASE', {
+			price: 99,
+			currency: 'USD',
+			transaction_id: 'order-123',
+			client_dedup_id: 'event-123',
+			item_ids: ['sku-123'],
+			number_items: 1,
+		});
+
+		expect(snaptr).toHaveBeenCalledWith('track', 'PURCHASE', {
+			price: 99,
+			currency: 'USD',
+			transaction_id: 'order-123',
+			client_dedup_id: 'event-123',
+			item_ids: ['sku-123'],
+			number_items: 1,
+		});
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
-	createCallbackInfo,
 	expectScriptMatchesIntegration,
+	expectStubCommandQueue,
 	getTestGlobal,
+	runOnBeforeLoad,
 	setupScriptHelperTest,
-	toArgumentsArray,
 } from '../../__tests__/helpers';
 import { snapchatPixel } from './snapchat-pixel';
 
@@ -25,7 +25,7 @@ describe('snapchatPixel', () => {
 		const globalRef = getTestGlobal();
 		const script = snapchatPixel({ pixelId: '123456789012345' });
 
-		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		runOnBeforeLoad(script);
 
 		const stub = globalRef.snaptr as
 			| (((...args: unknown[]) => void) & {
@@ -35,9 +35,9 @@ describe('snapchatPixel', () => {
 			| undefined;
 
 		expect(stub?.version).toBe('1.0');
-		expect(stub?.queue).toEqual([
-			toArgumentsArray(['init', '123456789012345']),
-			toArgumentsArray(['track', 'PAGE_VIEW']),
+		expectStubCommandQueue(stub, 'queue', [
+			['init', '123456789012345'],
+			['track', 'PAGE_VIEW'],
 		]);
 	});
 
@@ -51,17 +51,13 @@ describe('snapchatPixel', () => {
 		});
 
 		expect(script.src).toBe('https://cdn.example.com/scevent.min.js');
-		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
+		runOnBeforeLoad(script);
 
 		const stub = globalRef.snaptr as
 			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
 			| undefined;
-		expect(stub?.queue).toEqual([
-			toArgumentsArray([
-				'init',
-				'123456789012345',
-				{ user_email: 'hello@example.com' },
-			]),
+		expectStubCommandQueue(stub, 'queue', [
+			['init', '123456789012345', { user_email: 'hello@example.com' }],
 		]);
 	});
 });

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.test.ts
@@ -8,6 +8,13 @@ import {
 } from '../../__tests__/helpers';
 import { snapchatPixel } from './snapchat-pixel';
 
+type SnaptrStub =
+	| (((...args: unknown[]) => void) & {
+			queue?: unknown[][];
+			version?: string;
+	  })
+	| undefined;
+
 describe('snapchatPixel', () => {
 	setupScriptHelperTest();
 
@@ -27,12 +34,7 @@ describe('snapchatPixel', () => {
 
 		runOnBeforeLoad(script);
 
-		const stub = globalRef.snaptr as
-			| (((...args: unknown[]) => void) & {
-					queue?: unknown[][];
-					version?: string;
-			  })
-			| undefined;
+		const stub = globalRef.snaptr as SnaptrStub;
 
 		expect(stub?.version).toBe('1.0');
 		expectStubCommandQueue(stub, 'queue', [
@@ -53,9 +55,7 @@ describe('snapchatPixel', () => {
 		expect(script.src).toBe('https://cdn.example.com/scevent.min.js');
 		runOnBeforeLoad(script);
 
-		const stub = globalRef.snaptr as
-			| (((...args: unknown[]) => void) & { queue?: unknown[][] })
-			| undefined;
+		const stub = globalRef.snaptr as SnaptrStub;
 		expectStubCommandQueue(stub, 'queue', [
 			['init', '123456789012345', { user_email: 'hello@example.com' }],
 		]);

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { buildQueuePixelInstall } from '../_shared/install-builders';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 export type SnapchatPixelEventName =
 	| 'PAGE_VIEW'
@@ -186,26 +188,18 @@ export function snapchatPixel({
 		initArgs.push('{{initOptions}}');
 	}
 
-	const install: VendorManifest['install'] = [
-		{
-			type: 'callGlobal',
-			global: 'snaptr',
-			args: initArgs,
-		},
-	];
+	let trackStep: { args: unknown[] } | undefined;
 
 	if (trackPageView) {
-		install.push({
-			type: 'callGlobal',
-			global: 'snaptr',
+		trackStep = {
 			args: ['track', 'PAGE_VIEW'],
-		});
+		};
 	}
 
-	install.push({
-		type: 'loadScript',
-		src: '{{scriptUrl}}',
-		async: true,
+	const install = buildQueuePixelInstall({
+		global: 'snaptr',
+		initArgs,
+		trackStep,
 	});
 
 	const manifest = {
@@ -216,6 +210,9 @@ export function snapchatPixel({
 	return resolveManifest(manifest, {
 		pixelId,
 		initOptions: initOptions ?? {},
-		scriptUrl: scriptUrl ?? 'https://sc-static.net/scevent.min.js',
+		scriptUrl: resolveScriptUrl(
+			scriptUrl,
+			'https://sc-static.net/scevent.min.js'
+		),
 	});
 }

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
@@ -8,6 +8,7 @@ export type SnapchatPixelEventName =
 	| 'PAGE_VIEW'
 	| 'VIEW_CONTENT'
 	| 'ADD_CART'
+	| 'PURCHASE'
 	| 'SIGN_UP'
 	| 'SAVE'
 	| 'START_CHECKOUT'
@@ -31,22 +32,57 @@ export type SnapchatPixelEventName =
 	| 'LIST_VIEW';
 
 export interface SnapchatPixelEventProperties {
+	/** Total monetary value for commerce events such as `PURCHASE`. */
 	price?: number;
+
+	/**
+	 * Event identifier used to deduplicate browser Pixel events against
+	 * server-side Conversions API events.
+	 */
 	client_dedup_id?: string;
+
+	/** ISO 4217 currency code, for example `USD`. */
 	currency?: string;
+
+	/** Transaction/order identifier for purchase events. */
 	transaction_id?: string;
+
+	/** Product, SKU, or content identifiers associated with the event. */
 	item_ids?: string[];
+
+	/** Product or content category associated with the event. */
 	item_category?: string;
+
+	/** Free-form description for the event. */
 	description?: string;
+
+	/** Query text for `SEARCH` events. */
 	search_string?: string;
+
+	/** Number of items represented by the event. */
 	number_items?: number;
+
+	/** Whether payment information was available, represented as `0` or `1`. */
 	payment_info_available?: 0 | 1;
+
+	/** Signup method for `SIGN_UP` events. */
 	sign_up_method?: string;
+
+	/** Whether the action succeeded, represented as `0` or `1`. */
 	success?: 0 | 1;
+
+	/** Brand names associated with the event contents. */
 	brands?: string[];
+
+	/** Fulfillment method for commerce events. */
 	delivery_method?: 'in_store' | 'curbside' | 'delivery';
+
+	/** Customer lifecycle status associated with the event. */
 	customer_status?: 'new' | 'returning' | 'reactivated';
+
+	/** Optional custom tag for event segmentation in Snapchat. */
 	event_tag?: string;
+
 	[key: string]: unknown;
 }
 
@@ -105,7 +141,7 @@ export const snapchatPixelManifest = {
 		{
 			type: 'callGlobal',
 			global: 'snaptr',
-			args: ['init', '{{pixelId}}', '{{initOptions}}'],
+			args: ['init', '{{pixelId}}'],
 		},
 		{
 			type: 'callGlobal',
@@ -209,10 +245,32 @@ export function snapchatPixel({
 
 	return resolveManifest(manifest, {
 		pixelId,
-		initOptions: initOptions ?? {},
+		initOptions,
 		scriptUrl: resolveScriptUrl(
 			scriptUrl,
 			'https://sc-static.net/scevent.min.js'
 		),
 	});
 }
+
+/**
+ * Tracks a Snapchat Pixel event.
+ *
+ * @param eventName - Snapchat standard event name or a custom event name.
+ * @param properties - Optional event properties, including
+ *   `client_dedup_id` for Pixel plus Conversions API deduplication.
+ *
+ * @example
+ * ```ts
+ * snapchatPixelEvent('PURCHASE', {
+ * 	price: 99,
+ * 	currency: 'USD',
+ * 	transaction_id: 'order-123',
+ * 	client_dedup_id: 'event-123',
+ * });
+ * ```
+ */
+export const snapchatPixelEvent = (
+	eventName: SnapchatPixelEventName | (string & {}),
+	properties?: SnapchatPixelEventProperties
+) => window.snaptr('track', eventName, properties);

--- a/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	expectScriptMatchesIntegration,
+	getTestGlobal,
+	runOnBeforeLoad,
+	setupScriptHelperTest,
+	toArgumentsArray,
+} from '../../__tests__/helpers';
+import { tiktokPixel } from './tiktok-pixel';
+
+describe('tiktokPixel', () => {
+	setupScriptHelperTest();
+
+	it('matches registry metadata with default loader URL', () => {
+		const script = tiktokPixel({ pixelId: 'tt-123' });
+
+		expectScriptMatchesIntegration('tiktokPixel', script, {
+			alwaysLoad: undefined,
+			persistAfterConsentRevoked: true,
+			src: 'https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=tt-123&lib=ttq',
+		});
+	});
+
+	it('seeds the ttq queue and page event before script load', () => {
+		const globalRef = getTestGlobal();
+		const script = tiktokPixel({ pixelId: 'tt-123' });
+
+		runOnBeforeLoad(script, { hasConsent: true });
+
+		const queue = globalRef.ttq as unknown[] | undefined;
+
+		expect(globalRef.TiktokAnalyticsObject).toBe('ttq');
+		expect(queue?.map((entry) => toArgumentsArray(entry))).toEqual([
+			['grantConsent'],
+			['page'],
+		]);
+		expect(typeof window.ttq.track).toBe('function');
+	});
+
+	it('supports overriding the loader base URL', () => {
+		const script = tiktokPixel({
+			pixelId: 'tt-123',
+			scriptSrc: 'https://cdn.example.com/events.js',
+		});
+
+		expect(script.src).toBe(
+			'https://cdn.example.com/events.js?sdkid=tt-123&lib=ttq'
+		);
+	});
+
+	it('signals consent changes through TikTok consent methods', () => {
+		const grantConsent = vi.fn();
+		const revokeConsent = vi.fn();
+		const script = tiktokPixel({ pixelId: 'tt-123' });
+
+		runOnBeforeLoad(script, { hasConsent: true });
+		window.ttq.grantConsent = grantConsent;
+		window.ttq.revokeConsent = revokeConsent;
+
+		script.onConsentChange?.({
+			id: script.id,
+			elementId: script.id,
+			hasConsent: false,
+			consents: {
+				necessary: true,
+				functionality: false,
+				measurement: false,
+				marketing: false,
+				experience: false,
+			},
+		});
+		script.onConsentChange?.({
+			id: script.id,
+			elementId: script.id,
+			hasConsent: true,
+			consents: {
+				necessary: true,
+				functionality: false,
+				measurement: false,
+				marketing: true,
+				experience: false,
+			},
+		});
+
+		expect(revokeConsent).toHaveBeenCalledTimes(1);
+		expect(grantConsent).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.ts
@@ -2,14 +2,29 @@ import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 
+type TikTokPixelFunction = {
+	grantConsent: () => void;
+	revokeConsent: () => void;
+	page: () => void;
+	track: (eventName: string, properties?: Record<string, unknown>) => void;
+	identify: (properties?: Record<string, unknown>) => void;
+	instances: (...args: unknown[]) => void;
+	debug: (...args: unknown[]) => void;
+	on: (...args: unknown[]) => void;
+	off: (...args: unknown[]) => void;
+	once: (...args: unknown[]) => void;
+	ready: (...args: unknown[]) => void;
+	alias: (...args: unknown[]) => void;
+	group: (...args: unknown[]) => void;
+	enableCookie: (...args: unknown[]) => void;
+	disableCookie: (...args: unknown[]) => void;
+	holdConsent: (...args: unknown[]) => void;
+};
+
 // Extended Window interface to include TikTok Pixel-specific properties
 declare global {
 	interface Window {
-		ttq: {
-			grantConsent: () => void;
-			revokeConsent: () => void;
-			page: () => void;
-		};
+		ttq: TikTokPixelFunction;
 	}
 }
 

--- a/packages/scripts/src/vendors/ads-and-pixels/x-pixel.test.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/x-pixel.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	expectScriptMatchesIntegration,
+	expectStubCommandQueue,
+	getTestGlobal,
+	runOnBeforeLoad,
+	setupScriptHelperTest,
+} from '../../__tests__/helpers';
+import { xPixel, xPixelEvent } from './x-pixel';
+
+describe('xPixel', () => {
+	setupScriptHelperTest();
+
+	it('matches registry metadata with default loader URL', () => {
+		const script = xPixel({ pixelId: 'tw-123' });
+
+		expectScriptMatchesIntegration('xPixel', script, {
+			alwaysLoad: undefined,
+			persistAfterConsentRevoked: undefined,
+			src: 'https://static.ads-twitter.com/uwt.js',
+		});
+	});
+
+	it('seeds the twq queue and config call before script load', () => {
+		const globalRef = getTestGlobal();
+		const script = xPixel({ pixelId: 'tw-123' });
+
+		runOnBeforeLoad(script);
+
+		const stub = globalRef.twq as
+			| (((...args: unknown[]) => void) & {
+					queue?: unknown[][];
+					version?: string;
+			  })
+			| undefined;
+
+		expect(stub?.version).toBe('1.1');
+		expectStubCommandQueue(stub, 'queue', [['config', 'tw-123']]);
+	});
+
+	it('supports overriding the loader URL', () => {
+		const script = xPixel({
+			pixelId: 'tw-123',
+			scriptSrc: 'https://cdn.example.com/uwt.js',
+		});
+
+		expect(script.src).toBe('https://cdn.example.com/uwt.js');
+	});
+});
+
+describe('xPixelEvent', () => {
+	setupScriptHelperTest();
+
+	it('forwards event payload to twq when available', () => {
+		const globalRef = getTestGlobal();
+		const twq = vi.fn();
+		globalRef.twq = twq;
+
+		xPixelEvent('tw-pixel-event', {
+			value: 200,
+			currency: 'USD',
+			status: 'completed',
+			conversion_id: 'order-123',
+		});
+
+		expect(twq).toHaveBeenCalledWith('event', 'tw-pixel-event', {
+			value: 200,
+			currency: 'USD',
+			status: 'completed',
+			conversion_id: 'order-123',
+		});
+	});
+
+	it('is a no-op when twq is unavailable', () => {
+		const globalRef = getTestGlobal();
+		delete globalRef.twq;
+
+		expect(() => xPixelEvent('tw-pixel-event')).not.toThrow();
+	});
+});

--- a/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
@@ -73,9 +73,23 @@ export interface XPixelEvent {
 	twclid?: string;
 	/**
 	 * Status of the conversion event
-	 * @example completed
+	 * Should be set to values like "started" or "completed".
+	 * @example "completed"
 	 */
-	status?: boolean;
+	status?: 'started' | 'completed' | (string & {});
+	/**
+	 * Email address used for user matching.
+	 * The X Pixel hashes this value before transmission.
+	 * @example "[email protected]"
+	 */
+	email_address?: string;
+	/**
+	 * Phone number used for user matching.
+	 * Include country code in E.164 format (for example, +11234567890).
+	 * The X Pixel hashes this value before transmission.
+	 * @example "+11234567890"
+	 */
+	phone_number?: string;
 
 	/**
 	 * Content/products associated with the conversion event
@@ -156,7 +170,7 @@ export interface XPixelOptions {
  * });
  * ```
  *
- * @see {@link https://ads.twitter.com/help/article/x-pixel} X Pixel documentation
+ * @see {@link https://business.x.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites} X conversion tracking documentation
  */
 export function xPixel({ pixelId, scriptSrc }: XPixelOptions): Script {
 	const resolved = resolveManifest(xPixelManifest, {

--- a/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
@@ -76,7 +76,7 @@ export interface XPixelEvent {
 	 * Should be set to values like "started" or "completed".
 	 * @example "completed"
 	 */
-	status?: 'started' | 'completed' | (string & {});
+	status?: 'started' | 'completed';
 	/**
 	 * Email address used for user matching.
 	 * The X Pixel hashes this value before transmission.

--- a/packages/scripts/src/vendors/analytics/ahrefs-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/ahrefs-analytics.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -73,6 +74,9 @@ export interface AhrefsAnalyticsOptions {
 export function ahrefsAnalytics(options: AhrefsAnalyticsOptions): Script {
 	return resolveManifest(ahrefsAnalyticsManifest, {
 		key: options.key,
-		scriptUrl: options.scriptUrl ?? 'https://analytics.ahrefs.com/analytics.js',
+		scriptUrl: resolveScriptUrl(
+			options.scriptUrl,
+			'https://analytics.ahrefs.com/analytics.js'
+		),
 	});
 }

--- a/packages/scripts/src/vendors/analytics/cloudflare-web-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/cloudflare-web-analytics.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -76,9 +77,10 @@ export function cloudflareWebAnalytics(
 	options: CloudflareWebAnalyticsOptions
 ): Script {
 	const resolved = resolveManifest(cloudflareWebAnalyticsManifest, {
-		scriptUrl:
-			options.scriptUrl ??
-			'https://static.cloudflareinsights.com/beacon.min.js',
+		scriptUrl: resolveScriptUrl(
+			options.scriptUrl,
+			'https://static.cloudflareinsights.com/beacon.min.js'
+		),
 		beaconConfig: JSON.stringify({
 			token: options.token,
 			spa: options.spa ?? true,

--- a/packages/scripts/src/vendors/analytics/fathom-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/fathom-analytics.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { booleanDataAttribute } from '../_shared/attributes';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -17,14 +19,6 @@ declare global {
 			trackPageview: (opts?: { url: string; referrer?: string }) => void;
 		};
 	}
-}
-
-function booleanAttribute(value: boolean | undefined): string | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-
-	return value ? 'true' : 'false';
 }
 
 /**
@@ -111,10 +105,13 @@ export function fathomAnalytics(options: FathomAnalyticsOptions): Script {
 	const resolved = resolveManifest(fathomAnalyticsManifest, {
 		site: options.site,
 		spa: options.spa,
-		autoAttribute: booleanAttribute(options.auto),
-		canonicalAttribute: booleanAttribute(options.canonical),
-		honorDntAttribute: booleanAttribute(options.honorDnt),
-		scriptUrl: options.scriptUrl ?? 'https://cdn.usefathom.com/script.js',
+		autoAttribute: booleanDataAttribute(options.auto),
+		canonicalAttribute: booleanDataAttribute(options.canonical),
+		honorDntAttribute: booleanDataAttribute(options.honorDnt),
+		scriptUrl: resolveScriptUrl(
+			options.scriptUrl,
+			'https://cdn.usefathom.com/script.js'
+		),
 	});
 
 	return resolved;

--- a/packages/scripts/src/vendors/analytics/google-tag.test.ts
+++ b/packages/scripts/src/vendors/analytics/google-tag.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-	createCallbackInfo,
 	deniedConsentState,
+	expectGoogleConsentDefault,
 	getTestGlobal,
+	runOnBeforeLoad,
 	setupScriptHelperTest,
 	toArgumentsArray,
 } from '../../__tests__/helpers';
@@ -16,27 +17,12 @@ describe('gtag', () => {
 		const script = gtag({ id: 'G-ORDER', category: 'measurement' });
 		globalRef.dataLayer = [];
 
-		script.onBeforeLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: deniedConsentState,
-			})
-		);
+		runOnBeforeLoad(script, {
+			consents: deniedConsentState,
+		});
 
 		const dataLayer = globalRef.dataLayer as unknown[];
-		expect(toArgumentsArray(dataLayer[0])).toEqual([
-			'consent',
-			'default',
-			{
-				security_storage: 'granted',
-				functionality_storage: 'denied',
-				analytics_storage: 'denied',
-				ad_storage: 'denied',
-				ad_user_data: 'denied',
-				ad_personalization: 'denied',
-				personalization_storage: 'denied',
-			},
-		]);
+		expectGoogleConsentDefault(dataLayer[0]);
 		expect(toArgumentsArray(dataLayer[1])[0]).toBe('js');
 		expect(toArgumentsArray(dataLayer[2])).toEqual(['config', 'G-ORDER']);
 		expect(document.head.appendChild).not.toHaveBeenCalled();

--- a/packages/scripts/src/vendors/analytics/google-tag.ts
+++ b/packages/scripts/src/vendors/analytics/google-tag.ts
@@ -1,6 +1,10 @@
 import type { AllConsentNames, Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import {
+	GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+	withOptionalConsentMapping,
+} from '../_shared/google-consent';
 
 // Extended Window interface to include gtag specific properties
 declare global {
@@ -53,13 +57,7 @@ export const gtagManifest = {
 			async: true,
 		},
 	],
-	consentMapping: {
-		necessary: ['security_storage'],
-		functionality: ['functionality_storage'],
-		measurement: ['analytics_storage'],
-		marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
-		experience: ['personalization_storage'],
-	},
+	consentMapping: GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
 	consentSignal: 'gtag',
 } as const satisfies VendorManifest;
 
@@ -115,9 +113,7 @@ export function gtag({
 	consentMapping,
 	script,
 }: GtagOptions): Script {
-	const manifest = consentMapping
-		? { ...gtagManifest, consentMapping }
-		: gtagManifest;
+	const manifest = withOptionalConsentMapping(gtagManifest, consentMapping);
 
 	const resolved = resolveManifest(manifest, {
 		id,

--- a/packages/scripts/src/vendors/analytics/hotjar.ts
+++ b/packages/scripts/src/vendors/analytics/hotjar.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -87,8 +88,9 @@ export function hotjar({
 	return resolveManifest(hotjarManifest, {
 		siteId,
 		version,
-		scriptUrl:
-			scriptUrl ??
-			`https://static.hotjar.com/c/hotjar-${siteId}.js?sv=${version}`,
+		scriptUrl: resolveScriptUrl(
+			scriptUrl,
+			`https://static.hotjar.com/c/hotjar-${siteId}.js?sv=${version}`
+		),
 	});
 }

--- a/packages/scripts/src/vendors/analytics/matomo-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/matomo-analytics.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { joinUrlPath } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -28,19 +29,6 @@ function stripProtocol(value: string): string {
  */
 function stripTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, '');
-}
-
-/**
- * Concatenates a base URL and path into a single slash-separated URL.
- *
- * @param base - Base URL or origin. Any trailing slashes are removed before
- * joining.
- * @param path - URL path segment. Any leading slashes are removed before
- * joining.
- * @returns A URL string in the form `<normalized base>/<normalized path>`.
- */
-function joinUrl(base: string, path: string): string {
-	return `${stripTrailingSlash(base)}/${path.replace(/^\/+/, '')}`;
 }
 
 /**
@@ -254,12 +242,12 @@ export function matomoAnalytics(options: MatomoAnalyticsOptions = {}): Script {
 	const origin = resolveMatomoOrigin(options);
 	let trackerUrl = options.trackerUrl;
 	if (!trackerUrl && origin) {
-		trackerUrl = joinUrl(origin, 'matomo.php');
+		trackerUrl = joinUrlPath(origin, 'matomo.php');
 	}
 
 	let scriptUrl = options.scriptUrl;
 	if (!scriptUrl && origin) {
-		scriptUrl = joinUrl(origin, 'matomo.js');
+		scriptUrl = joinUrlPath(origin, 'matomo.js');
 	}
 
 	if (!trackerUrl || !scriptUrl) {

--- a/packages/scripts/src/vendors/analytics/posthog.test.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.test.ts
@@ -26,6 +26,7 @@ describe('posthog', () => {
 			opt_in_capturing: optIn,
 			opt_out_capturing: optOut,
 			get_explicit_consent_status: vi.fn(() => 'pending'),
+			capture: vi.fn(),
 		};
 
 		const script = posthog({
@@ -61,6 +62,7 @@ describe('posthog', () => {
 			autocapture: false,
 			person_profiles: 'identified_only',
 			cookieless_mode: 'on_reject',
+			defaults: '2026-01-30',
 		});
 		expect(optOut).toHaveBeenCalledTimes(1);
 
@@ -75,7 +77,17 @@ describe('posthog', () => {
 		expect(optIn).toHaveBeenCalledTimes(1);
 	});
 
-	it('uses defaults when optional options are omitted', () => {
+	it('uses consent-aware defaults when optional options are omitted', () => {
+		const globalRef = getTestGlobal();
+		const init = vi.fn();
+		globalRef.posthog = {
+			init,
+			opt_in_capturing: vi.fn(),
+			opt_out_capturing: vi.fn(),
+			get_explicit_consent_status: vi.fn(() => 'pending'),
+			capture: vi.fn(),
+		};
+
 		const script = posthog({
 			id: 'phc_defaults',
 		});
@@ -85,6 +97,54 @@ describe('posthog', () => {
 			crossorigin: 'anonymous',
 			'data-api-host': 'https://eu.i.posthog.com',
 			'data-ui-host': 'https://eu.i.posthog.com',
+		});
+
+		script.onLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		expect(init).toHaveBeenCalledWith('phc_defaults', {
+			api_host: 'https://eu.i.posthog.com',
+			defaults: '2026-01-30',
+			cookieless_mode: 'on_reject',
+		});
+	});
+
+	it('allows explicit init options to override helper defaults', () => {
+		const globalRef = getTestGlobal();
+		const init = vi.fn();
+		globalRef.posthog = {
+			init,
+			opt_in_capturing: vi.fn(),
+			opt_out_capturing: vi.fn(),
+			get_explicit_consent_status: vi.fn(() => 'pending'),
+			capture: vi.fn(),
+		};
+
+		const script = posthog({
+			id: 'phc_overrides',
+			apiHost: 'https://eu.i.posthog.com',
+			initOptions: {
+				api_host: 'https://us.i.posthog.com',
+				defaults: '2025-05-24',
+				cookieless_mode: 'always',
+			},
+		});
+
+		script.onLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: deniedConsentState,
+			})
+		);
+
+		expect(init).toHaveBeenCalledWith('phc_overrides', {
+			api_host: 'https://us.i.posthog.com',
+			defaults: '2025-05-24',
+			cookieless_mode: 'always',
 		});
 	});
 });

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -17,9 +17,14 @@ declare global {
 			opt_in_capturing: () => void;
 			opt_out_capturing: () => void;
 			get_explicit_consent_status: () => string;
+			capture: (event: string, properties?: Record<string, unknown>) => void;
 		};
 	}
 }
+
+const DEFAULT_API_HOST = 'https://eu.i.posthog.com';
+const DEFAULT_SCRIPT_URL = 'https://eu-assets.i.posthog.com/static/array.js';
+const DEFAULTS_DATE = '2026-01-30';
 
 /**
  * PostHog vendor manifest.
@@ -44,6 +49,7 @@ export const posthogManifest = {
 			target: 'posthog',
 			methods: [
 				{ name: 'init', behavior: 'noop' },
+				{ name: 'capture', behavior: 'noop' },
 				{ name: 'opt_in_capturing', behavior: 'noop' },
 				{ name: 'opt_out_capturing', behavior: 'noop' },
 				{
@@ -132,12 +138,17 @@ export interface PosthogConsentOptions {
  * @returns The Posthog script
  */
 export function posthog(options: PosthogConsentOptions): Script {
+	const apiHost = options.apiHost ?? DEFAULT_API_HOST;
 	const resolved = resolveManifest(posthogManifest, {
 		id: options.id,
-		apiHost: options.apiHost ?? 'https://eu.i.posthog.com',
-		scriptUrl:
-			options.scriptUrl ?? 'https://eu-assets.i.posthog.com/static/array.js',
-		initOptions: options.initOptions ?? {},
+		apiHost,
+		scriptUrl: options.scriptUrl ?? DEFAULT_SCRIPT_URL,
+		initOptions: {
+			api_host: apiHost,
+			defaults: DEFAULTS_DATE,
+			cookieless_mode: 'on_reject',
+			...options.initOptions,
+		},
 	});
 
 	return resolved;

--- a/packages/scripts/src/vendors/analytics/promptwatch.ts
+++ b/packages/scripts/src/vendors/analytics/promptwatch.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';
 
 /**
  * Promptwatch vendor manifest.
@@ -51,10 +52,10 @@ export function promptwatch({
 	}
 
 	const defaultScriptUrl = 'https://ingest.promptwatch.com/js/client.min.js';
-	let normalizedScriptUrl = defaultScriptUrl;
-	if (scriptUrl !== undefined && scriptUrl.trim().length > 0) {
-		normalizedScriptUrl = scriptUrl.trim();
-	}
+	const normalizedScriptUrl = resolveScriptUrl(
+		trimToUndefined(scriptUrl),
+		defaultScriptUrl
+	);
 
 	return resolveManifest(promptwatchManifest, {
 		projectId: normalizedProjectId,

--- a/packages/scripts/src/vendors/analytics/rybbit-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/rybbit-analytics.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { booleanDataAttribute } from '../_shared/attributes';
+import { joinUrlPath } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -12,17 +14,6 @@ declare global {
 			pageview: () => void;
 		};
 	}
-}
-
-function booleanAttribute(value: boolean | undefined): string | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-	if (value) {
-		return 'true';
-	}
-
-	return 'false';
 }
 
 /**
@@ -93,8 +84,7 @@ function getRybbitScriptUrl(options: RybbitAnalyticsOptions): string {
 		return options.scriptUrl;
 	}
 	if (options.analyticsHost) {
-		const normalizedAnalyticsHost = options.analyticsHost.replace(/\/+$/, '');
-		return `${normalizedAnalyticsHost}/script.js`;
+		return joinUrlPath(options.analyticsHost, 'script.js');
 	}
 
 	return 'https://app.rybbit.io/api/script.js';
@@ -125,13 +115,13 @@ export function rybbitAnalytics(options: RybbitAnalyticsOptions): Script {
 	return resolveManifest(rybbitAnalyticsManifest, {
 		scriptUrl: getRybbitScriptUrl(options),
 		siteId: String(options.siteId),
-		autoTrackPageview: booleanAttribute(options.autoTrackPageview),
-		trackSpa: booleanAttribute(options.trackSpa),
-		trackQuery: booleanAttribute(options.trackQuery),
-		trackOutbound: booleanAttribute(options.trackOutbound),
-		trackErrors: booleanAttribute(options.trackErrors),
-		sessionReplay: booleanAttribute(options.sessionReplay),
-		webVitals: booleanAttribute(options.webVitals),
+		autoTrackPageview: booleanDataAttribute(options.autoTrackPageview),
+		trackSpa: booleanDataAttribute(options.trackSpa),
+		trackQuery: booleanDataAttribute(options.trackQuery),
+		trackOutbound: booleanDataAttribute(options.trackOutbound),
+		trackErrors: booleanDataAttribute(options.trackErrors),
+		sessionReplay: booleanDataAttribute(options.sessionReplay),
+		webVitals: booleanDataAttribute(options.webVitals),
 		skipPatterns,
 		maskPatterns,
 		debounce,

--- a/packages/scripts/src/vendors/analytics/segment.ts
+++ b/packages/scripts/src/vendors/analytics/segment.ts
@@ -1,6 +1,7 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 /**
  * Public Segment Analytics.js API exposed on `window.analytics`.
@@ -201,8 +202,9 @@ export function segment({
 	}
 
 	return resolveManifest(manifest, {
-		scriptUrl:
-			scriptUrl ??
-			`https://cdn.segment.com/analytics.js/v1/${writeKey}/analytics.min.js`,
+		scriptUrl: resolveScriptUrl(
+			scriptUrl,
+			`https://cdn.segment.com/analytics.js/v1/${writeKey}/analytics.min.js`
+		),
 	});
 }

--- a/packages/scripts/src/vendors/analytics/umami-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/umami-analytics.ts
@@ -1,6 +1,8 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import { booleanDataAttribute, listDataAttribute } from '../_shared/attributes';
+import { resolveScriptUrl } from '../_shared/script-url';
 
 declare global {
 	interface Window {
@@ -12,32 +14,6 @@ declare global {
 			};
 		};
 	}
-}
-
-function booleanAttribute(value: boolean | undefined): string | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-
-	if (value) {
-		return 'true';
-	}
-
-	return 'false';
-}
-
-function listAttribute(
-	value: string[] | string | undefined
-): string | undefined {
-	if (value === undefined) {
-		return undefined;
-	}
-
-	if (Array.isArray(value)) {
-		return value.join(',');
-	}
-
-	return value;
 }
 
 /**
@@ -139,11 +115,14 @@ export function umamiAnalytics(options: UmamiAnalyticsOptions): Script {
 	const resolved = resolveManifest(umamiAnalyticsManifest, {
 		websiteId: options.websiteId,
 		hostUrl: options.hostUrl,
-		autoTrackAttribute: booleanAttribute(options.autoTrack),
-		domains: listAttribute(options.domains),
+		autoTrackAttribute: booleanDataAttribute(options.autoTrack),
+		domains: listDataAttribute(options.domains),
 		tag: options.tag,
 		beforeSend: options.beforeSend,
-		scriptUrl: options.scriptUrl ?? 'https://cloud.umami.is/script.js',
+		scriptUrl: resolveScriptUrl(
+			options.scriptUrl,
+			'https://cloud.umami.is/script.js'
+		),
 	});
 
 	return resolved;

--- a/packages/scripts/src/vendors/tag-managers/google-tag-manager.test.ts
+++ b/packages/scripts/src/vendors/tag-managers/google-tag-manager.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
-	createCallbackInfo,
 	deniedConsentState,
+	expectGoogleConsentDefault,
 	getTestGlobal,
+	runOnBeforeLoad,
 	setupScriptHelperTest,
-	toArgumentsArray,
 } from '../../__tests__/helpers';
 import { googleTagManager } from './google-tag-manager';
 
@@ -16,27 +16,12 @@ describe('googleTagManager', () => {
 		const script = googleTagManager({ id: 'GTM-ORDER' });
 		globalRef.dataLayer = [];
 
-		script.onBeforeLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: deniedConsentState,
-			})
-		);
+		runOnBeforeLoad(script, {
+			consents: deniedConsentState,
+		});
 
 		const dataLayer = globalRef.dataLayer as unknown[];
-		expect(toArgumentsArray(dataLayer[0])).toEqual([
-			'consent',
-			'default',
-			{
-				security_storage: 'granted',
-				functionality_storage: 'denied',
-				analytics_storage: 'denied',
-				ad_storage: 'denied',
-				ad_user_data: 'denied',
-				ad_personalization: 'denied',
-				personalization_storage: 'denied',
-			},
-		]);
+		expectGoogleConsentDefault(dataLayer[0]);
 		expect(dataLayer[1]).toMatchObject({ event: 'gtm.js' });
 		expect(document.head.appendChild).not.toHaveBeenCalled();
 	});

--- a/packages/scripts/src/vendors/tag-managers/google-tag-manager.ts
+++ b/packages/scripts/src/vendors/tag-managers/google-tag-manager.ts
@@ -1,6 +1,10 @@
 import type { Script } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
+import {
+	GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
+	withOptionalConsentMapping,
+} from '../_shared/google-consent';
 
 // Extended Window interface to include GTM-specific properties
 declare global {
@@ -59,13 +63,7 @@ export const googleTagManagerManifest = {
 			args: ['event', '{{updateEventName}}'],
 		},
 	],
-	consentMapping: {
-		necessary: ['security_storage'],
-		functionality: ['functionality_storage'],
-		measurement: ['analytics_storage'],
-		marketing: ['ad_storage', 'ad_user_data', 'ad_personalization'],
-		experience: ['personalization_storage'],
-	},
+	consentMapping: GOOGLE_CONSENT_MODE_V2_DEFAULT_MAPPING,
 	consentSignal: 'gtag',
 } as const satisfies VendorManifest;
 
@@ -115,9 +113,10 @@ export function googleTagManager({
 	updateEventName,
 	consentMapping,
 }: GoogleTagManagerOptions): Script {
-	const manifest = consentMapping
-		? { ...googleTagManagerManifest, consentMapping }
-		: googleTagManagerManifest;
+	const manifest = withOptionalConsentMapping(
+		googleTagManagerManifest,
+		consentMapping
+	);
 
 	const resolved = resolveManifest(manifest, {
 		id,


### PR DESCRIPTION
## Summary
- Add shared vendor utility modules for data attributes, script URL handling, Google consent mapping, and queue-pixel install steps.
- Migrate repeated helper logic across analytics, pixels, and Google tag integrations without changing vendor behavior.
- Add focused helper tests and shared test assertions for lifecycle callbacks, Google consent defaults, and stub queues.

## Test plan
- bun run test
- bun run lint
- bun run check-types
- bun biome format "packages/scripts/src/vendors/_shared"
- bun biome lint "packages/scripts/src/vendors/_shared"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meta Pixel: initOptions, trackPageView toggle, data-processing options; Snapchat adds PURCHASE event; Reddit retains pixel on marketing revoke and supports first-party cookie control; Microsoft UET loads with consent-mode default denied.

* **Refactor**
  * Shared URL/attribute utilities and queue-install builders applied across vendors; X Pixel status tightened to 'started'|'completed'.

* **Tests**
  * New high-level test helpers for consent and queue assertions; expanded vendor integration tests.

* **Documentation**
  * Updated guides for X, LinkedIn, Meta, Reddit, Snapchat, PostHog, Microsoft UET.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c15t/c15t/pull/848)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->