### PR TITLE
docs: clarify consent subject identification

### DIFF
--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -30,7 +30,11 @@ You can link consent records to your own internal user IDs or anonymous visitor 
 
 ### 1. Setting the Initial User ID (Server Component Example)
 
-If you store a visitor token in an HttpOnly cookie, you can read it server-side in Next.js and pass it to the `ConsentManagerProvider` options:
+If you store a visitor token in an HttpOnly cookie, you can read it server-side in Next.js and pass it to the `ConsentManagerProvider` options.
+
+<Callout type="info">
+  This example uses the asynchronous `cookies()` API available in **Next.js 15+**. For **Next.js 14 and earlier**, use the synchronous form: `const cookieStore = cookies();` (without `await`).
+</Callout>
 
 ```tsx
 // app/layout.tsx

--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -24,9 +24,41 @@ function MyComponent() {
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#state-and-actions" />
 
-## identifyUser
+## User Identification
 
-The `identifyUser()` method links anonymous consent records to an authenticated user. Call it after a user logs in to associate their consent preferences with their account.
+You can link consent records to your own internal user IDs or anonymous visitor tokens (such as a UUID stored in a first-party cookie). This maps the consent history to the `externalId` field on the subject row in the database, allowing you to include consent records in GDPR Article 15 exports.
+
+### 1. Setting the Initial User ID (Server Component Example)
+
+If you store a visitor token in an HttpOnly cookie, you can read it server-side in Next.js and pass it to the `ConsentManagerProvider` options:
+
+```tsx
+// app/layout.tsx
+import { cookies } from 'next/headers';
+import { ConsentManagerProvider } from '@c15t/nextjs';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const visitorToken = cookieStore.get('visitor_token')?.value;
+
+  return (
+    <ConsentManagerProvider
+      options={{
+        mode: 'hosted',
+        backendURL: '/api/c15t',
+        consentCategories: ['necessary', 'measurement', 'marketing'],
+        user: visitorToken ? { id: visitorToken, identityProvider: 'cookie' } : undefined,
+      }}
+    >
+      {children}
+    </ConsentManagerProvider>
+  );
+}
+```
+
+### 2. Updating the ID After Login (`identifyUser`)
+
+When a user logs in, call the `identifyUser()` method to link their previous anonymous consent history to their new authenticated account:
 
 ```tsx
 import { useConsentManager } from '@c15t/nextjs';
@@ -38,10 +70,10 @@ function LoginForm() {
     // ... your login logic
     const user = await api.login(email);
 
-    // Link consent to the authenticated user
+    // Link the current subject's consent history to the authenticated user ID
     await identifyUser({
       id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0'
+      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0', 'custom'
     });
   }
 
