### PR TITLE
feat: enhance PostHog integration with region selection and loading m…

### DIFF
--- a/.changeset/swift-feet-draw.md
+++ b/.changeset/swift-feet-draw.md
@@ -31,5 +31,10 @@ Google Tag and Google Tag Manager boot timestamps now resolve during script
 lifecycle execution instead of helper construction, which keeps documented setup
 patterns compatible with Next.js Cache Components prerendering.
 
+PostHog now supports explicit EU/US region selection, keeps the bootstrap script
+host aligned with an explicit API host, and exposes loading modes for immediate
+cookieless consent sync, consent-gated loading, or disabling the helper without
+issuing a PostHog network request.
+
 Updated the docs and CLI generation prompts so these providers are discoverable
 from the integration docs and script-loader setup flows.

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostHog
 description: PostHog is an open-source product analytics platform for tracking user behavior, session replays, feature flags, and A/B testing. It supports cookieless tracking, allowing analytics to continue even without cookie consent.
-lastModified: 2026-05-11
+lastModified: 2026-05-12
 icon: posthog
 ---
 
@@ -100,15 +100,28 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
 
 <Steps>
   <Step>
-    ### Configure cookieless mode
+    ### Choose a region and loading mode
 
     The c15t helper loads PostHog's bootstrap script, calls `posthog.init()` for you, and then synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
