### PR TITLE
test(scripts): add bootstrap contract coverage

### DIFF
--- a/packages/scripts/src/ads-pixels-contracts.e2e.test.ts
+++ b/packages/scripts/src/ads-pixels-contracts.e2e.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMarketingConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+} from './e2e-test-utils';
+import { redditPixel } from './vendors/ads-and-pixels/reddit-pixel';
+import { snapchatPixel } from './vendors/ads-and-pixels/snapchat-pixel';
+
+describe('ads pixel queue contracts', () => {
+	registerVendorContractCleanup();
+
+	it('boots Reddit Pixel queue before append', () => {
+		let queueSnapshot: unknown[][] | undefined;
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('redditstatic.com/ads/pixel.js')) {
+				return;
+			}
+
+			win.rdt?.('track', 'Purchase', { currency: 'USD', valueDecimal: 49 });
+			queueSnapshot = win.rdt?.callQueue?.map((entry) => [...entry]);
+			scriptSrc = node.src;
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...redditPixel({
+						disableFirstPartyCookies: true,
+						initOptions: { email: 'hash@example.com' },
+						pixelId: 'REDDIT-CONTRACT',
+					}),
+					id: 'reddit-pixel-contract',
+				},
+			],
+			grantedMarketingConsents
+		);
+
+		expect(scriptSrc).toContain('/ads/pixel.js');
+		expect(queueSnapshot).toEqual([
+			[
+				'init',
+				'REDDIT-CONTRACT',
+				{
+					disableFirstPartyCookies: true,
+					email: 'hash@example.com',
+				},
+			],
+			['track', 'PageVisit'],
+			['track', 'Purchase', { currency: 'USD', valueDecimal: 49 }],
+		]);
+	});
+
+	it('boots Snapchat Pixel metadata, alias, and queue before append', () => {
+		let aliasMatches: boolean | undefined;
+		let pushMatches: boolean | undefined;
+		let queueSnapshot: unknown[][] | undefined;
+		let scriptSrc: string | undefined;
+		let stubMetadata: Record<string, unknown> | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('sc-static.net/scevent.min.js')) {
+				return;
+			}
+
+			win.snaptr?.('track', 'SIGN_UP', { sign_up_method: 'email' });
+			aliasMatches = win._snaptr === win.snaptr;
+			pushMatches = win.snaptr?.push === win.snaptr;
+			queueSnapshot = win.snaptr?.queue?.map((entry) => [...entry]);
+			scriptSrc = node.src;
+			stubMetadata = {
+				loaded: win.snaptr?.loaded,
+				version: win.snaptr?.version,
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...snapchatPixel({
+						initOptions: { user_email: 'hash@example.com' },
+						pixelId: 'SNAPCHAT-CONTRACT',
+					}),
+					id: 'snapchat-pixel-contract',
+				},
+			],
+			grantedMarketingConsents
+		);
+
+		expect(scriptSrc).toContain('/scevent.min.js');
+		expect(aliasMatches).toBe(true);
+		expect(pushMatches).toBe(true);
+		expect(stubMetadata).toEqual({
+			loaded: true,
+			version: '1.0',
+		});
+		expect(queueSnapshot).toEqual([
+			[
+				'init',
+				'SNAPCHAT-CONTRACT',
+				{
+					user_email: 'hash@example.com',
+				},
+			],
+			['track', 'PAGE_VIEW'],
+			['track', 'SIGN_UP', { sign_up_method: 'email' }],
+		]);
+	});
+});

--- a/packages/scripts/src/analytics-loaders.e2e.test.ts
+++ b/packages/scripts/src/analytics-loaders.e2e.test.ts
@@ -60,10 +60,11 @@ describe('analytics loader contracts', () => {
 			}
 
 			const rawConfig = node.getAttribute('data-cf-beacon');
-			beaconConfig =
-				typeof rawConfig === 'string'
-					? (JSON.parse(rawConfig) as Record<string, unknown>)
-					: undefined;
+			if (typeof rawConfig === 'string') {
+				beaconConfig = JSON.parse(rawConfig) as Record<string, unknown>;
+			} else {
+				beaconConfig = undefined;
+			}
 			defer = node.defer;
 			node.dispatchEvent(new Event('load'));
 		});

