### PR TITLE
Fix broken documentation links

### DIFF
--- a/changelog/2025-04-30-v1.1.4.mdx
+++ b/changelog/2025-04-30-v1.1.4.mdx
@@ -51,7 +51,7 @@ This release addresses a **critical issue with translation functionality** acros
 
 - feat(docs): re-added theme switcher, added color scheme docs by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#206](https://github.com/c15t/c15t/pull/206)
 - fix(core, react): translations not working by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#207](https://github.com/c15t/c15t/pull/207)
-- Version Packages by [@github-actions](https://github.com/github-actions) in [#209](https://github.com/c15t/c15t/pull/209)
+- Version Packages by [@github-actions](https://github.com/features/actions) in [#209](https://github.com/c15t/c15t/pull/209)
 
 **Full Changelog**: [c15t@1.1.3...c15t@1.1.4](https://github.com/c15t/c15t/compare/c15t@1.1.3...c15t@1.1.4)
 
@@ -78,7 +78,7 @@ This release addresses a **critical issue with translation functionality** acros
 - Updated dependencies [2d81c9f]:
   - c15t@1.1.4
 
-Published via commit [21eb1a3](https://github.com/c15t/c15t/commit/21eb1a3) by [@github-actions](https://github.com/github-actions)
+Published via commit [21eb1a3](https://github.com/c15t/c15t/commit/21eb1a3) by [@github-actions](https://github.com/features/actions)
 
 This release **restores critical translation functionality** and establishes a solid foundation for international deployments with comprehensive testing and improved developer experience.
 

--- a/changelog/2025-05-04-v1.1.5.mdx
+++ b/changelog/2025-05-04-v1.1.5.mdx
@@ -109,7 +109,7 @@ import { CookieBanner } from '@c15t/react';
 
 ## ✨ What's Changed
 
-Published via commit [0d421be](https://github.com/c15t/c15t/commit/0d421be) by [@github-actions](https://github.com/github-actions)
+Published via commit [0d421be](https://github.com/c15t/c15t/commit/0d421be) by [@github-actions](https://github.com/features/actions)
 
 - fix(react): removed layers to fix collision with Tailwind 3 by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#218](https://github.com/c15t/c15t/pull/218)
 - fix(react): no style component theme not removing default classes by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#208](https://github.com/c15t/c15t/pull/208)

--- a/changelog/2025-05-12-v1.2.0.mdx
+++ b/changelog/2025-05-12-v1.2.0.mdx
@@ -210,7 +210,7 @@ expect(result.showConsentBanner).toBe(true);
 
 ## ✨ What's Changed
 
-Published via commit [54b03d4](https://github.com/c15t/c15t/commit/54b03d4) by [@github-actions](https://github.com/github-actions)
+Published via commit [54b03d4](https://github.com/c15t/c15t/commit/54b03d4) by [@github-actions](https://github.com/features/actions)
 
 - feat(api): add c15t instance API route with OpenAPI support by [@BurnedChris](https://github.com/BurnedChris) in [#224](https://github.com/c15t/c15t/pull/224)
 - fix(core, react): added "common" translations, removed widget translations by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#222](https://github.com/c15t/c15t/pull/222)

--- a/changelog/2025-05-12-v1.2.1.mdx
+++ b/changelog/2025-05-12-v1.2.1.mdx
@@ -65,12 +65,11 @@ This release delivers a major refactor and architecture upgrade across the API s
 - fix(styles): remove Tailwind layer to avoid collision by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#217](https://github.com/c15t/c15t/pull/217)
 - refactor(translations): consolidate into common + remove widget keys by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#219](https://github.com/c15t/c15t/pull/219)
 - fix(schema): improve `setConsent` validation by [@KayleeWilliams](https://github.com/KayleeWilliams)
-- Version Packages by [@github-actions](https://github.com/github-actions) in [#220](https://github.com/c15t/c15t/pull/220)
+- Version Packages by [@github-actions](https://github.com/features/actions) in [#220](https://github.com/c15t/c15t/pull/220)
 
-Published via commit [f82e56a](https://github.com/c15t/c15t/commit/f82e56a) by [@github-actions](https://github.com/github-actions)
+Published via commit [f82e56a](https://github.com/c15t/c15t/commit/f82e56a) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.2.0...c15t@1.2.1](https://github.com/c15t/c15t/compare/c15t@1.2.0...c15t@1.2.1)
 
 <ContributorBlock usernames={["BurnedChris", "KayleeWilliams"]} />
-
 

--- a/changelog/2025-06-09-v1.3.0.mdx
+++ b/changelog/2025-06-09-v1.3.0.mdx
@@ -131,9 +131,9 @@ This release represents a major step forward in internationalization support, de
 - feat(sdk): introduce Node.js client with OpenAPI support by [@BurnedChris](https://github.com/BurnedChris) in [#214](https://github.com/c15t/c15t/pull/214)
 - fix(styles): remove Tailwind layer to avoid collision by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#217](https://github.com/c15t/c15t/pull/217)
 - refactor(translations): consolidate into common + remove widget keys by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#219](https://github.com/c15t/c15t/pull/219)
-- Version Packages by [@github-actions](https://github.com/github-actions) in [#249](https://github.com/c15t/c15t/pull/249)
+- Version Packages by [@github-actions](https://github.com/features/actions) in [#249](https://github.com/c15t/c15t/pull/249)
 
-Published via commit [3eadfd5](https://github.com/c15t/c15t/commit/3eadfd5) by [@github-actions](https://github.com/github-actions)
+Published via commit [3eadfd5](https://github.com/c15t/c15t/commit/3eadfd5) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.2.1...c15t@1.3.0](https://github.com/c15t/c15t/compare/c15t@1.2.1...c15t@1.3.0)
 

--- a/changelog/2025-06-23-v1.3.1.mdx
+++ b/changelog/2025-06-23-v1.3.1.mdx
@@ -40,10 +40,9 @@ group: changelog
 - For `@c15t/cli@1.3.1`: `@c15t/backend@1.3.1`, `@c15t/react@1.3.1`
 - For `@c15t/backend@1.3.1`: `@c15t/translations@1.3.1`
 
-Published via commit [5f5b01a](https://github.com/c15t/c15t/commit/5f5b01a) by [@github-actions](https://github.com/github-actions)
+Published via commit [5f5b01a](https://github.com/c15t/c15t/commit/5f5b01a) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.3.0...c15t@1.3.1](https://github.com/c15t/c15t/compare/c15t@1.3.0...c15t@1.3.1)
 
 <ContributorBlock usernames={["KayleeWilliams"]} />
-
 

--- a/changelog/2025-06-23-v1.3.2.mdx
+++ b/changelog/2025-06-23-v1.3.2.mdx
@@ -25,12 +25,11 @@ group: changelog
 
 - fix(nextjs): resolved relative URL error in Next.js integration
 
-Published via commit [31fafe7](https://github.com/c15t/c15t/commit/31fafe7b158843e53bad1b2c2fd89d9e71263e6a) by [@github-actions](https://github.com/github-actions)
+Published via commit [31fafe7](https://github.com/c15t/c15t/commit/31fafe7b158843e53bad1b2c2fd89d9e71263e6a) by [@github-actions](https://github.com/features/actions)
 
 **Release**: [`@c15t/nextjs@1.3.2`](https://github.com/c15t/c15t/releases/tag/%40c15t%2Fnextjs%401.3.2)
 
 **Full Changelog**: [c15t@1.3.1...c15t@1.3.2](https://github.com/c15t/c15t/compare/c15t@1.3.1...c15t@1.3.2)
 
 <ContributorBlock usernames={["KayleeWilliams"]} />
-
 

--- a/changelog/2025-06-24-v1.3.3.mdx
+++ b/changelog/2025-06-24-v1.3.3.mdx
@@ -72,12 +72,11 @@ export const c15tConfig = {
 - feat(core): add Google Tag Manager support by [@BurnedChris](https://github.com/BurnedChris) in [#283](https://github.com/c15t/c15t/pull/283)
 - fix(react): allow `trapFocus={false}` in `CookieBanner` by [@KayleeWilliams](https://github.com/KayleeWilliams) in [#291](https://github.com/c15t/c15t/pull/291)
 - fix(nextjs): improved URL validation by [@BurnedChris](https://github.com/BurnedChris) in [#284](https://github.com/c15t/c15t/pull/284)
-- Version Packages by [@github-actions](https://github.com/github-actions) in [#293](https://github.com/c15t/c15t/pull/293)
+- Version Packages by [@github-actions](https://github.com/features/actions) in [#293](https://github.com/c15t/c15t/pull/293)
 
-Published via commit [b4d53be](https://github.com/c15t/c15t/commit/b4d53be) by [@github-actions](https://github.com/github-actions)
+Published via commit [b4d53be](https://github.com/c15t/c15t/commit/b4d53be) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.3.2...c15t@1.3.3](https://github.com/c15t/c15t/compare/c15t@1.3.2...c15t@1.3.3)
 
 <ContributorBlock usernames={["BurnedChris", "KayleeWilliams"]} />
-
 

--- a/changelog/2025-06-26-v1.4.0.mdx
+++ b/changelog/2025-06-26-v1.4.0.mdx
@@ -73,10 +73,9 @@ createConsentManagerStore({
 - chore(core/react): provider/store cleanup — [e30ffaf](https://github.com/c15t/c15t/commit/e30ffafe872eefe883384d07e1da07ae81660e23)
 - misc: housekeeping — [169de72](https://github.com/c15t/c15t/commit/169de720fcd745e5759685f694dbb9a373dbcc96)
 
-Published via commit [e0026b4](https://github.com/c15t/c15t/commit/e0026b4) by [@github-actions](https://github.com/github-actions)
+Published via commit [e0026b4](https://github.com/c15t/c15t/commit/e0026b4) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.3.3...c15t@1.4.0](https://github.com/c15t/c15t/compare/c15t@1.3.3...c15t@1.4.0)
 
 <ContributorBlock usernames={["BurnedChris", "KayleeWilliams"]} />
-
 

--- a/changelog/2025-06-26-v1.4.1.mdx
+++ b/changelog/2025-06-26-v1.4.1.mdx
@@ -27,12 +27,11 @@ group: changelog
 
 ## ✨ What's Changed
 
-- fix(nextjs): add custom c15t headers to initial data fetch in Next.js by [@github-actions](https://github.com/github-actions) in [#307](https://github.com/c15t/c15t/pull/307)
+- fix(nextjs): add custom c15t headers to initial data fetch in Next.js by [@github-actions](https://github.com/features/actions) in [#307](https://github.com/c15t/c15t/pull/307)
 
-Published via commit [6d4ccf1](https://github.com/c15t/c15t/commit/6d4ccf1) by [@github-actions](https://github.com/github-actions)
+Published via commit [6d4ccf1](https://github.com/c15t/c15t/commit/6d4ccf1) by [@github-actions](https://github.com/features/actions)
 
 **Full Changelog**: [c15t@1.4.0...c15t@1.4.1](https://github.com/c15t/c15t/compare/c15t@1.4.0...c15t@1.4.1)
 
 <ContributorBlock usernames={["KayleeWilliams"]} />
-
 

--- a/changelog/2025-09-09-v1.6.0.mdx
+++ b/changelog/2025-09-09-v1.6.0.mdx
@@ -38,7 +38,7 @@ The old backend was showing its age and could be difficult to implement. We have
 
 This unlocks support for more databases and ORMs such as TypeORM, Microsoft SQL Server, and MongoDB, with more coming soon.
 
-If you have an existing backend v1 implementation, check out the [migration guide](/docs/self-host/v2/migrate-from-v1).
+If you have an existing backend v1 implementation, review the current [self-host quickstart](/docs/self-host/quickstart) and [database setup guide](/docs/self-host/guides/database-setup).
 
 ⚠️ **Heads-up:** support for the old backend will be removed in the next major release.
 
@@ -61,7 +61,7 @@ const hasEitherAnalyticsOrMarketing = has({
 });
 ```
 
-See the [API documentation](/docs/frameworks/javascript/store/checking-consent) for full details.
+See the [API documentation](/docs/frameworks/javascript/api/checking-consent) for full details.
 
 **Deprecated:** `hasConsentFor()` and `getEffectiveConsents()`. These will be removed in the next major release.
 

--- a/docs/cli/commands/self-host.mdx
+++ b/docs/cli/commands/self-host.mdx
@@ -4,7 +4,7 @@ description: Workflow commands for self-hosted @c15t/backend deployments.
 group: cli
 ---
 
-`self-host` is the namespace for commands that only apply when you run your own [`@c15t/backend`](/docs/self-host/v2). The hosted product (inth.com) handles these automatically.
+`self-host` is the namespace for commands that only apply when you run your own [`@c15t/backend`](/docs/self-host/quickstart). The hosted product (inth.com) handles these automatically.
 
 ## Usage
 
@@ -36,5 +36,5 @@ pnpm dlx @c15t/cli self-host migrate
 
 ## Related
 
-- [Self-host overview](/docs/self-host/v2) — full deployment guide.
+- [Self-host overview](/docs/self-host/quickstart) — full deployment guide.
 - [`generate`](./generate) — regenerate schema files before migrating.

--- a/docs/frameworks/javascript/quickstart.mdx
+++ b/docs/frameworks/javascript/quickstart.mdx
@@ -32,7 +32,7 @@ const { consentManager, consentStore } = getOrCreateConsentRuntime({
 
 ## Subscribe to State Changes
 
-The store is a [Zustand vanilla store](https://zustand.docs.pmnd.rs/guides/extracting-actions). Use `subscribe()` for UI and general state updates, `subscribeToConsentChanges()` for change-only consent integrations, and `getState()` to read the current state:
+The store is a [Zustand vanilla store](https://zustand.docs.pmnd.rs/reference/apis/create-store). Use `subscribe()` for UI and general state updates, `subscribeToConsentChanges()` for change-only consent integrations, and `getState()` to read the current state:
 
 ```ts
 // React to every state change

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -161,4 +161,4 @@ Learn when to use a raw `Script`, when to use a manifest, and how to debug and t
 
 - Read the script loader guide for your framework: [JavaScript](/docs/frameworks/javascript/script-loader), [React](/docs/frameworks/react/script-loader), [Next.js](/docs/frameworks/next/script-loader).
 - See the [iframe blocking](/docs/frameworks/react/iframe-blocking) pattern for visible embeds (YouTube, maps, calendars).
-- Use [`has()`](/docs/frameworks/javascript/store/checking-consent) to conditionally run app code based on consent state.
+- Use [`has()`](/docs/frameworks/javascript/api/checking-consent) to conditionally run app code based on consent state.

--- a/docs/oss/code-of-conduct.mdx
+++ b/docs/oss/code-of-conduct.mdx
@@ -124,4 +124,4 @@ This Code of Conduct is inspired by the [Contributor Covenant](https://www.contr
 
 ## Questions?
 
-If you have questions about this Code of Conduct, please [open an issue](https://github.com/c15t/community/issues) or email [conduct@c15t.dev](mailto:conduct@c15t.dev).
+If you have questions about this Code of Conduct, please [open an issue](https://github.com/c15t/c15t/issues) or email [conduct@c15t.dev](mailto:conduct@c15t.dev).

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -48,7 +48,7 @@ Configure your database adapter (supports Drizzle, Kysely, Prisma, TypeORM, and 
 
 ## Documentation
 
-For further information, guides, and examples visit the [reference documentation](https://c15t.com/docs/self-host/v2).
+For further information, guides, and examples visit the [reference documentation](https://c15t.com/docs/self-host/quickstart).
 
 ## Support
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,7 +19,7 @@
 		"cmp",
 		"consent-banner"
 	],
-	"homepage": "https://c15t.com/docs/self-host/v2",
+	"homepage": "https://c15t.com/docs/self-host/quickstart",
 	"bugs": {
 		"url": "https://github.com/c15t/c15t/issues"
 	},

--- a/packages/backend/readme.json
+++ b/packages/backend/readme.json
@@ -23,8 +23,8 @@
 		"Use the provided router and schema for consent management",
 		"Implement consent tracking and management in your application"
 	],
-	"docsLink": "https://c15t.com/docs/self-host/v2",
-	"quickStartLink": "https://c15t.com/docs/self-host/v2",
+	"docsLink": "https://c15t.com/docs/self-host/quickstart",
+	"quickStartLink": "https://c15t.com/docs/self-host/quickstart",
 	"githubLink": "https://github.com/c15t/c15t",
 	"showCLIGeneration": false
 }

--- a/packages/cli/src/machines/generate/machine.ts
+++ b/packages/cli/src/machines/generate/machine.ts
@@ -532,7 +532,7 @@ export const generateMachine = setup({
 					context.hostedProvider === 'self-hosted'
 				) {
 					logger.info('Setup your backend with the c15t docs:');
-					logger.info('https://c15t.com/docs/self-host/v2');
+					logger.info('https://c15t.com/docs/self-host/quickstart');
 				} else if (context.selectedMode === 'custom') {
 					logger.info(
 						'Configuration Complete! Implement your custom endpoint handlers.'

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,7 +34,7 @@ Headless cookie banner, consent manager & preference center for JavaScript / Typ
 - JavaScript or TypeScript project
 - Node.js 18.17.0 or later
 - npm, pnpm, or yarn package manager
-- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)
+- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)
 
 ## Quick Start
 

--- a/packages/core/readme.json
+++ b/packages/core/readme.json
@@ -12,7 +12,7 @@
 		"JavaScript or TypeScript project",
 		"Node.js 18.17.0 or later",
 		"npm, pnpm, or yarn package manager",
-		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)"
+		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)"
 	],
 	"manualInstallation": [
 		"",

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -36,7 +36,7 @@ Headless cookie banner, consent manager & preference center for Next.js. App Rou
 - Next.js 13.5.4 or later
 - React 18 or later
 - Node.js 18.17.0 or later
-- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)
+- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)
 
 ## Quick Start
 

--- a/packages/nextjs/readme.json
+++ b/packages/nextjs/readme.json
@@ -15,7 +15,7 @@
 		"Next.js 13.5.4 or later",
 		"React 18 or later",
 		"Node.js 18.17.0 or later",
-		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)"
+		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)"
 	],
 	"manualInstallation": [
 		"",

--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -32,7 +32,7 @@ A fully typed, flexible Node.js SDK for seamless interaction with the c15t conse
 ## Prerequisites
 
 - Node.js 18.17.0 or later
-- A Hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)
+- A Hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)
 
 ## Manual Installation
 

--- a/packages/node-sdk/readme.json
+++ b/packages/node-sdk/readme.json
@@ -11,7 +11,7 @@
 	],
 	"prerequisites": [
 		"Node.js 18.17.0 or later",
-		"A Hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)"
+		"A Hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)"
 	],
 	"manualInstallation": ["", "```bash\npnpm add @c15t/node-sdk\n```"],
 	"usage": [

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -36,7 +36,7 @@ Headless cookie banner, consent manager & preference center for React. RSC-compa
 
 - React 16.8 or later
 - Node.js 18.17.0 or later
-- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)
+- A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)
 
 ## Quick Start
 

--- a/packages/react/readme.json
+++ b/packages/react/readme.json
@@ -15,7 +15,7 @@
 	"prerequisites": [
 		"React 16.8 or later",
 		"Node.js 18.17.0 or later",
-		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/v2)"
+		"A hosted [c15t instance](https://inth.com) (free sign-up) or [self-hosted deployment](https://c15t.com/docs/self-host/quickstart)"
 	],
 	"manualInstallation": [
 		"",


### PR DESCRIPTION
## Summary

- Replaced broken changelog author links for `@github-actions` with GitHub's current Actions page.
- Updated stale internal docs routes for self-hosting and JavaScript consent checks.
- Updated package README and metadata links that still pointed at the old self-host route.
- Replaced the stale Zustand and community issue links with current destinations.

## Why

The broken-link export from June 5, 2026 reported 16 broken rows across 6 unique targets. These stale links affected changelog pages, docs pages, and package documentation metadata.

## Validation

- Confirmed all 6 reported broken target URLs no longer appear in the workspace.
- Confirmed replacement internal docs routes exist locally.
- `bun run lint:docs` did not complete: first blocked by sandbox temp-dir permissions, then failed with `could not determine executable to run for package remark` after approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated documentation links across guides and package references to point to the new self-hosted quickstart instead of v2 documentation.
  * Updated API documentation references, including consent-checking and state management paths, to current locations.
  * Updated issue tracking reference in community guidelines.

* **Chores**
  * Updated changelog entries with formatting and metadata adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->