+
+    Use `region` to keep PostHog's API, UI, and bootstrap script hosts aligned. c15t defaults to `region: 'eu'`; set `region: 'us'` for PostHog Cloud US. You can still pass `apiHost`, `uiHost`, or `scriptUrl` for self-hosted or proxied setups.
+
+    The helper supports three loading modes:
+
+    - `loadMode: 'always'` — the backwards-compatible default. PostHog loads immediately and c15t synchronizes measurement consent through PostHog's APIs. Use this when you intentionally want PostHog cookieless behavior after rejection.
+    - `loadMode: 'after-consent'` — PostHog is not requested until measurement consent is granted. This is the recommended GDPR/EU cookie-banner default when your policy requires no PostHog network activity before consent.
+    - `loadMode: 'disabled'` — returns an inert callback-only script with no PostHog network request. Use this for environment flags or temporary rollouts.
+
+    <Callout type="info">
+      For a privacy-first GDPR/EU cookie-banner setup, use `region: 'eu'` with `loadMode: 'after-consent'`. This keeps PostHog Cloud in the EU region and prevents any PostHog script request until measurement consent is granted.
+    </Callout>
 
     The helper includes these PostHog init defaults:
 
     ```ts
     const initOptions = {
       api_host: 'https://eu.i.posthog.com',
+      ui_host: 'https://eu.posthog.com',
       defaults: '2026-01-30',
       cookieless_mode: 'on_reject',
     };
@@ -120,7 +133,7 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
   <Step>
     ### Enable cookieless tracking in PostHog
 
-    Enable **Cookieless server hash mode** in your PostHog project under **Project Settings** > **Web analytics**. This is required by PostHog before cookieless events are accepted.
+    Enable **Cookieless server hash mode** in your PostHog project under **Project Settings** > **Web analytics** when you use `loadMode: 'always'` and want rejected-consent traffic to be recorded cookielessly. This is required by PostHog before cookieless events are accepted.
   </Step>
 
   <Step>
@@ -136,8 +149,8 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
         const scripts = [
           posthog({
             id: 'phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-            apiHost: 'https://eu.i.posthog.com',
-            scriptUrl: 'https://eu-assets.i.posthog.com/static/array.js',
+            region: 'eu',
+            loadMode: 'after-consent',
           }),
         ];
 
@@ -168,8 +181,8 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
         const scripts = [
           posthog({
             id: 'phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-            apiHost: 'https://eu.i.posthog.com',
-            scriptUrl: 'https://eu-assets.i.posthog.com/static/array.js',
+            region: 'eu',
+            loadMode: 'after-consent',
           }),
         ];
 
@@ -200,8 +213,8 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
           scripts: [
             posthog({
               id: 'phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-              apiHost: 'https://eu.i.posthog.com',
-              scriptUrl: 'https://eu-assets.i.posthog.com/static/array.js',
+              region: 'eu',
+              loadMode: 'after-consent',
             }),
           ],
         });
@@ -211,22 +224,51 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
   </Step>
 </Steps>
 
+### No PostHog request before consent
+
+If your policy requires PostHog to be completely absent until the user grants measurement consent, use `loadMode: 'after-consent'`:
+
+```ts
+import { posthog } from '@c15t/scripts/posthog';
+
+const scripts = [
+  posthog({
+    id: 'phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    region: 'eu',
+    loadMode: 'after-consent',
+  }),
+];
+```
+
+With this mode, c15t does not inject the PostHog script until `measurement` consent is granted. PostHog cannot record cookieless rejected-consent events because the SDK has not loaded.
+
+For PostHog Cloud US, switch the region:
+
+```ts
+posthog({
+  id: 'phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+  region: 'us',
+});
+```
+
 ## How c15t loads it
 
 - **Category:** `measurement` (Analytics)
 - **SDK pattern:** your app loads `posthog-js`; c15t synchronizes
   measurement consent with PostHog opt-in and opt-out APIs.
-- **Script helper pattern:** c15t loads PostHog on page start with
+- **Script helper pattern:** by default, c15t loads PostHog on page start with
   [`alwaysLoad`](/docs/frameworks/react/script-loader#always-load), then
   switches PostHog between cookie-based and cookieless capture as consent
-  changes.
+  changes. Set `loadMode: 'after-consent'` to block the script request until
+  measurement consent is granted.
 
 ## Tracking events in your app
 
 The behavior depends on which pattern you chose:
 
 - **SDK Implementation** — your app loaded `posthog-js` itself, so `posthog.capture(...)` is available once your SDK setup has run. c15t calls `opt_in_capturing()` / `opt_out_capturing()` for you. Pending events before c15t syncs consent may be dropped; after denial, PostHog captures cookieless events.
-- **Script Implementation** — the c15t helper uses `alwaysLoad: true`, so `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events.
+- **Script Implementation with `loadMode: 'always'`** — `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events when your PostHog project supports cookieless mode.
+- **Script Implementation with `loadMode: 'after-consent'`** — PostHog is unavailable until measurement consent is granted. Guard `posthog.capture(...)` calls or call them only after consent.
 
 <Callout type="warning">
   PostHog may start a new session when a user moves between cookieless and cookie-based capture. This can split pre-consent and post-consent activity into separate sessions, which may inflate session counts or affect funnels around the consent boundary. Treat this as a PostHog analytics limitation, not a c15t consent sync issue. See the upstream [PostHog session continuity issue](https://github.com/PostHog/posthog-js/issues/3130).

--- a/packages/scripts/src/vendors/analytics/posthog.test.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.test.ts
@@ -58,7 +58,7 @@ describe('posthog', () => {
 
 		expect(init).toHaveBeenCalledWith(globalRef.posthog, 'phc_123', {
 			api_host: 'https://eu.i.posthog.com',
-			ui_host: 'https://eu.i.posthog.com',
+			ui_host: 'https://eu.posthog.com',
 			autocapture: false,
 			person_profiles: 'identified_only',
 			cookieless_mode: 'on_reject',
@@ -207,6 +207,20 @@ describe('posthog', () => {
 		});
 	});
 
+	it('uses explicit region UI host for custom API hosts', () => {
+		const script = posthog({
+			id: 'phc_custom_region',
+			region: 'us',
+			apiHost: 'https://events.example.com/posthog',
+		});
+
+		expect(script.attributes).toEqual({
+			crossorigin: 'anonymous',
+			'data-api-host': 'https://events.example.com/posthog',
+			'data-ui-host': 'https://us.posthog.com',
+		});
+	});
+
 	it('can wait for measurement consent before loading PostHog', () => {
 		const script = posthog({
 			id: 'phc_after_consent',
@@ -234,7 +248,7 @@ describe('posthog', () => {
 		expect(script.onConsentChange).toBeUndefined();
 	});
 
-	it('allows explicit init options to override helper defaults', () => {
+	it('allows init options to override non-host helper defaults', () => {
 		const globalRef = getTestGlobal();
 		const init = vi.fn();
 		globalRef.posthog = {
@@ -264,8 +278,8 @@ describe('posthog', () => {
 		);
 
 		expect(init).toHaveBeenCalledWith('phc_overrides', {
-			api_host: 'https://us.i.posthog.com',
-			ui_host: 'https://us.posthog.com',
+			api_host: 'https://eu.i.posthog.com',
+			ui_host: 'https://eu.posthog.com',
 			defaults: '2025-05-24',
 			cookieless_mode: 'always',
 		});

--- a/packages/scripts/src/vendors/analytics/posthog.test.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.test.ts
@@ -46,7 +46,7 @@ describe('posthog', () => {
 		expect(script.attributes).toEqual({
 			crossorigin: 'anonymous',
 			'data-api-host': 'https://eu.i.posthog.com',
-			'data-ui-host': 'https://eu.i.posthog.com',
+			'data-ui-host': 'https://eu.posthog.com',
 		});
 
 		script.onLoad?.(
@@ -96,7 +96,7 @@ describe('posthog', () => {
 		expect(script.attributes).toEqual({
 			crossorigin: 'anonymous',
 			'data-api-host': 'https://eu.i.posthog.com',
-			'data-ui-host': 'https://eu.i.posthog.com',
+			'data-ui-host': 'https://eu.posthog.com',
 		});
 
 		script.onLoad?.(
@@ -108,9 +108,130 @@ describe('posthog', () => {
 
 		expect(init).toHaveBeenCalledWith('phc_defaults', {
 			api_host: 'https://eu.i.posthog.com',
+			ui_host: 'https://eu.posthog.com',
 			defaults: '2026-01-30',
 			cookieless_mode: 'on_reject',
 		});
+	});
+
+	it('derives US hosts from the region option', () => {
+		const globalRef = getTestGlobal();
+		const init = vi.fn();
+		globalRef.posthog = {
+			init,
+			opt_in_capturing: vi.fn(),
+			opt_out_capturing: vi.fn(),
+			get_explicit_consent_status: vi.fn(() => 'pending'),
+			capture: vi.fn(),
+		};
+
+		const script = posthog({
+			id: 'phc_us',
+			region: 'us',
+		});
+
+		expect(script.src).toBe('https://us-assets.i.posthog.com/static/array.js');
+		expect(script.attributes).toEqual({
+			crossorigin: 'anonymous',
+			'data-api-host': 'https://us.i.posthog.com',
+			'data-ui-host': 'https://us.posthog.com',
+		});
+
+		script.onLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		expect(init).toHaveBeenCalledWith('phc_us', {
+			api_host: 'https://us.i.posthog.com',
+			ui_host: 'https://us.posthog.com',
+			defaults: '2026-01-30',
+			cookieless_mode: 'on_reject',
+		});
+	});
+
+	it('derives the bootstrap script URL from an explicit API host', () => {
+		const script = posthog({
+			id: 'phc_us_host',
+			apiHost: 'https://us.i.posthog.com',
+		});
+
+		expect(script.src).toBe('https://us-assets.i.posthog.com/static/array.js');
+		expect(script.attributes).toEqual({
+			crossorigin: 'anonymous',
+			'data-api-host': 'https://us.i.posthog.com',
+			'data-ui-host': 'https://us.posthog.com',
+		});
+	});
+
+	it('allows explicit host and script URL overrides', () => {
+		const globalRef = getTestGlobal();
+		const init = vi.fn();
+		globalRef.posthog = {
+			init,
+			opt_in_capturing: vi.fn(),
+			opt_out_capturing: vi.fn(),
+			get_explicit_consent_status: vi.fn(() => 'pending'),
+			capture: vi.fn(),
+		};
+
+		const script = posthog({
+			id: 'phc_custom',
+			region: 'us',
+			apiHost: 'https://events.example.com/posthog',
+			uiHost: 'https://app.example.com/posthog',
+			scriptUrl: 'https://cdn.example.com/posthog/array.js',
+		});
+
+		expect(script.src).toBe('https://cdn.example.com/posthog/array.js');
+		expect(script.attributes).toEqual({
+			crossorigin: 'anonymous',
+			'data-api-host': 'https://events.example.com/posthog',
+			'data-ui-host': 'https://app.example.com/posthog',
+		});
+
+		script.onLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		expect(init).toHaveBeenCalledWith('phc_custom', {
+			api_host: 'https://events.example.com/posthog',
+			ui_host: 'https://app.example.com/posthog',
+			defaults: '2026-01-30',
+			cookieless_mode: 'on_reject',
+		});
+	});
+
+	it('can wait for measurement consent before loading PostHog', () => {
+		const script = posthog({
+			id: 'phc_after_consent',
+			loadMode: 'after-consent',
+		});
+
+		expect(script.alwaysLoad).toBeUndefined();
+		expect(script.src).toBe('https://eu-assets.i.posthog.com/static/array.js');
+	});
+
+	it('can be disabled without creating a PostHog script request', () => {
+		const script = posthog({
+			id: 'phc_disabled',
+			loadMode: 'disabled',
+		});
+
+		expect(script).toEqual({
+			id: 'posthog',
+			category: 'measurement',
+			callbackOnly: true,
+		});
+		expect(script.src).toBeUndefined();
+		expect(script.onBeforeLoad).toBeUndefined();
+		expect(script.onLoad).toBeUndefined();
+		expect(script.onConsentChange).toBeUndefined();
 	});
 
 	it('allows explicit init options to override helper defaults', () => {
@@ -129,6 +250,7 @@ describe('posthog', () => {
 			apiHost: 'https://eu.i.posthog.com',
 			initOptions: {
 				api_host: 'https://us.i.posthog.com',
+				ui_host: 'https://us.posthog.com',
 				defaults: '2025-05-24',
 				cookieless_mode: 'always',
 			},
@@ -143,6 +265,7 @@ describe('posthog', () => {
 
 		expect(init).toHaveBeenCalledWith('phc_overrides', {
 			api_host: 'https://us.i.posthog.com',
+			ui_host: 'https://us.posthog.com',
 			defaults: '2025-05-24',
 			cookieless_mode: 'always',
 		});

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -90,9 +90,10 @@ function deriveScriptUrlFromApiHost(apiHost: string): string {
  * is not supported by the option types and should not be passed.
  *
  * For custom `apiHost` values that do not match known PostHog Cloud regions,
- * `uiHost` defaults to the normalized `apiHost`. When `scriptUrl` is omitted,
- * an explicit `apiHost` derives it with `deriveScriptUrlFromApiHost`; otherwise
- * the selected region default script URL is used.
+ * `uiHost` uses an explicitly selected region when present and otherwise
+ * defaults to the normalized `apiHost`. When `scriptUrl` is omitted, an explicit
+ * `apiHost` derives it with `deriveScriptUrlFromApiHost`; otherwise the
+ * selected region default script URL is used.
  *
  * @example
  * `{ region: 'us' }` resolves US API, UI, and bootstrap script hosts.
@@ -109,19 +110,30 @@ function resolvePosthogHosts(
 	const regionDefaults = REGION_HOSTS[options.region ?? 'eu'];
 	const apiHost = normalizeHost(options.apiHost ?? regionDefaults.apiHost);
 	const inferredRegion = regionFromHost(apiHost);
-	const uiHost = normalizeHost(
-		options.uiHost ??
-			(inferredRegion ? REGION_HOSTS[inferredRegion].uiHost : apiHost)
-	);
+	let uiHost: string;
+	if (options.uiHost !== undefined) {
+		uiHost = options.uiHost;
+	} else if (inferredRegion) {
+		uiHost = REGION_HOSTS[inferredRegion].uiHost;
+	} else if (options.region !== undefined) {
+		uiHost = REGION_HOSTS[options.region].uiHost;
+	} else {
+		uiHost = apiHost;
+	}
+
+	let scriptUrl: string;
+	if (options.scriptUrl !== undefined) {
+		scriptUrl = options.scriptUrl;
+	} else if (options.apiHost !== undefined) {
+		scriptUrl = deriveScriptUrlFromApiHost(apiHost);
+	} else {
+		scriptUrl = regionDefaults.scriptUrl;
+	}
 
 	return {
 		apiHost,
-		uiHost,
-		scriptUrl:
-			options.scriptUrl ??
-			(options.apiHost
-				? deriveScriptUrlFromApiHost(apiHost)
-				: regionDefaults.scriptUrl),
+		uiHost: normalizeHost(uiHost),
+		scriptUrl,
 	};
 }
 
@@ -278,11 +290,11 @@ export function posthog(options: PosthogConsentOptions): Script {
 		uiHost,
 		scriptUrl,
 		initOptions: {
-			api_host: apiHost,
-			ui_host: uiHost,
 			defaults: DEFAULTS_DATE,
 			cookieless_mode: 'on_reject',
 			...options.initOptions,
+			api_host: apiHost,
+			ui_host: uiHost,
 		},
 	});
 

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -24,13 +24,84 @@ declare global {
 
 const DEFAULT_API_HOST = 'https://eu.i.posthog.com';
 const DEFAULT_SCRIPT_URL = 'https://eu-assets.i.posthog.com/static/array.js';
+const DEFAULT_UI_HOST = 'https://eu.posthog.com';
 const DEFAULTS_DATE = '2026-01-30';
+
+export type PosthogRegion = 'eu' | 'us';
+export type PosthogLoadMode = 'always' | 'after-consent' | 'disabled';
+
+interface PosthogHostProfile {
+	apiHost: string;
+	uiHost: string;
+	scriptUrl: string;
+}
+
+const REGION_HOSTS = {
+	eu: {
+		apiHost: DEFAULT_API_HOST,
+		uiHost: DEFAULT_UI_HOST,
+		scriptUrl: DEFAULT_SCRIPT_URL,
+	},
+	us: {
+		apiHost: 'https://us.i.posthog.com',
+		uiHost: 'https://us.posthog.com',
+		scriptUrl: 'https://us-assets.i.posthog.com/static/array.js',
+	},
+} as const satisfies Record<PosthogRegion, PosthogHostProfile>;
+
+function normalizeHost(host: string): string {
+	return host.replace(/\/+$/, '');
+}
+
+function regionFromHost(host: string): PosthogRegion | undefined {
+	const normalized = normalizeHost(host);
+	if (/^https:\/\/(app|us|us-assets)(\.i)?\.posthog\.com$/i.test(normalized)) {
+		return 'us';
+	}
+
+	if (/^https:\/\/(eu|eu-assets)(\.i)?\.posthog\.com$/i.test(normalized)) {
+		return 'eu';
+	}
+}
+
+function deriveScriptUrlFromApiHost(apiHost: string): string {
+	const normalized = normalizeHost(apiHost);
+	const region = regionFromHost(normalized);
+	if (region) {
+		return REGION_HOSTS[region].scriptUrl;
+	}
+
+	return `${normalized}/static/array.js`;
+}
+
+function resolvePosthogHosts(
+	options: PosthogConsentOptions
+): PosthogHostProfile {
+	const regionDefaults = REGION_HOSTS[options.region ?? 'eu'];
+	const apiHost = normalizeHost(options.apiHost ?? regionDefaults.apiHost);
+	const inferredRegion = regionFromHost(apiHost);
+	const uiHost = normalizeHost(
+		options.uiHost ??
+			(inferredRegion ? REGION_HOSTS[inferredRegion].uiHost : apiHost)
+	);
+
+	return {
+		apiHost,
+		uiHost,
+		scriptUrl:
+			options.scriptUrl ??
+			(options.apiHost
+				? deriveScriptUrlFromApiHost(apiHost)
+				: regionDefaults.scriptUrl),
+	};
+}
 
 /**
  * PostHog vendor manifest.
  *
- * PostHog manages its own consent internally via opt_in/opt_out capturing.
- * The script always loads, and consent is toggled via the PostHog API.
+ * By default, PostHog manages its own consent internally via
+ * opt_in/opt_out capturing. The helper can also gate loading until
+ * measurement consent is granted.
  */
 export const posthogManifest = {
 	...vendorManifestContract,
@@ -68,7 +139,7 @@ export const posthogManifest = {
 			attributes: {
 				crossorigin: 'anonymous',
 				'data-api-host': '{{apiHost}}',
-				'data-ui-host': '{{apiHost}}',
+				'data-ui-host': '{{uiHost}}',
 			},
 		},
 	],
@@ -117,13 +188,37 @@ export interface PosthogConsentOptions {
 	id: string;
 
 	/**
+	 * PostHog Cloud region used to derive hosts when explicit host options are not
+	 * provided.
+	 * @default 'eu'
+	 */
+	region?: PosthogRegion;
+
+	/**
 	 * Your posthog api host.
 	 * @default 'https://eu.i.posthog.com'
 	 */
 	apiHost?: string;
 
+	/**
+	 * Your PostHog UI host. Defaults to the UI host for the selected region or
+	 * inferred API host region.
+	 */
+	uiHost?: string;
+
 	/** The PostHog array loader URL. */
 	scriptUrl?: string;
+
+	/**
+	 * How c15t should load the PostHog script.
+	 *
+	 * - `always`: load immediately and synchronize consent through PostHog APIs.
+	 * - `after-consent`: wait for measurement consent before loading PostHog.
+	 * - `disabled`: return an inert callback-only script with no network request.
+	 *
+	 * @default 'always'
+	 */
+	loadMode?: PosthogLoadMode;
 
 	/** PostHog init options passed to `posthog.init(...)`. */
 	initOptions?: Record<string, unknown>;
@@ -131,25 +226,40 @@ export interface PosthogConsentOptions {
 
 /**
  * Loads the PostHog script and initializes it with the given options.
- * This uses posthog.opt_in_capturing() to opt in to capturing. And posthog.opt_out_capturing() to opt out of capturing.
+ * This uses posthog.opt_in_capturing() to opt in to capturing and
+ * posthog.opt_out_capturing() to opt out of capturing.
  * @see https://posthog.com/docs/libraries/js#opt-in-capturing
  *
  * @param options - Optional configuration for the PostHog consent script
  * @returns The Posthog script
  */
 export function posthog(options: PosthogConsentOptions): Script {
-	const apiHost = options.apiHost ?? DEFAULT_API_HOST;
+	if (options.loadMode === 'disabled') {
+		return {
+			id: 'posthog',
+			category: 'measurement',
+			callbackOnly: true,
+		};
+	}
+
+	const { apiHost, uiHost, scriptUrl } = resolvePosthogHosts(options);
 	const resolved = resolveManifest(posthogManifest, {
 		id: options.id,
 		apiHost,
-		scriptUrl: options.scriptUrl ?? DEFAULT_SCRIPT_URL,
+		uiHost,
+		scriptUrl,
 		initOptions: {
 			api_host: apiHost,
+			ui_host: uiHost,
 			defaults: DEFAULTS_DATE,
 			cookieless_mode: 'on_reject',
 			...options.initOptions,
 		},
 	});
+
+	if (options.loadMode === 'after-consent') {
+		resolved.alwaysLoad = undefined;
+	}
 
 	return resolved;
 }

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -74,6 +74,35 @@ function deriveScriptUrlFromApiHost(apiHost: string): string {
 	return `${normalized}/static/array.js`;
 }
 
+/**
+ * Resolves the PostHog host profile from helper options.
+ *
+ * Precedence is:
+ * 1. Explicit `options.apiHost`, `options.uiHost`, and `options.scriptUrl`.
+ * 2. Region inferred from an explicit `apiHost` via `regionFromHost` and
+ *    `REGION_HOSTS`.
+ * 3. `REGION_HOSTS[options.region ?? 'eu']` defaults.
+ *
+ * `options` is a `PosthogConsentOptions` object with optional string host
+ * fields; the returned `PosthogHostProfile` always contains string `apiHost`,
+ * `uiHost`, and `scriptUrl` values. `apiHost` and `uiHost` are always
+ * normalized with `normalizeHost`. `undefined` values select defaults; `null`
+ * is not supported by the option types and should not be passed.
+ *
+ * For custom `apiHost` values that do not match known PostHog Cloud regions,
+ * `uiHost` defaults to the normalized `apiHost`. When `scriptUrl` is omitted,
+ * an explicit `apiHost` derives it with `deriveScriptUrlFromApiHost`; otherwise
+ * the selected region default script URL is used.
+ *
+ * @example
+ * `{ region: 'us' }` resolves US API, UI, and bootstrap script hosts.
+ * @example
+ * `{ apiHost: 'https://us.i.posthog.com/' }` normalizes the API host and
+ * derives the US bootstrap script URL.
+ * @example
+ * `{ apiHost: 'https://events.example.com' }` resolves UI to the same custom
+ * host and script URL to `https://events.example.com/static/array.js`.
+ */
 function resolvePosthogHosts(
 	options: PosthogConsentOptions
 ): PosthogHostProfile {

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -266,9 +266,22 @@ export interface PosthogConsentOptions {
 }
 
 /**
- * Loads the PostHog script and initializes it with the given options.
- * This uses posthog.opt_in_capturing() to opt in to capturing and
- * posthog.opt_out_capturing() to opt out of capturing.
+ * Creates a c15t PostHog script helper.
+ *
+ * The `posthog()` helper uses `region` to resolve the PostHog API, UI, and
+ * bootstrap script hosts. By default, `loadMode: 'always'` loads PostHog
+ * immediately and syncs consent with `posthog.opt_in_capturing()` or
+ * `posthog.opt_out_capturing()`.
+ *
+ * With `loadMode: 'after-consent'`, the script is consent-gated and c15t calls
+ * `posthog.opt_in_capturing()` or `posthog.opt_out_capturing()` after load
+ * based on the user's measurement consent. With `loadMode: 'disabled'`, no
+ * PostHog script is loaded and no `posthog.opt_in_capturing()` or
+ * `posthog.opt_out_capturing()` calls are made.
+ *
+ * Edge case: `loadMode: 'disabled'` skips consent-related flows entirely; use it
+ * only when consumers manage PostHog loading and consent externally.
+ *
  * @see https://posthog.com/docs/libraries/js#opt-in-capturing
  *
  * @param options - Optional configuration for the PostHog consent script


### PR DESCRIPTION
## Overview

Fixes #781.

This updates the PostHog script helper so teams can choose the right regional and consent-loading behavior for their policy.

The helper now supports explicit EU/US region selection, keeps the initial PostHog bootstrap script aligned with the configured API host, and adds loading modes for immediate cookieless consent sync, consent-gated loading, or disabling the helper entirely.

## Type of Change

- [x] Bug fix
- [x] Enhancement
- [x] Documentation

## Implementation Details

### Key Changes

1. Added `region: 'eu' | 'us'` to derive matching PostHog API, UI, and bootstrap script hosts.
2. Added `uiHost` support and fixed `data-ui-host` so it no longer mirrors the ingestion API host.
3. Added `loadMode: 'always' | 'after-consent' | 'disabled'`.
4. Updated PostHog docs to recommend `region: 'eu'` with `loadMode: 'after-consent'` as the privacy-first GDPR/EU cookie-banner setup.
5. Added tests for region-derived hosts, explicit host overrides, API-host-derived script URLs, consent-gated loading, disabled mode, and existing consent sync behavior.

### Technical Notes

`loadMode: 'always'` remains the backwards-compatible default. It preserves the current PostHog cookieless consent-sync behavior.

`loadMode: 'after-consent'` is the stricter option: c15t does not inject the PostHog script until measurement consent is granted.

## Testing

- [x] `bun run --cwd packages/scripts test -- posthog.test.ts registry.test.ts engine.test.ts`
- [x] `bun run --cwd packages/scripts test`
- [x] `bun run --cwd packages/scripts check-types`
- [x] `bun run --cwd packages/scripts lint`

## Checklist

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consent-aware script loader/provider system and broader provider support for analytics/ads/tag managers
  * PostHog: explicit EU/US region selection, unified host resolution, and load modes — always, after-consent (consent-gated), and disabled (no network)

* **Documentation**
  * Updated PostHog guide: region + loadMode usage, cookieless-tracking note, and “no request before consent” examples

* **Tests**
  * Expanded PostHog tests for region/host resolution, loadMode behaviors, and override scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/c15t/c15t/pull/856)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->