--- a/packages/scripts/src/analytics-loaders.e2e.test.ts
+++ b/packages/scripts/src/analytics-loaders.e2e.test.ts
@@ -1,0 +1,281 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMeasurementConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+} from './e2e-test-utils';
+import { ahrefsAnalytics } from './vendors/analytics/ahrefs-analytics';
+import { cloudflareWebAnalytics } from './vendors/analytics/cloudflare-web-analytics';
+import { fathomAnalytics } from './vendors/analytics/fathom-analytics';
+import { promptwatch } from './vendors/analytics/promptwatch';
+import { rybbitAnalytics } from './vendors/analytics/rybbit-analytics';
+import { umamiAnalytics } from './vendors/analytics/umami-analytics';
+
+describe('analytics loader contracts', () => {
+	registerVendorContractCleanup();
+
+	it('exposes Ahrefs loader attributes before append', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('analytics.ahrefs.com/analytics.js')) {
+				return;
+			}
+
+			attributes = {
+				async: node.async,
+				dataKey: node.getAttribute('data-key'),
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...ahrefsAnalytics({ key: 'AHREFS-CONTRACT' }),
+					id: 'ahrefs-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			async: true,
+			dataKey: 'AHREFS-CONTRACT',
+		});
+	});
+
+	it('serializes Cloudflare beacon config before append', () => {
+		let beaconConfig: Record<string, unknown> | undefined;
+		let defer: boolean | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('static.cloudflareinsights.com/beacon.min.js')) {
+				return;
+			}
+
+			const rawConfig = node.getAttribute('data-cf-beacon');
+			beaconConfig =
+				typeof rawConfig === 'string'
+					? (JSON.parse(rawConfig) as Record<string, unknown>)
+					: undefined;
+			defer = node.defer;
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...cloudflareWebAnalytics({
+						spa: false,
+						token: 'CLOUDFLARE-CONTRACT',
+					}),
+					id: 'cloudflare-web-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(beaconConfig).toEqual({
+			spa: false,
+			token: 'CLOUDFLARE-CONTRACT',
+		});
+		expect(defer).toBe(true);
+	});
+
+	it('exposes Fathom loader options as data attributes', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('cdn.usefathom.com/script.js')) {
+				return;
+			}
+
+			attributes = {
+				dataAuto: node.getAttribute('data-auto'),
+				dataCanonical: node.getAttribute('data-canonical'),
+				dataHonorDnt: node.getAttribute('data-honor-dnt'),
+				dataSite: node.getAttribute('data-site'),
+				dataSpa: node.getAttribute('data-spa'),
+				defer: node.defer,
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...fathomAnalytics({
+						auto: false,
+						canonical: true,
+						honorDnt: true,
+						site: 'FATHOM-CONTRACT',
+						spa: 'history',
+					}),
+					id: 'fathom-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			dataAuto: 'false',
+			dataCanonical: 'true',
+			dataHonorDnt: 'true',
+			dataSite: 'FATHOM-CONTRACT',
+			dataSpa: 'history',
+			defer: true,
+		});
+	});
+
+	it('exposes Promptwatch project id before append', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('ingest.promptwatch.com/js/client.min.js')) {
+				return;
+			}
+
+			attributes = {
+				async: node.async,
+				dataProjectId: node.getAttribute('data-project-id'),
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...promptwatch({ projectId: 'PROMPTWATCH-CONTRACT' }),
+					id: 'promptwatch-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			async: true,
+			dataProjectId: 'PROMPTWATCH-CONTRACT',
+		});
+	});
+
+	it('exposes Rybbit loader configuration before append', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('analytics.example.com/script.js')) {
+				return;
+			}
+
+			attributes = {
+				dataApiKey: node.getAttribute('data-api-key'),
+				dataAutoTrackPageview: node.getAttribute('data-auto-track-pageview'),
+				dataDebounce: node.getAttribute('data-debounce'),
+				dataMaskPatterns: node.getAttribute('data-mask-patterns'),
+				dataSessionReplay: node.getAttribute('data-session-replay'),
+				dataSiteId: node.getAttribute('data-site-id'),
+				dataSkipPatterns: node.getAttribute('data-skip-patterns'),
+				dataTrackErrors: node.getAttribute('data-track-errors'),
+				dataTrackOutbound: node.getAttribute('data-track-outbound'),
+				dataTrackQuery: node.getAttribute('data-track-query'),
+				dataTrackSpa: node.getAttribute('data-track-spa'),
+				dataWebVitals: node.getAttribute('data-web-vitals'),
+				defer: node.defer,
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...rybbitAnalytics({
+						analyticsHost: 'https://analytics.example.com',
+						apiKey: 'RYBBIT-API-KEY',
+						autoTrackPageview: false,
+						debounce: 250,
+						maskPatterns: ['/account/*'],
+						sessionReplay: true,
+						siteId: 'RYBBIT-CONTRACT',
+						skipPatterns: ['/admin/*'],
+						trackErrors: true,
+						trackOutbound: true,
+						trackQuery: true,
+						trackSpa: true,
+						webVitals: true,
+					}),
+					id: 'rybbit-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			dataApiKey: 'RYBBIT-API-KEY',
+			dataAutoTrackPageview: 'false',
+			dataDebounce: '250',
+			dataMaskPatterns: '["/account/*"]',
+			dataSessionReplay: 'true',
+			dataSiteId: 'RYBBIT-CONTRACT',
+			dataSkipPatterns: '["/admin/*"]',
+			dataTrackErrors: 'true',
+			dataTrackOutbound: 'true',
+			dataTrackQuery: 'true',
+			dataTrackSpa: 'true',
+			dataWebVitals: 'true',
+			defer: true,
+		});
+	});
+
+	it('exposes Umami loader configuration before append', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+
+		installHeadProbe((node) => {
+			if (!node.src.includes('cloud.umami.is/script.js')) {
+				return;
+			}
+
+			attributes = {
+				dataAutoTrack: node.getAttribute('data-auto-track'),
+				dataBeforeSend: node.getAttribute('data-before-send'),
+				dataDomains: node.getAttribute('data-domains'),
+				dataHostUrl: node.getAttribute('data-host-url'),
+				dataTag: node.getAttribute('data-tag'),
+				dataWebsiteId: node.getAttribute('data-website-id'),
+				defer: node.defer,
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...umamiAnalytics({
+						autoTrack: false,
+						beforeSend: 'beforeSendHook',
+						domains: ['example.com', 'www.example.com'],
+						hostUrl: 'https://analytics.example.com',
+						tag: 'canary',
+						websiteId: 'UMAMI-CONTRACT',
+					}),
+					id: 'umami-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			dataAutoTrack: 'false',
+			dataBeforeSend: 'beforeSendHook',
+			dataDomains: '["example.com","www.example.com"]',
+			dataHostUrl: 'https://analytics.example.com',
+			dataTag: 'canary',
+			dataWebsiteId: 'UMAMI-CONTRACT',
+			defer: true,
+		});
+	});
+});

