### PR TITLE
Fix Microsoft Clarity consent bootstrap

### DIFF
--- a/.changeset/fix-clarity-consent-bootstrap.md
+++ b/.changeset/fix-clarity-consent-bootstrap.md
@@ -1,0 +1,5 @@
+---
+'@c15t/scripts': minor
+---
+
+Fix Microsoft Clarity integration: the pre-load stub no longer sets the `v` version marker — Clarity's runtime treats a pre-set `v` as a duplicate install ("Error CL001: Multiple Clarity tags detected") and never starts, so installs collected no data. Consent synchronization now uses Clarity Consent V2 (`consentv2` with `ad_Storage`/`analytics_Storage`), mapping c15t `marketing` to `ad_Storage` and `measurement` to `analytics_Storage`. The `defaultConsent` option now accepts a Consent V2 payload; boolean values are still supported and expand to both storage channels.

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -378,42 +378,57 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	},
 	{
 		vendor: 'microsoft-clarity',
-		// clarity.ms answers unknown project ids with an empty 204, so runtime
-		// behavior can only be asserted with a real project id (planned as a
-		// repo-secret follow-up). Bootstrap and consent gating still run against
-		// the live endpoint.
-		tier: 'loader-only',
-		createScript: () =>
-			clarity({
-				id: 'c15tfake00',
-				defaultConsent: {
-					ad_storage: 'denied',
-					analytics_storage: 'denied',
-				},
-			}),
+		// Real project id: Clarity ids are public by nature (visible in the
+		// page source of every site using Clarity) and the runner blocks all
+		// collect endpoints, so probes send no analytics data to the project.
+		// A real id means the tag serves the real runtime — full tier.
+		tier: 'full',
+		createScript: () => clarity({ id: 'xin9eohwfp' }),
 		loaderUrlSubstring: 'clarity.ms/tag/',
-		allowUrlSubstrings: ['clarity.ms/s/'],
+		// The tag chain-loads the versioned runtime bundle from
+		// scripts.clarity.ms; collect endpoints stay blocked.
+		allowUrlSubstrings: ['clarity.ms/s/', 'scripts.clarity.ms/'],
+		runtimeReplacedGlobals: ['clarity'],
 		bootstrapCheck: () => {
-			const stub = window.clarity;
+			const stub = window.clarity as
+				| (Window['clarity'] & { v?: unknown })
+				| undefined;
 
 			if (typeof stub !== 'function') {
 				return check(false, 'expected window.clarity stub function');
 			}
 
-			if (stub.v !== '0.7.0') {
-				return check(false, `expected stub version 0.7.0, got ${stub.v}`);
+			// The stub must NOT carry the runtime version marker: clarity.js
+			// refuses to start when `v` is pre-set ("Error CL001: Multiple
+			// Clarity tags detected") — the production bug fixed in #898.
+			if (stub.v !== undefined) {
+				return check(
+					false,
+					`stub carries v=${String(stub.v)}; clarity.js treats this as a duplicate install (CL001) and never starts`
+				);
 			}
 
+			const firstCall = stub.q?.[0];
+			const isConsentV2 =
+				Array.isArray(firstCall) && firstCall[0] === 'consentv2';
+
 			return check(
-				Array.isArray(stub.q) && stub.q.length > 0,
-				'clarity queue seeded with default consent before load'
+				isConsentV2,
+				'clarity queue seeded with a consentv2 call before load'
 			);
 		},
-		runtimeCheck: () =>
-			check(
-				typeof window.clarity === 'function',
-				'window.clarity callable after loader executed'
-			),
+		runtimeCheck: () => {
+			const runtime = window.clarity as
+				| (Window['clarity'] & { v?: unknown })
+				| undefined;
+
+			// clarity.js assigns `v` only after the real runtime replaces the
+			// queued stub — its presence proves the runtime actually started.
+			return check(
+				typeof runtime === 'function' && typeof runtime.v === 'string',
+				'clarity runtime installed and stamped its version after load'
+			);
+		},
 	},
 	{
 		vendor: 'databuddy',

--- a/packages/scripts/src/microsoft-clarity.e2e.test.ts
+++ b/packages/scripts/src/microsoft-clarity.e2e.test.ts
@@ -19,14 +19,10 @@ type ClarityStub = ((...args: unknown[]) => void) & {
 describe('microsoft clarity contract', () => {
 	registerVendorContractCleanup();
 
-	it('preserves the stub metadata and object default consent payload', () => {
-		const defaultConsent = {
-			ad_storage: 'denied',
-			analytics_storage: 'denied',
-		};
+	it('queues Consent V2 before load without duplicate-install metadata', () => {
 		let queueSnapshot: unknown[][] | undefined;
 		let scriptSrc: string | undefined;
-		let stubVersion: string | undefined;
+		let stubVersion: unknown;
 
 		installHeadProbe((node, win) => {
 			if (!node.src.includes('clarity.ms/tag/CLARITY-CONTRACT')) {
@@ -44,10 +40,7 @@ describe('microsoft clarity contract', () => {
 		loadScripts(
 			[
 				{
-					...clarity({
-						id: 'CLARITY-CONTRACT',
-						defaultConsent,
-					}),
+					...clarity({ id: 'CLARITY-CONTRACT' }),
 					id: 'microsoft-clarity-contract',
 				},
 			],
@@ -55,7 +48,15 @@ describe('microsoft clarity contract', () => {
 		);
 
 		expect(scriptSrc).toContain('/tag/CLARITY-CONTRACT');
-		expect(stubVersion).toBe('0.7.0');
-		expect(queueSnapshot).toEqual([['consent', defaultConsent]]);
+		expect(stubVersion).toBeUndefined();
+		expect(queueSnapshot).toEqual([
+			[
+				'consentv2',
+				{
+					ad_Storage: 'denied',
+					analytics_Storage: 'granted',
+				},
+			],
+		]);
 	});
 });

--- a/packages/scripts/src/vendors/analytics/microsoft-clarity.test.ts
+++ b/packages/scripts/src/vendors/analytics/microsoft-clarity.test.ts
@@ -7,7 +7,10 @@ import {
 	setupScriptHelperTest,
 	toArgumentsArray,
 } from '../../__tests__/helpers';
-import { clarity } from './microsoft-clarity';
+import { type ClarityConsentV2Payload, clarity } from './microsoft-clarity';
+
+const consentv2Call = (payload: ClarityConsentV2Payload) =>
+	toArgumentsArray(['consentv2', payload]);
 
 describe('microsoft-clarity', () => {
 	setupScriptHelperTest();
@@ -26,7 +29,7 @@ describe('microsoft-clarity', () => {
 		const globalRef = getTestGlobal();
 		const script = clarity({
 			id: 'abcdef1234',
-			defaultConsent: { ad_Storage: 'denied' },
+			defaultConsent: { ad_Storage: 'granted' },
 		});
 
 		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
@@ -37,19 +40,20 @@ describe('microsoft-clarity', () => {
 			  })
 			| undefined;
 		expect(stub?.q).toEqual([
-			toArgumentsArray([
-				'consentv2',
-				{
-					ad_Storage: 'denied',
-					analytics_Storage: 'denied',
-				},
-			]),
+			consentv2Call({
+				ad_Storage: 'granted',
+				analytics_Storage: 'denied',
+			}),
 		]);
 	});
 
 	it('maps consent updates to Clarity Consent V2 calls', () => {
 		const globalRef = getTestGlobal();
 		const script = clarity({ id: 'abcdef1234' });
+		const grantedMeasurementAndMarketingConsentState = {
+			...grantedMeasurementConsentState,
+			marketing: true,
+		};
 
 		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
 		script.onConsentChange?.(
@@ -62,6 +66,13 @@ describe('microsoft-clarity', () => {
 		script.onConsentChange?.(
 			createCallbackInfo({
 				id: script.id,
+				hasConsent: true,
+				consents: grantedMeasurementAndMarketingConsentState,
+			})
+		);
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
 			})
 		);
 
@@ -69,27 +80,22 @@ describe('microsoft-clarity', () => {
 			| (((...args: unknown[]) => void) & { q?: unknown[][] })
 			| undefined;
 		expect(stub?.q).toEqual([
-			toArgumentsArray([
-				'consentv2',
-				{
-					ad_Storage: 'denied',
-					analytics_Storage: 'denied',
-				},
-			]),
-			toArgumentsArray([
-				'consentv2',
-				{
-					ad_Storage: 'denied',
-					analytics_Storage: 'granted',
-				},
-			]),
-			toArgumentsArray([
-				'consentv2',
-				{
-					ad_Storage: 'denied',
-					analytics_Storage: 'denied',
-				},
-			]),
+			consentv2Call({
+				ad_Storage: 'denied',
+				analytics_Storage: 'denied',
+			}),
+			consentv2Call({
+				ad_Storage: 'denied',
+				analytics_Storage: 'granted',
+			}),
+			consentv2Call({
+				ad_Storage: 'granted',
+				analytics_Storage: 'granted',
+			}),
+			consentv2Call({
+				ad_Storage: 'denied',
+				analytics_Storage: 'denied',
+			}),
 		]);
 	});
 });

--- a/packages/scripts/src/vendors/analytics/microsoft-clarity.test.ts
+++ b/packages/scripts/src/vendors/analytics/microsoft-clarity.test.ts
@@ -26,7 +26,7 @@ describe('microsoft-clarity', () => {
 		const globalRef = getTestGlobal();
 		const script = clarity({
 			id: 'abcdef1234',
-			defaultConsent: { ad_storage: 'denied' },
+			defaultConsent: { ad_Storage: 'denied' },
 		});
 
 		script.onBeforeLoad?.(createCallbackInfo({ id: script.id }));
@@ -34,16 +34,20 @@ describe('microsoft-clarity', () => {
 		const stub = globalRef.clarity as
 			| (((...args: unknown[]) => void) & {
 					q?: unknown[][];
-					v?: string;
 			  })
 			| undefined;
-		expect(stub?.v).toBe('0.7.0');
 		expect(stub?.q).toEqual([
-			toArgumentsArray(['consent', { ad_storage: 'denied' }]),
+			toArgumentsArray([
+				'consentv2',
+				{
+					ad_Storage: 'denied',
+					analytics_Storage: 'denied',
+				},
+			]),
 		]);
 	});
 
-	it('maps consent updates to Clarity consent calls', () => {
+	it('maps consent updates to Clarity Consent V2 calls', () => {
 		const globalRef = getTestGlobal();
 		const script = clarity({ id: 'abcdef1234' });
 
@@ -65,8 +69,27 @@ describe('microsoft-clarity', () => {
 			| (((...args: unknown[]) => void) & { q?: unknown[][] })
 			| undefined;
 		expect(stub?.q).toEqual([
-			toArgumentsArray(['consent', true]),
-			toArgumentsArray(['consent', false]),
+			toArgumentsArray([
+				'consentv2',
+				{
+					ad_Storage: 'denied',
+					analytics_Storage: 'denied',
+				},
+			]),
+			toArgumentsArray([
+				'consentv2',
+				{
+					ad_Storage: 'denied',
+					analytics_Storage: 'granted',
+				},
+			]),
+			toArgumentsArray([
+				'consentv2',
+				{
+					ad_Storage: 'denied',
+					analytics_Storage: 'denied',
+				},
+			]),
 		]);
 	});
 });

--- a/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
+++ b/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
@@ -1,11 +1,31 @@
-import type { Script } from 'c15t';
+import type { ConsentState, Script, ScriptCallbackInfo } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 
-export type ClarityConsentValue = boolean | Record<string, string>;
+export type ClarityConsentState = 'granted' | 'denied';
+
+export interface ClarityConsentV2Payload {
+	ad_Storage: ClarityConsentState;
+	analytics_Storage: ClarityConsentState;
+}
+
+export type ClarityConsentValue =
+	| boolean
+	| Partial<
+			Record<
+				| keyof ClarityConsentV2Payload
+				| 'ad_storage'
+				| 'analytics_storage'
+				| 'marketing'
+				| 'measurement'
+				| 'analytics',
+				ClarityConsentState | boolean
+			>
+	  >;
 
 type ClarityFunction = {
-	(command: 'consent', value?: ClarityConsentValue): void;
+	(command: 'consent', value?: boolean): void;
+	(command: 'consentv2', value: ClarityConsentV2Payload): void;
 	(command: 'event', value: string): void;
 	(command: 'identify', id: string, session?: string, page?: string): unknown;
 	(command: 'set', key: string, value: string | string[]): void;
@@ -18,16 +38,114 @@ declare global {
 	interface Window {
 		clarity?: ClarityFunction & {
 			q?: unknown[][];
-			v?: string;
 		};
 	}
+}
+
+function toClarityConsentState(
+	value: unknown
+): ClarityConsentState | undefined {
+	if (value === true) {
+		return 'granted';
+	}
+
+	if (value === false) {
+		return 'denied';
+	}
+
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+
+	const normalized = value.toLowerCase();
+	if (normalized === 'granted' || normalized === 'true') {
+		return 'granted';
+	}
+
+	if (normalized === 'denied' || normalized === 'false') {
+		return 'denied';
+	}
+
+	return undefined;
+}
+
+function getConsentValue(
+	value: Record<string, unknown>,
+	keys: string[]
+): ClarityConsentState | undefined {
+	for (const key of keys) {
+		const consent = toClarityConsentState(value[key]);
+		if (consent) {
+			return consent;
+		}
+	}
+
+	return undefined;
+}
+
+function getConsentPayloadFromState(
+	consents: ConsentState
+): ClarityConsentV2Payload {
+	return {
+		ad_Storage: consents.marketing ? 'granted' : 'denied',
+		analytics_Storage: consents.measurement ? 'granted' : 'denied',
+	};
+}
+
+function getClarityConsentPayload(
+	consents: ConsentState,
+	defaultConsent?: ClarityConsentValue
+): ClarityConsentV2Payload {
+	const fallback = getConsentPayloadFromState(consents);
+
+	if (defaultConsent === undefined) {
+		return fallback;
+	}
+
+	const booleanConsent = toClarityConsentState(defaultConsent);
+	if (booleanConsent) {
+		return {
+			ad_Storage: booleanConsent,
+			analytics_Storage: booleanConsent,
+		};
+	}
+
+	if (defaultConsent !== null && typeof defaultConsent === 'object') {
+		return {
+			ad_Storage:
+				getConsentValue(defaultConsent, [
+					'ad_Storage',
+					'ad_storage',
+					'marketing',
+				]) ?? fallback.ad_Storage,
+			analytics_Storage:
+				getConsentValue(defaultConsent, [
+					'analytics_Storage',
+					'analytics_storage',
+					'measurement',
+					'analytics',
+				]) ?? fallback.analytics_Storage,
+		};
+	}
+
+	return fallback;
+}
+
+function syncClarityConsent(
+	info: ScriptCallbackInfo,
+	defaultConsent?: ClarityConsentValue
+): void {
+	window.clarity?.(
+		'consentv2',
+		getClarityConsentPayload(info.consents, defaultConsent)
+	);
 }
 
 /**
  * Microsoft Clarity vendor manifest.
  *
  * Seeds the global queue stub before loading the vendor bundle and uses
- * Clarity's consent API for simple granted and denied transitions.
+ * Clarity's Consent V2 API for granular analytics and ad storage transitions.
  */
 export const clarityManifest = {
 	...vendorManifestContract,
@@ -42,9 +160,6 @@ export const clarityManifest = {
 				property: 'q',
 			},
 			queueFormat: 'array',
-			properties: {
-				v: '0.7.0',
-			},
 			ifUndefined: true,
 		},
 	],
@@ -53,20 +168,6 @@ export const clarityManifest = {
 			type: 'loadScript',
 			src: '{{scriptUrl}}',
 			async: true,
-		},
-	],
-	onConsentGranted: [
-		{
-			type: 'callGlobal',
-			global: 'clarity',
-			args: ['consent', true],
-		},
-	],
-	onConsentDenied: [
-		{
-			type: 'callGlobal',
-			global: 'clarity',
-			args: ['consent', false],
 		},
 	],
 } as const satisfies VendorManifest;
@@ -79,10 +180,11 @@ export interface ClarityOptions {
 	id: string;
 
 	/**
-	 * Optional initial consent value queued before the script loads.
+	 * Optional initial Consent V2 value queued before the script loads.
 	 *
-	 * Object-shaped advanced consent vectors are supported only for this initial
-	 * boot-time value. Later c15t consent changes are mapped to simple booleans.
+	 * By default, c15t maps `measurement` to `analytics_Storage` and `marketing`
+	 * to `ad_Storage`. Pass this only when boot-time consent must override the
+	 * current c15t consent state.
 	 */
 	defaultConsent?: ClarityConsentValue;
 
@@ -112,24 +214,21 @@ export function clarity({
 		);
 	}
 
-	let manifest: VendorManifest = clarityManifest;
-
-	if (defaultConsent !== undefined) {
-		manifest = {
-			...clarityManifest,
-			install: [
-				{
-					type: 'callGlobal',
-					global: 'clarity',
-					args: ['consent', '{{defaultConsent}}'],
-				},
-				...clarityManifest.install,
-			],
-		};
-	}
-
-	return resolveManifest(manifest, {
-		defaultConsent,
+	const resolved = resolveManifest(clarityManifest, {
 		scriptUrl: scriptUrl ?? `https://www.clarity.ms/tag/${normalizedId}`,
 	});
+	const onBeforeLoad = resolved.onBeforeLoad;
+	const onConsentChange = resolved.onConsentChange;
+
+	return {
+		...resolved,
+		onBeforeLoad: (info) => {
+			onBeforeLoad?.(info);
+			syncClarityConsent(info, defaultConsent);
+		},
+		onConsentChange: (info) => {
+			onConsentChange?.(info);
+			syncClarityConsent(info);
+		},
+	};
 }

--- a/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
+++ b/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
@@ -2,13 +2,32 @@ import type { ConsentState, Script, ScriptCallbackInfo } from 'c15t';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 
+/**
+ * Microsoft Clarity Consent V2 storage state.
+ *
+ * Clarity accepts string consent values instead of booleans for its granular
+ * `ad_Storage` and `analytics_Storage` channels.
+ */
 export type ClarityConsentState = 'granted' | 'denied';
 
+/**
+ * Consent V2 payload sent to Microsoft Clarity.
+ *
+ * c15t maps `marketing` consent to `ad_Storage` and `measurement` consent to
+ * `analytics_Storage`.
+ */
 export interface ClarityConsentV2Payload {
 	ad_Storage: ClarityConsentState;
 	analytics_Storage: ClarityConsentState;
 }
 
+/**
+ * Optional boot-time consent override accepted by the Clarity helper.
+ *
+ * Booleans apply the same value to both Clarity Consent V2 channels. Object
+ * values may use Clarity keys or c15t category aliases and are merged over the
+ * current c15t consent state.
+ */
 export type ClarityConsentValue =
 	| boolean
 	| Partial<
@@ -42,6 +61,11 @@ declare global {
 	}
 }
 
+/**
+ * Converts c15t and user-supplied consent values into Clarity Consent V2 state.
+ *
+ * @internal
+ */
 function toClarityConsentState(
 	value: unknown
 ): ClarityConsentState | undefined {
@@ -86,12 +110,31 @@ function getConsentValue(
 function getConsentPayloadFromState(
 	consents: ConsentState
 ): ClarityConsentV2Payload {
+	let adStorage: ClarityConsentState;
+	if (consents.marketing) {
+		adStorage = 'granted';
+	} else {
+		adStorage = 'denied';
+	}
+
+	let analyticsStorage: ClarityConsentState;
+	if (consents.measurement) {
+		analyticsStorage = 'granted';
+	} else {
+		analyticsStorage = 'denied';
+	}
+
 	return {
-		ad_Storage: consents.marketing ? 'granted' : 'denied',
-		analytics_Storage: consents.measurement ? 'granted' : 'denied',
+		ad_Storage: adStorage,
+		analytics_Storage: analyticsStorage,
 	};
 }
 
+/**
+ * Builds the Consent V2 payload for Clarity from c15t state and overrides.
+ *
+ * @internal
+ */
 function getClarityConsentPayload(
 	consents: ConsentState,
 	defaultConsent?: ClarityConsentValue
@@ -131,6 +174,11 @@ function getClarityConsentPayload(
 	return fallback;
 }
 
+/**
+ * Queues or sends the current Clarity Consent V2 payload.
+ *
+ * @internal
+ */
 function syncClarityConsent(
 	info: ScriptCallbackInfo,
 	defaultConsent?: ClarityConsentValue


### PR DESCRIPTION
## Summary

- remove the pre-load `window.clarity.v` marker from the Microsoft Clarity stub so Clarity's own loader no longer treats c15t as a duplicate install
- switch c15t's Clarity synchronization to Consent V2 with `ad_Storage` and `analytics_Storage`
- map c15t `marketing` consent to Clarity `ad_Storage` and `measurement` consent to Clarity `analytics_Storage`
- update unit/e2e coverage to assert Consent V2 is queued before the Clarity tag loads and that the stub does not expose `v`

## Context

Microsoft's current `clarity-js` queue processor exits early when `window.clarity.v` is already present. c15t was setting `v: "0.7.0"` on the bootstrap stub before `https://www.clarity.ms/tag/{id}` ran, so the Microsoft tag loader detected a duplicate install and skipped loading `clarity.js`. That left customers with the Clarity tag request but no `clarity.js`, no collect calls, and no dashboard data.

Microsoft's implementation sets `window.clarity.v` only after the real runtime replaces the queued stub, so the c15t stub should only queue calls. This also updates the helper to use Clarity Consent V2 instead of the older boolean consent API.

## Verification

- `bun run --filter @c15t/scripts test -- microsoft-clarity`
- `bun run --filter @c15t/scripts check-types`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded Microsoft Clarity consent support to **Consent V2**, with separate controls for **ad storage** and **analytics storage**.
  * Consent inputs now support both simple boolean values and a typed consent-vector style payload.
* **Bug Fixes**
  * Ensured Consent V2 is queued **before** the Clarity script loads, with the correct payload shape and updated channel mapping.
  * Fixed an issue that could cause Clarity to fail due to duplicate-install metadata during bootstrap.
* **Tests**
  * Updated Clarity unit and e2e tests to assert **`consentv2`** payloads and queued consent sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->