### PR TITLE
feat: adds support for legal docs prefix

### DIFF
--- a/.changeset/prefix-match-legal-document-types.md
+++ b/.changeset/prefix-match-legal-document-types.md
@@ -1,0 +1,6 @@
+---
+"@c15t/backend": patch
+"@c15t/schema": patch
+---
+
+Match legal-document policy types (`privacy_policy`, `dpa`, `terms_and_conditions`) by prefix so suffixed variants like `terms_and_conditions_b2b` are accepted, letting multiple policies of one family be active at once. Unknown types are still rejected.

--- a/.changeset/prefix-match-legal-document-types.md
+++ b/.changeset/prefix-match-legal-document-types.md
@@ -1,6 +1,7 @@
 ---
 "@c15t/backend": patch
 "@c15t/schema": patch
+"c15t": patch
 ---
 
 Match legal-document policy types (`privacy_policy`, `dpa`, `terms_and_conditions`) by prefix so suffixed variants like `terms_and_conditions_b2b` are accepted, letting multiple policies of one family be active at once. Unknown types are still rejected.

--- a/docs/self-host/api/endpoints.mdx
+++ b/docs/self-host/api/endpoints.mdx
@@ -82,7 +82,7 @@ Records a consent event. This is an append-only operation — every call creates
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `type` | string | Yes | `cookie_banner`, `privacy_policy`, `dpa`, `terms_and_conditions`, `marketing_communications`, `age_verification`, `other` |
+| `type` | string | Yes | `cookie_banner`, `privacy_policy`, `dpa`, `terms_and_conditions`, `marketing_communications`, `age_verification`, `other`. Legal-document types (`privacy_policy`, `dpa`, `terms_and_conditions`) also accept suffixed variants, e.g. `terms_and_conditions_b2b`, so multiple policies of one family can be active at once |
 | `subjectId` | string | Yes | Client-generated subject identifier |
 | `domain` | string | Yes | Domain where consent was given |
 | `preferences` | object | No | Consent category preferences (for `cookie_banner` type) |

--- a/examples/demo/lib/unsafe-demo-legal-document-snapshot.ts
+++ b/examples/demo/lib/unsafe-demo-legal-document-snapshot.ts
@@ -1,13 +1,12 @@
+import type { LegalDocumentPolicyType } from '@c15t/schema/types';
 import { SignJWT } from 'jose';
 import {
 	DEMO_LEGAL_DOCUMENT_SNAPSHOT,
 	DEMO_LEGAL_DOCUMENT_SNAPSHOT_AUDIENCE,
 } from './demo-legal-document-snapshot';
 