--- a/packages/scripts/src/analytics-queues.e2e.test.ts
+++ b/packages/scripts/src/analytics-queues.e2e.test.ts
@@ -63,9 +63,12 @@ describe('analytics queue contracts', () => {
 			}
 
 			scriptSrc = node.src;
-			queueSnapshot = win._paq?.map((entry) =>
-				Array.isArray(entry) ? [...entry] : entry
-			);
+			queueSnapshot = win._paq?.map((entry) => {
+				if (Array.isArray(entry)) {
+					return [...entry];
+				}
+				return entry;
+			});
 			node.dispatchEvent(new Event('load'));
 		});
 

--- a/packages/scripts/src/analytics-queues.e2e.test.ts
+++ b/packages/scripts/src/analytics-queues.e2e.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMeasurementConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+	type TestWindow,
+} from './e2e-test-utils';
+import { hotjar } from './vendors/analytics/hotjar';
+import { matomoAnalytics } from './vendors/analytics/matomo-analytics';
+import { mixpanelAnalytics } from './vendors/analytics/mixpanel-analytics';
+import { vercelAnalytics } from './vendors/analytics/vercel-analytics';
+
+describe('analytics queue contracts', () => {
+	registerVendorContractCleanup();
+
+	it('boots Hotjar settings and queue before append', () => {
+		let queueSnapshot: unknown[][] | undefined;
+		let settingsSnapshot: TestWindow['_hjSettings'];
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('static.hotjar.com/c/hotjar-123456.js')) {
+				return;
+			}
+
+			win.hj?.('event', 'Signup');
+			queueSnapshot = win.hj?.q?.map((entry) => [...entry]);
+			settingsSnapshot = win._hjSettings;
+			scriptSrc = node.src;
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...hotjar({ siteId: 123456, version: 7 }),
+					id: 'hotjar-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(scriptSrc).toContain('/hotjar-123456.js?sv=7');
+		expect(settingsSnapshot).toEqual({
+			hjid: '123456',
+			hjsv: 7,
+		});
+		expect(queueSnapshot).toEqual([['event', 'Signup']]);
+	});
+
+	it('queues Matomo setup and consent commands before append', () => {
+		let queueSnapshot: unknown[] | undefined;
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('analytics.example.com/matomo.js')) {
+				return;
+			}
+
+			scriptSrc = node.src;
+			queueSnapshot = win._paq?.map((entry) =>
+				Array.isArray(entry) ? [...entry] : entry
+			);
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...matomoAnalytics({
+						defaultConsent: 'required',
+						disableCookies: true,
+						enableLinkTracking: true,
+						matomoUrl: 'https://analytics.example.com',
+						siteId: 42,
+					}),
+					id: 'matomo-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(scriptSrc).toContain('/matomo.js');
+		expect(queueSnapshot).toEqual([
+			['setTrackerUrl', 'https://analytics.example.com/matomo.php'],
+			['setSiteId', '42'],
+			['enableLinkTracking'],
+			['disableCookies'],
+			['requireConsent'],
+			['setConsentGiven'],
+			['trackPageView'],
+		]);
+	});
+
+	it('boots Mixpanel queue methods and load-time consent handoff', () => {
+		const initCalls: unknown[][] = [];
+		let methodTypes: Record<string, string> | undefined;
+		let queueBeforeLoad: unknown[] | undefined;
+		let queueAfterLoad: unknown[] | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('cdn.mxpnl.com/libs/mixpanel-2-latest.min.js')) {
+				return;
+			}
+
+			const mixpanel = win.mixpanel;
+			methodTypes = {
+				identify: typeof mixpanel?.identify,
+				init: typeof mixpanel?.init,
+				optIn: typeof mixpanel?.opt_in_tracking,
+				optOut: typeof mixpanel?.opt_out_tracking,
+				register: typeof mixpanel?.register,
+				reset: typeof mixpanel?.reset,
+				track: typeof mixpanel?.track,
+			};
+
+			mixpanel?.track?.('Signup', { plan: 'pro' });
+			queueBeforeLoad = Array.from(mixpanel ?? []);
+			if (mixpanel) {
+				mixpanel.init = (...args: unknown[]) => {
+					initCalls.push(args);
+				};
+			}
+			node.dispatchEvent(new Event('load'));
+			queueAfterLoad = Array.from(mixpanel ?? []);
+		});
+
+		loadScripts(
+			[
+				{
+					...mixpanelAnalytics({
+						initOptions: { debug: true },
+						token: '1234567890abcdef1234567890abcdef',
+					}),
+					id: 'mixpanel-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(methodTypes).toEqual({
+			identify: 'function',
+			init: 'undefined',
+			optIn: 'function',
+			optOut: 'function',
+			register: 'function',
+			reset: 'function',
+			track: 'function',
+		});
+		expect(queueBeforeLoad).toEqual([['track', 'Signup', { plan: 'pro' }]]);
+		expect(initCalls).toEqual([
+			['1234567890abcdef1234567890abcdef', { debug: true }],
+		]);
+		expect(queueAfterLoad).toEqual([
+			['track', 'Signup', { plan: 'pro' }],
+			['opt_in_tracking'],
+		]);
+	});
+
+	it('boots Vercel Analytics queue and loader attributes before append', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+		let queueSnapshot: unknown[] | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('va.vercel-scripts.com/v1/script.debug.js')) {
+				return;
+			}
+
+			win.va?.('Signup', { plan: 'pro' });
+			attributes = {
+				dataDisableAutoTrack: node.getAttribute('data-disable-auto-track'),
+				dataDsn: node.getAttribute('data-dsn'),
+				dataEndpoint: node.getAttribute('data-endpoint'),
+				dataSdkn: node.getAttribute('data-sdkn'),
+				defer: node.defer,
+			};
+			queueSnapshot = win.vaq?.map((entry) => [...entry]);
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...vercelAnalytics({
+						debug: true,
+						disableAutoTrack: true,
+						dsn: 'VERCEL-CONTRACT',
+						endpoint: '/analytics',
+					}),
+					id: 'vercel-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			dataDisableAutoTrack: '1',
+			dataDsn: 'VERCEL-CONTRACT',
+			dataEndpoint: '/analytics',
+			dataSdkn: 'c15t',
+			defer: true,
+		});
+		expect(queueSnapshot).toEqual([['Signup', { plan: 'pro' }]]);
+	});
+});