@@ -58,9 +90,7 @@ function LoginForm() {
 ```
 
 <Callout type="info">
-  `identifyUser` sends the user data to the c15t backend. It works in hosted
-  mode, including the legacy alias `mode: 'c15t'`. In `mode: 'offline'`, the
-  call is a no-op.
+  User identification (`options.user` and `identifyUser`) requires hosted mode (`mode: 'hosted'`). In `mode: 'offline'`, these configurations are a no-op as consent is stored locally in client-side cookies only.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />

--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -33,7 +33,7 @@ You can link consent records to your own internal user IDs or anonymous visitor 
 If you store a visitor token in an HttpOnly cookie, you can read it server-side in Next.js and pass it to the `ConsentManagerProvider` options.
 
 <Callout type="info">
-  This example uses the asynchronous `cookies()` API available in **Next.js 15+**. For **Next.js 14 and earlier**, use the synchronous form: `const cookieStore = cookies();` (without `await`).
+  This example uses the asynchronous `cookies()` API available in **Next.js 15+**. For **Next.js 14 and earlier**, use the synchronous form `const cookieStore = cookies();` (without `await`) and remove `async` from the `RootLayout` signature if no other async operations exist.
 </Callout>
 
 ```tsx
@@ -65,6 +65,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 When a user logs in, call the `identifyUser()` method to link their previous anonymous consent history to their new authenticated account:
 
 ```tsx
+'use client';
+
 import { useConsentManager } from '@c15t/nextjs';
 
 function LoginForm() {

--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -26,77 +26,111 @@ function MyComponent() {
 
 ## User Identification
 
-You can link consent records to your own internal user IDs or anonymous visitor tokens (such as a UUID stored in a first-party cookie). This maps the consent history to the `externalId` field on the subject row in the database, allowing you to include consent records in GDPR Article 15 exports.
+You can link a consent subject to your own internal user ID or a non-secret anonymous visitor ID. c15t stores the identifier in the subject row's `externalId` field. Consent records remain associated with that subject through `subjectId`, so your backend can find the subject and its related consent records by external ID for GDPR Article 15 exports.
 
-### 1. Setting the Initial User ID (Server Component Example)
+### 1. Providing the Current User ID
 
-If you store a visitor token in an HttpOnly cookie, you can read it server-side in Next.js and pass it to the `ConsentManagerProvider` options.
+When using Clerk, prefer the Clerk `userId` whenever the visitor is signed in. Before sign-in, you can fall back to a non-secret visitor ID stored in a first-party cookie:
+
+<Callout type="warn">
+  `ConsentManagerProvider` runs on the client. Values passed through
+  `options.user` are therefore available to client-side JavaScript, even when
+  they were read from an HttpOnly cookie on the server. Pass only a non-secret
+  identifier, such as a Clerk `userId` or an opaque visitor ID. Never pass a
+  Clerk session token or a value returned by `getToken()`.
+</Callout>
 
 <Callout type="info">
-  This example uses the asynchronous `cookies()` API available in **Next.js 15+**. For **Next.js 14 and earlier**, use the synchronous form `const cookieStore = cookies();` (without `await`) and remove `async` from the `RootLayout` signature if no other async operations exist.
+  Clerk's `auth()` helper requires `clerkMiddleware()` to be configured. This
+  example also uses the asynchronous `cookies()` API from **Next.js 15+**. For
+  **Next.js 14 and earlier**, use `const cookieStore = cookies();` without
+  `await`. Keep the layout asynchronous because Clerk's `auth()` is
+  asynchronous.
 </Callout>
 
 ```tsx
 // app/layout.tsx
-import { cookies } from 'next/headers';
+import { ClerkProvider } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import { ConsentManagerProvider } from '@c15t/nextjs';
+import { cookies } from 'next/headers';
+import { ClerkConsentSync } from './clerk-consent-sync';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const { userId } = await auth();
   const cookieStore = await cookies();
-  const visitorToken = cookieStore.get('visitor_token')?.value;
+  const visitorId = cookieStore.get('consent_visitor_id')?.value;
+  const consentUser = userId
+    ? { id: userId, identityProvider: 'clerk' }
+    : visitorId
+      ? { id: visitorId, identityProvider: 'anonymous-visitor' }
+      : undefined;
 
   return (
-    <ConsentManagerProvider
-      options={{
-        mode: 'hosted',
-        backendURL: '/api/c15t',
-        consentCategories: ['necessary', 'measurement', 'marketing'],
-        user: visitorToken ? { id: visitorToken, identityProvider: 'cookie' } : undefined,
-      }}
-    >
-      {children}
-    </ConsentManagerProvider>
+    <html lang="en">
+      <body>
+        <ClerkProvider>
+          <ConsentManagerProvider
+            options={{
+              mode: 'hosted',
+              backendURL: '/api/c15t',
+              consentCategories: ['necessary', 'measurement', 'marketing'],
+              user: consentUser,
+            }}
+          >
+            <ClerkConsentSync />
+            {children}
+          </ConsentManagerProvider>
+        </ClerkProvider>
+      </body>
+    </html>
   );
 }
 ```
 
-### 2. Updating the ID After Login (`identifyUser`)
+### 2. Synchronizing Clerk Sign-ins
 
-When a user logs in, call the `identifyUser()` method to link their previous anonymous consent history to their new authenticated account:
+Clerk can complete a sign-in without reloading the page. Add a client component inside `ConsentManagerProvider` to update the current consent subject as soon as Clerk exposes the authenticated `userId`:
 
 ```tsx