-type LegalDocumentType = 'privacy_policy' | 'terms_and_conditions' | 'dpa';
-
 export interface UnsafeDemoLegalDocumentSnapshotInput {
-	type: LegalDocumentType;
+	type: LegalDocumentPolicyType;
 	version: string;
 	hash: string;
 	effectiveDate: string;
@@ -20,7 +19,7 @@ export interface UnsafeDemoLegalDocumentSnapshotResult {
 		aud: string;
 		sub: string;
 		tenantId?: string;
-		type: LegalDocumentType;
+		type: LegalDocumentPolicyType;
 		version: string;
 		hash: string;
 		effectiveDate: string;

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -17,6 +17,7 @@
 		"@c15t/nextjs": "workspace:*",
 		"@c15t/react": "workspace:*",
 		"@c15t/scripts": "workspace:*",
+		"@c15t/schema": "workspace:*",
 		"@c15t/translations": "workspace:*",
 		"@c15t/ui": "workspace:*",
 		"@hookform/resolvers": "^5.2.2",

--- a/packages/backend/SKILL.md
+++ b/packages/backend/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: c15t-backend-docs
+description: Read and search the @c15t/backend documentation. Use when working with @c15t/backend — its setup, configuration, API, and behavior.
+metadata:
+  source: leadtype
+---
+# @c15t/backend documentation
+
+Self-hosted c15t backend docs for configuration, APIs, storage, policy packs, and operations.
+
+To work with @c15t/backend, read its bundled docs — they ship with the package and are version-matched to the installed code:
+
+- Start with `./AGENTS.md`; it links every per-topic Markdown file under `./docs/`.
+- Prefer these local files over fetching anything over the network.

--- a/packages/backend/src/db/registry/consent-policy.test.ts
+++ b/packages/backend/src/db/registry/consent-policy.test.ts
@@ -524,6 +524,64 @@ describe('policyRegistry', () => {
 			);
 		});
 
+		it('syncCurrentLegalDocumentPolicy scopes suffixed variant deactivation to the exact type', async () => {
+			const policyId = await buildLegalDocumentPolicyId({
+				tenantId: 'ins_123',
+				type: 'terms_and_conditions_b2b',
+				hash: 'hash_b2b',
+			});
+			const createdPolicy = createMockConsentPolicy({
+				id: policyId,
+				type: 'terms_and_conditions_b2b',
+				version: '2026-04-07',
+				hash: 'hash_b2b',
+				effectiveDate: new Date('2026-04-07T00:00:00.000Z'),
+				isActive: true,
+			});
+			const tx = {
+				findFirst: vi.fn().mockResolvedValue(null),
+				updateMany: vi.fn().mockResolvedValue(undefined),
+				create: vi.fn().mockResolvedValue(createdPolicy),
+			};
+			const db = {
+				transaction: vi.fn(async (fn: (tx: typeof tx) => unknown) => fn(tx)),
+			};
+
+			const registry = policyRegistry({
+				db,
+				ctx: { logger: mockLogger, tenantId: 'ins_123' },
+			} as unknown as Registry);
+
+			const result = await registry.syncCurrentLegalDocumentPolicy({
+				type: 'terms_and_conditions_b2b',
+				version: '2026-04-07',
+				hash: 'hash_b2b',
+				effectiveDate: new Date('2026-04-07T00:00:00.000Z'),
+			});
+			const comparisons: Array<[string, string, unknown]> = [];
+			const builder = ((field: string, operator: string, value: unknown) => {
+				comparisons.push([field, operator, value]);
+				return { field, operator, value };
+			}) as ((field: string, operator: string, value: unknown) => unknown) & {
+				and: (...conditions: unknown[]) => unknown;
+			};
+			builder.and = (...conditions: unknown[]) => ({ and: conditions });
+
+			tx.updateMany.mock.calls[0]?.[1].where(builder);
+
+			expect(result).toEqual(createdPolicy);
+			expect(comparisons).toContainEqual([
+				'type',
+				'=',
+				'terms_and_conditions_b2b',
+			]);
+			expect(comparisons).not.toContainEqual([
+				'type',
+				'=',
+				'terms_and_conditions_b2c',
+			]);
+		});
+
 		it('syncCurrentLegalDocumentPolicy is idempotent for the same release metadata', async () => {
 			const policyId = await buildLegalDocumentPolicyId({
 				tenantId: 'ins_123',

--- a/packages/backend/src/db/schema/2.0.0/consent-policy.ts
+++ b/packages/backend/src/db/schema/2.0.0/consent-policy.ts
@@ -1,6 +1,8 @@
 import {
 	type ConsentPolicy,
+	type ConsentPolicyType,
 	consentPolicySchema,
+	consentPolicyTypeSchema,
 	type LegalDocumentPolicyType,
 	legalDocumentPolicyTypeSchema,
 	type PolicyType,
@@ -22,7 +24,9 @@ export const consentPolicyTable = table('consentPolicy', {
 // Re-export for backward compatibility
 export {
 	type ConsentPolicy,
+	type ConsentPolicyType,
 	consentPolicySchema,
+	consentPolicyTypeSchema,
 	type LegalDocumentPolicyType,
 	legalDocumentPolicyTypeSchema,
 	type PolicyType,

--- a/packages/backend/src/handlers/legal-document/current.handler.ts
+++ b/packages/backend/src/handlers/legal-document/current.handler.ts
@@ -1,6 +1,6 @@
 import type {
 	LegalDocumentCurrentInput,
-	LegalDocumentCurrentParams,
+	LegalDocumentPolicyType,
 } from '@c15t/schema';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
@@ -20,7 +20,7 @@ export const syncCurrentLegalDocumentHandler = async (c: Context) => {
 		});
 	}
 
-	const type = c.req.param('type') as LegalDocumentCurrentParams['type'];
+	const type = c.req.param('type') as LegalDocumentPolicyType;
 	const body = await c.req.json<LegalDocumentCurrentInput>();
 	const effectiveDate = new Date(body.effectiveDate);
 	if (Number.isNaN(effectiveDate.getTime())) {

--- a/packages/backend/src/handlers/legal-document/snapshot.test.ts
+++ b/packages/backend/src/handlers/legal-document/snapshot.test.ts
@@ -48,6 +48,29 @@ describe('legal document snapshot token', () => {
 		expect(verified.payload.effectiveDate).toBe('2026-04-07T00:00:00.000Z');
 	});
 
+	it('creates and verifies a suffixed legal-document type variant', async () => {
+		const tokenResult = await createLegalDocumentSnapshotToken({
+			options: { signingKey: 'test-signing-key' },
+			tenantId: 'ins_123',
+			type: 'terms_and_conditions_b2b',
+			version: '2026-04-07',
+			hash: 'hash_123',
+			effectiveDate: '2026-04-07T00:00:00.000Z',
+		});
+
+		const verified = await verifyLegalDocumentSnapshotToken({
+			token: tokenResult?.token,
+			options: { signingKey: 'test-signing-key' },
+			tenantId: 'ins_123',
+		});
+
+		expect(verified.valid).toBe(true);
+		if (!verified.valid) {
+			throw new Error('Expected valid legal document snapshot');
+		}
+		expect(verified.payload.type).toBe('terms_and_conditions_b2b');
+	});
+
 	it('rejects tampered token payloads', async () => {
 		const tokenResult = await createLegalDocumentSnapshotToken({
 			options: { signingKey: 'test-signing-key' },

--- a/packages/backend/src/handlers/legal-document/snapshot.ts
+++ b/packages/backend/src/handlers/legal-document/snapshot.ts
@@ -1,3 +1,4 @@
+import { isLegalDocumentType } from '@c15t/schema';
 import {
 	type JWTHeaderParameters,
 	type JWTPayload,
@@ -51,16 +52,6 @@ const LEGAL_DOCUMENT_SNAPSHOT_JWT_HEADER: JwtHeader = {
 const DEFAULT_ISSUER = 'c15t';
 const DEFAULT_AUDIENCE = 'c15t-legal-document-snapshot';
 
-function isLegalDocumentPolicyType(
-	type: unknown
-): type is LegalDocumentPolicyType {
-	return (
-		type === 'privacy_policy' ||
-		type === 'terms_and_conditions' ||
-		type === 'dpa'
-	);
-}
-
 function resolveSnapshotIssuer(options?: LegalDocumentSnapshotOptions): string {
 	return options?.issuer?.trim() || DEFAULT_ISSUER;
 }
@@ -90,7 +81,7 @@ function isLegalDocumentSnapshotPayload(
 		typeof payload.iss === 'string' &&
 		typeof payload.aud === 'string' &&
 		typeof payload.sub === 'string' &&
-		isLegalDocumentPolicyType(payload.type) &&
+		isLegalDocumentType(payload.type) &&
 		typeof payload.version === 'string' &&
 		typeof payload.hash === 'string' &&
 		typeof payload.effectiveDate === 'string' &&

--- a/packages/backend/src/handlers/subject/post.handler.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.test.ts
@@ -1028,6 +1028,30 @@ describe('postSubjectHandler legal document snapshots', () => {
 		expect(db.transaction).not.toHaveBeenCalled();
 	});
 
+	it('treats a suffixed legal-document type as legal document consent', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.legalDocumentSnapshot = {
+			signingKey: 'test-signing-key',
+		};
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			type: 'terms_and_conditions_b2b',
+		});
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 409,
+			message: 'Legal document snapshot token is required',
+			cause: {
+				code: 'LEGAL_DOCUMENT_SNAPSHOT_REQUIRED',
+			},
+		});
+
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
 	it('rejects missing legal document snapshot tokens when verification is enabled', async () => {
 		const db = createMockDb(null);
 		const registry = createMockRegistry();

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { PostSubjectInput } from '@c15t/schema';
+import { isLegalDocumentType, type PostSubjectInput } from '@c15t/schema';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { LegalDocumentPolicyConflictError } from '~/db/registry/consent-policy';
@@ -156,16 +156,6 @@ function parseLanguageFromHeader(header: string | null): string | undefined {
 	}
 
 	return firstLanguage.split('-')[0]?.toLowerCase();
-}
-
-function isLegalDocumentType(
-	type: string
-): type is 'privacy_policy' | 'terms_and_conditions' | 'dpa' {
-	return (
-		type === 'privacy_policy' ||
-		type === 'terms_and_conditions' ||
-		type === 'dpa'
-	);
 }
 
 function resolveSnapshotFailureMode(

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -4,7 +4,11 @@
  * @packageDocumentation
  */
 
-import { isLegalDocumentType, type PostSubjectInput } from '@c15t/schema';
+import {
+	isLegalDocumentType,
+	type PolicyType,
+	type PostSubjectInput,
+} from '@c15t/schema';
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { LegalDocumentPolicyConflictError } from '~/db/registry/consent-policy';
@@ -504,7 +508,7 @@ export const postSubjectHandler = async (c: Context) => {
 				});
 			}
 		} else {
-			const policy = await registry.findOrCreatePolicy(type);
+			const policy = await registry.findOrCreatePolicy(type as PolicyType);
 			if (!policy) {
 				throw new HTTPException(500, {
 					message: 'Failed to create policy',

--- a/packages/backend/src/routes/subject.ts
+++ b/packages/backend/src/routes/subject.ts
@@ -69,7 +69,7 @@ export const createSubjectRoutes = () => {
 
 **Request body by \`type\`:**
 - \`cookie_banner\` – Requires \`preferences\` object
-- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\` – Prefer a signed \`documentSnapshotToken\`; otherwise use a release \`policyHash\`, with \`policyId\` kept only for compatibility
+- \`privacy_policy\`, \`dpa\`, \`terms_and_conditions\`, and suffixed legal-document variants such as \`terms_and_conditions_b2b\` – Prefer a signed \`documentSnapshotToken\`; otherwise use a release \`policyHash\`, with \`policyId\` kept only for compatibility
 - \`marketing_communications\`, \`age_verification\`, \`other\` – Optional \`preferences\``,
 			tags: ['Subject', 'Consent'],
 			responses: {

--- a/packages/core/src/store/__tests__/consent-store.test.ts
+++ b/packages/core/src/store/__tests__/consent-store.test.ts
@@ -133,6 +133,37 @@ describe('Consent Store', () => {
 		});
 	});
 
+	describe('unstable_acceptPolicyConsent', () => {
+		it('passes proof fields for suffixed legal-document types', async () => {
+			mockManager.setConsent.mockResolvedValueOnce({
+				ok: true,
+				data: {
+					subjectId: 'sub_2jv6z8n4q9',
+					consentId: 'cns_123',
+					domainId: 'dom_123',
+					domain: 'example.com',
+					type: 'terms_and_conditions_b2b',
+					givenAt: new Date('2026-04-07T00:00:00.000Z'),
+				},
+			});
+			const store = createConsentManagerStore(mockManager);
+
+			await store.getState().unstable_acceptPolicyConsent({
+				type: 'terms_and_conditions_b2b',
+				policyHash: 'sha256:abc123',
+				domain: 'example.com',
+				givenAt: 1_775_520_000_000,
+			});
+
+			expect(mockManager.setConsent).toHaveBeenCalledWith({
+				body: expect.objectContaining({
+					type: 'terms_and_conditions_b2b',
+					policyHash: 'sha256:abc123',
+				}),
+			});
+		});
+	});
+
 	describe('Consent Actions', () => {
 		it('should update selected consent with setSelectedConsent', () => {
 			const store = createConsentManagerStore(mockManager);

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,6 +4,7 @@
  * This module provides the main store creation and management functionality.
  */
 
+import { isLegalDocumentType } from '@c15t/schema/types';
 import { resolveTranslationInput } from '@c15t/translations';
 import { createStore } from 'zustand/vanilla';
 import type { ConsentManagerInterface } from '../client/client-factory';
@@ -45,7 +46,12 @@ import {
 	consentTypes,
 } from '../types/consent-types';
 import { initialState } from './initial-state';
-import type { ConsentStoreState, StoreOptions } from './type';
+import type {
+	ConsentStoreState,
+	StoreOptions,
+	UnstableLegalDocumentConsentInput,
+	UnstablePolicyConsentInput,
+} from './type';
 
 /**
  * Structure of consent data stored in localStorage.
@@ -64,6 +70,12 @@ interface StoredConsent {
 
 	/** Stored custom vendor LI state (IAB mode only) */
 	iabCustomVendorLegitimateInterests?: Record<string, boolean>;
+}
+
+function isLegalDocumentConsentInput(
+	input: UnstablePolicyConsentInput
+): input is UnstableLegalDocumentConsentInput {
+	return isLegalDocumentType(input.type);
 }
 
 /**
@@ -502,13 +514,10 @@ export const createConsentManagerStore = (
 				(typeof window !== 'undefined'
 					? window.location.hostname
 					: 'localhost');
-			const isLegalDocumentType =
-				input.type === 'privacy_policy' ||
-				input.type === 'terms_and_conditions' ||
-				input.type === 'dpa';
+			const legalDocumentConsent = isLegalDocumentConsentInput(input);
 			let legalDocumentFields: Record<string, string> = {};
 
-			if (isLegalDocumentType) {
+			if (legalDocumentConsent) {
 				if (input.documentSnapshotToken) {
 					legalDocumentFields = {
 						documentSnapshotToken: input.documentSnapshotToken,

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -6,6 +6,7 @@
 import type {
 	Branding,
 	InitOutput,
+	LegalDocumentPolicyType,
 	PolicyConfig,
 	PolicyScopeMode,
 	PolicyUiAction,
@@ -121,7 +122,7 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Keys extends keyof T
  * @experimental
  */
 type UnstableLegalDocumentConsentInputBase = {
-	type: 'privacy_policy' | 'terms_and_conditions' | 'dpa';
+	type: LegalDocumentPolicyType;
 	policyId?: string;
 	policyHash?: string;
 	documentSnapshotToken?: string;

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -5,7 +5,10 @@
  */
 
 import * as v from 'valibot';
-import { policyTypeSchema } from '../../domain/consent-policy';
+import {
+	legalDocumentPolicyTypeSchema,
+	policyTypeSchema,
+} from '../../domain/consent-policy';
 
 /**
  * Base subject ID validation - must be in sub_xxx format
@@ -140,7 +143,7 @@ export const subjectCookieBannerInputSchema = v.object({
  */
 export const subjectPolicyBasedInputSchema = v.object({
 	...baseSubjectConsentSchema.entries,
-	type: v.picklist(['privacy_policy', 'dpa', 'terms_and_conditions']),
+	type: legalDocumentPolicyTypeSchema,
 	policyId: v.optional(
 		v.pipe(
 			v.string(),

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -6,6 +6,7 @@
 
 import * as v from 'valibot';
 import {
+	consentPolicyTypeSchema,
 	legalDocumentPolicyTypeSchema,
 	policyTypeSchema,
 } from '../../domain/consent-policy';
@@ -199,7 +200,7 @@ export const postSubjectOutputSchema = v.object({
 	consentId: v.string(),
 	domainId: v.string(),
 	domain: v.string(),
-	type: policyTypeSchema,
+	type: consentPolicyTypeSchema,
 	metadata: v.optional(v.record(v.string(), v.unknown())),
 	appliedPreferences: v.optional(v.record(v.string(), v.boolean())),
 	uiSource: v.optional(v.string()),

--- a/packages/schema/src/domain/consent-policy.test.ts
+++ b/packages/schema/src/domain/consent-policy.test.ts
@@ -27,6 +27,9 @@ describe('legalDocumentPolicyTypeSchema', () => {
 	it.each([
 		'terms_and_conditions2', // suffix without the `_` boundary
 		'privacy_policyx',
+		'terms_and_conditions_', // `_` boundary with empty suffix
+		'privacy_policy_',
+		'dpa_',
 		'terms',
 		'',
 		'cookie_banner',

--- a/packages/schema/src/domain/consent-policy.test.ts
+++ b/packages/schema/src/domain/consent-policy.test.ts
@@ -1,0 +1,89 @@
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import {
+	postSubjectInputSchema,
+	subjectPolicyBasedInputSchema,
+} from '../api/subject/post';
+import { legalDocumentPolicyTypeSchema } from './consent-policy';
+
+describe('legalDocumentPolicyTypeSchema', () => {
+	it.each([
+		'privacy_policy',
+		'dpa',
+		'terms_and_conditions',
+	])('accepts the base legal-document type %s', (type) => {
+		expect(v.is(legalDocumentPolicyTypeSchema, type)).toBe(true);
+	});
+
+	it.each([
+		'terms_and_conditions_b2b',
+		'terms_and_conditions_b2c',
+		'privacy_policy_v2',
+		'dpa_2026',
+	])('accepts the suffixed legal-document variant %s', (type) => {
+		expect(v.is(legalDocumentPolicyTypeSchema, type)).toBe(true);
+	});
+
+	it.each([
+		'terms_and_conditions2', // suffix without the `_` boundary
+		'privacy_policyx',
+		'terms',
+		'',
+		'cookie_banner',
+		'marketing_communications',
+	])('rejects the non-legal-document or boundary-violating type %s', (type) => {
+		expect(v.is(legalDocumentPolicyTypeSchema, type)).toBe(false);
+	});
+
+	it.each([
+		42,
+		null,
+		undefined,
+		{},
+		['privacy_policy'],
+	])('rejects the non-string value %j', (value) => {
+		expect(v.is(legalDocumentPolicyTypeSchema, value)).toBe(false);
+	});
+});
+
+const baseInput = {
+	subjectId: 'sub_2jv6z8n4q9',
+	domain: 'example.com',
+	givenAt: 1_735_689_600_000,
+};
+
+describe('subjectPolicyBasedInputSchema', () => {
+	it('accepts a suffixed legal-document type', () => {
+		const result = v.safeParse(subjectPolicyBasedInputSchema, {
+			...baseInput,
+			type: 'terms_and_conditions_b2b',
+			policyHash: 'sha256:abc123',
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('postSubjectInputSchema variant routing', () => {
+	it('routes a suffixed legal-document type to the policy-based branch', () => {
+		const result = v.safeParse(postSubjectInputSchema, {
+			...baseInput,
+			type: 'terms_and_conditions_b2b',
+			policyHash: 'sha256:abc123',
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.output.type).toBe('terms_and_conditions_b2b');
+		}
+	});
+
+	it('still rejects an unknown consent type', () => {
+		const result = v.safeParse(postSubjectInputSchema, {
+			...baseInput,
+			type: 'totally_unknown_type',
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/schema/src/domain/consent-policy.test.ts
+++ b/packages/schema/src/domain/consent-policy.test.ts
@@ -2,9 +2,13 @@ import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import {
 	postSubjectInputSchema,
+	postSubjectOutputSchema,
 	subjectPolicyBasedInputSchema,
 } from '../api/subject/post';
-import { legalDocumentPolicyTypeSchema } from './consent-policy';
+import {
+	consentPolicySchema,
+	legalDocumentPolicyTypeSchema,
+} from './consent-policy';
 
 describe('legalDocumentPolicyTypeSchema', () => {
 	it.each([
@@ -67,6 +71,23 @@ describe('subjectPolicyBasedInputSchema', () => {
 	});
 });
 
+describe('consentPolicySchema', () => {
+	it('accepts a stored policy with a suffixed legal-document type', () => {
+		const result = v.safeParse(consentPolicySchema, {
+			id: 'pol_123',
+			version: '2026-04-07',
+			type: 'terms_and_conditions_b2b',
+			hash: 'sha256:abc123',
+			effectiveDate: new Date('2026-04-07T00:00:00.000Z'),
+			isActive: true,
+			createdAt: new Date('2026-04-07T00:00:00.000Z'),
+			tenantId: null,
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
 describe('postSubjectInputSchema variant routing', () => {
 	it('routes a suffixed legal-document type to the policy-based branch', () => {
 		const result = v.safeParse(postSubjectInputSchema, {
@@ -88,5 +109,20 @@ describe('postSubjectInputSchema variant routing', () => {
 		});
 
 		expect(result.success).toBe(false);
+	});
+});
+
+describe('postSubjectOutputSchema', () => {
+	it('accepts a response with a suffixed legal-document type', () => {
+		const result = v.safeParse(postSubjectOutputSchema, {
+			subjectId: 'sub_2jv6z8n4q9',
+			consentId: 'cns_123',
+			domainId: 'dom_123',
+			domain: 'example.com',
+			type: 'terms_and_conditions_b2b',
+			givenAt: new Date('2026-04-07T00:00:00.000Z'),
+		});
+
+		expect(result.success).toBe(true);
 	});
 });

--- a/packages/schema/src/domain/consent-policy.ts
+++ b/packages/schema/src/domain/consent-policy.ts
@@ -1,10 +1,24 @@
 import * as v from 'valibot';
 
-export const legalDocumentPolicyTypeSchema = v.picklist([
+export const LEGAL_DOCUMENT_TYPE_PREFIXES = [
 	'privacy_policy',
 	'dpa',
 	'terms_and_conditions',
-]);
+] as const;
+
+export const isLegalDocumentType = (value: unknown): value is string =>
+	typeof value === 'string' &&
+	LEGAL_DOCUMENT_TYPE_PREFIXES.some(
+		(prefix) => value === prefix || value.startsWith(`${prefix}_`)
+	);
+
+export const legalDocumentPolicyTypeSchema = v.pipe(
+	v.string(),
+	v.check(
+		(value: string): boolean => isLegalDocumentType(value),
+		'Invalid legal document type'
+	)
+);
 
 export const policyTypeSchema = v.picklist([
 	// Deprecated in 2.0 RC. Runtime banner behavior should use backend policies.

--- a/packages/schema/src/domain/consent-policy.ts
+++ b/packages/schema/src/domain/consent-policy.ts
@@ -1,17 +1,65 @@
 import * as v from 'valibot';
 
+/**
+ * Base legal-document policy families recognized by c15t.
+ *
+ * A concrete consent `type` is valid when it equals one of these prefixes or is
+ * a suffixed variant of one (see {@link isLegalDocumentType}). Declared
+ * `as const`, so the entries are literal types and the array is read-only.
+ */
 export const LEGAL_DOCUMENT_TYPE_PREFIXES = [
 	'privacy_policy',
 	'dpa',
 	'terms_and_conditions',
 ] as const;
 
+/**
+ * Type guard for legal-document consent types.
+ *
+ * Matches when `value` is a string that either equals one of
+ * {@link LEGAL_DOCUMENT_TYPE_PREFIXES} or starts with a prefix followed by `_`
+ * (e.g. `terms_and_conditions_b2b`). The `_` boundary plus a non-empty suffix
+ * are both required, so near matches like `terms_and_conditions2` and
+ * empty-suffix values like `terms_and_conditions_` are rejected. Fail-closed:
+ * unknown families and non-string values return `false`.
+ *
+ * @param value - Candidate consent type; may be any value.
+ * @returns `true` when `value` is a base or suffixed legal-document type,
+ * narrowing it to `string`; otherwise `false`.
+ *
+ * @example
+ * ```ts
+ * isLegalDocumentType('terms_and_conditions'); // true (base family)
+ * isLegalDocumentType('terms_and_conditions_b2b'); // true (suffixed variant)
+ * isLegalDocumentType('terms_and_conditions2'); // false (missing `_` boundary)
+ * isLegalDocumentType('terms_and_conditions_'); // false (empty suffix)
+ * isLegalDocumentType('cookie_banner'); // false (not a legal-document type)
+ * isLegalDocumentType(42); // false (not a string)
+ * ```
+ */
 export const isLegalDocumentType = (value: unknown): value is string =>
 	typeof value === 'string' &&
 	LEGAL_DOCUMENT_TYPE_PREFIXES.some(
-		(prefix) => value === prefix || value.startsWith(`${prefix}_`)
+		(prefix) =>
+			value === prefix ||
+			(value.startsWith(`${prefix}_`) && value.length > prefix.length + 1)
 	);
 
+/**
+ * Valibot schema validating a legal-document policy `type`.
+ *
+ * Accepts any string for which {@link isLegalDocumentType} returns `true` — a
+ * base family or a suffixed variant — and reports `Invalid legal document type`
+ * for anything else. Output type is `string` (see {@link LegalDocumentPolicyType}).
+ *
+ * @example
+ * ```ts
+ * import * as v from 'valibot';
+ *
+ * v.parse(legalDocumentPolicyTypeSchema, 'terms_and_conditions_b2c'); // 'terms_and_conditions_b2c'
+ * v.is(legalDocumentPolicyTypeSchema, 'marketing_communications'); // false
+ * ```
+ */
 export const legalDocumentPolicyTypeSchema = v.pipe(
 	v.string(),
 	v.check(

--- a/packages/schema/src/domain/consent-policy.ts
+++ b/packages/schema/src/domain/consent-policy.ts
@@ -1,49 +1,15 @@
 import * as v from 'valibot';
+import type { LegalDocumentPolicyType } from '../shared/legal-document-types';
+import { isLegalDocumentType } from '../shared/legal-document-types';
 
-/**
- * Base legal-document policy families recognized by c15t.
- *
- * A concrete consent `type` is valid when it equals one of these prefixes or is
- * a suffixed variant of one (see {@link isLegalDocumentType}). Declared
- * `as const`, so the entries are literal types and the array is read-only.
- */
-export const LEGAL_DOCUMENT_TYPE_PREFIXES = [
-	'privacy_policy',
-	'dpa',
-	'terms_and_conditions',
-] as const;
-
-/**
- * Type guard for legal-document consent types.
- *
- * Matches when `value` is a string that either equals one of
- * {@link LEGAL_DOCUMENT_TYPE_PREFIXES} or starts with a prefix followed by `_`
- * (e.g. `terms_and_conditions_b2b`). The `_` boundary plus a non-empty suffix
- * are both required, so near matches like `terms_and_conditions2` and
- * empty-suffix values like `terms_and_conditions_` are rejected. Fail-closed:
- * unknown families and non-string values return `false`.
- *
- * @param value - Candidate consent type; may be any value.
- * @returns `true` when `value` is a base or suffixed legal-document type,
- * narrowing it to `string`; otherwise `false`.
- *
- * @example
- * ```ts
- * isLegalDocumentType('terms_and_conditions'); // true (base family)
- * isLegalDocumentType('terms_and_conditions_b2b'); // true (suffixed variant)
- * isLegalDocumentType('terms_and_conditions2'); // false (missing `_` boundary)
- * isLegalDocumentType('terms_and_conditions_'); // false (empty suffix)
- * isLegalDocumentType('cookie_banner'); // false (not a legal-document type)
- * isLegalDocumentType(42); // false (not a string)
- * ```
- */
-export const isLegalDocumentType = (value: unknown): value is string =>
-	typeof value === 'string' &&
-	LEGAL_DOCUMENT_TYPE_PREFIXES.some(
-		(prefix) =>
-			value === prefix ||
-			(value.startsWith(`${prefix}_`) && value.length > prefix.length + 1)
-	);
+export type {
+	LegalDocumentPolicyType,
+	LegalDocumentTypePrefix,
+} from '../shared/legal-document-types';
+export {
+	isLegalDocumentType,
+	LEGAL_DOCUMENT_TYPE_PREFIXES,
+} from '../shared/legal-document-types';
 
 /**
  * Valibot schema validating a legal-document policy `type`.
@@ -79,10 +45,23 @@ export const policyTypeSchema = v.picklist([
 	'other',
 ]);
 
+/**
+ * Valibot schema validating any consent policy type that can be stored or
+ * returned by c15t.
+ *
+ * This preserves the closed built-in {@link policyTypeSchema} while also
+ * accepting suffixed legal-document variants through
+ * {@link legalDocumentPolicyTypeSchema}.
+ */
+export const consentPolicyTypeSchema = v.union([
+	policyTypeSchema,
+	legalDocumentPolicyTypeSchema,
+]);
+
 export const consentPolicySchema = v.object({
 	id: v.string(),
 	version: v.string(),
-	type: policyTypeSchema,
+	type: consentPolicyTypeSchema,
 	hash: v.nullish(v.string()),
 	effectiveDate: v.date(),
 	isActive: v.optional(v.boolean(), true),
@@ -90,8 +69,11 @@ export const consentPolicySchema = v.object({
 	tenantId: v.nullish(v.string()),
 });
 
-export type ConsentPolicy = v.InferOutput<typeof consentPolicySchema>;
-export type LegalDocumentPolicyType = v.InferOutput<
-	typeof legalDocumentPolicyTypeSchema
->;
 export type PolicyType = v.InferOutput<typeof policyTypeSchema>;
+export type ConsentPolicyType = PolicyType | LegalDocumentPolicyType;
+export type ConsentPolicy = Omit<
+	v.InferOutput<typeof consentPolicySchema>,
+	'type'
+> & {
+	type: ConsentPolicyType;
+};

--- a/packages/schema/src/domain/index.ts
+++ b/packages/schema/src/domain/index.ts
@@ -11,6 +11,8 @@ export {
 export {
 	type ConsentPolicy,
 	consentPolicySchema,
+	isLegalDocumentType,
+	LEGAL_DOCUMENT_TYPE_PREFIXES,
 	type LegalDocumentPolicyType,
 	legalDocumentPolicyTypeSchema,
 	type PolicyType,

--- a/packages/schema/src/domain/index.ts
+++ b/packages/schema/src/domain/index.ts
@@ -10,10 +10,13 @@ export {
 
 export {
 	type ConsentPolicy,
+	type ConsentPolicyType,
 	consentPolicySchema,
+	consentPolicyTypeSchema,
 	isLegalDocumentType,
 	LEGAL_DOCUMENT_TYPE_PREFIXES,
 	type LegalDocumentPolicyType,
+	type LegalDocumentTypePrefix,
 	legalDocumentPolicyTypeSchema,
 	type PolicyType,
 	policyTypeSchema,

--- a/packages/schema/src/shared/legal-document-types.ts
+++ b/packages/schema/src/shared/legal-document-types.ts
@@ -1,0 +1,53 @@
+/**
+ * Base legal-document policy families recognized by c15t.
+ *
+ * A concrete consent `type` is valid when it equals one of these prefixes or is
+ * a suffixed variant of one (see {@link isLegalDocumentType}). Declared
+ * `as const`, so the entries are literal types and the array is read-only.
+ */
+export const LEGAL_DOCUMENT_TYPE_PREFIXES = [
+	'privacy_policy',
+	'dpa',
+	'terms_and_conditions',
+] as const;
+
+export type LegalDocumentTypePrefix =
+	(typeof LEGAL_DOCUMENT_TYPE_PREFIXES)[number];
+
+export type LegalDocumentPolicyType =
+	| LegalDocumentTypePrefix
+	| `${LegalDocumentTypePrefix}_${string}`;
+
+/**
+ * Type guard for legal-document consent types.
+ *
+ * Matches when `value` is a string that either equals one of
+ * {@link LEGAL_DOCUMENT_TYPE_PREFIXES} or starts with a prefix followed by `_`
+ * (e.g. `terms_and_conditions_b2b`). The `_` boundary plus a non-empty suffix
+ * are both required, so near matches like `terms_and_conditions2` and
+ * empty-suffix values like `terms_and_conditions_` are rejected. Fail-closed:
+ * unknown families and non-string values return `false`.
+ *
+ * @param value - Candidate consent type; may be any value.
+ * @returns `true` when `value` is a base or suffixed legal-document type,
+ * narrowing it to `string`; otherwise `false`.
+ *
+ * @example
+ * ```ts
+ * isLegalDocumentType('terms_and_conditions'); // true (base family)
+ * isLegalDocumentType('terms_and_conditions_b2b'); // true (suffixed variant)
+ * isLegalDocumentType('terms_and_conditions2'); // false (missing `_` boundary)
+ * isLegalDocumentType('terms_and_conditions_'); // false (empty suffix)
+ * isLegalDocumentType('cookie_banner'); // false (not a legal-document type)
+ * isLegalDocumentType(42); // false (not a string)
+ * ```
+ */
+export const isLegalDocumentType = (
+	value: unknown
+): value is LegalDocumentPolicyType =>
+	typeof value === 'string' &&
+	LEGAL_DOCUMENT_TYPE_PREFIXES.some(
+		(prefix) =>
+			value === prefix ||
+			(value.startsWith(`${prefix}_`) && value.length > prefix.length + 1)
+	);

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -52,13 +52,19 @@ export type {
 	AuditLog,
 	Consent,
 	ConsentPolicy,
+	ConsentPolicyType,
 	ConsentPurpose,
 	Domain,
 	LegalDocumentPolicyType,
+	LegalDocumentTypePrefix,
 	PolicyType,
 	RuntimePolicyDecision,
 	Subject,
 } from './domain';
+export {
+	isLegalDocumentType,
+	LEGAL_DOCUMENT_TYPE_PREFIXES,
+} from './shared/legal-document-types';
 
 // Shared types - derived from constants without Zod
 export type Branding = (typeof brandingValues)[number];


### PR DESCRIPTION
## Overview

Legal-document consent types were a fixed enum (`privacy_policy`, `dpa`, `terms_and_conditions`), so a customer couldn't have more than one terms-and-conditions policy active at once. This changes validation to match by prefix, so suffixed variants like `terms_and_conditions_b2b` and `terms_and_conditions_b2c` are accepted while unknown families are still rejected. The matcher lives in one place in `@c15t/schema` and is reused by the `@c15t/backend` guards so all three checks stay in sync.

## Related Issue
Fixes https://github.com/c15t/c15t/issues/884

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [ ] 🚀 New feature
- [ ] 💥 Breaking change (requires migration)
- [ ] 📚 Documentation
- [ ] 🏗️ Refactor (no functional changes)
- [ ] 🎨 Style (formatting, no code changes)
- [ ] ⚡ Performance

## Implementation Details

### Key Changes
1. `@c15t/schema`: replaced the `legalDocumentPolicyTypeSchema` picklist with a prefix-based check (`v.pipe(v.string(), v.check(...))`), backed by exported `LEGAL_DOCUMENT_TYPE_PREFIXES` + `isLegalDocumentType`; pointed `subjectPolicyBasedInputSchema.type` at it.
2. `@c15t/backend`: removed the duplicated exact-match guards in `snapshot.ts` and `post.handler.ts` and reused the shared `isLegalDocumentType`.

### Technical Notes
- Boundary check is `value === prefix || value.startsWith(prefix + '_')`, fail-closed (unknown family rejected).
- `LegalDocumentPolicyType` widens from a 3-value union to `string`; no consumer relied on the union (verified by build).
- `postSubjectInputSchema` is a `v.variant('type', ...)`; valibot routes by running each branch's discriminator, so a `pipe(string, check)` discriminator works.

## Testing

### Test Plan

- [x] Scenario 1: schema accepts base + suffixed types, rejects bad ones

  ```ts
  v.is(legalDocumentPolicyTypeSchema, 'terms_and_conditions_b2b'); // true
  v.is(legalDocumentPolicyTypeSchema, 'terms_and_conditions2');    // false
  ```

  ✓ Expected: suffixed variant passes, boundary-violating string fails

- [x] Scenario 2: backend treats a suffixed type as legal-document consent

  ```ts
  // POST /subjects with type 'terms_and_conditions_b2b' and legalDocumentSnapshot enabled, no token
  ```

  ✓ Expected: 409 `LEGAL_DOCUMENT_SNAPSHOT_REQUIRED`

### Edge Cases
- [x] Error handling: unknown/non-string types rejected; snapshot token type mismatch still 409
- [x] Performance: none (one string check per validation)
- [x] Security: fail-closed — unknown families rejected, not allowed through

## Checklist

### Required

- [x] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally (schema 79/79, backend 519/519, builds pass)
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legal-document consent/policy `type` now supports suffixed variants (e.g., `terms_and_conditions_b2b`) for `privacy_policy`, `dpa`, and `terms_and_conditions`.
* **Documentation**
  * Updated `POST /subjects` and related endpoint docs to reflect prefixed/suffixed `type` handling.
* **Bug Fixes**
  * Improved shared validation so suffixed legal-document types are consistently accepted across token verification, policy matching, and consent writes.
* **Tests**
  * Added and expanded schema, snapshot-token, and idempotency/scope tests for suffixed `type` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->