--- a/packages/scripts/src/e2e-test-utils.ts
+++ b/packages/scripts/src/e2e-test-utils.ts
@@ -38,6 +38,14 @@ export type TikTokQueue = {
 	[K in TikTokQueueMethodName]?: (...args: unknown[]) => unknown;
 };
 
+type SnapchatQueueStub = ((...args: unknown[]) => void) & {
+	handleRequest?: (...args: unknown[]) => void;
+	loaded?: boolean;
+	push?: SnapchatQueueStub;
+	queue?: unknown[][];
+	version?: string;
+};
+
 export type TestWindow = Window &
 	typeof globalThis & {
 		TiktokAnalyticsObject?: string;
@@ -46,9 +54,25 @@ export type TestWindow = Window &
 		) => {
 			push: (...args: unknown[]) => void;
 		};
+		$crisp?: unknown[][];
+		CRISP_COOKIE_DOMAIN?: string;
+		CRISP_COOKIE_EXPIRE?: number;
+		CRISP_RUNTIME_CONFIG?: {
+			locale?: string;
+			session_merge?: boolean;
+		};
+		CRISP_TOKEN_ID?: string;
+		CRISP_WEBSITE_ID?: string;
+		Intercom?: ((...args: unknown[]) => void) & { q?: unknown[][] };
 		_linkedin_data_partner_ids?: string[];
 		_linkedin_partner_id?: string;
 		_fbq?: Record<string, unknown>;