+// app/clerk-consent-sync.tsx
 'use client';
 
+import { useAuth } from '@clerk/nextjs';
 import { useConsentManager } from '@c15t/nextjs';
+import { useEffect } from 'react';
 
-function LoginForm() {
+export function ClerkConsentSync() {
+  const { isLoaded, isSignedIn, userId } = useAuth();
   const { identifyUser } = useConsentManager();
 
-  async function handleLogin(email: string) {
-    // ... your login logic
-    const user = await api.login(email);
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !userId) {
+      return;
+    }
 
-    // Link the current subject's consent history to the authenticated user ID
-    await identifyUser({
-      id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0', 'custom'
+    void identifyUser({
+      id: userId,
+      identityProvider: 'clerk',
+    }).then(() => {
+      // Prevent the old anonymous ID from replacing the Clerk ID after sign-out.
+      document.cookie =
+        'consent_visitor_id=; Max-Age=0; Path=/; SameSite=Lax';
     });
-  }
+  }, [identifyUser, isLoaded, isSignedIn, userId]);
 
-  return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      handleLogin(new FormData(e.currentTarget).get('email') as string);
-    }}>
-      <input name="email" type="email" placeholder="Email" />
-      <button type="submit">Log in</button>
-    </form>
-  );
+  return null;
 }
 ```
 
+`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, stop supplying the former visitor ID. The example clears its client-readable cookie only after `identifyUser()` succeeds so a later render cannot change the subject back to the anonymous ID.
+
 <Callout type="info">
-  User identification (`options.user` and `identifyUser`) requires hosted mode (`mode: 'hosted'`). In `mode: 'offline'`, these configurations are a no-op as consent is stored locally in client-side cookies only.
+  Backend subject identification requires hosted mode (`mode: 'hosted'`). In
+  offline mode, `identifyUser()` cannot update a backend subject. Identifiers
+  supplied through `options.user` can still be held in client state and
+  persisted with locally stored consent, so do not place sensitive values
+  there.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />

