### PR TITLE
Update Leadtype docs navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "fast-glob": "3.3.3",
         "json5": "2.2.3",
         "knip": "6.1.1",
-        "leadtype": "^0.1.1",
+        "leadtype": "^0.2.0",
         "lefthook": "2.1.4",
         "mdast-util-compact": "5.0.0",
         "mdast-util-mdx": "3.0.0",
@@ -3339,7 +3339,7 @@
 
     "launch-editor": ["launch-editor@2.13.2", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg=="],
 
-    "leadtype": ["leadtype@0.1.1", "", { "dependencies": { "@types/mdast": "4.0.4", "json5": "2.2.3", "mdast-util-to-string": "4.0.0", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-mdx": "3.1.1", "tinyglobby": "0.2.16", "unified": "11.0.5", "unist-util-visit": "5.1.0", "valibot": "1.4.0", "vfile": "^6.0.3", "vfile-matter": "^5.0.1", "yaml": "^2.9.0" }, "peerDependencies": { "@cloudflare/tanstack-ai": ">=0.1.7", "@tanstack/ai": ">=0.15.0", "ai": ">=6.0.0", "bash-tool": ">=1.3.16", "jiti": ">=2.0.0", "just-bash": ">=2.14.5", "typescript": ">=5.0.0" }, "optionalPeers": ["@cloudflare/tanstack-ai", "@tanstack/ai", "ai", "bash-tool", "jiti", "just-bash", "typescript"], "bin": { "leadtype": "dist/cli.js" } }, "sha512-qF89L0FZaiE1SZe9zm41Zb1HcxJgJ6jppkgUZ5pNwNU0CscdGJtsdJMXoBzL8yXO4aBl1qx/R2lb6XDo8llArQ=="],
+    "leadtype": ["leadtype@0.2.0", "", { "dependencies": { "@types/mdast": "4.0.4", "json5": "2.2.3", "mdast-util-to-string": "4.0.0", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-mdx": "3.1.1", "tinyglobby": "0.2.16", "unified": "11.0.5", "unist-util-visit": "5.1.0", "valibot": "1.4.0", "vfile": "^6.0.3", "vfile-matter": "^5.0.1", "yaml": "^2.9.0" }, "peerDependencies": { "@cloudflare/tanstack-ai": ">=0.1.7", "@modelcontextprotocol/sdk": ">=1.29.0", "@tanstack/ai": ">=0.15.0", "ai": ">=6.0.0", "bash-tool": ">=1.3.16", "fumadocs-core": ">=15.0.0", "jiti": ">=2.0.0", "just-bash": ">=2.14.5", "react": ">=18.0.0", "svelte": ">=5.0.0", "typescript": ">=5.0.0", "vue": ">=3.5.0" }, "optionalPeers": ["@cloudflare/tanstack-ai", "@modelcontextprotocol/sdk", "@tanstack/ai", "ai", "bash-tool", "fumadocs-core", "jiti", "just-bash", "react", "svelte", "typescript", "vue"], "bin": { "leadtype": "dist/cli.js" } }, "sha512-ojSFF0MnNswzqHUEWCq42QBjiUgyBNlkXEfZ4B87Gplql+ZSXna2luSyGyr97IKqi9+DZmjZPgkBvi0ztfgjPg=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "fast-glob": "3.3.3",
         "json5": "2.2.3",
         "knip": "6.1.1",
-        "leadtype": "^0.2.0",
+        "leadtype": "^0.2.1",
         "lefthook": "2.1.4",
         "mdast-util-compact": "5.0.0",
         "mdast-util-mdx": "3.0.0",
@@ -3339,7 +3339,7 @@
 
     "launch-editor": ["launch-editor@2.13.2", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg=="],
 
-    "leadtype": ["leadtype@0.2.0", "", { "dependencies": { "@types/mdast": "4.0.4", "json5": "2.2.3", "mdast-util-to-string": "4.0.0", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-mdx": "3.1.1", "tinyglobby": "0.2.16", "unified": "11.0.5", "unist-util-visit": "5.1.0", "valibot": "1.4.0", "vfile": "^6.0.3", "vfile-matter": "^5.0.1", "yaml": "^2.9.0" }, "peerDependencies": { "@cloudflare/tanstack-ai": ">=0.1.7", "@modelcontextprotocol/sdk": ">=1.29.0", "@tanstack/ai": ">=0.15.0", "ai": ">=6.0.0", "bash-tool": ">=1.3.16", "fumadocs-core": ">=15.0.0", "jiti": ">=2.0.0", "just-bash": ">=2.14.5", "react": ">=18.0.0", "svelte": ">=5.0.0", "typescript": ">=5.0.0", "vue": ">=3.5.0" }, "optionalPeers": ["@cloudflare/tanstack-ai", "@modelcontextprotocol/sdk", "@tanstack/ai", "ai", "bash-tool", "fumadocs-core", "jiti", "just-bash", "react", "svelte", "typescript", "vue"], "bin": { "leadtype": "dist/cli.js" } }, "sha512-ojSFF0MnNswzqHUEWCq42QBjiUgyBNlkXEfZ4B87Gplql+ZSXna2luSyGyr97IKqi9+DZmjZPgkBvi0ztfgjPg=="],
+    "leadtype": ["leadtype@0.2.1", "", { "dependencies": { "@types/mdast": "4.0.4", "json5": "2.2.3", "mdast-util-to-string": "4.0.0", "remark": "15.0.1", "remark-gfm": "4.0.1", "remark-mdx": "3.1.1", "tinyglobby": "0.2.16", "unified": "11.0.5", "unist-util-visit": "5.1.0", "valibot": "1.4.0", "vfile": "^6.0.3", "vfile-matter": "^5.0.1", "yaml": "^2.9.0" }, "peerDependencies": { "@cloudflare/tanstack-ai": ">=0.1.7", "@modelcontextprotocol/sdk": ">=1.29.0", "@tanstack/ai": ">=0.15.0", "ai": ">=6.0.0", "bash-tool": ">=1.3.16", "fumadocs-core": ">=15.0.0", "jiti": ">=2.0.0", "just-bash": ">=2.14.5", "react": ">=18.0.0", "svelte": ">=5.0.0", "typescript": ">=5.0.0", "vue": ">=3.5.0" }, "optionalPeers": ["@cloudflare/tanstack-ai", "@modelcontextprotocol/sdk", "@tanstack/ai", "ai", "bash-tool", "fumadocs-core", "jiti", "just-bash", "react", "svelte", "typescript", "vue"], "bin": { "leadtype": "dist/cli.js" } }, "sha512-9LSu2a9QvvBJbIgbvzEw+wgraVlAV0SffWjWf0ZXbUJCNQtZmbzbcZukd/HhljGazf/k6DnHnoDpc6Q78+qThA=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 

--- a/docs/ai-agents/index.mdx
+++ b/docs/ai-agents/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: AI Agents
 description: Integrate c15t with AI coding assistants using the docs bundled in each package and c15t agent skills. Give agents version-matched local docs for consent management, banners, script loading, callbacks, and integrations.
-lastModified: 2026-03-24
 group: reference
 ---
 

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -1,108 +1,6 @@
-import { defineDocsConfig } from 'leadtype';
+import { defineDocsConfig, defineFrameworkNavigation } from 'leadtype';
 
 const generateDocsConfig = () => {
-	const frameworkConceptPages = [
-		'concepts/initialization-flow',
-		'concepts/client-modes',
-		'concepts/consent-models',
-		'concepts/policy-packs',
-		'concepts/consent-categories',
-		'concepts/cookie-management',
-		'concepts/glossary',
-	];
-
-	const reactFrameworkGuidePages = [
-		'script-loader',
-		'iframe-blocking',
-		'network-blocker',
-		'callbacks',
-		'internationalization',
-		'policy-packs',
-		'server-side',
-	];
-
-	const reactFrameworkComponentPages = [
-		'components/consent-manager-provider',
-		'components/consent-banner',
-		'components/consent-dialog',
-		'components/consent-widget',
-		'components/consent-dialog-trigger',
-		'components/consent-dialog-link',
-		'components/frame',
-		'components/dev-tools',
-	];
-
-	const reactFrameworkStylingPages = [
-		'styling/overview',
-		'styling/tokens',
-		'styling/slots',
-		'styling/classnames',
-		'styling/tailwind',
-		'styling/color-scheme',
-		'styling/css-variables',
-	];
-
-	const reactFrameworkHookPages = [
-		'hooks/use-consent-manager/overview',
-		'hooks/use-consent-manager/checking-consent',
-		'hooks/use-consent-manager/setting-consent',
-		'hooks/use-consent-manager/location-info',
-		'hooks/use-translations',
-		'hooks/use-focus-trap',
-		'hooks/use-color-scheme',
-		'hooks/use-reduced-motion',
-		'hooks/use-text-direction',
-		'hooks/use-ssr-status',
-		'hooks/use-draggable',
-	];
-
-	const reactFrameworkIabPages = [
-		'iab/overview',
-		'iab/consent-banner',
-		'iab/consent-dialog',
-		'iab/use-gvl-data',
-	];
-
-	const buildReactFrameworkNavigation = (title: string, base: string) => ({
-		title,
-		base,
-		pages: ['quickstart', 'optimization', '/ai-agents'],
-		children: [
-			{
-				title: 'Concepts',
-				pages: frameworkConceptPages,
-			},
-			{
-				title: 'Guides',
-				pages: reactFrameworkGuidePages,
-			},
-			{
-				title: 'Components',
-				pages: reactFrameworkComponentPages,
-			},
-			{
-				title: 'Styling',
-				pages: reactFrameworkStylingPages,
-			},
-			{
-				title: 'Hooks',
-				pages: reactFrameworkHookPages,
-			},
-			{
-				title: 'Troubleshooting',
-				pages: ['troubleshooting'],
-			},
-			{
-				title: 'Headless',
-				pages: ['building-headless-components', 'headless'],
-			},
-			{
-				title: 'IAB TCF',
-				pages: reactFrameworkIabPages,
-			},
-		],
-	});
-
 	return defineDocsConfig({
 		product: {
 			name: 'c15t',
@@ -166,20 +64,112 @@ const generateDocsConfig = () => {
 			},
 		],
 		navigation: [
-			{
+			defineFrameworkNavigation({
 				title: 'Frameworks',
 				base: 'frameworks',
-				pages: [''],
-				children: [
-					buildReactFrameworkNavigation('React', 'react'),
-					{
-						title: 'JavaScript',
-						base: 'javascript',
+				pages: ['index'],
+				templates: {
+					componentFramework: {
 						pages: ['quickstart', 'optimization', '/ai-agents'],
 						children: [
 							{
 								title: 'Concepts',
-								pages: frameworkConceptPages,
+								pages: [
+									'concepts/initialization-flow',
+									'concepts/client-modes',
+									'concepts/consent-models',
+									'concepts/policy-packs',
+									'concepts/consent-categories',
+									'concepts/cookie-management',
+									'concepts/glossary',
+								],
+							},
+							{
+								title: 'Guides',
+								pages: [
+									'script-loader',
+									'iframe-blocking',
+									'network-blocker',
+									'callbacks',
+									'internationalization',
+									'policy-packs',
+									'server-side',
+								],
+							},
+							{
+								title: 'Components',
+								pages: [
+									'components/consent-manager-provider',
+									'components/consent-banner',
+									'components/consent-dialog',
+									'components/consent-widget',
+									'components/consent-dialog-trigger',
+									'components/consent-dialog-link',
+									'components/frame',
+									'components/dev-tools',
+								],
+							},
+							{
+								title: 'Styling',
+								pages: [
+									'styling/overview',
+									'styling/tokens',
+									'styling/slots',
+									'styling/classnames',
+									'styling/tailwind',
+									'styling/color-scheme',
+									'styling/css-variables',
+								],
+							},
+							{
+								title: 'Hooks',
+								pages: [
+									'hooks/use-consent-manager/overview',
+									'hooks/use-consent-manager/checking-consent',
+									'hooks/use-consent-manager/setting-consent',
+									'hooks/use-consent-manager/location-info',
+									'hooks/use-translations',
+									'hooks/use-focus-trap',
+									'hooks/use-color-scheme',
+									'hooks/use-reduced-motion',
+									'hooks/use-text-direction',
+									'hooks/use-ssr-status',
+									'hooks/use-draggable',
+								],
+							},
+							{
+								title: 'Troubleshooting',
+								pages: ['troubleshooting'],
+							},
+							{
+								title: 'Headless',
+								pages: ['building-headless-components', 'headless'],
+							},
+							{
+								title: 'IAB TCF',
+								pages: [
+									'iab/overview',
+									'iab/consent-banner',
+									'iab/consent-dialog',
+									'iab/use-gvl-data',
+								],
+							},
+						],
+					},
+					javascript: {
+						pages: ['quickstart', 'optimization', '/ai-agents'],
+						children: [
+							{
+								title: 'Concepts',
+								pages: [
+									'concepts/initialization-flow',
+									'concepts/client-modes',
+									'concepts/consent-models',
+									'concepts/policy-packs',
+									'concepts/consent-categories',
+									'concepts/cookie-management',
+									'concepts/glossary',
+								],
 							},
 							{
 								title: 'Guides',
@@ -215,9 +205,25 @@ const generateDocsConfig = () => {
 							},
 						],
 					},
-					buildReactFrameworkNavigation('Next.js', 'next'),
+				},
+				frameworks: [
+					{
+						title: 'React',
+						base: 'react',
+						template: 'componentFramework',
+					},
+					{
+						title: 'JavaScript',
+						base: 'javascript',
+						template: 'javascript',
+					},
+					{
+						title: 'Next.js',
+						base: 'next',
+						template: 'componentFramework',
+					},
 				],
-			},
+			}),
 			{
 				title: 'CLI',
 				base: 'cli',

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -1,63 +1,339 @@
 import { defineDocsConfig } from 'leadtype';
 
-export default defineDocsConfig({
-	product: {
-		name: 'c15t',
-		summary:
-			'Developer-first consent management for JavaScript, React, Next.js, and self-hosted deployments.',
-		bullets: [
-			'Add GDPR-ready cookie banners, consent dialogs, and preference flows.',
-			'Use framework-specific guides for JavaScript, React, and Next.js.',
-			'Load scripts, iframes, and analytics only after the required consent.',
-			'Self-host the consent backend when managed hosting is not the right fit.',
+const generateDocsConfig = () => {
+	const frameworkConceptPages = [
+		'concepts/initialization-flow',
+		'concepts/client-modes',
+		'concepts/consent-models',
+		'concepts/policy-packs',
+		'concepts/consent-categories',
+		'concepts/cookie-management',
+		'concepts/glossary',
+	];
+
+	const reactFrameworkGuidePages = [
+		'script-loader',
+		'iframe-blocking',
+		'network-blocker',
+		'callbacks',
+		'internationalization',
+		'policy-packs',
+		'server-side',
+	];
+
+	const reactFrameworkComponentPages = [
+		'components/consent-manager-provider',
+		'components/consent-banner',
+		'components/consent-dialog',
+		'components/consent-widget',
+		'components/consent-dialog-trigger',
+		'components/consent-dialog-link',
+		'components/frame',
+		'components/dev-tools',
+	];
+
+	const reactFrameworkStylingPages = [
+		'styling/overview',
+		'styling/tokens',
+		'styling/slots',
+		'styling/classnames',
+		'styling/tailwind',
+		'styling/color-scheme',
+		'styling/css-variables',
+	];
+
+	const reactFrameworkHookPages = [
+		'hooks/use-consent-manager/overview',
+		'hooks/use-consent-manager/checking-consent',
+		'hooks/use-consent-manager/setting-consent',
+		'hooks/use-consent-manager/location-info',
+		'hooks/use-translations',
+		'hooks/use-focus-trap',
+		'hooks/use-color-scheme',
+		'hooks/use-reduced-motion',
+		'hooks/use-text-direction',
+		'hooks/use-ssr-status',
+		'hooks/use-draggable',
+	];
+
+	const reactFrameworkIabPages = [
+		'iab/overview',
+		'iab/consent-banner',
+		'iab/consent-dialog',
+		'iab/use-gvl-data',
+	];
+
+	const buildReactFrameworkNavigation = (title: string, base: string) => ({
+		title,
+		base,
+		pages: ['quickstart', 'optimization', '/ai-agents'],
+		children: [
+			{
+				title: 'Concepts',
+				pages: frameworkConceptPages,
+			},
+			{
+				title: 'Guides',
+				pages: reactFrameworkGuidePages,
+			},
+			{
+				title: 'Components',
+				pages: reactFrameworkComponentPages,
+			},
+			{
+				title: 'Styling',
+				pages: reactFrameworkStylingPages,
+			},
+			{
+				title: 'Hooks',
+				pages: reactFrameworkHookPages,
+			},
+			{
+				title: 'Troubleshooting',
+				pages: ['troubleshooting'],
+			},
+			{
+				title: 'Headless',
+				pages: ['building-headless-components', 'headless'],
+			},
+			{
+				title: 'IAB TCF',
+				pages: reactFrameworkIabPages,
+			},
 		],
-		bestStartingPoints: [
-			{ urlPath: '/docs/frameworks/next/quickstart' },
-			{ urlPath: '/docs/frameworks/react/quickstart' },
-			{ urlPath: '/docs/frameworks/javascript/quickstart' },
-			{ urlPath: '/docs/self-host/quickstart' },
-			{ urlPath: '/docs/cli/quickstart' },
-			{ urlPath: '/changelog' },
+	});
+
+	return defineDocsConfig({
+		product: {
+			name: 'c15t',
+			tagline:
+				'Developer-first consent management for JavaScript, React, Next.js, and self-hosted deployments.',
+			summary:
+				'Developer-first consent management for JavaScript, React, Next.js, and self-hosted deployments.',
+			bullets: [
+				'Add GDPR-ready cookie banners, consent dialogs, and preference flows.',
+				'Use framework-specific guides for JavaScript, React, and Next.js.',
+				'Load scripts, iframes, and analytics only after the required consent.',
+				'Self-host the consent backend when managed hosting is not the right fit.',
+			],
+			bestStartingPoints: [
+				{ urlPath: '/docs/frameworks/next/quickstart' },
+				{ urlPath: '/docs/frameworks/react/quickstart' },
+				{ urlPath: '/docs/frameworks/javascript/quickstart' },
+				{ urlPath: '/docs/self-host/quickstart' },
+				{ urlPath: '/docs/cli/quickstart' },
+				{ urlPath: '/changelog' },
+			],
+			agentGuidance:
+				'Start with the framework-specific quickstart for the target app. Use /docs/llms.txt for routing and /llms-full.txt when page-level context is not enough.',
+		},
+		groups: [
+			{
+				slug: 'frameworks',
+				title: 'Frameworks',
+				description:
+					'Install and configure c15t in JavaScript, React, and Next.js applications.',
+			},
+			{
+				slug: 'self-host',
+				title: 'Self Host',
+				description:
+					'Run the c15t backend, configure storage, and operate consent infrastructure.',
+			},
+			{
+				slug: 'integrations',
+				title: 'Integrations',
+				description:
+					'Connect analytics, advertising, and tag-management tools behind consent.',
+			},
+			{
+				slug: 'cli',
+				title: 'CLI',
+				description:
+					'Scaffold, migrate, and configure c15t projects from the command line.',
+			},
+			{
+				slug: 'reference',
+				title: 'Reference',
+				description:
+					'Concepts, legal templates, open-source policies, and contributor documentation.',
+			},
+			{
+				slug: 'changelog',
+				title: 'Changelog',
+				description:
+					'Release notes and migration context for c15t package versions.',
+			},
 		],
-		agentGuidance:
-			'Start with the framework-specific quickstart for the target app. Use /docs/llms.txt for routing and /llms-full.txt when page-level context is not enough.',
-	},
-	groups: [
-		{
-			slug: 'frameworks',
-			title: 'Frameworks',
-			description:
-				'Install and configure c15t in JavaScript, React, and Next.js applications.',
-		},
-		{
-			slug: 'self-host',
-			title: 'Self Host',
-			description:
-				'Run the c15t backend, configure storage, and operate consent infrastructure.',
-		},
-		{
-			slug: 'integrations',
-			title: 'Integrations',
-			description:
-				'Connect analytics, advertising, and tag-management tools behind consent.',
-		},
-		{
-			slug: 'cli',
-			title: 'CLI',
-			description:
-				'Scaffold, migrate, and configure c15t projects from the command line.',
-		},
-		{
-			slug: 'reference',
-			title: 'Reference',
-			description:
-				'Concepts, legal templates, open-source policies, and contributor documentation.',
-		},
-		{
-			slug: 'changelog',
-			title: 'Changelog',
-			description:
-				'Release notes and migration context for c15t package versions.',
-		},
-	],
-});
+		navigation: [
+			{
+				title: 'Frameworks',
+				base: 'frameworks',
+				pages: [''],
+				children: [
+					buildReactFrameworkNavigation('React', 'react'),
+					{
+						title: 'JavaScript',
+						base: 'javascript',
+						pages: ['quickstart', 'optimization', '/ai-agents'],
+						children: [
+							{
+								title: 'Concepts',
+								pages: frameworkConceptPages,
+							},
+							{
+								title: 'Guides',
+								pages: [
+									'script-loader',
+									'iframe-blocking',
+									'network-blocker',
+									'callbacks',
+									'internationalization',
+									'policy-packs',
+								],
+							},
+							{
+								title: 'Store API',
+								pages: [
+									'api/overview',
+									'api/checking-consent',
+									'api/setting-consent',
+									'api/location-info',
+								],
+							},
+							{
+								title: 'Building Framework Libraries',
+								pages: ['building-ui'],
+							},
+							{
+								title: 'Troubleshooting',
+								pages: ['troubleshooting'],
+							},
+							{
+								title: 'IAB TCF',
+								pages: ['iab/overview'],
+							},
+						],
+					},
+					buildReactFrameworkNavigation('Next.js', 'next'),
+				],
+			},
+			{
+				title: 'CLI',
+				base: 'cli',
+				pages: ['overview', 'quickstart'],
+				children: [
+					{
+						title: 'Commands',
+						pages: [
+							'commands/setup',
+							'commands/generate',
+							'commands/codemods',
+							'commands/self-host',
+							'commands/skills',
+							'commands/auth',
+						],
+					},
+					{
+						title: 'Reference',
+						pages: ['global-flags', 'telemetry'],
+					},
+				],
+			},
+			{
+				title: 'Integrations',
+				base: 'integrations',
+				pages: ['overview', 'building-integrations'],
+				children: [
+					{
+						title: 'Analytics',
+						pages: [
+							'google-tag',
+							'ahrefs-analytics',
+							'cloudflare-web-analytics',
+							'microsoft-clarity',
+							'databuddy',
+							'fathom-analytics',
+							'matomo-analytics',
+							'mixpanel-analytics',
+							'hotjar',
+							'plausible-analytics',
+							'posthog',
+							'promptwatch',
+							'segment',
+							'rybbit-analytics',
+							'umami-analytics',
+							'vercel-analytics',
+						],
+					},
+					{
+						title: 'Functional',
+						pages: ['crisp', 'intercom'],
+					},
+					{
+						title: 'Ads & Pixels',
+						pages: [
+							'meta-pixel',
+							'reddit-pixel',
+							'tiktok-pixel',
+							'linkedin-insights',
+							'microsoft-uet',
+							'snapchat-pixel',
+							'x-pixel',
+						],
+					},
+					{
+						title: 'Tag Managers',
+						pages: ['google-tag-manager'],
+					},
+				],
+			},
+			{
+				title: 'Self Host',
+				base: 'self-host',
+				pages: ['quickstart'],
+				children: [
+					{
+						title: 'Guides',
+						pages: [
+							'guides/database-setup',
+							'guides/framework-integration',
+							'guides/edge-deployment',
+							'guides/caching',
+							'guides/iab-tcf',
+							'guides/policy-packs',
+							'guides/observability',
+						],
+					},
+					{
+						title: 'API Reference',
+						pages: ['api/endpoints', 'api/configuration'],
+					},
+				],
+			},
+			{
+				title: 'Contributing',
+				base: 'contributing',
+				pages: ['index', 'docs-preview-action', 'documentation-setup'],
+			},
+			{
+				title: 'Open Source',
+				base: 'oss',
+				pages: [
+					'why-open-source',
+					'contributing',
+					'code-of-conduct',
+					'license',
+				],
+			},
+			{
+				title: 'Legal',
+				base: 'legals',
+				pages: ['cookie-policy', 'privacy-policy'],
+				optional: true,
+			},
+		],
+	});
+};
+
+export default generateDocsConfig();

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -249,8 +249,12 @@ const generateDocsConfig = () => {
 			{
 				title: 'Integrations',
 				base: 'integrations',
-				pages: ['overview', 'building-integrations', 'google-tag-manager'],
+				pages: ['overview', 'building-integrations'],
 				children: [
+					{
+						title: 'Tag Managers',
+						pages: ['google-tag-manager'],
+					},
 					{
 						title: 'Analytics',
 						pages: [

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -249,7 +249,7 @@ const generateDocsConfig = () => {
 			{
 				title: 'Integrations',
 				base: 'integrations',
-				pages: ['overview', 'building-integrations'],
+				pages: ['overview', 'building-integrations', 'google-tag-manager'],
 				children: [
 					{
 						title: 'Analytics',
@@ -287,10 +287,6 @@ const generateDocsConfig = () => {
 							'snapchat-pixel',
 							'x-pixel',
 						],
-					},
-					{
-						title: 'Tag Managers',
-						pages: ['google-tag-manager'],
 					},
 				],
 			},

--- a/docs/frameworks/javascript/optimization.mdx
+++ b/docs/frameworks/javascript/optimization.mdx
@@ -1,7 +1,6 @@
 ---
 title: Optimization
 description: Improve c15t startup performance with prefetching and network tuning.
-lastModified: 2026-03-17
 group: frameworks
 ---
 

--- a/docs/frameworks/next/concepts/cookie-management.mdx
+++ b/docs/frameworks/next/concepts/cookie-management.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cookie Management
 description: How c15t manages cookies through script, iframe, and network gating
-lastModified: 2026-02-10
 group: frameworks
 ---
 

--- a/docs/frameworks/next/optimization.mdx
+++ b/docs/frameworks/next/optimization.mdx
@@ -1,7 +1,6 @@
 ---
 title: Optimization
 description: Improve c15t startup performance in Next.js with same-origin rewrites, static prefetching, and dynamic-route SSR.
-lastModified: 2026-04-14
 group: frameworks
 ---
 

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -1,17 +1,16 @@
 ---
 title: Quickstart
 description: Add consent management to your Next.js app in under 5 minutes.
-lastModified: 2026-03-11
-availableIn:
-  - framework: 'javascript'
-    url: '/docs/frameworks/javascript/quickstart'
-    title: 'JavaScript'
-  - framework: 'react'
-    url: '/docs/frameworks/react/quickstart'
-    title: 'React'
-  - framework: 'next'
-    url: '/docs/frameworks/next/quickstart'
-    title: 'Next.js'
+variants:
+  - value: "javascript"
+    href: "/docs/frameworks/javascript/quickstart"
+    label: "JavaScript"
+  - value: "react"
+    href: "/docs/frameworks/react/quickstart"
+    label: "React"
+  - value: "next"
+    href: "/docs/frameworks/next/quickstart"
+    label: "Next.js"
 group: frameworks
 ---
 
@@ -26,6 +25,7 @@ group: frameworks
     ### Install package
 
     <PackageCommandTabs mode="install" command="@c15t/nextjs" />
+
   </Step>
 
   <Step>
@@ -42,6 +42,7 @@ group: frameworks
     <Callout type="info">
       If you are using the headless API or fully custom styling, you can skip this import. Your root layout should continue importing `./globals.css` as usual.
     </Callout>
+
   </Step>
 
   <Step>
@@ -94,6 +95,7 @@ group: frameworks
     <Callout type="warn">
       Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/next/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
+
   </Step>
 
   <Step>
@@ -114,6 +116,7 @@ group: frameworks
       );
     }
     ```
+
   </Step>
 
   <Step>
@@ -124,11 +127,15 @@ group: frameworks
     1. A **consent banner** appears at the bottom of the page
     2. Clicking **"Customize"** opens a dialog with toggles for each consent category
     3. After accepting or rejecting, the banner dismisses and your choice persists across page reloads
+
   </Step>
 </Steps>
 
 <Callout type="info">
-  Want better performance and static-route support? See [Optimization](/docs/frameworks/next/optimization) for rewrites, prefetching, and network tuning. If you want server-side data prefetching, see [Server-Side Data Fetching](/docs/frameworks/next/server-side).
+	Want better performance and static-route support? See
+	[Optimization](/docs/frameworks/next/optimization) for rewrites, prefetching, and network tuning.
+	If you want server-side data prefetching, see [Server-Side Data
+	Fetching](/docs/frameworks/next/server-side).
 </Callout>
 
 ## Optional: Add DevTools
@@ -153,7 +160,10 @@ import { DevTools } from '@c15t/dev-tools/react';
 ```
 
 <Callout type="info">
-  Want to understand what's happening under the hood? See [Initialization Flow](/docs/frameworks/next/concepts/initialization-flow) for the lifecycle and [Cookie Management](/docs/frameworks/next/concepts/cookie-management) for script/cookie behavior and revocation handling.
+	Want to understand what's happening under the hood? See [Initialization
+	Flow](/docs/frameworks/next/concepts/initialization-flow) for the lifecycle and [Cookie
+	Management](/docs/frameworks/next/concepts/cookie-management) for script/cookie behavior and
+	revocation handling.
 </Callout>
 
 ## Optional: AI Agents
@@ -169,13 +179,33 @@ See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 <Cards className="not-prose grid gap-4 grid-cols-1 sm:grid-cols-2">
   <Card variant="interactive" title="Optimization" description="Improve banner visibility and lower latency with rewrites, browser prefetch, and SSR tradeoffs." href="/docs/frameworks/next/optimization" />
 
-  <Card variant="interactive" title="Script Loader" description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent." href="/docs/frameworks/next/script-loader" />
+<Card
+	variant="interactive"
+	title="Script Loader"
+	description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent."
+	href="/docs/frameworks/next/script-loader"
+/>
 
-  <Card variant="interactive" title="Styling" description="Customize colors, typography, spacing, and individual component slots." href="/docs/frameworks/next/styling/overview" />
+<Card
+	variant="interactive"
+	title="Styling"
+	description="Customize colors, typography, spacing, and individual component slots."
+	href="/docs/frameworks/next/styling/overview"
+/>
 
-  <Card variant="interactive" title="Consent Categories" description="Understand the five consent categories and how to configure them." href="/docs/frameworks/next/concepts/consent-categories" />
+<Card
+	variant="interactive"
+	title="Consent Categories"
+	description="Understand the five consent categories and how to configure them."
+	href="/docs/frameworks/next/concepts/consent-categories"
+/>
 
-  <Card variant="interactive" title="Components" description="Explore the full set of pre-built consent UI components." href="/docs/frameworks/next/components/consent-banner" />
+<Card
+	variant="interactive"
+	title="Components"
+	description="Explore the full set of pre-built consent UI components."
+	href="/docs/frameworks/next/components/consent-banner"
+/>
 
   <Card variant="interactive" title="AI Agents" description="Help AI tools with bundled package docs and reusable c15t agent skills." href="/docs/ai-agents" />
 </Cards>

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -25,7 +25,6 @@ group: frameworks
     ### Install package
 
     <PackageCommandTabs mode="install" command="@c15t/nextjs" />
-
   </Step>
 
   <Step>
@@ -42,7 +41,6 @@ group: frameworks
     <Callout type="info">
       If you are using the headless API or fully custom styling, you can skip this import. Your root layout should continue importing `./globals.css` as usual.
     </Callout>
-
   </Step>
 
   <Step>
@@ -95,7 +93,6 @@ group: frameworks
     <Callout type="warn">
       Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/next/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
-
   </Step>
 
   <Step>
@@ -116,7 +113,6 @@ group: frameworks
       );
     }
     ```
-
   </Step>
 
   <Step>
@@ -127,15 +123,14 @@ group: frameworks
     1. A **consent banner** appears at the bottom of the page
     2. Clicking **"Customize"** opens a dialog with toggles for each consent category
     3. After accepting or rejecting, the banner dismisses and your choice persists across page reloads
-
   </Step>
 </Steps>
 
 <Callout type="info">
-	Want better performance and static-route support? See
-	[Optimization](/docs/frameworks/next/optimization) for rewrites, prefetching, and network tuning.
-	If you want server-side data prefetching, see [Server-Side Data
-	Fetching](/docs/frameworks/next/server-side).
+  Want better performance and static-route support? See
+  [Optimization](/docs/frameworks/next/optimization) for rewrites, prefetching, and network tuning.
+  If you want server-side data prefetching, see [Server-Side Data
+  Fetching](/docs/frameworks/next/server-side).
 </Callout>
 
 ## Optional: Add DevTools
@@ -160,10 +155,10 @@ import { DevTools } from '@c15t/dev-tools/react';
 ```
 
 <Callout type="info">
-	Want to understand what's happening under the hood? See [Initialization
-	Flow](/docs/frameworks/next/concepts/initialization-flow) for the lifecycle and [Cookie
-	Management](/docs/frameworks/next/concepts/cookie-management) for script/cookie behavior and
-	revocation handling.
+  Want to understand what's happening under the hood? See [Initialization
+  Flow](/docs/frameworks/next/concepts/initialization-flow) for the lifecycle and [Cookie
+  Management](/docs/frameworks/next/concepts/cookie-management) for script/cookie behavior and
+  revocation handling.
 </Callout>
 
 ## Optional: AI Agents
@@ -179,33 +174,13 @@ See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 <Cards className="not-prose grid gap-4 grid-cols-1 sm:grid-cols-2">
   <Card variant="interactive" title="Optimization" description="Improve banner visibility and lower latency with rewrites, browser prefetch, and SSR tradeoffs." href="/docs/frameworks/next/optimization" />
 
-<Card
-	variant="interactive"
-	title="Script Loader"
-	description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent."
-	href="/docs/frameworks/next/script-loader"
-/>
+  <Card variant="interactive" title="Script Loader" description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent." href="/docs/frameworks/next/script-loader" />
 
-<Card
-	variant="interactive"
-	title="Styling"
-	description="Customize colors, typography, spacing, and individual component slots."
-	href="/docs/frameworks/next/styling/overview"
-/>
+  <Card variant="interactive" title="Styling" description="Customize colors, typography, spacing, and individual component slots." href="/docs/frameworks/next/styling/overview" />
 
-<Card
-	variant="interactive"
-	title="Consent Categories"
-	description="Understand the five consent categories and how to configure them."
-	href="/docs/frameworks/next/concepts/consent-categories"
-/>
+  <Card variant="interactive" title="Consent Categories" description="Understand the five consent categories and how to configure them." href="/docs/frameworks/next/concepts/consent-categories" />
 
-<Card
-	variant="interactive"
-	title="Components"
-	description="Explore the full set of pre-built consent UI components."
-	href="/docs/frameworks/next/components/consent-banner"
-/>
+  <Card variant="interactive" title="Components" description="Explore the full set of pre-built consent UI components." href="/docs/frameworks/next/components/consent-banner" />
 
   <Card variant="interactive" title="AI Agents" description="Help AI tools with bundled package docs and reusable c15t agent skills." href="/docs/ai-agents" />
 </Cards>

--- a/docs/frameworks/react/concepts/cookie-management.mdx
+++ b/docs/frameworks/react/concepts/cookie-management.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cookie Management
 description: How c15t manages cookies through script, iframe, and network gating
-lastModified: 2026-02-10
 group: frameworks
 ---
 

--- a/docs/frameworks/react/optimization.mdx
+++ b/docs/frameworks/react/optimization.mdx
@@ -1,7 +1,6 @@
 ---
 title: Optimization
 description: Improve c15t startup performance in React with prefetching, proxy rewrites, and rendering tradeoffs.
-lastModified: 2026-04-14
 group: frameworks
 ---
 

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -1,17 +1,16 @@
 ---
 title: Quickstart
 description: Add consent management to your React app in under 5 minutes.
-lastModified: 2026-02-10
-availableIn:
-  - framework: 'javascript'
-    url: '/docs/frameworks/javascript/quickstart'
-    title: 'JavaScript'
-  - framework: 'react'
-    url: '/docs/frameworks/react/quickstart'
-    title: 'React'
-  - framework: 'next'
-    url: '/docs/frameworks/next/quickstart'
-    title: 'Next.js'
+variants:
+  - value: "javascript"
+    href: "/docs/frameworks/javascript/quickstart"
+    label: "JavaScript"
+  - value: "react"
+    href: "/docs/frameworks/react/quickstart"
+    label: "React"
+  - value: "next"
+    href: "/docs/frameworks/next/quickstart"
+    label: "Next.js"
 group: frameworks
 ---
 
@@ -26,6 +25,7 @@ group: frameworks
     ### Install package
 
     <PackageCommandTabs mode="install" command="@c15t/react" />
+
   </Step>
 
   <Step>
@@ -42,6 +42,7 @@ group: frameworks
     <Callout type="info">
       If you are using the headless API or fully custom styling, you can skip this import. `src/main.tsx` should keep importing `./index.css` as usual.
     </Callout>
+
   </Step>
 
   <Step>
@@ -90,6 +91,7 @@ group: frameworks
     <Callout type="warn">
       Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/react/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
+
   </Step>
 
   <Step>
@@ -108,6 +110,7 @@ group: frameworks
       );
     }
     ```
+
   </Step>
 
   <Step>
@@ -118,11 +121,13 @@ group: frameworks
     1. A **consent banner** appears at the bottom of the page
     2. Clicking **"Customize"** opens a dialog with toggles for each consent category
     3. After accepting or rejecting, the banner dismisses and your choice persists across page reloads
+
   </Step>
 </Steps>
 
 <Callout type="info">
-  Want to improve startup performance? See [Optimization](/docs/frameworks/react/optimization) for the decision guide, prefetch setup, and network tuning.
+	Want to improve startup performance? See [Optimization](/docs/frameworks/react/optimization) for
+	the decision guide, prefetch setup, and network tuning.
 </Callout>
 
 ## Optional: Add DevTools
@@ -147,7 +152,10 @@ import { DevTools } from '@c15t/dev-tools/react';
 ```
 
 <Callout type="info">
-  Want to understand what's happening under the hood? See [Initialization Flow](/docs/frameworks/react/concepts/initialization-flow) for the lifecycle and [Cookie Management](/docs/frameworks/react/concepts/cookie-management) for script/cookie behavior and revocation handling.
+	Want to understand what's happening under the hood? See [Initialization
+	Flow](/docs/frameworks/react/concepts/initialization-flow) for the lifecycle and [Cookie
+	Management](/docs/frameworks/react/concepts/cookie-management) for script/cookie behavior and
+	revocation handling.
 </Callout>
 
 ## Optional: AI Agents
@@ -163,13 +171,33 @@ See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 <Cards className="not-prose grid gap-4 grid-cols-1 sm:grid-cols-2">
   <Card variant="interactive" title="Optimization" description="Choose the right startup optimizations, then wire up proxying, prefetching, and network tuning." href="/docs/frameworks/react/optimization" />
 
-  <Card variant="interactive" title="Script Loader" description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent." href="/docs/frameworks/react/script-loader" />
+<Card
+	variant="interactive"
+	title="Script Loader"
+	description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent."
+	href="/docs/frameworks/react/script-loader"
+/>
 
-  <Card variant="interactive" title="Styling" description="Customize colors, typography, spacing, and individual component slots." href="/docs/frameworks/react/styling/overview" />
+<Card
+	variant="interactive"
+	title="Styling"
+	description="Customize colors, typography, spacing, and individual component slots."
+	href="/docs/frameworks/react/styling/overview"
+/>
 
-  <Card variant="interactive" title="Consent Categories" description="Understand the five consent categories and how to configure them." href="/docs/frameworks/react/concepts/consent-categories" />
+<Card
+	variant="interactive"
+	title="Consent Categories"
+	description="Understand the five consent categories and how to configure them."
+	href="/docs/frameworks/react/concepts/consent-categories"
+/>
 
-  <Card variant="interactive" title="Components" description="Explore the full set of pre-built consent UI components." href="/docs/frameworks/react/components/consent-banner" />
+<Card
+	variant="interactive"
+	title="Components"
+	description="Explore the full set of pre-built consent UI components."
+	href="/docs/frameworks/react/components/consent-banner"
+/>
 
   <Card variant="interactive" title="AI Agents" description="Help AI tools with bundled package docs and reusable c15t agent skills." href="/docs/ai-agents" />
 </Cards>

--- a/docs/frameworks/react/quickstart.mdx
+++ b/docs/frameworks/react/quickstart.mdx
@@ -25,7 +25,6 @@ group: frameworks
     ### Install package
 
     <PackageCommandTabs mode="install" command="@c15t/react" />
-
   </Step>
 
   <Step>
@@ -42,7 +41,6 @@ group: frameworks
     <Callout type="info">
       If you are using the headless API or fully custom styling, you can skip this import. `src/main.tsx` should keep importing `./index.css` as usual.
     </Callout>
-
   </Step>
 
   <Step>
@@ -91,7 +89,6 @@ group: frameworks
     <Callout type="warn">
       Don't have a backend yet? You can use `mode: 'offline'` for local-only consent storage, but it gives up backend audit history, server-side consent awareness, and automatic jurisdiction detection. Review the [browser-only storage consequences](/docs/frameworks/react/concepts/client-modes#offline-mode) before choosing it for production.
     </Callout>
-
   </Step>
 
   <Step>
@@ -110,7 +107,6 @@ group: frameworks
       );
     }
     ```
-
   </Step>
 
   <Step>
@@ -121,13 +117,12 @@ group: frameworks
     1. A **consent banner** appears at the bottom of the page
     2. Clicking **"Customize"** opens a dialog with toggles for each consent category
     3. After accepting or rejecting, the banner dismisses and your choice persists across page reloads
-
   </Step>
 </Steps>
 
 <Callout type="info">
-	Want to improve startup performance? See [Optimization](/docs/frameworks/react/optimization) for
-	the decision guide, prefetch setup, and network tuning.
+  Want to improve startup performance? See [Optimization](/docs/frameworks/react/optimization) for
+  the decision guide, prefetch setup, and network tuning.
 </Callout>
 
 ## Optional: Add DevTools
@@ -152,10 +147,10 @@ import { DevTools } from '@c15t/dev-tools/react';
 ```
 
 <Callout type="info">
-	Want to understand what's happening under the hood? See [Initialization
-	Flow](/docs/frameworks/react/concepts/initialization-flow) for the lifecycle and [Cookie
-	Management](/docs/frameworks/react/concepts/cookie-management) for script/cookie behavior and
-	revocation handling.
+  Want to understand what's happening under the hood? See [Initialization
+  Flow](/docs/frameworks/react/concepts/initialization-flow) for the lifecycle and [Cookie
+  Management](/docs/frameworks/react/concepts/cookie-management) for script/cookie behavior and
+  revocation handling.
 </Callout>
 
 ## Optional: AI Agents
@@ -171,33 +166,13 @@ See [AI Agents](/docs/ai-agents) for bundled package docs and agent skills.
 <Cards className="not-prose grid gap-4 grid-cols-1 sm:grid-cols-2">
   <Card variant="interactive" title="Optimization" description="Choose the right startup optimizations, then wire up proxying, prefetching, and network tuning." href="/docs/frameworks/react/optimization" />
 
-<Card
-	variant="interactive"
-	title="Script Loader"
-	description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent."
-	href="/docs/frameworks/react/script-loader"
-/>
+  <Card variant="interactive" title="Script Loader" description="Gate third-party scripts like Google Analytics and Meta Pixel behind consent." href="/docs/frameworks/react/script-loader" />
 
-<Card
-	variant="interactive"
-	title="Styling"
-	description="Customize colors, typography, spacing, and individual component slots."
-	href="/docs/frameworks/react/styling/overview"
-/>
+  <Card variant="interactive" title="Styling" description="Customize colors, typography, spacing, and individual component slots." href="/docs/frameworks/react/styling/overview" />
 
-<Card
-	variant="interactive"
-	title="Consent Categories"
-	description="Understand the five consent categories and how to configure them."
-	href="/docs/frameworks/react/concepts/consent-categories"
-/>
+  <Card variant="interactive" title="Consent Categories" description="Understand the five consent categories and how to configure them." href="/docs/frameworks/react/concepts/consent-categories" />
 
-<Card
-	variant="interactive"
-	title="Components"
-	description="Explore the full set of pre-built consent UI components."
-	href="/docs/frameworks/react/components/consent-banner"
-/>
+  <Card variant="interactive" title="Components" description="Explore the full set of pre-built consent UI components." href="/docs/frameworks/react/components/consent-banner" />
 
   <Card variant="interactive" title="AI Agents" description="Help AI tools with bundled package docs and reusable c15t agent skills." href="/docs/ai-agents" />
 </Cards>

--- a/docs/integrations/ahrefs-analytics.mdx
+++ b/docs/integrations/ahrefs-analytics.mdx
@@ -2,7 +2,6 @@
 title: Ahrefs Analytics
 description: Cookieless web analytics from Ahrefs with a prebuilt helper that wires the project key into a c15t-managed script.
 group: integrations
-lastModified: 2026-05-10
 icon: ahrefs
 ---
 

--- a/docs/integrations/building-integrations.mdx
+++ b/docs/integrations/building-integrations.mdx
@@ -1,7 +1,6 @@
 ---
 title: Build a Custom Script Integration
 description: Learn when to use a raw Script, when to build a reusable manifest-backed integration, and how to debug and test custom consent-aware scripts in c15t.
-lastModified: 2026-04-10
 group: integrations
 ---
 

--- a/docs/integrations/cloudflare-web-analytics.mdx
+++ b/docs/integrations/cloudflare-web-analytics.mdx
@@ -2,7 +2,6 @@
 title: Cloudflare Web Analytics
 description: Cookieless analytics from Cloudflare with a prebuilt helper that serializes the beacon config into the `data-cf-beacon` attribute.
 group: integrations
-lastModified: 2026-05-10
 icon: cloudflare-web-analytics
 ---
 

--- a/docs/integrations/crisp.mdx
+++ b/docs/integrations/crisp.mdx
@@ -2,7 +2,6 @@
 title: Crisp
 description: Load Crisp live chat with website ID, runtime, cookie, and session options.
 group: integrations
-lastModified: 2026-05-11
 icon: crisp
 ---
 

--- a/docs/integrations/databuddy.mdx
+++ b/docs/integrations/databuddy.mdx
@@ -1,7 +1,6 @@
 ---
 title: Databuddy
 description: Databuddy is a privacy-focused analytics platform that helps you understand user behavior and track events. It supports cookieless tracking and manages consent automatically through c15t's consent state synchronization.
-lastModified: 2025-10-31
 icon: databuddy
 group: integrations
 ---

--- a/docs/integrations/fathom-analytics.mdx
+++ b/docs/integrations/fathom-analytics.mdx
@@ -2,7 +2,6 @@
 title: Fathom Analytics
 description: Privacy-friendly cookieless analytics with a prebuilt helper that maps Fathom's data attributes into a c15t-managed script.
 group: integrations
-lastModified: 2026-05-10
 icon: fathom-analytics
 ---
 

--- a/docs/integrations/google-tag-manager.mdx
+++ b/docs/integrations/google-tag-manager.mdx
@@ -1,7 +1,6 @@
 ---
 title: Google Tag Manager
 description: Deploy and manage marketing tags centrally with automatic consent state synchronization.
-lastModified: 2026-02-10
 icon: google-tag-manager
 group: integrations
 ---

--- a/docs/integrations/google-tag.mdx
+++ b/docs/integrations/google-tag.mdx
@@ -1,7 +1,6 @@
 ---
 title: GA4 + Google Ads (gtag.js)
 description: Send data to Google Analytics 4 and Google Ads with automatic Consent Mode v2 support.
-lastModified: 2026-02-10
 icon: google-analytics
 group: integrations
 ---

--- a/docs/integrations/hotjar.mdx
+++ b/docs/integrations/hotjar.mdx
@@ -2,7 +2,6 @@
 title: Hotjar
 description: Product analytics and behavior insights with a prebuilt helper that seeds Hotjar globals before loading the vendor bundle.
 group: integrations
-lastModified: 2026-05-10
 icon: hotjar
 ---
 

--- a/docs/integrations/intercom.mdx
+++ b/docs/integrations/intercom.mdx
@@ -2,7 +2,6 @@
 title: Intercom
 description: Bootstrap Intercom settings and load the messenger widget bundle.
 group: integrations
-lastModified: 2026-05-12
 icon: intercom
 ---
 

--- a/docs/integrations/linkedin-insights.mdx
+++ b/docs/integrations/linkedin-insights.mdx
@@ -1,7 +1,6 @@
 ---
 title: LinkedIn Insights
 description: Track conversions and build matched audiences for LinkedIn advertising campaigns.
-lastModified: 2026-05-11
 icon: linkedin
 group: integrations
 ---

--- a/docs/integrations/matomo-analytics.mdx
+++ b/docs/integrations/matomo-analytics.mdx
@@ -2,7 +2,6 @@
 title: Matomo Analytics
 description: Load Matomo with c15t and keep Matomo's queue aligned with measurement consent.
 group: integrations
-lastModified: 2026-05-10
 icon: matomo
 ---
 

--- a/docs/integrations/meta-pixel.mdx
+++ b/docs/integrations/meta-pixel.mdx
@@ -1,7 +1,6 @@
 ---
 title: Meta Pixel
 description: Track conversions and build audiences for Facebook and Instagram advertising campaigns.
-lastModified: 2026-05-11
 icon: meta
 group: integrations
 ---

--- a/docs/integrations/microsoft-clarity.mdx
+++ b/docs/integrations/microsoft-clarity.mdx
@@ -2,7 +2,6 @@
 title: Microsoft Clarity
 description: Session replay and behavior analytics with a prebuilt helper that keeps Clarity consent synchronized with c15t measurement state.
 group: integrations
-lastModified: 2026-05-10
 icon: microsoft-clarity
 ---
 

--- a/docs/integrations/microsoft-uet.mdx
+++ b/docs/integrations/microsoft-uet.mdx
@@ -1,7 +1,6 @@
 ---
 title: Microsoft UET
 description: Track conversions and measure performance for Microsoft Advertising and Bing Ads.
-lastModified: 2026-05-11
 icon: microsoft
 group: integrations
 ---

--- a/docs/integrations/mixpanel-analytics.mdx
+++ b/docs/integrations/mixpanel-analytics.mdx
@@ -2,7 +2,6 @@
 title: Mixpanel Analytics
 description: Load Mixpanel with c15t and let Mixpanel's own opt-in and opt-out APIs follow measurement consent.
 group: integrations
-lastModified: 2026-05-10
 icon: mixpanel
 ---
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 description: "Load analytics, pixels, tag managers, and widgets through c15t so consent state controls when they run, update, and appear in your consent UI."
-lastModified: 2026-05-12
 
 group: integrations
 ---

--- a/docs/integrations/plausible-analytics.mdx
+++ b/docs/integrations/plausible-analytics.mdx
@@ -2,7 +2,6 @@
 title: Plausible Analytics
 description: Privacy-friendly cookieless analytics with a prebuilt helper that preserves Plausible's queue bootstrap and loader attributes.
 group: integrations
-lastModified: 2026-05-10
 icon: plausible
 ---
 

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -1,7 +1,6 @@
 ---
 title: PostHog
 description: PostHog is an open-source product analytics platform for tracking user behavior, session replays, feature flags, and A/B testing. It supports cookieless tracking, allowing analytics to continue even without cookie consent.
-lastModified: 2026-05-12
 icon: posthog
 group: integrations
 ---

--- a/docs/integrations/promptwatch.mdx
+++ b/docs/integrations/promptwatch.mdx
@@ -2,7 +2,6 @@
 title: Promptwatch
 description: Promptwatch analyzes traffic on your site for Artificial Intelligence (AI) traffic and usage insights. Data is stored in the EU without user-identifiable information.
 group: integrations
-lastModified: 2026-05-10
 icon: promptwatch
 ---
 

--- a/docs/integrations/reddit-pixel.mdx
+++ b/docs/integrations/reddit-pixel.mdx
@@ -2,7 +2,6 @@
 title: Reddit Pixel
 description: Track conversions and build retargeting audiences for Reddit advertising campaigns.
 group: integrations
-lastModified: 2026-05-11
 icon: reddit
 ---
 

--- a/docs/integrations/rybbit-analytics.mdx
+++ b/docs/integrations/rybbit-analytics.mdx
@@ -2,7 +2,6 @@
 title: Rybbit Analytics
 description: Privacy-friendly analytics with script-tag configuration via Rybbit's data attributes.
 group: integrations
-lastModified: 2026-05-10
 icon: rybbit-analytics
 ---
 

--- a/docs/integrations/segment.mdx
+++ b/docs/integrations/segment.mdx
@@ -2,7 +2,6 @@
 title: Segment
 description: Load Segment Analytics.js with c15t and gate it behind measurement consent.
 group: integrations
-lastModified: 2026-05-10
 icon: segment
 ---
 

--- a/docs/integrations/snapchat-pixel.mdx
+++ b/docs/integrations/snapchat-pixel.mdx
@@ -2,7 +2,6 @@
 title: Snapchat Pixel
 description: Measure Snapchat ad performance and build remarketing audiences with a prebuilt pixel helper.
 group: integrations
-lastModified: 2026-05-10
 icon: snapchat
 ---
 

--- a/docs/integrations/tiktok-pixel.mdx
+++ b/docs/integrations/tiktok-pixel.mdx
@@ -1,7 +1,6 @@
 ---
 title: TikTok Pixel
 description: Measure ad performance and build audiences for TikTok advertising campaigns.
-lastModified: 2025-09-24
 icon: tiktok
 group: integrations
 ---

--- a/docs/integrations/umami-analytics.mdx
+++ b/docs/integrations/umami-analytics.mdx
@@ -2,7 +2,6 @@
 title: Umami Analytics
 description: Open-source, cookieless analytics with a prebuilt helper that maps Umami's data attributes into a c15t-managed script.
 group: integrations
-lastModified: 2026-05-10
 icon: umami-analytics
 ---
 

--- a/docs/integrations/vercel-analytics.mdx
+++ b/docs/integrations/vercel-analytics.mdx
@@ -2,7 +2,6 @@
 title: Vercel Analytics
 description: Bootstrap Vercel Analytics with a declarative queue and script attributes.
 group: integrations
-lastModified: 2026-05-10
 icon: vercel-analytics
 ---
 

--- a/docs/integrations/x-pixel.mdx
+++ b/docs/integrations/x-pixel.mdx
@@ -1,7 +1,6 @@
 ---
 title: X Pixel (Twitter Pixel)
 description: Track conversions and build audiences for advertising campaigns on X (formerly Twitter).
-lastModified: 2025-09-24
 icon: x
 group: integrations
 ---

--- a/docs/legals/cookie-policy.mdx
+++ b/docs/legals/cookie-policy.mdx
@@ -1,6 +1,5 @@
 ---
 title: Cookie Policy
-lastModified: 2025-04-17
 group: reference
 ---
 

--- a/docs/legals/privacy-policy.mdx
+++ b/docs/legals/privacy-policy.mdx
@@ -1,6 +1,5 @@
 ---
 title:  Privacy Policy
-lastModified: 2025-04-17
 group: reference
 ---
 

--- a/docs/oss/contributing.mdx
+++ b/docs/oss/contributing.mdx
@@ -1,6 +1,5 @@
 ---
 title: Contributing to c15t.com
-lastModified: 2025-04-17
 group: reference
 ---
 

--- a/docs/oss/license.mdx
+++ b/docs/oss/license.mdx
@@ -1,7 +1,6 @@
 ---
 title: License
 description: Apache License 2.0 applies to c15t open source packages and this repository.
-lastModified: 2026-04-13
 group: reference
 ---
 

--- a/docs/oss/why-open-source.mdx
+++ b/docs/oss/why-open-source.mdx
@@ -1,7 +1,6 @@
 ---
 title: Building Privacy Tools in the Open
 description: We believe great developer tools should be built in the open, with transparency and community collaboration at their core. This philosophy guides how we're building modern privacy infrastructure.
-lastModified: 2025-04-17
 group: reference
 ---
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"fast-glob": "3.3.3",
 		"json5": "2.2.3",
 		"knip": "6.1.1",
-		"leadtype": "^0.2.0",
+		"leadtype": "^0.2.1",
 		"lefthook": "2.1.4",
 		"mdast-util-compact": "5.0.0",
 		"mdast-util-mdx": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"fast-glob": "3.3.3",
 		"json5": "2.2.3",
 		"knip": "6.1.1",
-		"leadtype": "^0.1.1",
+		"leadtype": "^0.2.0",
 		"lefthook": "2.1.4",
 		"mdast-util-compact": "5.0.0",
 		"mdast-util-mdx": "3.0.0",


### PR DESCRIPTION
## Summary

- Upgrade the repo to Leadtype 0.2.0.
- Move docs IA into `docs/docs.config.ts` with explicit navigation based on the old pre-migration structure.
- Replace legacy quickstart `availableIn` metadata with Leadtype-supported `variants` and remove source-authored `lastModified` frontmatter.

## Validation

- `bunx prettier --check docs/docs.config.ts docs/frameworks/react/quickstart.mdx docs/frameworks/next/quickstart.mdx`
- `bunx leadtype generate --src . --docs-dir docs --out /tmp/c15t-leadtype-output --base-url https://c15t.com`
- `bunx leadtype score --src docs --out /tmp/c15t-leadtype-output`
- `bunx leadtype lint --src docs` still reports existing content/link/flattener issues outside this navigation-only change scope.

## Notes

- `docs/shared/**` is still used by MDX includes, so it should not be excluded at conversion time in this source repo. Public inventory filtering should be handled in the UI repo collection/output pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured site navigation into comprehensive sections (frameworks, CLI, integrations, self‑host, guides, legal) and added framework variant support; standardized frontmatter across many guides and integrations by removing legacy lastModified metadata, with minor callout rewrapping and a few integration icon/frontmatter tweaks (including cookie/privacy policy frontmatter updates).
* **Dependencies**
  * Bumped leadtype dev dependency to ^0.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->