+		_hjSettings?: {
+			hjid: number | string;
+			hjsv: number;
+		};
+		_paq?: unknown[];
+		_snaptr?: SnapchatQueueStub;
 		analytics?: unknown[] & Record<string, (...args: unknown[]) => void>;
 		clarity?: ((...args: unknown[]) => void) & {
 			q?: unknown[][];
@@ -63,7 +87,10 @@ export type TestWindow = Window &
 		databuddyConfig?: Record<string, unknown>;
 		fbq?: Record<string, unknown>;
 		google_tag_data?: GoogleTagDataState;
+		hj?: ((...args: unknown[]) => void) & { q?: unknown[][] };
+		intercomSettings?: Record<string, unknown>;
 		lintrk?: ((...args: unknown[]) => void) & { q?: unknown[] };
+		mixpanel?: unknown[] & Record<string, (...args: unknown[]) => void>;
 		plausible?: ((...args: unknown[]) => void) & {
 			o?: Record<string, unknown>;
 			q?: unknown[][];
@@ -74,9 +101,16 @@ export type TestWindow = Window &
 			opt_in_capturing: () => void;
 			opt_out_capturing: () => void;
 		};
+		rdt?: ((...args: unknown[]) => void) & {
+			callQueue?: unknown[][];
+			sendEvent?: (...args: unknown[]) => void;
+		};
+		snaptr?: SnapchatQueueStub;
 		ttq?: TikTokQueue;
 		twq?: ((...args: unknown[]) => void) & { queue?: unknown[] };
 		uetq?: unknown[] | { push: (...args: unknown[]) => void };
+		va?: (event: string, properties?: unknown) => void;
+		vaq?: unknown[][];
 	};
 
 export { loadScripts };