--- a/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
@@ -24,9 +24,39 @@ function MyComponent() {
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#state-and-actions" />
 
-## identifyUser
+## User Identification
 
-The `identifyUser()` method links anonymous consent records to an authenticated user. Call it after a user logs in to associate their consent preferences with their account.
+You can link consent records to your own internal user IDs or anonymous visitor tokens. This maps the consent history to the `externalId` field on the subject row in the database, allowing you to include consent records in GDPR Article 15 exports.
+
+### 1. Setting the Initial User ID
+
+Pass the initial user or visitor ID to the `ConsentManagerProvider` via the `options.user` object:
+
+```tsx
+import { ConsentManagerProvider } from '@c15t/react';
+
+function App() {
+  // Retrieve your visitor token from cookies, local storage, or application context
+  const visitorToken = getVisitorToken();
+
+  return (
+    <ConsentManagerProvider
+      options={{
+        mode: 'hosted',
+        backendURL: 'https://your-instance.c15t.dev',
+        consentCategories: ['necessary', 'measurement', 'marketing'],
+        user: visitorToken ? { id: visitorToken, identityProvider: 'custom-visitor' } : undefined,
+      }}
+    >
+      <MyComponents />
+    </ConsentManagerProvider>
+  );
+}
+```
+
+### 2. Updating the ID After Login (`identifyUser`)
+
+When a user logs in, call the `identifyUser()` method to link their previous anonymous consent history to their new authenticated account:
 
 ```tsx
 import { useConsentManager } from '@c15t/react';
@@ -38,10 +68,10 @@ function LoginForm() {
     // ... your login logic
     const user = await api.login(email);
 
-    // Link consent to the authenticated user
+    // Link the current subject's consent history to the authenticated user ID
     await identifyUser({
       id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0'
+      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0', 'custom'
     });
   }
 
@@ -58,9 +88,7 @@ function LoginForm() {
 ```
 
 <Callout type="info">
-  `identifyUser` sends the user data to the c15t backend. It works in hosted
-  mode, including the legacy alias `mode: 'c15t'`. In `mode: 'offline'`, the
-  call is a no-op.
+  User identification (`options.user` and `identifyUser`) requires hosted mode (`mode: 'hosted'`). In `mode: 'offline'`, these configurations are a no-op as consent is stored locally in client-side cookies only.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />

--- a/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
@@ -26,18 +26,37 @@ function MyComponent() {
 
 ## User Identification
 
-You can link consent records to your own internal user IDs or anonymous visitor tokens. This maps the consent history to the `externalId` field on the subject row in the database, allowing you to include consent records in GDPR Article 15 exports.
+You can link a consent subject to your own internal user ID or a non-secret anonymous visitor ID. c15t stores the identifier in the subject row's `externalId` field. Consent records remain associated with that subject through `subjectId`, so your backend can find the subject and its related consent records by external ID for GDPR Article 15 exports.
 
-### 1. Setting the Initial User ID
+### 1. Providing the Current User ID
 
-Pass the initial user or visitor ID to the `ConsentManagerProvider` via the `options.user` object:
+When using Clerk, wait for Clerk to load and prefer its authenticated `userId`. Before sign-in, you can fall back to a non-secret visitor ID from your application:
+
+<Callout type="warn">
+  Values passed through `options.user` are available to client-side JavaScript.
+  Pass only a non-secret identifier, such as a Clerk `userId` or an opaque
+  visitor ID. Never pass a Clerk session token or a value returned by
+  `getToken()`.
+</Callout>
 
 ```tsx
+import { useAuth } from '@clerk/react';
 import { ConsentManagerProvider } from '@c15t/react';
 
-function App() {
-  // Retrieve your visitor token from cookies, local storage, or application context
-  const visitorToken = getVisitorToken();
+function ConsentApp() {
+  // Render this component beneath your existing ClerkProvider.
+  const { isLoaded, isSignedIn, userId } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  const visitorId = getVisitorId();
+  const consentUser = isSignedIn && userId
+    ? { id: userId, identityProvider: 'clerk' }
+    : visitorId
+      ? { id: visitorId, identityProvider: 'anonymous-visitor' }
+      : undefined;
 
   return (
     <ConsentManagerProvider
@@ -45,50 +64,54 @@ function App() {
         mode: 'hosted',
         backendURL: 'https://your-instance.c15t.dev',
         consentCategories: ['necessary', 'measurement', 'marketing'],
-        user: visitorToken ? { id: visitorToken, identityProvider: 'custom-visitor' } : undefined,
+        user: consentUser,
       }}
     >
+      <ClerkConsentSync />
       <MyComponents />
     </ConsentManagerProvider>
   );
 }
 ```
 
-### 2. Updating the ID After Login (`identifyUser`)
+### 2. Synchronizing Clerk Sign-ins
 
-When a user logs in, call the `identifyUser()` method to link their previous anonymous consent history to their new authenticated account:
+Use a component inside `ConsentManagerProvider` to update the current consent subject when Clerk's authentication state changes:
 
 ```tsx
+import { useAuth } from '@clerk/react';
 import { useConsentManager } from '@c15t/react';
+import { useEffect } from 'react';
 
-function LoginForm() {
+function ClerkConsentSync() {
+  const { isLoaded, isSignedIn, userId } = useAuth();
   const { identifyUser } = useConsentManager();
 
-  async function handleLogin(email: string) {
-    // ... your login logic
-    const user = await api.login(email);
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !userId) {
+      return;
+    }
 
-    // Link the current subject's consent history to the authenticated user ID
-    await identifyUser({
-      id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0', 'custom'
+    void identifyUser({
+      id: userId,
+      identityProvider: 'clerk',
+    }).then(() => {
+      clearVisitorId();
     });
-  }
+  }, [identifyUser, isLoaded, isSignedIn, userId]);
 
-  return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      handleLogin(new FormData(e.currentTarget).get('email') as string);
-    }}>
-      <input name="email" type="email" placeholder="Email" />
-      <button type="submit">Log in</button>
-    </form>
-  );
+  return null;
 }
 ```
 
+`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, clear the previous visitor ID from the application state or storage used by `getVisitorId()` so it cannot replace the Clerk ID later.
+
 <Callout type="info">
-  User identification (`options.user` and `identifyUser`) requires hosted mode (`mode: 'hosted'`). In `mode: 'offline'`, these configurations are a no-op as consent is stored locally in client-side cookies only.
+  Backend subject identification requires hosted mode (`mode: 'hosted'`). In
+  offline mode, `identifyUser()` cannot update a backend subject. Identifiers
+  supplied through `options.user` can still be held in client state and
+  persisted with locally stored consent, so do not place sensitive values
+  there.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />


### PR DESCRIPTION
## Overview

This clarifies how applications can link c15t consent records to their own user IDs or anonymous visitor tokens.

Issue #868 asks for clearer docs around using an app-owned identifier, such as a visitor UUID stored in a first-party cookie, so consent history can be included with privacy exports. The updated React and Next.js `useConsentManager` docs now show the full lifecycle: passing an initial identifier through `ConsentManagerProvider` via `options.user`, and later linking the same subject to an authenticated user with `identifyUser()`.

## Related Issue

Fixes #868

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves existing functionality)
- [ ] New feature
- [ ] Breaking change (requires migration)
- [x] Documentation
- [ ] Refactor (no functional changes)
- [ ] Style (formatting, no code changes)
- [ ] Performance

## Implementation Details

### Key Changes

1. Added Next.js docs showing how to read a visitor token server-side and pass it to `ConsentManagerProvider` through `options.user`.
2. Added React docs showing the same app-owned identifier flow for client-side apps.
3. Clarified that `identifyUser()` can link the current subject's consent history to an authenticated user ID after login.

### Technical Notes

This is docs-only. The documented behavior uses the existing `options.user.id`, `identityProvider`, and `useConsentManager().identifyUser()` APIs.

`mode: 'hosted'` is used for API-backed consent persistence, including self-hosted backend/API deployments. `mode: 'offline'` remains local-only and does not persist subject identity to the backend.

## Testing

### Test Plan

- [x] Scenario 1: Reviewed the changed docs pages for issue scope.

  Command run: `git diff -- docs/frameworks/next/hooks/use-consent-manager/overview.mdx docs/frameworks/react/hooks/use-consent-manager/overview.mdx`

  Expected: Only the React and Next.js `useConsentManager` docs are updated, and the content is limited to subject identification through `options.user` and `identifyUser()`.

- [x] Scenario 2: Checked the working tree for unrelated changes.

  Commands run: `git status --short --branch` and `git diff --stat`

  Expected: Only the two intended docs files are modified.

- [x] Scenario 3: Validated MDX formatting/linting.

  Command run: `bunx remark docs/frameworks/next/hooks/use-consent-manager/overview.mdx docs/frameworks/react/hooks/use-consent-manager/overview.mdx --use remark-mdx --use remark-frontmatter --use remark-preset-lint-recommended --use remark-preset-lint-consistent`

  Expected: Docs checks pass.

### Edge Cases

- [x] Error handling: N/A, docs-only change.
- [x] Performance: N/A, docs-only change.
- [x] Security: The examples use app-owned identifiers and do not expose secrets or tokens beyond normal provider configuration.

### Visual Changes

N/A, docs-only content change.

## Checklist

### Required

- [x] Issue is linked
- [ ] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow conventional commits

### Breaking Changes

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “User Identification” guide for linking consent subjects to an internal user ID or an anonymous visitor token via `externalId`.
  * Updated examples for initializing identity in `ConsentManagerProvider` (hosted mode) and for calling `identifyUser()` after authentication changes, including an identity provider payload pattern.
  * Clarified that user identification applies only in hosted mode (no-op in offline mode), that `options.user` is client-visible (use non-secret identifiers), and that `identifyUser()` replaces the stored `externalId`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->