### PR TITLE
Require 24 hour dependency minimum age

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+minimumReleaseAge = 86400

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,13 @@
 		{
 			"matchPackagePatterns": ["*"],
 			"groupName": "dependencies",
+			"minimumReleaseAge": "24 hours",
 			"schedule": ["before 5am every monday"]
 		}
 	],
 	"ignorePaths": ["**/node_modules/**"],
+	"internalChecksFilter": "strict",
+	"prCreation": "not-pending",
 	"rangeStrategy": "bump",
 	"timezone": "UTC",
 	"schedule": ["before 5am every monday"]


### PR DESCRIPTION
## Summary

- Add Bun install configuration to filter package versions published less than 24 hours ago.
- Configure Renovate to wait 24 hours before proposing dependency updates.
- Set Renovate `internalChecksFilter` to `strict` and `prCreation` to `not-pending` so pending stability checks suppress branch/PR creation instead of opening immediate pending PRs.

## Impact

This adds a dependency cooldown for both local/CI installs and automated dependency PRs, reducing exposure to newly published package versions before they have had time to settle.

## Validation

- `git diff --check`
- Parsed `renovate.json` with Bun
- Confirmed Bun supports `--minimum-release-age`
- Pre-commit hook completed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened dependency update and installation timing: packages now require a minimum release age (24 hours) before being considered for automated updates.
  * Strengthened update process: stricter internal checks and adjusted PR creation behavior to reduce noisy or premature automated PRs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c15t/c15t/pull/850)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->