@@ -142,9 +176,19 @@ function resetVendorGlobals() {
 	for (const key of [
 		'TiktokAnalyticsObject',
 		'UET',
+		'$crisp',
+		'CRISP_COOKIE_DOMAIN',
+		'CRISP_COOKIE_EXPIRE',
+		'CRISP_RUNTIME_CONFIG',
+		'CRISP_TOKEN_ID',
+		'CRISP_WEBSITE_ID',
+		'Intercom',
 		'_linkedin_data_partner_ids',
 		'_linkedin_partner_id',
 		'_fbq',
+		'_hjSettings',
+		'_paq',
+		'_snaptr',
 		'analytics',
 		'clarity',
 		'dataLayer',
@@ -152,12 +196,19 @@ function resetVendorGlobals() {
 		'databuddyConfig',
 		'fbq',
 		'google_tag_data',
+		'hj',
+		'intercomSettings',
 		'lintrk',
+		'mixpanel',
 		'plausible',
 		'posthog',
+		'rdt',
+		'snaptr',
 		'ttq',
 		'twq',
 		'uetq',
+		'va',
+		'vaq',
 	] as const) {
 		delete win[key];
 	}

--- a/packages/scripts/src/e2e-test-utils.ts
+++ b/packages/scripts/src/e2e-test-utils.ts
@@ -49,6 +49,11 @@ export type TestWindow = Window &
 		_linkedin_data_partner_ids?: string[];
 		_linkedin_partner_id?: string;
 		_fbq?: Record<string, unknown>;
+		analytics?: unknown[] & Record<string, (...args: unknown[]) => void>;
+		clarity?: ((...args: unknown[]) => void) & {
+			q?: unknown[][];
+			v?: string;
+		};
 		dataLayer?: unknown[];
 		databuddy?: {
 			options: {
@@ -59,6 +64,10 @@ export type TestWindow = Window &
 		fbq?: Record<string, unknown>;
 		google_tag_data?: GoogleTagDataState;
 		lintrk?: ((...args: unknown[]) => void) & { q?: unknown[] };
+		plausible?: ((...args: unknown[]) => void) & {
+			o?: Record<string, unknown>;
+			q?: unknown[][];
+		};
 		posthog?: {
 			get_explicit_consent_status: () => string;
 			init: (...args: unknown[]) => void;
@@ -136,12 +145,15 @@ function resetVendorGlobals() {
 		'_linkedin_data_partner_ids',
 		'_linkedin_partner_id',
 		'_fbq',
+		'analytics',
+		'clarity',
 		'dataLayer',
 		'databuddy',
 		'databuddyConfig',
 		'fbq',
 		'google_tag_data',
 		'lintrk',
+		'plausible',
 		'posthog',
 		'ttq',
 		'twq',

--- a/packages/scripts/src/functional-vendors.e2e.test.ts
+++ b/packages/scripts/src/functional-vendors.e2e.test.ts
@@ -18,7 +18,7 @@ const grantedFunctionalityConsents = {
 	functionality: true,
 };
 
-function deepFreeze<T>(value: T): T {
+function deepFreeze<ValueType>(value: ValueType): ValueType {
 	if (value === null || typeof value !== 'object') {
 		return value;
 	}
@@ -30,7 +30,7 @@ function deepFreeze<T>(value: T): T {
 	return Object.freeze(value);
 }
 
-function cloneFrozen<T>(value: T): T {
+function cloneFrozen<ValueType>(value: ValueType): ValueType {
 	return deepFreeze(structuredClone(value));
 }
 

--- a/packages/scripts/src/functional-vendors.e2e.test.ts
+++ b/packages/scripts/src/functional-vendors.e2e.test.ts
@@ -18,6 +18,22 @@ const grantedFunctionalityConsents = {
 	functionality: true,
 };
 
+function deepFreeze<T>(value: T): T {
+	if (value === null || typeof value !== 'object') {
+		return value;
+	}
+
+	for (const nestedValue of Object.values(value as Record<string, unknown>)) {
+		deepFreeze(nestedValue);
+	}
+
+	return Object.freeze(value);
+}
+
+function cloneFrozen<T>(value: T): T {
+	return deepFreeze(structuredClone(value));
+}
+
 describe('functional vendor contracts', () => {
 	registerVendorContractCleanup();
 
@@ -95,8 +111,16 @@ describe('functional vendor contracts', () => {
 			}
 
 			win.Intercom?.('boot', { app_id: 'INTERCOM-CONTRACT' });
-			queueSnapshot = win.Intercom?.q?.map((entry) => [...entry]);
-			settingsSnapshot = win.intercomSettings;
+			if (win.Intercom?.q) {
+				queueSnapshot = cloneFrozen(win.Intercom.q);
+			} else {
+				queueSnapshot = undefined;
+			}
+			if (win.intercomSettings) {
+				settingsSnapshot = cloneFrozen(win.intercomSettings);
+			} else {
+				settingsSnapshot = undefined;
+			}
 			scriptSrc = node.src;
 			node.dispatchEvent(new Event('load'));
 		});

--- a/packages/scripts/src/functional-vendors.e2e.test.ts
+++ b/packages/scripts/src/functional-vendors.e2e.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	deniedConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+	type TestWindow,
+} from './e2e-test-utils';
+import { crisp } from './vendors/functional/crisp';
+import { INTERCOM_API_BASES, intercom } from './vendors/functional/intercom';
+
+const grantedFunctionalityConsents = {
+	...deniedConsents,
+	functionality: true,
+};
+
+describe('functional vendor contracts', () => {
+	registerVendorContractCleanup();
+
+	it('boots Crisp globals and safe-mode queue before append', () => {
+		let crispQueue: unknown[][] | undefined;
+		let globals:
+			| Pick<
+					TestWindow,
+					| 'CRISP_COOKIE_DOMAIN'
+					| 'CRISP_COOKIE_EXPIRE'
+					| 'CRISP_RUNTIME_CONFIG'
+					| 'CRISP_TOKEN_ID'
+					| 'CRISP_WEBSITE_ID'
+			  >
+			| undefined;
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('client.crisp.chat/l.js')) {
+				return;
+			}
+
+			scriptSrc = node.src;
+			crispQueue = win.$crisp?.map((entry) => [...entry]);
+			globals = {
+				CRISP_COOKIE_DOMAIN: win.CRISP_COOKIE_DOMAIN,
+				CRISP_COOKIE_EXPIRE: win.CRISP_COOKIE_EXPIRE,
+				CRISP_RUNTIME_CONFIG: win.CRISP_RUNTIME_CONFIG,
+				CRISP_TOKEN_ID: win.CRISP_TOKEN_ID,
+				CRISP_WEBSITE_ID: win.CRISP_WEBSITE_ID,
+			};
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...crisp({
+						cookieDomain: 'example.com',
+						cookieExpiry: 3600,
+						locale: 'en',
+						safeMode: true,
+						sessionMerge: true,
+						tokenId: 'CRISP-TOKEN',
+						websiteId: 'CRISP-CONTRACT',
+					}),
+					id: 'crisp-contract',
+				},
+			],
+			grantedFunctionalityConsents
+		);
+
+		expect(scriptSrc).toContain('/l.js');
+		expect(globals).toEqual({
+			CRISP_COOKIE_DOMAIN: 'example.com',
+			CRISP_COOKIE_EXPIRE: 3600,
+			CRISP_RUNTIME_CONFIG: {
+				locale: 'en',
+				session_merge: true,
+			},
+			CRISP_TOKEN_ID: 'CRISP-TOKEN',
+			CRISP_WEBSITE_ID: 'CRISP-CONTRACT',
+		});
+		expect(crispQueue).toEqual([['safe', true]]);
+	});
+
+	it('boots Intercom settings and queue before append', () => {
+		let queueSnapshot: unknown[][] | undefined;
+		let settingsSnapshot: Record<string, unknown> | undefined;
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('widget.intercom.io/widget/INTERCOM-CONTRACT')) {
+				return;
+			}
+
+			win.Intercom?.('boot', { app_id: 'INTERCOM-CONTRACT' });
+			queueSnapshot = win.Intercom?.q?.map((entry) => [...entry]);
+			settingsSnapshot = win.intercomSettings;
+			scriptSrc = node.src;
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...intercom({
+						apiBase: INTERCOM_API_BASES.eu,
+						appId: 'INTERCOM-CONTRACT',
+						settings: {
+							hide_default_launcher: true,
+							user_id: 'user-123',
+						},
+					}),
+					id: 'intercom-contract',
+				},
+			],
+			grantedFunctionalityConsents
+		);
+
+		expect(scriptSrc).toContain('/widget/INTERCOM-CONTRACT');
+		expect(settingsSnapshot).toEqual({
+			api_base: INTERCOM_API_BASES.eu,
+			app_id: 'INTERCOM-CONTRACT',
+			hide_default_launcher: true,
+			user_id: 'user-123',
+		});
+		expect(queueSnapshot).toEqual([['boot', { app_id: 'INTERCOM-CONTRACT' }]]);
+	});
+});

--- a/packages/scripts/src/microsoft-clarity.e2e.test.ts
+++ b/packages/scripts/src/microsoft-clarity.e2e.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMeasurementConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+} from './e2e-test-utils';
+import { clarity } from './vendors/analytics/microsoft-clarity';
+
+type ClarityStub = ((...args: unknown[]) => void) & {
+	q?: unknown[][];
+	v?: string;
+};
+
+describe('microsoft clarity contract', () => {
+	registerVendorContractCleanup();
+
+	it('preserves the stub metadata and object default consent payload', () => {
+		const defaultConsent = {
+			ad_storage: 'denied',
+			analytics_storage: 'denied',
+		};
+		let queueSnapshot: unknown[][] | undefined;
+		let scriptSrc: string | undefined;
+		let stubVersion: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('clarity.ms/tag/CLARITY-CONTRACT')) {
+				return;
+			}
+
+			const clarityStub = win.clarity as ClarityStub | undefined;
+			scriptSrc = node.src;
+			stubVersion = clarityStub?.v;
+			queueSnapshot = clarityStub?.q?.map((entry) => [...entry]);
+
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...clarity({
+						id: 'CLARITY-CONTRACT',
+						defaultConsent,
+					}),
+					id: 'microsoft-clarity-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(scriptSrc).toContain('/tag/CLARITY-CONTRACT');
+		expect(stubVersion).toBe('0.7.0');
+		expect(queueSnapshot).toEqual([['consent', defaultConsent]]);
+	});
+});

