### PR TITLE
fix(backend): honor explicit ports in trusted origins

### DIFF
--- a/.changeset/honor-explicit-ports-in-trusted-origins.md
+++ b/.changeset/honor-explicit-ports-in-trusted-origins.md
@@ -1,0 +1,7 @@
+---
+"@c15t/backend": patch
+---
+
+# Honor explicit ports in trusted origins
+
+Preserve explicit ports configured in `trustedOrigins` during CORS origin checks instead of stripping them. Host-only entries (e.g. `example.com`) remain port-agnostic, but entries with an explicit port (e.g. `localhost:3000`) now only trust that exact port.

--- a/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
@@ -59,7 +59,7 @@ describe('CORS utilities', () => {
 			expect(isOriginTrusted('wss://example.com', trustedDomains)).toBe(true);
 		});
 
-		it('should handle ports in origins', () => {
+		it('should handle ports in origins when the trusted domain is host-only', () => {
 			const trustedDomains = ['example.com'];
 			expect(isOriginTrusted('https://example.com:3000', trustedDomains)).toBe(
 				true
@@ -67,6 +67,21 @@ describe('CORS utilities', () => {
 			expect(isOriginTrusted('http://example.com:8080', trustedDomains)).toBe(
 				true
 			);
+		});
+
+		it('should scope origins to explicit trusted ports', () => {
+			expect(isOriginTrusted('http://localhost:3000', ['localhost:3000'])).toBe(
+				true
+			);
+			expect(isOriginTrusted('http://localhost:5173', ['localhost:3000'])).toBe(
+				false
+			);
+			expect(
+				isOriginTrusted('https://api.example.com:8443', ['*.example.com:8443'])
+			).toBe(true);
+			expect(
+				isOriginTrusted('https://api.example.com:9443', ['*.example.com:8443'])
+			).toBe(false);
 		});
 
 		it('should handle empty trusted domains array', () => {

--- a/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.test.ts
@@ -84,6 +84,23 @@ describe('CORS utilities', () => {
 			).toBe(false);
 		});
 
+		it('should honor explicitly configured default ports', () => {
+			// :443 is the https default, but writing it should still scope the port
+			expect(isOriginTrusted('https://example.com', ['example.com:443'])).toBe(
+				true
+			);
+			expect(
+				isOriginTrusted('https://example.com:8443', ['example.com:443'])
+			).toBe(false);
+			// :80 written without a protocol must still match an http origin
+			expect(isOriginTrusted('http://example.com', ['example.com:80'])).toBe(
+				true
+			);
+			expect(isOriginTrusted('https://example.com', ['example.com:80'])).toBe(
+				false
+			);
+		});
+
 		it('should handle empty trusted domains array', () => {
 			const trustedDomains: string[] = [];
 			expect(isOriginTrusted('https://example.com', trustedDomains)).toBe(

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -7,15 +7,6 @@
 import type { Logger } from '@c15t/logger';
 import { matchesWildcard } from './matches-wildcard';
 
-/**
- * Regular expression to strip protocol and trailing slashes from URLs.
- * Port numbers are intentionally preserved so entries such as
- * `localhost:3000` do not trust every service on `localhost`.
- *
- * @internal
- */
-export const STRIP_REGEX = /^(?:https?:\/\/)|^(?:wss?:\/\/)|(?:\/+$)/g;
-
 /** Regular expression to match www prefix in domain names */
 const WWW_REGEX = /^www\./;
 

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -19,9 +19,39 @@ export const STRIP_REGEX = /^(?:https?:\/\/)|^(?:wss?:\/\/)|(?:\/+$)/g;
 /** Regular expression to match www prefix in domain names */
 const WWW_REGEX = /^www\./;
 
+/** Regular expression matching a URL scheme prefix (e.g. `https://`) */
+const PROTOCOL_REGEX = /^[a-z][a-z\d+.-]*:\/\//i;
+
+/** Default ports for the protocols we accept, used to resolve origins. */
+const DEFAULT_PORTS: Record<string, string> = {
+	'http:': '80',
+	'https:': '443',
+	'ws:': '80',
+	'wss:': '443',
+};
+
 interface NormalizedTrustedDomain {
 	hostname: string;
 	port?: string;
+}
+
+/**
+ * Extracts an explicitly written port from an authority component.
+ *
+ * Unlike `URL.port`, this preserves default ports (e.g. `:443`) because the
+ * port was deliberately configured and should still scope the origin.
+ *
+ * @internal
+ */
+function extractExplicitPort(authority: string): string | undefined {
+	// IPv6 literals carry the port after the closing bracket: [::1]:3000
+	const ipv6 = authority.match(/^\[[^\]]+\](?::(\d+))?$/);
+	if (ipv6) {
+		return ipv6[1] || undefined;
+	}
+
+	const match = authority.match(/:(\d+)$/);
+	return match ? match[1] : undefined;
 }
 
 function normalizeTrustedDomain(
@@ -32,17 +62,19 @@ function normalizeTrustedDomain(
 		return null;
 	}
 
-	const withoutProtocolOrSlash = trimmed.replace(STRIP_REGEX, '');
+	const hasProtocol = PROTOCOL_REGEX.test(trimmed);
+	const withoutProtocol = trimmed.replace(PROTOCOL_REGEX, '');
+	// The authority is everything before the first path/query/fragment marker.
+	const authority = withoutProtocol.split(/[/?#]/)[0] ?? '';
+
 	try {
-		const parsed = new URL(
-			/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)
-				? trimmed
-				: `https://${withoutProtocolOrSlash}`
-		);
+		const parsed = new URL(hasProtocol ? trimmed : `https://${authority}`);
 
 		return {
 			hostname: parsed.hostname.toLowerCase(),
-			port: parsed.port || undefined,
+			// Read the port from the raw input rather than `parsed.port`, which
+			// drops scheme-default ports such as `:443` on https.
+			port: extractExplicitPort(authority),
 		};
 	} catch {
 		return null;
@@ -102,7 +134,9 @@ export function isOriginTrusted(
 		// Parse the origin URL to get host components
 		const url = new URL(origin);
 		const originHostname = url.hostname.toLowerCase();
-		const originPort = url.port || undefined;
+		// Resolve the scheme default (e.g. 443 for https) so a trusted entry
+		// like `example.com:443` still matches `https://example.com`.
+		const originPort = url.port || DEFAULT_PORTS[url.protocol] || undefined;
 		logger?.debug(`Parsed origin hostname: ${originHostname}`);
 
 		return trustedDomains.some((domain) => {

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -8,20 +8,46 @@ import type { Logger } from '@c15t/logger';
 import { matchesWildcard } from './matches-wildcard';
 
 /**
- * Regular expression to strip protocol, trailing slashes, and port numbers from URLs
- * Matches:
- * - http:// or https:// protocol
- * - ws:// or wss:// protocol
- * - trailing slashes
- * - port numbers with colon
+ * Regular expression to strip protocol and trailing slashes from URLs.
+ * Port numbers are intentionally preserved so entries such as
+ * `localhost:3000` do not trust every service on `localhost`.
  *
  * @internal
  */
-export const STRIP_REGEX =
-	/^(?:https?:\/\/)|^(?:wss?:\/\/)|(?:\/+$)|(?::\d+$)/g;
+export const STRIP_REGEX = /^(?:https?:\/\/)|^(?:wss?:\/\/)|(?:\/+$)/g;
 
 /** Regular expression to match www prefix in domain names */
 const WWW_REGEX = /^www\./;
+
+interface NormalizedTrustedDomain {
+	hostname: string;
+	port?: string;
+}
+
+function normalizeTrustedDomain(
+	domain: string
+): NormalizedTrustedDomain | null {
+	const trimmed = domain.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	const withoutProtocolOrSlash = trimmed.replace(STRIP_REGEX, '');
+	try {
+		const parsed = new URL(
+			/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)
+				? trimmed
+				: `https://${withoutProtocolOrSlash}`
+		);
+
+		return {
+			hostname: parsed.hostname.toLowerCase(),
+			port: parsed.port || undefined,
+		};
+	} catch {
+		return null;
+	}
+}
 
 /**
  * Validates if a given origin matches any of the trusted domain patterns
@@ -73,9 +99,10 @@ export function isOriginTrusted(
 			return true;
 		}
 
-		// Parse the origin URL to get just the hostname
+		// Parse the origin URL to get host components
 		const url = new URL(origin);
 		const originHostname = url.hostname.toLowerCase();
+		const originPort = url.port || undefined;
 		logger?.debug(`Parsed origin hostname: ${originHostname}`);
 
 		return trustedDomains.some((domain) => {
@@ -85,22 +112,42 @@ export function isOriginTrusted(
 				return false;
 			}
 
-			const strippedDomain = domain.replace(STRIP_REGEX, '').toLowerCase();
-			logger?.debug(`Checking against stripped domain: ${strippedDomain}`);
+			const normalizedDomain = normalizeTrustedDomain(domain);
+			if (!normalizedDomain) {
+				logger?.debug('Skipping invalid domain');
+				return false;
+			}
 
-			if (strippedDomain.startsWith('*.')) {
-				const isMatch = matchesWildcard(originHostname, strippedDomain);
+			logger?.debug(
+				`Checking against stripped domain: ${normalizedDomain.hostname}`
+			);
+
+			if (normalizedDomain.port && normalizedDomain.port !== originPort) {
 				logger?.debug(
-					`Wildcard match result: ${isMatch} ${originHostname} matches ${strippedDomain}`
+					`Port mismatch: ${originPort ?? '<default>'} !== ${normalizedDomain.port}`
+				);
+				return false;
+			}
+
+			if (normalizedDomain.hostname.startsWith('*.')) {
+				const isMatch = matchesWildcard(
+					originHostname,
+					normalizedDomain.hostname
+				);
+				logger?.debug(
+					`Wildcard match result: ${isMatch} ${originHostname} matches ${normalizedDomain.hostname}`
 				);
 				return isMatch;
 			}
 
 			const normalizedOriginHostname = originHostname.replace(WWW_REGEX, '');
-			const normalizedDomain = strippedDomain.replace(WWW_REGEX, '');
-			const isMatch = normalizedOriginHostname === normalizedDomain;
+			const normalizedTrustedHostname = normalizedDomain.hostname.replace(
+				WWW_REGEX,
+				''
+			);
+			const isMatch = normalizedOriginHostname === normalizedTrustedHostname;
 			logger?.debug(
-				`Exact match result: ${isMatch} ${normalizedOriginHostname} === ${normalizedDomain}`
+				`Exact match result: ${isMatch} ${normalizedOriginHostname} === ${normalizedTrustedHostname}`
 			);
 			return isMatch;
 		});


### PR DESCRIPTION
## Summary
- preserve explicit ports configured in trustedOrigins instead of stripping them during CORS origin checks
- keep host-only trusted origins protocol-agnostic and port-agnostic for existing behavior
- add regression coverage for localhost and wildcard subdomain port scoping

## Validation
- bunx biome check --write packages/backend/src/middleware/cors/is-origin-trusted.ts packages/backend/src/middleware/cors/is-origin-trusted.test.ts
- bun test packages/backend/src/middleware/cors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CORS origin validation now respects explicit ports in trusted entries, while host-only patterns remain port-agnostic; default ports are honored for protocol-less origins. Wildcard subdomain and localhost port-matching improved.
* **Tests**
  * Added and clarified tests covering port-scoping, wildcard subdomains, and default-port behavior.
* **Documentation**
  * Added a changeset documenting the port-preservation behavior for trusted origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->