--- a/packages/scripts/src/plausible-analytics.e2e.test.ts
+++ b/packages/scripts/src/plausible-analytics.e2e.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMeasurementConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+} from './e2e-test-utils';
+import { plausibleAnalytics } from './vendors/analytics/plausible-analytics';
+
+type PlausibleStub = ((...args: unknown[]) => void) & {
+	o?: Record<string, unknown>;
+	q?: unknown[][];
+};
+
+describe('plausible analytics contract', () => {
+	registerVendorContractCleanup();
+
+	it('exposes init options and data attributes before the loader appends', () => {
+		let attributes: Record<string, string | boolean | null> | undefined;
+		let initOptions: Record<string, unknown> | undefined;
+		let queueSnapshot: unknown[][] | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('plausible.io/js/script.js')) {
+				return;
+			}
+
+			const plausible = win.plausible as PlausibleStub | undefined;
+			plausible?.('Signup', { props: { plan: 'pro' } });
+
+			attributes = {
+				dataApi: node.getAttribute('data-api'),
+				dataDomain: node.getAttribute('data-domain'),
+				defer: node.defer,
+			};
+			initOptions = plausible?.o;
+			queueSnapshot = plausible?.q?.map((entry) => [...entry]);
+
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...plausibleAnalytics({
+						autoCapturePageviews: false,
+						customProperties: { release: 'canary' },
+						domain: 'example.com',
+						endpoint: 'https://analytics.example.com/api/event',
+					}),
+					id: 'plausible-analytics-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(attributes).toEqual({
+			dataApi: 'https://analytics.example.com/api/event',
+			dataDomain: 'example.com',
+			defer: true,
+		});
+		expect(initOptions).toEqual({
+			autoCapturePageviews: false,
+			customProperties: { release: 'canary' },
+			endpoint: 'https://analytics.example.com/api/event',
+		});
+		expect(queueSnapshot).toEqual([['Signup', { props: { plan: 'pro' } }]]);
+	});
+});

--- a/packages/scripts/src/segment.e2e.test.ts
+++ b/packages/scripts/src/segment.e2e.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	grantedMeasurementConsents,
+	installHeadProbe,
+	loadScripts,
+	registerVendorContractCleanup,
+} from './e2e-test-utils';
+import { segment } from './vendors/analytics/segment';
+
+type SegmentQueue = unknown[] & {
+	alias?: (...args: unknown[]) => void;
+	group?: (...args: unknown[]) => void;
+	identify?: (...args: unknown[]) => void;
+	page?: (...args: unknown[]) => void;
+	reset?: (...args: unknown[]) => void;
+	track?: (...args: unknown[]) => void;
+};
+
+describe('segment contract', () => {
+	registerVendorContractCleanup();
+
+	it('boots the analytics.js queue and methods before the loader appends', () => {
+		let methodTypes: Record<string, string> | undefined;
+		let queueSnapshot: unknown[] | undefined;
+		let scriptSrc: string | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('cdn.segment.com/analytics.js')) {
+				return;
+			}
+
+			const analytics = win.analytics as SegmentQueue | undefined;
+			scriptSrc = node.src;
+			methodTypes = {
+				alias: typeof analytics?.alias,
+				group: typeof analytics?.group,
+				identify: typeof analytics?.identify,
+				page: typeof analytics?.page,
+				reset: typeof analytics?.reset,
+				track: typeof analytics?.track,
+			};
+
+			analytics?.track?.('Signup', { plan: 'pro' });
+			queueSnapshot = Array.from(analytics ?? []);
+
+			node.dispatchEvent(new Event('load'));
+		});
+
+		loadScripts(
+			[
+				{
+					...segment({ writeKey: 'SEGMENT-CONTRACT' }),
+					id: 'segment-contract',
+				},
+			],
+			grantedMeasurementConsents
+		);
+
+		expect(scriptSrc).toContain(
+			'/analytics.js/v1/SEGMENT-CONTRACT/analytics.min.js'
+		);
+		expect(methodTypes).toEqual({
+			alias: 'function',
+			group: 'function',
+			identify: 'function',
+			page: 'function',
+			reset: 'function',
+			track: 'function',
+		});
+		expect(queueSnapshot).toEqual([
+			['page'],
+			['track', 'Signup', { plan: 'pro' }],
+		]);
+	});
+});


### PR DESCRIPTION
## Overview

Adds browser-level contract coverage for three shipped `@c15t/scripts` helpers that previously only had unit-level or metadata assertions:

1. Segment: verifies the analytics.js queue stub exposes vendor methods and preserves queued `page`/`track` payloads before the loader appends.
2. Microsoft Clarity: verifies the queue stub metadata and object-shaped default consent payload are present before the vendor script loads.
3. Plausible Analytics: verifies bootstrap init options, queue payloads, and loader `data-*` attributes are available at append time.

## Related Issue

Refs #776

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance
- [x] 🧪 Test coverage

## Implementation Details

### Key Changes

1. Added jsdom e2e contract tests for Segment, Microsoft Clarity, and Plausible Analytics.
2. Extended shared e2e cleanup/type support for `analytics`, `clarity`, and `plausible` globals.

### Technical Notes

These tests use the existing append probe to assert vendor-facing globals and script attributes at the same moment a real browser would append the external vendor loader, which catches regressions in bootstrap order and payload shape.

## Testing

### Test Plan

- [x] Focused new e2e coverage

  ```sh
  cd packages/scripts
  bun run test src/segment.e2e.test.ts src/microsoft-clarity.e2e.test.ts src/plausible-analytics.e2e.test.ts
  ```

  ✓ Expected: 3 tests pass.

- [x] Full scripts test suite

  ```sh
  bun turbo run test --filter=@c15t/scripts
  ```

  ✓ Expected: 44 files and 178 tests pass.

- [x] Scripts type check

  ```sh
  bun turbo run check-types --filter=@c15t/scripts
  ```

  ✓ Expected: TypeScript passes.

- [x] Scripts lint

  ```sh
  bun turbo run lint --filter=@c15t/scripts
  ```

  ✓ Expected: Lint task succeeds. Existing `noArguments` warnings remain in `src/engine/runtime.ts`.

### Edge Cases

- [x] Error handling: Test-only change, no runtime error handling behavior changed.
- [x] Performance: Test-only change, no production runtime impact.
- [x] Security: Test-only change, no security-sensitive code paths changed.

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated (not applicable, test-only change)
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for many analytics and ads vendor contracts (Plausible, Segment, Microsoft Clarity, Reddit, Snapchat, Hotjar, Mixpanel, Matomo, Vercel, Crisp, Intercom, Ahrefs, Cloudflare, Fathom, Promptwatch, Rybbit, Umami, and more) validating script injection, data-* attributes, queue initialization, event payloads, and consent behavior.

* **Chores**
  * Expanded test harness to model additional vendor globals and improved cleanup so vendor globals are reset between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->