### PR TITLE
feat(scripts): add daily live vendor script monitor

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@f0a91ff48ac74ee1ecd46fb02774fef9a10e4024 # v0
         with:
           prompt: ${{ inputs.prompt }}
         env:

--- a/.github/workflows/script-vendor-monitor.yml
+++ b/.github/workflows/script-vendor-monitor.yml
@@ -17,10 +17,17 @@ on:
 
 permissions: {}
 
+# Overlapping scheduled/manual runs could race to open duplicate issues for
+# the same vendor; queue them instead.
+concurrency:
+  group: script-vendor-monitor
+  cancel-in-progress: false
+
 jobs:
   live-vendor-probes:
     name: Live Vendor Probes
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write
@@ -39,7 +46,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: bunx playwright@1.58.2 install --with-deps chromium
+        # Derive the version from the package devDependency so browser builds
+        # can never drift from the API version runner.ts links against.
+        run: |
+          PLAYWRIGHT_VERSION=$(bun -e "console.log(require('./packages/scripts/package.json').devDependencies.playwright)")
+          bunx "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium
 
       - name: Build c15t core
         run: bun turbo run build --filter=c15t

--- a/.github/workflows/script-vendor-monitor.yml
+++ b/.github/workflows/script-vendor-monitor.yml
@@ -1,0 +1,77 @@
+name: Script Vendor Monitor
+
+# Daily live browser probes for every built-in @c15t/scripts integration.
+# Runs outside normal CI so transient third-party/network failures never
+# block PRs. Failures open one deduped issue per vendor; recoveries close
+# that vendor's issue automatically.
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      vendor:
+        description: 'Probe a single vendor id (for example microsoft-clarity). Leave empty for all vendors.'
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  live-vendor-probes:
+    name: Live Vendor Probes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: bunx playwright@1.58.2 install --with-deps chromium
+
+      - name: Build c15t core
+        run: bun turbo run build --filter=c15t
+
+      - name: Run live vendor probes
+        working-directory: packages/scripts
+        env:
+          VENDOR_FILTER: ${{ inputs.vendor }}
+        run: |
+          if [ -n "$VENDOR_FILTER" ]; then
+            bun run test:live-vendors -- --vendor "$VENDOR_FILTER"
+          else
+            bun run test:live-vendors
+          fi
+
+      - name: Upload probe report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: live-vendors-report
+          path: packages/scripts/live-vendors-report.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Sync monitor issues
+        if: always()
+        working-directory: packages/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f live-vendors-report.json ]; then
+            bun --tsconfig-override live-vendors/tsconfig.json live-vendors/manage-issues.ts --report live-vendors-report.json
+          else
+            echo "No report produced; skipping issue sync."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ debug-storybook.log
 
 # Agent worktrees
 .claude/worktrees/
+
+# Live vendor monitor output
+live-vendors-report.json

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@rsbuild/core": "1.7.5",
         "@rsbuild/plugin-react": "1.4.6",
         "@rsdoctor/rspack-plugin": "1.5.7",
-        "@rslib/core": "0.20.2",
+        "@rslib/core": "0.23.2",
         "@rspack/resolver-binding-wasm32-wasi": "0.2.8",
         "@types/bun": "latest",
         "@types/mdast": "4.0.4",
@@ -726,7 +726,7 @@
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
-        "@rslib/core": "0.20.2",
+        "@rslib/core": "0.23.2",
         "typescript": "6.0.2",
         "vitest": "4.1.2",
       },
@@ -1880,7 +1880,7 @@
 
     "@rsdoctor/utils": ["@rsdoctor/utils@1.5.7", "", { "dependencies": { "@babel/code-frame": "7.26.2", "@rsdoctor/types": "1.5.7", "@types/estree": "1.0.5", "acorn": "^8.10.0", "acorn-import-attributes": "^1.9.5", "acorn-walk": "8.3.5", "deep-eql": "4.1.4", "envinfo": "7.21.0", "fs-extra": "^11.1.1", "get-port": "5.1.1", "json-stream-stringify": "3.0.1", "lines-and-columns": "2.0.4", "picocolors": "^1.1.1", "rslog": "^1.3.2", "strip-ansi": "^6.0.1" } }, "sha512-uxmEkFFYgu3mbJELI+X9MXGbCSWwdfVWQbdCe9r61mlzTeOttkCbMsipErKc/UTwGYH34ujJhLYLwP2b+DCL2g=="],
 
-    "@rslib/core": ["@rslib/core@0.20.2", "", { "dependencies": { "@rsbuild/core": "2.0.0-beta.11", "rsbuild-plugin-dts": "0.20.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7", "typescript": "^5 || ^6" }, "optionalPeers": ["@microsoft/api-extractor", "typescript"], "bin": { "rslib": "bin/rslib.js" } }, "sha512-NJk2GasIvgfZdQ9CUTh/JxFvlhKiBv9BOa8GsnRrkRZ62CzSVrfiCT+FaBnqMk5adt+m2T9n+4Clrm6Rl0eoGw=="],
+    "@rslib/core": ["@rslib/core@0.23.2", "", { "dependencies": { "@rsbuild/core": "~2.1.4", "rsbuild-plugin-dts": "0.23.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7", "typescript": "^5 || ^6 || ^7.0.1-0" }, "optionalPeers": ["@microsoft/api-extractor", "typescript"], "bin": { "rslib": "./bin/rslib.js" } }, "sha512-KxSp+/y0BJ1O4oKwxX4ydBY7/ZVeJCUpWAmQniCIct8mTxIQFPGO/ibKbKq2IxZYqRuRpM8g+Dtyq0VbEQf9HQ=="],
 
     "@rspack/binding": ["@rspack/binding@1.7.11", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "1.7.11", "@rspack/binding-darwin-x64": "1.7.11", "@rspack/binding-linux-arm64-gnu": "1.7.11", "@rspack/binding-linux-arm64-musl": "1.7.11", "@rspack/binding-linux-x64-gnu": "1.7.11", "@rspack/binding-linux-x64-musl": "1.7.11", "@rspack/binding-wasm32-wasi": "1.7.11", "@rspack/binding-win32-arm64-msvc": "1.7.11", "@rspack/binding-win32-ia32-msvc": "1.7.11", "@rspack/binding-win32-x64-msvc": "1.7.11" } }, "sha512-2MGdy2s2HimsDT444Bp5XnALzNRxuBNc7y0JzyuqKbHBywd4x2NeXyhWXXoxufaCFu5PBc9Qq9jyfjW2Aeh06Q=="],
 
@@ -1891,6 +1891,10 @@
     "@rspack/binding-linux-arm64-gnu": ["@rspack/binding-linux-arm64-gnu@1.7.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0QrGRPbTWu6RKWfN0bDtbnEps3rXH0MWIMreZABoUrVmNQKtXR6e73J3ub6a+di5s2+K0M2LJ9Bh2/H4UsDUA=="],
 
     "@rspack/binding-linux-arm64-musl": ["@rspack/binding-linux-arm64-musl@1.7.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw=="],
+
+    "@rspack/binding-linux-riscv64-gnu": ["@rspack/binding-linux-riscv64-gnu@2.1.2", "", { "os": "linux", "cpu": "none" }, "sha512-uys8Jyw8Z3ralvICbN/L/nZfy5qELIwpOY72rhIqhoDYwFcL4fmMaY7WsvUcJOjCB2rqOcWPaWKuF2oPvo9iDQ=="],
+
+    "@rspack/binding-linux-riscv64-musl": ["@rspack/binding-linux-riscv64-musl@2.1.2", "", { "os": "linux", "cpu": "none" }, "sha512-JYNVQwqCaRGQWvjHQYzZkIzQiwllMaJwh4Rdu3ww6W2OJcJUqT08sL1pkOtU0iCxT4VUYiRRcp93VGTGpHr8fg=="],
 
     "@rspack/binding-linux-x64-gnu": ["@rspack/binding-linux-x64-gnu@1.7.11", "", { "os": "linux", "cpu": "x64" }, "sha512-cuOJMfCOvb2Wgsry5enXJ3iT1FGUjdPqtGUBVupQlEG4ntSYsQ2PtF4wIDVasR3wdxC5nQbipOrDiN/u6fYsdQ=="],
 
@@ -4108,7 +4112,7 @@
 
     "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
 
-    "rsbuild-plugin-dts": ["rsbuild-plugin-dts@0.20.2", "", { "dependencies": { "@ast-grep/napi": "0.37.0" }, "peerDependencies": { "@microsoft/api-extractor": "^7", "@rsbuild/core": "^1.0.0 || ^2.0.0-0", "@typescript/native-preview": "7.x", "typescript": "^5 || ^6" }, "optionalPeers": ["@microsoft/api-extractor", "@typescript/native-preview", "typescript"] }, "sha512-GM2sNAXjMgm8X3HrASn6znHLoxkGRqQZrdbGqaV0nqzqIz1h9JF3PlsUAcI6iAxzWQYuTwNfIly2SnKzsB/PjA=="],
+    "rsbuild-plugin-dts": ["rsbuild-plugin-dts@0.23.2", "", { "dependencies": { "@ast-grep/napi": "0.37.0" }, "peerDependencies": { "@microsoft/api-extractor": "^7", "@rsbuild/core": "^1.0.0 || ^2.0.0-0", "@typescript/native-preview": "^7.0.0-0", "typescript": "^5 || ^6 || ^7.0.1-0" }, "optionalPeers": ["@microsoft/api-extractor", "@typescript/native-preview", "typescript"] }, "sha512-Ve8WOSPyTBjxH40O/6fChJtflL7yqcUtt5zbF0eHDM4hIt35jqLocRlSdCxFJdQm0blTjl6+hkmPa/vNI06ArA=="],
 
     "rslog": ["rslog@1.3.2", "", {}, "sha512-1YyYXBvN0a2b1MSIDLwDTqqgjDzRKxUg/S/+KO6EAgbtZW1B3fdLHAMhEEtvk1patJYMqcRvlp3HQwnxj7AdGQ=="],
 
@@ -4974,7 +4978,7 @@
 
     "@rsdoctor/utils/@types/estree": ["@types/estree@1.0.5", "", {}, "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="],
 
-    "@rslib/core/@rsbuild/core": ["@rsbuild/core@2.0.0-beta.11", "", { "dependencies": { "@rspack/core": "2.0.0-beta.9", "@swc/helpers": "^0.5.20" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "bin/rsbuild.js" } }, "sha512-IBbQx7SrnSpD7j2p2qyq3qDxoqmG4E6lcflTpbBitX6iUrzpVRQbP4rktXZ2iuY7ph9+FtUK/SVAVA+Ocm3Nig=="],
+    "@rslib/core/@rsbuild/core": ["@rsbuild/core@2.1.4", "", { "dependencies": { "@rspack/core": "~2.1.2", "@swc/helpers": "^0.5.23" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "./bin/rsbuild.js" } }, "sha512-kdubx/qB6tXduCdqaW78OULLZJ3ludpuA4mOkDko18THsI1rUy9U34DsaDSnotE8GAvTeme+FX9MnqLEUlg8kQ=="],
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
@@ -5980,7 +5984,9 @@
 
     "@octokit/webhooks/@octokit/request-error/@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core": ["@rspack/core@2.0.0-beta.9", "", { "dependencies": { "@rspack/binding": "2.0.0-beta.9" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": ">=0.5.1" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-4sN3f72l4cj8n/dSCdWn6FkSjfHiDxHWrO1Kmqd0Bk0MmgyW+ldHitsSWPETCAxjTJGXY34r5sou5sYzb0DRww=="],
+    "@rslib/core/@rsbuild/core/@rspack/core": ["@rspack/core@2.1.2", "", { "dependencies": { "@rspack/binding": "2.1.2" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": "^0.5.23" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-crpNQKhHfnzrIl4Sa4fjH30Ho5aAPgyqpmJZ41SkUFOzyKHdZKYfE5LF3CMh7MiFQFPPxiiKf5BcpxmtZZx4MQ=="],
+
+    "@rslib/core/@rsbuild/core/@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
     "@testing-library/dom/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -6754,7 +6760,7 @@
 
     "@octokit/webhooks/@octokit/request-error/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@25.1.0", "", {}, "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding": ["@rspack/binding@2.0.0-beta.9", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "2.0.0-beta.9", "@rspack/binding-darwin-x64": "2.0.0-beta.9", "@rspack/binding-linux-arm64-gnu": "2.0.0-beta.9", "@rspack/binding-linux-arm64-musl": "2.0.0-beta.9", "@rspack/binding-linux-x64-gnu": "2.0.0-beta.9", "@rspack/binding-linux-x64-musl": "2.0.0-beta.9", "@rspack/binding-wasm32-wasi": "2.0.0-beta.9", "@rspack/binding-win32-arm64-msvc": "2.0.0-beta.9", "@rspack/binding-win32-ia32-msvc": "2.0.0-beta.9", "@rspack/binding-win32-x64-msvc": "2.0.0-beta.9" } }, "sha512-QgkOvzl6BJc4Vg5eaY9r7MkHNfXvVZPgTIeYkdBEOYPowdyCLhlG9vH7QltqLKP9KDNel70YIeMyUrpTqez01w=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding": ["@rspack/binding@2.1.2", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "2.1.2", "@rspack/binding-darwin-x64": "2.1.2", "@rspack/binding-linux-arm64-gnu": "2.1.2", "@rspack/binding-linux-arm64-musl": "2.1.2", "@rspack/binding-linux-riscv64-gnu": "2.1.2", "@rspack/binding-linux-riscv64-musl": "2.1.2", "@rspack/binding-linux-x64-gnu": "2.1.2", "@rspack/binding-linux-x64-musl": "2.1.2", "@rspack/binding-wasm32-wasi": "2.1.2", "@rspack/binding-win32-arm64-msvc": "2.1.2", "@rspack/binding-win32-ia32-msvc": "2.1.2", "@rspack/binding-win32-x64-msvc": "2.1.2" } }, "sha512-/mFcRSUW7Pl19KeaBIujJvZYNJQu0wD5D3aa5h+Qcph26v7nmLYlX7eajIHGi8tt2qTZX1lXifw2KLIXKwYaRQ=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -7050,25 +7056,25 @@
 
     "@npmcli/package-json/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-darwin-arm64": ["@rspack/binding-darwin-arm64@2.0.0-beta.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9Aao24b+lrVGG25itl2c7e6HK6eNH5J5ao1Uq5UoSwSJZOxRPuY+QlHIvE2tyt833Ly9qcT1J7os2AIUNlF6Vw=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-darwin-arm64": ["@rspack/binding-darwin-arm64@2.1.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IYcxareUOYJZz+uNMSIwn+iDRiVyjZNOjoxO/zL4OFaPK8Ncrw0ka/9DqL9Gd7OpnAXN1zK3uS8yD0O1yIYI3Q=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-darwin-x64": ["@rspack/binding-darwin-x64@2.0.0-beta.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-sP6gusMsxm3W4aHpRsmVaBQU09n1p/1+XpLHT/gZy6nJ7Wy3nqfNKNoybNBORwCuFcGUon6cVRcieN9AEm6iJA=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-darwin-x64": ["@rspack/binding-darwin-x64@2.1.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-aoifkILvx/XEHyvg8yW57xu95nx7f9f/3ah1+RguHSNKcJMcoCep9VX1Ct1N0ftqg8MC0JUObc7xWL5W14hmjA=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-arm64-gnu": ["@rspack/binding-linux-arm64-gnu@2.0.0-beta.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-k2DPN3B2qaz4L/h/R+l7rbDk/lLwbR/sayfsHZ8sLdZ3f6pvaSI9ejrsFv0nU4OmKCQsz4zYuoKTVFPtDfbGjA=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-arm64-gnu": ["@rspack/binding-linux-arm64-gnu@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-My4m40tyJSgiCEf3bB2KIEX710q3nZg99LIjy+8Zxgi3oZTkg1bFmFRusFU5U4eN5408zfSqDDGvjDE3Yv7o4w=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-arm64-musl": ["@rspack/binding-linux-arm64-musl@2.0.0-beta.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-7+XwAsqhfc2rIHMc9mY6RMBTP76RRqmUm1UjidqYdJl5hYBa5apffjeZfJYgAhVbSwKB/tUffzPpEffGUuc5kw=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-arm64-musl": ["@rspack/binding-linux-arm64-musl@2.1.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-yt+GGWUH7WPE8K97cRc8OpZhH7Pbj1vU+lkvKbDtF/rR8X9a/bJsA/nBqyUV2oBKOVbrp5I8rFZlnDskMqgvKw=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-x64-gnu": ["@rspack/binding-linux-x64-gnu@2.0.0-beta.9", "", { "os": "linux", "cpu": "x64" }, "sha512-z/EOUKEq5rq4sYsVSFL9uzdPtTPVA82x3gsRJlDTfEcruZZI7Y6JKUkpDYkC0LivXqyOnoOz8slAFd2/dByRtA=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-x64-gnu": ["@rspack/binding-linux-x64-gnu@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-KDoPy0Msf/JLhxgPPrJQzZeB4Qpqd32em8AP5lSW2s6jR5I35dHgAe9xc2A++EQtnSrU4GTn6DBvFC7q84SihQ=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-x64-musl": ["@rspack/binding-linux-x64-musl@2.0.0-beta.9", "", { "os": "linux", "cpu": "x64" }, "sha512-LVIXrqtAOy/DowIB04jyUyYy+5kHtZNJ0W5EJd39OwY/9gGvhgAEVvSWu7JrRAvKW1kQsV7GnRT5ninbDrRw1A=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-linux-x64-musl": ["@rspack/binding-linux-x64-musl@2.1.2", "", { "os": "linux", "cpu": "x64" }, "sha512-66hWmIGvn4zCKAYXJE9Bp5SNSLYnLFq2Ke/efE+ZtWy43Dd5vk9AAOmThVGBwdwmIxmGtHGCp+cAuS4G0wu0TA=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi": ["@rspack/binding-wasm32-wasi@2.0.0-beta.9", "", { "dependencies": { "@napi-rs/wasm-runtime": "1.1.1" }, "cpu": "none" }, "sha512-Vl7aDAt7DCqtZ/RJd8hLFjQqufX+efL/XZG3qADsagl/SspH1ItJ7N6X1S8o50eKoshy27Jr7mQYZEdufX9qhQ=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi": ["@rspack/binding-wasm32-wasi@2.1.2", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "1.1.6" }, "cpu": "none" }, "sha512-EB4SqH8DW/E/OmqssNQvnIVGQiVUyYNlA/pcc6Ia4MlTNwu6eNDppcNLrToH+kSZpL4CpHSFfSM3eIsSuar2Rw=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-arm64-msvc": ["@rspack/binding-win32-arm64-msvc@2.0.0-beta.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-g4Fc3JjfibuHt5ltoV64eK0bs6NKlh8kgHA8Go3ETwEGO6OBck877e+5CqPtjTH8c1/KQPbnCoccGR1OScoZGg=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-arm64-msvc": ["@rspack/binding-win32-arm64-msvc@2.1.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-T6Fs/g32MRja/UpCq4AdyPRj8tA0cOkcEa4PrAcn/ztUgK8b/qMVxj5mhMI+n7k+kHZQnpeB1Q4HqdSJi6OocA=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-ia32-msvc": ["@rspack/binding-win32-ia32-msvc@2.0.0-beta.9", "", { "os": "win32", "cpu": "ia32" }, "sha512-Oii4HpCEH3CBDKSXcS6EVlV9nGYVKAV/uBLSsuZ0RNdEG0i+OHvEiicqHAwuIYZNlH4Ea/Vwc+Dl5PM2twCZ4Q=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-ia32-msvc": ["@rspack/binding-win32-ia32-msvc@2.1.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-OtxkFVz14mVL4QK8QriSELn9B6PaYGHw1jGJwVDEzpu2ZxSHCTQPz9dVE1ekYtREEqZUkRU7Fp7VfhJSmjTt2Q=="],
 
-    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-x64-msvc": ["@rspack/binding-win32-x64-msvc@2.0.0-beta.9", "", { "os": "win32", "cpu": "x64" }, "sha512-7UFjyy7QMtWvf1CBEVQkHL6bJBKaVY9yq9+Qxb7ggtxvpBbkoYykdsrhMTvr/f5TBjBqHmyeb0/oYXqo5pWFBQ=="],
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-win32-x64-msvc": ["@rspack/binding-win32-x64-msvc@2.1.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Am+nx9fLF3nzgD/K05Bs1Bb+WO8SFLWAYRbXkymaL1r+RQxjRj7jd5ap2PhGOCcfaNA4yVWkAFvmFP92eRu7bQ=="],
 
     "diffable-html/htmlparser2/domutils/dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
@@ -7130,6 +7136,12 @@
 
     "@npmcli/package-json/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "jest-config/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "jest-config/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -7153,5 +7165,9 @@
     "unified-engine/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "unified-engine/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -680,6 +680,7 @@
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
         "c15t": "workspace:*",
+        "playwright": "1.58.2",
       },
     },
     "packages/solid": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"@rsbuild/core": "1.7.5",
 		"@rsbuild/plugin-react": "1.4.6",
 		"@rsdoctor/rspack-plugin": "1.5.7",
-		"@rslib/core": "0.20.2",
+		"@rslib/core": "0.23.2",
 		"@rspack/resolver-binding-wasm32-wasi": "0.2.8",
 		"@types/bun": "latest",
 		"@types/mdast": "4.0.4",

--- a/packages/core/SKILL.md
+++ b/packages/core/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: c15t-docs
+description: Read and search the c15t documentation. Use when working with c15t — its setup, configuration, API, and behavior.
+metadata:
+  source: leadtype
+---
+# c15t documentation
+
+Core JavaScript consent management docs for c15t, including client modes, script loading, callbacks, and integrations.
+
+To work with c15t, read its bundled docs — they ship with the package and are version-matched to the installed code:
+
+- Start with `./AGENTS.md`; it links every per-topic Markdown file under `./docs/`.
+- Prefer these local files over fetching anything over the network.

--- a/packages/scripts/knip.json
+++ b/packages/scripts/knip.json
@@ -1,6 +1,12 @@
 {
 	"$schema": "https://unpkg.com/knip@latest/schema.json",
-	"entry": ["./src/index.ts", "./src/adapters/next.ts"],
+	"entry": [
+		"./src/index.ts",
+		"./src/adapters/next.ts",
+		"./live-vendors/runner.ts",
+		"./live-vendors/manage-issues.ts",
+		"./live-vendors/harness/entry.ts"
+	],
 	"ignoreBinaries": ["biome", "rslib", "tsc", "vitest"],
 	"ignore": [
 		"**/*.spec.{js,ts,tsx}",

--- a/packages/scripts/live-vendors/README.md
+++ b/packages/scripts/live-vendors/README.md
@@ -1,0 +1,87 @@
+# Live vendor monitor
+
+Live browser probes for every built-in `@c15t/scripts` integration, run daily
+by `.github/workflows/script-vendor-monitor.yml` (issue
+[#899](https://github.com/c15t/c15t/issues/899)). Unlike the jsdom contract
+tests in `src/`, these probes load the **real** vendor loader scripts in real
+Chromium, so they catch remote loader changes that static tests cannot — like
+the Microsoft Clarity loader change that silently broke bootstrap assumptions.
+
+## Running locally
+
+The probes exercise the built `c15t` package, so build core first:
+
+```sh
+bun turbo run build --filter=c15t
+bunx playwright install chromium
+```
+
+Then:
+
+```sh
+# All vendors
+bun run --filter @c15t/scripts test:live-vendors
+
+# One vendor
+bun run --filter @c15t/scripts test:live-vendors -- --vendor microsoft-clarity
+
+# Custom report path
+bun run --filter @c15t/scripts test:live-vendors -- --report ./report.json
+```
+
+The runner exits non-zero when any probed vendor fails and always writes a
+JSON report (`live-vendors-report.json` by default, gitignored).
+
+## What a probe asserts
+
+Each vendor runs through five phases in a fresh browser context, with one
+retry before a failure is reported:
+
+1. **consent** — with denied consent, the script must not load and no loader
+   request may leave the page. Skipped for `alwaysLoad` vendors, which manage
+   consent internally.
+2. **bootstrap** — immediately after `loadScripts()` with granted consent,
+   the manifest's queue stubs/globals must exist (before the network answers).
+3. **load** — the real vendor loader must respond. `full` tier requires a
+   2xx JavaScript response; `loader-only` accepts any HTTP answer, including
+   Chromium ORB-filtered error pages, because placeholder ids are rejected by
+   some vendors (GTM 404s, Clarity answers 204).
+4. **runtime** — (`full` tier only) the real vendor runtime must initialize,
+   polled for up to 10s.
+5. **network** — every third-party request outside the loader allowlist is
+   answered with an empty 204, so probes never send real analytics data. The
+   count is reported.
+
+Probe tiers are declared per vendor in `vendors.ts` with a comment justifying
+anything below `full`. Vendors that cannot be probed at all use `skip` with a
+`skipReason` so coverage gaps stay visible in the report instead of silently
+disappearing.
+
+## GitHub issue lifecycle
+
+`manage-issues.ts` reconciles the report with GitHub after every scheduled
+run: one deduped issue per failing vendor (titled
+`[vendor-script-monitor] <vendor> live script contract failed`), a follow-up
+comment while it keeps failing, and an automatic close once the vendor passes
+again. Focused runs only touch the vendors they probed. The dedupe/planning
+logic is pure and unit-tested in `report.test.ts`.
+
+## Files
+
+- `types.ts` — probe config, harness protocol, and report types
+- `vendors.ts` — per-vendor probe configs (shared by runner and harness)
+- `harness/entry.ts` — browser-side harness bundled by `Bun.build`, drives
+  the production `c15t` script loader inside the probed page
+- `runner.ts` — Playwright orchestration, phase assertions, JSON report
+- `report.ts` — pure report/issue helpers (unit-tested)
+- `manage-issues.ts` — GitHub issue sync used by the workflow
+
+## Known limitations
+
+- Vendors whose loaders reject placeholder ids (`loader-only` tier) get
+  bootstrap + consent + endpoint-reachability coverage, but not runtime
+  validation. Upgrading them to `full` needs real test account ids provided
+  as repo secrets — tracked as a follow-up.
+- The runner needs `--tsconfig-override live-vendors/tsconfig.json` (already
+  baked into the package scripts) because Bun otherwise applies the package
+  tsconfig's `c15t → dist-types` path mapping at runtime.

--- a/packages/scripts/live-vendors/README.md
+++ b/packages/scripts/live-vendors/README.md
@@ -13,7 +13,7 @@ The probes exercise the built `c15t` package, so build core first:
 
 ```sh
 bun turbo run build --filter=c15t
-bunx playwright install chromium
+bunx playwright install --with-deps chromium
 ```
 
 Then:

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -51,9 +51,31 @@ function runCheck(
 	}
 }
 
+/**
+ * Pre-load global references captured per vendor, keyed by vendor id. Used to
+ * prove the remote runtime replaced the bootstrap stub rather than the stub
+ * merely still existing.
+ */
+const capturedStubRefs = new Map<string, Map<string, unknown>>();
+
+function windowRecord(): Record<string, unknown> {
+	return window as unknown as Record<string, unknown>;
+}
+
 const harness: LiveVendorProbeHarness = {
 	vendors: liveVendorProbeConfigs.map((config) => config.vendor),
 
+	/**
+	 * Loads one vendor through the production script loader.
+	 *
+	 * @param vendor - Registry vendor id with a probe config.
+	 * @param granted - Whether to load with granted (all categories) or denied
+	 * (necessary-only) consent.
+	 * @returns Whether the loader injected the script, its `alwaysLoad` flag,
+	 * and the bootstrap assertion captured synchronously — before the remote
+	 * loader can respond. Harness failures are serialized into `error` instead
+	 * of throwing across the `page.evaluate` boundary.
+	 */
 	load(vendor: string, granted: boolean): LiveProbeLoadOutcome {
 		const config = getLiveVendorProbeConfig(vendor);
 
@@ -68,17 +90,36 @@ const harness: LiveVendorProbeHarness = {
 
 		try {
 			const script = config.createScript();
-			const loadedIds = loadScripts(
-				[script],
-				granted ? grantedConsents : deniedConsents
-			);
+			let consents = deniedConsents;
+			if (granted) {
+				consents = grantedConsents;
+			}
+			const loadedIds = loadScripts([script], consents);
 			const requested = loadedIds.includes(script.id);
+
+			// Snapshot stub identities so the runtime phase can prove the real
+			// SDK replaced them (a stub passing `typeof x === 'function'` is not
+			// evidence the vendor runtime ever executed).
+			if (requested && config.runtimeReplacedGlobals) {
+				const snapshot = new Map<string, unknown>();
+				for (const name of config.runtimeReplacedGlobals) {
+					snapshot.set(name, windowRecord()[name]);
+				}
+				capturedStubRefs.set(vendor, snapshot);
+			}
 
 			// Bootstrap steps run synchronously in onBeforeLoad, so the queue
 			// stubs must already exist here — before the remote loader responds.
-			const bootstrap = requested
-				? runCheck(config.bootstrapCheck, 'no bootstrap check defined')
-				: { ok: true, detail: 'script not loaded; bootstrap not asserted' };
+			let bootstrap: LiveProbeCheckResult = {
+				ok: true,
+				detail: 'script not loaded; bootstrap not asserted',
+			};
+			if (requested) {
+				bootstrap = runCheck(
+					config.bootstrapCheck,
+					'no bootstrap contract declared for this vendor (attribute-based loaders seed no globals)'
+				);
+			}
 
 			return {
 				requested,
@@ -95,11 +136,51 @@ const harness: LiveVendorProbeHarness = {
 		}
 	},
 
+	/**
+	 * Runs the vendor's runtime assertion.
+	 *
+	 * When the config declares `runtimeReplacedGlobals`, every listed global
+	 * must be defined and differ by identity from the pre-load stub snapshot
+	 * before any custom `runtimeCheck` runs — proving the remote bundle
+	 * actually executed.
+	 *
+	 * @param vendor - Registry vendor id with a probe config.
+	 * @returns The runtime assertion result; never throws across the
+	 * `page.evaluate` boundary.
+	 */
 	check(vendor: string): LiveProbeCheckResult {
 		const config = getLiveVendorProbeConfig(vendor);
 
 		if (!config) {
 			return { ok: false, detail: `unknown vendor "${vendor}"` };
+		}
+
+		if (config.runtimeReplacedGlobals) {
+			const snapshot = capturedStubRefs.get(vendor);
+			for (const name of config.runtimeReplacedGlobals) {
+				const current = windowRecord()[name];
+				if (current === undefined) {
+					return {
+						ok: false,
+						detail: `window.${name} is undefined after load`,
+					};
+				}
+				if (snapshot && current === snapshot.get(name)) {
+					return {
+						ok: false,
+						detail: `window.${name} still references the pre-load stub; the vendor runtime never replaced it`,
+					};
+				}
+			}
+
+			if (!config.runtimeCheck) {
+				return {
+					ok: true,
+					detail: `vendor runtime replaced ${config.runtimeReplacedGlobals
+						.map((name) => `window.${name}`)
+						.join(', ')}`,
+				};
+			}
 		}
 
 		return runCheck(config.runtimeCheck, 'no runtime check defined');

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -1,0 +1,109 @@
+/**
+ * Browser-side harness for the live vendor monitor.
+ *
+ * Bundled with `Bun.build` and served into a real Chromium page by the
+ * runner. Exposes a small window API that loads one vendor script through the
+ * production `c15t` script loader and runs the probe checks defined in
+ * `../vendors`.
+ */
+import { type ConsentState, loadScripts } from 'c15t';
+import type {
+	LiveProbeCheckResult,
+	LiveProbeLoadOutcome,
+	LiveVendorProbeHarness,
+} from '../types';
+import { getLiveVendorProbeConfig, liveVendorProbeConfigs } from '../vendors';
+
+declare global {
+	interface Window {
+		__c15tLiveVendorProbe?: LiveVendorProbeHarness;
+	}
+}
+
+const deniedConsents: ConsentState = {
+	necessary: true,
+	functionality: false,
+	experience: false,
+	measurement: false,
+	marketing: false,
+};
+
+const grantedConsents: ConsentState = {
+	necessary: true,
+	functionality: true,
+	experience: true,
+	measurement: true,
+	marketing: true,
+};
+
+function runCheck(
+	check: (() => LiveProbeCheckResult) | undefined,
+	missingDetail: string
+): LiveProbeCheckResult {
+	if (!check) {
+		return { ok: true, detail: missingDetail };
+	}
+
+	try {
+		return check();
+	} catch (error) {
+		return { ok: false, detail: `check threw: ${String(error)}` };
+	}
+}
+
+const harness: LiveVendorProbeHarness = {
+	vendors: liveVendorProbeConfigs.map((config) => config.vendor),
+
+	load(vendor: string, granted: boolean): LiveProbeLoadOutcome {
+		const config = getLiveVendorProbeConfig(vendor);
+
+		if (!config?.createScript) {
+			return {
+				requested: false,
+				alwaysLoad: false,
+				bootstrap: { ok: false },
+				error: `no probe config with createScript for vendor "${vendor}"`,
+			};
+		}
+
+		try {
+			const script = config.createScript();
+			const loadedIds = loadScripts(
+				[script],
+				granted ? grantedConsents : deniedConsents
+			);
+			const requested = loadedIds.includes(script.id);
+
+			// Bootstrap steps run synchronously in onBeforeLoad, so the queue
+			// stubs must already exist here — before the remote loader responds.
+			const bootstrap = requested
+				? runCheck(config.bootstrapCheck, 'no bootstrap check defined')
+				: { ok: true, detail: 'script not loaded; bootstrap not asserted' };
+
+			return {
+				requested,
+				alwaysLoad: script.alwaysLoad === true,
+				bootstrap,
+			};
+		} catch (error) {
+			return {
+				requested: false,
+				alwaysLoad: false,
+				bootstrap: { ok: false },
+				error: String(error),
+			};
+		}
+	},
+
+	check(vendor: string): LiveProbeCheckResult {
+		const config = getLiveVendorProbeConfig(vendor);
+
+		if (!config) {
+			return { ok: false, detail: `unknown vendor "${vendor}"` };
+		}
+
+		return runCheck(config.runtimeCheck, 'no runtime check defined');
+	},
+};
+
+window.__c15tLiveVendorProbe = harness;

--- a/packages/scripts/live-vendors/manage-issues.ts
+++ b/packages/scripts/live-vendors/manage-issues.ts
@@ -1,0 +1,160 @@
+/**
+ * Reconciles GitHub monitor issues with a live vendor report.
+ *
+ * Reads the JSON report produced by `runner.ts`, then opens one deduped issue
+ * per failing vendor, comments on still-failing vendors, and closes issues
+ * for vendors that recovered. Focused runs only touch the vendors they probed.
+ *
+ * Usage (GitHub Actions):
+ *   GITHUB_TOKEN=... GITHUB_REPOSITORY=owner/repo \
+ *     bun live-vendors/manage-issues.ts --report live-vendors-report.json
+ */
+import {
+	type ExistingMonitorIssue,
+	MONITOR_ISSUE_TITLE_PREFIX,
+	planMonitorIssueActions,
+} from './report';
+import type { LiveVendorReport } from './types';
+
+interface GitHubIssue {
+	number: number;
+	title: string;
+	pull_request?: unknown;
+}
+
+function parseReportPath(argv: string[]): string {
+	const index = argv.indexOf('--report');
+
+	if (index !== -1) {
+		const value = argv[index + 1];
+		if (!value) {
+			throw new Error('--report requires a file path');
+		}
+		return value;
+	}
+
+	return 'live-vendors-report.json';
+}
+
+function requireEnv(name: string): string {
+	const value = Bun.env[name];
+
+	if (!value) {
+		throw new Error(`Missing required environment variable ${name}`);
+	}
+
+	return value;
+}
+
+async function githubRequest<T>(
+	token: string,
+	method: string,
+	path: string,
+	body?: unknown
+): Promise<T> {
+	const response = await fetch(`https://api.github.com${path}`, {
+		method,
+		headers: {
+			accept: 'application/vnd.github+json',
+			authorization: `Bearer ${token}`,
+			'x-github-api-version': '2022-11-28',
+			...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+		},
+		body: body !== undefined ? JSON.stringify(body) : undefined,
+	});
+
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(
+			`GitHub API ${method} ${path} failed with ${response.status}: ${text}`
+		);
+	}
+
+	return (await response.json()) as T;
+}
+
+async function listOpenMonitorIssues(
+	token: string,
+	repository: string
+): Promise<ExistingMonitorIssue[]> {
+	const issues: ExistingMonitorIssue[] = [];
+
+	for (let page = 1; page <= 10; page++) {
+		const batch = await githubRequest<GitHubIssue[]>(
+			token,
+			'GET',
+			`/repos/${repository}/issues?state=open&per_page=100&page=${page}`
+		);
+
+		for (const issue of batch) {
+			// The issues endpoint also returns pull requests; skip those.
+			if (issue.pull_request) {
+				continue;
+			}
+
+			if (issue.title.startsWith(MONITOR_ISSUE_TITLE_PREFIX)) {
+				issues.push({ number: issue.number, title: issue.title });
+			}
+		}
+
+		if (batch.length < 100) {
+			break;
+		}
+	}
+
+	return issues;
+}
+
+async function main(): Promise<void> {
+	const reportPath = parseReportPath(Bun.argv.slice(2));
+	const token = requireEnv('GITHUB_TOKEN');
+	const repository = requireEnv('GITHUB_REPOSITORY');
+
+	const report = (await Bun.file(reportPath).json()) as LiveVendorReport;
+	const existingIssues = await listOpenMonitorIssues(token, repository);
+	const plan = planMonitorIssueActions(report, existingIssues);
+
+	for (const action of plan.create) {
+		const issue = await githubRequest<GitHubIssue>(
+			token,
+			'POST',
+			`/repos/${repository}/issues`,
+			{ title: action.title, body: action.body }
+		);
+		console.log(`Opened #${issue.number} for ${action.vendor}`);
+	}
+
+	for (const action of plan.comment) {
+		await githubRequest(
+			token,
+			'POST',
+			`/repos/${repository}/issues/${action.issueNumber}/comments`,
+			{ body: action.body }
+		);
+		console.log(
+			`Commented on #${action.issueNumber} for still-failing ${action.vendor}`
+		);
+	}
+
+	for (const action of plan.close) {
+		await githubRequest(
+			token,
+			'POST',
+			`/repos/${repository}/issues/${action.issueNumber}/comments`,
+			{ body: action.body }
+		);
+		await githubRequest(
+			token,
+			'PATCH',
+			`/repos/${repository}/issues/${action.issueNumber}`,
+			{ state: 'closed', state_reason: 'completed' }
+		);
+		console.log(`Closed #${action.issueNumber} — ${action.vendor} recovered`);
+	}
+
+	console.log(
+		`Issue sync complete: ${plan.create.length} opened, ${plan.comment.length} updated, ${plan.close.length} closed.`
+	);
+}
+
+await main();

--- a/packages/scripts/live-vendors/manage-issues.ts
+++ b/packages/scripts/live-vendors/manage-issues.ts
@@ -2,8 +2,10 @@
  * Reconciles GitHub monitor issues with a live vendor report.
  *
  * Reads the JSON report produced by `runner.ts`, then opens one deduped issue
- * per failing vendor, comments on still-failing vendors, and closes issues
- * for vendors that recovered. Focused runs only touch the vendors they probed.
+ * per failing vendor, edits the issue body when a vendor's failure signature
+ * changes, and closes issues for vendors that recovered. Sustained identical
+ * failures produce no writes, so long incidents do not accumulate noise.
+ * Focused runs only touch the vendors they probed.
  *
  * Usage (GitHub Actions):
  *   GITHUB_TOKEN=... GITHUB_REPOSITORY=owner/repo \
@@ -16,12 +18,22 @@ import {
 } from './report';
 import type { LiveVendorReport } from './types';
 
+const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
 interface GitHubIssue {
 	number: number;
 	title: string;
+	body?: string;
 	pull_request?: unknown;
 }
 
+/**
+ * Reads the `--report` path from CLI arguments.
+ *
+ * @param argv - Arguments after the script path.
+ * @returns The report path, defaulting to `live-vendors-report.json`.
+ * @throws `Error` when `--report` is passed without a value.
+ */
 function parseReportPath(argv: string[]): string {
 	const index = argv.indexOf('--report');
 
@@ -36,6 +48,13 @@ function parseReportPath(argv: string[]): string {
 	return 'live-vendors-report.json';
 }
 
+/**
+ * Reads a required environment variable.
+ *
+ * @param name - Environment variable name.
+ * @returns The non-empty value.
+ * @throws `Error` naming the variable when it is unset or empty.
+ */
 function requireEnv(name: string): string {
 	const value = Bun.env[name];
 
@@ -46,21 +65,39 @@ function requireEnv(name: string): string {
 	return value;
 }
 
+/**
+ * Performs an authenticated GitHub REST request.
+ *
+ * @param token - GitHub token with `issues: write` scope.
+ * @param method - HTTP method.
+ * @param path - REST path beginning with `/`.
+ * @param body - Optional JSON payload.
+ * @returns The parsed JSON response.
+ * @throws `Error` with the status and response text on non-2xx responses,
+ * or an abort error when the request exceeds 30s.
+ */
 async function githubRequest<T>(
 	token: string,
 	method: string,
 	path: string,
 	body?: unknown
 ): Promise<T> {
+	const headers: Record<string, string> = {
+		accept: 'application/vnd.github+json',
+		authorization: `Bearer ${token}`,
+		'x-github-api-version': '2022-11-28',
+	};
+	let serializedBody: string | undefined;
+	if (body !== undefined) {
+		headers['content-type'] = 'application/json';
+		serializedBody = JSON.stringify(body);
+	}
+
 	const response = await fetch(`https://api.github.com${path}`, {
 		method,
-		headers: {
-			accept: 'application/vnd.github+json',
-			authorization: `Bearer ${token}`,
-			'x-github-api-version': '2022-11-28',
-			...(body !== undefined ? { 'content-type': 'application/json' } : {}),
-		},
-		body: body !== undefined ? JSON.stringify(body) : undefined,
+		headers,
+		body: serializedBody,
+		signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
 	});
 
 	if (!response.ok) {
@@ -73,6 +110,12 @@ async function githubRequest<T>(
 	return (await response.json()) as T;
 }
 
+/**
+ * Lists open monitor issues (deduped by title prefix), including bodies so
+ * failure signatures can be compared.
+ *
+ * @throws `Error` when a GitHub API page request fails.
+ */
 async function listOpenMonitorIssues(
 	token: string,
 	repository: string
@@ -93,7 +136,11 @@ async function listOpenMonitorIssues(
 			}
 
 			if (issue.title.startsWith(MONITOR_ISSUE_TITLE_PREFIX)) {
-				issues.push({ number: issue.number, title: issue.title });
+				issues.push({
+					number: issue.number,
+					title: issue.title,
+					body: issue.body,
+				});
 			}
 		}
 
@@ -113,48 +160,66 @@ async function main(): Promise<void> {
 	const report = (await Bun.file(reportPath).json()) as LiveVendorReport;
 	const existingIssues = await listOpenMonitorIssues(token, repository);
 	const plan = planMonitorIssueActions(report, existingIssues);
+	const failures: string[] = [];
 
 	for (const action of plan.create) {
-		const issue = await githubRequest<GitHubIssue>(
-			token,
-			'POST',
-			`/repos/${repository}/issues`,
-			{ title: action.title, body: action.body }
-		);
-		console.log(`Opened #${issue.number} for ${action.vendor}`);
+		try {
+			const issue = await githubRequest<GitHubIssue>(
+				token,
+				'POST',
+				`/repos/${repository}/issues`,
+				{ title: action.title, body: action.body }
+			);
+			console.log(`Opened #${issue.number} for ${action.vendor}`);
+		} catch (error) {
+			failures.push(`create ${action.vendor}: ${String(error)}`);
+		}
 	}
 
-	for (const action of plan.comment) {
-		await githubRequest(
-			token,
-			'POST',
-			`/repos/${repository}/issues/${action.issueNumber}/comments`,
-			{ body: action.body }
-		);
-		console.log(
-			`Commented on #${action.issueNumber} for still-failing ${action.vendor}`
-		);
+	for (const action of plan.update) {
+		try {
+			await githubRequest(
+				token,
+				'PATCH',
+				`/repos/${repository}/issues/${action.issueNumber}`,
+				{ body: action.body }
+			);
+			console.log(
+				`Updated #${action.issueNumber} — ${action.vendor} failure signature changed`
+			);
+		} catch (error) {
+			failures.push(`update ${action.vendor}: ${String(error)}`);
+		}
 	}
 
 	for (const action of plan.close) {
-		await githubRequest(
-			token,
-			'POST',
-			`/repos/${repository}/issues/${action.issueNumber}/comments`,
-			{ body: action.body }
-		);
-		await githubRequest(
-			token,
-			'PATCH',
-			`/repos/${repository}/issues/${action.issueNumber}`,
-			{ state: 'closed', state_reason: 'completed' }
-		);
-		console.log(`Closed #${action.issueNumber} — ${action.vendor} recovered`);
+		try {
+			await githubRequest(
+				token,
+				'POST',
+				`/repos/${repository}/issues/${action.issueNumber}/comments`,
+				{ body: action.body }
+			);
+			await githubRequest(
+				token,
+				'PATCH',
+				`/repos/${repository}/issues/${action.issueNumber}`,
+				{ state: 'closed', state_reason: 'completed' }
+			);
+			console.log(`Closed #${action.issueNumber} — ${action.vendor} recovered`);
+		} catch (error) {
+			failures.push(`close ${action.vendor}: ${String(error)}`);
+		}
 	}
 
 	console.log(
-		`Issue sync complete: ${plan.create.length} opened, ${plan.comment.length} updated, ${plan.close.length} closed.`
+		`Issue sync complete: ${plan.create.length} opened, ${plan.update.length} updated, ${plan.close.length} closed.`
 	);
+
+	if (failures.length > 0) {
+		console.error(`Issue sync errors:\n- ${failures.join('\n- ')}`);
+		process.exitCode = 1;
+	}
 }
 
 await main();

--- a/packages/scripts/live-vendors/report.test.ts
+++ b/packages/scripts/live-vendors/report.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	buildMonitorIssueBody,
 	buildMonitorIssueTitle,
+	buildMonitorSignature,
 	failedPhases,
 	planMonitorIssueActions,
+	signatureFromIssueBody,
 	vendorFromMonitorIssueTitle,
 } from './report';
 import type { LiveVendorReport, LiveVendorResult } from './types';
@@ -67,6 +69,24 @@ describe('failedPhases', () => {
 	});
 });
 
+describe('failure signatures', () => {
+	it('round-trips through the issue body marker', () => {
+		const result = makeResult({
+			ok: false,
+			phases: {
+				load: { ok: false },
+				runtime: { ok: false },
+			},
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(buildMonitorSignature(result)).toBe('load,runtime');
+		expect(signatureFromIssueBody(body)).toBe('load,runtime');
+		expect(signatureFromIssueBody(undefined)).toBeUndefined();
+		expect(signatureFromIssueBody('no marker here')).toBeUndefined();
+	});
+});
+
 describe('buildMonitorIssueBody', () => {
 	it('includes vendor, phases, loader, run metadata, and repro command', () => {
 		const result = makeResult({
@@ -96,6 +116,33 @@ describe('buildMonitorIssueBody', () => {
 		);
 		expect(body).toContain('Console errors');
 	});
+
+	it('sanitizes third-party text and notes overflowed error lists', () => {
+		const errors = Array.from(
+			{ length: 12 },
+			(_, index) => `error ${index} with \`backticks\`\nand newlines`
+		);
+		const result = makeResult({
+			ok: false,
+			phases: {
+				load: {
+					ok: false,
+					detail: 'loader said `<img src=x onerror=alert(1)>`',
+				},
+			},
+			loader: {
+				url: 'https://evil.example/`payload`',
+				status: 500,
+			},
+			consoleErrors: errors,
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).not.toContain('`<img');
+		expect(body).not.toContain('```payload');
+		expect(body).toContain('…and 2 more');
+		expect(body).not.toContain('and newlines\n-');
+	});
 });
 
 describe('planMonitorIssueActions', () => {
@@ -113,18 +160,46 @@ describe('planMonitorIssueActions', () => {
 
 		expect(plan.create).toHaveLength(1);
 		expect(plan.create[0]?.title).toBe(buildMonitorIssueTitle('posthog'));
-		expect(plan.comment).toHaveLength(0);
+		expect(plan.update).toHaveLength(0);
 		expect(plan.close).toHaveLength(0);
 	});
 
-	it('comments instead of duplicating an open issue', () => {
+	it('stays silent when a vendor keeps failing with the same signature', () => {
+		const existingBody = buildMonitorIssueBody(failing, makeReport([failing]));
 		const plan = planMonitorIssueActions(makeReport([failing]), [
-			{ number: 42, title: buildMonitorIssueTitle('posthog') },
+			{
+				number: 42,
+				title: buildMonitorIssueTitle('posthog'),
+				body: existingBody,
+			},
 		]);
 
 		expect(plan.create).toHaveLength(0);
-		expect(plan.comment).toHaveLength(1);
-		expect(plan.comment[0]?.issueNumber).toBe(42);
+		expect(plan.update).toHaveLength(0);
+		expect(plan.close).toHaveLength(0);
+	});
+
+	it('updates the issue when the failure signature changes', () => {
+		const previous = makeResult({
+			vendor: 'posthog',
+			ok: false,
+			phases: { runtime: { ok: false } },
+		});
+		const existingBody = buildMonitorIssueBody(
+			previous,
+			makeReport([previous])
+		);
+		const plan = planMonitorIssueActions(makeReport([failing]), [
+			{
+				number: 42,
+				title: buildMonitorIssueTitle('posthog'),
+				body: existingBody,
+			},
+		]);
+
+		expect(plan.update).toHaveLength(1);
+		expect(plan.update[0]?.issueNumber).toBe(42);
+		expect(signatureFromIssueBody(plan.update[0]?.body)).toBe('load');
 	});
 
 	it('closes the open issue when the vendor recovers', () => {
@@ -159,7 +234,7 @@ describe('planMonitorIssueActions', () => {
 		]);
 
 		expect(plan.create).toHaveLength(0);
-		expect(plan.comment).toHaveLength(0);
+		expect(plan.update).toHaveLength(0);
 		expect(plan.close).toHaveLength(0);
 	});
 });

--- a/packages/scripts/live-vendors/report.test.ts
+++ b/packages/scripts/live-vendors/report.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildMonitorIssueBody,
+	buildMonitorIssueTitle,
+	failedPhases,
+	planMonitorIssueActions,
+	vendorFromMonitorIssueTitle,
+} from './report';
+import type { LiveVendorReport, LiveVendorResult } from './types';
+
+function makeResult(overrides: Partial<LiveVendorResult>): LiveVendorResult {
+	return {
+		vendor: 'microsoft-clarity',
+		packageSubpath: 'microsoft-clarity',
+		label: 'Microsoft Clarity',
+		tier: 'full',
+		ok: true,
+		attempts: 1,
+		phases: {},
+		blockedRequests: 0,
+		consoleErrors: [],
+		pageErrors: [],
+		...overrides,
+	};
+}
+
+function makeReport(results: LiveVendorResult[]): LiveVendorReport {
+	return {
+		generatedAt: '2026-07-06T06:30:00.000Z',
+		commitSha: 'abc1234',
+		runUrl: 'https://github.com/c15t/c15t/actions/runs/1',
+		results,
+	};
+}
+
+describe('monitor issue titles', () => {
+	it('round-trips vendor ids through the issue title', () => {
+		const title = buildMonitorIssueTitle('microsoft-clarity');
+
+		expect(title).toBe(
+			'[vendor-script-monitor] microsoft-clarity live script contract failed'
+		);
+		expect(vendorFromMonitorIssueTitle(title)).toBe('microsoft-clarity');
+	});
+
+	it('rejects unrelated issue titles', () => {
+		expect(vendorFromMonitorIssueTitle('Fix the docs')).toBeUndefined();
+		expect(
+			vendorFromMonitorIssueTitle('[vendor-script-monitor] something else')
+		).toBeUndefined();
+	});
+});
+
+describe('failedPhases', () => {
+	it('lists failing phases in probe order', () => {
+		const result = makeResult({
+			ok: false,
+			phases: {
+				runtime: { ok: false, detail: 'stub never replaced' },
+				consent: { ok: true },
+				bootstrap: { ok: false, detail: 'queue missing' },
+				load: { ok: true },
+			},
+		});
+
+		expect(failedPhases(result)).toEqual(['bootstrap', 'runtime']);
+	});
+});
+
+describe('buildMonitorIssueBody', () => {
+	it('includes vendor, phases, loader, run metadata, and repro command', () => {
+		const result = makeResult({
+			ok: false,
+			phases: {
+				bootstrap: { ok: true, detail: 'queue seeded' },
+				load: { ok: false, detail: 'loader responded with HTTP 500' },
+			},
+			loader: {
+				url: 'https://www.clarity.ms/tag/c15tfake00',
+				status: 500,
+				contentType: 'text/html',
+			},
+			consoleErrors: ['boom'],
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).toContain('`microsoft-clarity`');
+		expect(body).toContain('@c15t/scripts/microsoft-clarity');
+		expect(body).toContain('**Failed phase(s)**: load');
+		expect(body).toContain('https://www.clarity.ms/tag/c15tfake00');
+		expect(body).toContain('HTTP 500');
+		expect(body).toContain('abc1234');
+		expect(body).toContain('https://github.com/c15t/c15t/actions/runs/1');
+		expect(body).toContain(
+			'bun run --filter @c15t/scripts test:live-vendors -- --vendor microsoft-clarity'
+		);
+		expect(body).toContain('Console errors');
+	});
+});
+
+describe('planMonitorIssueActions', () => {
+	const failing = makeResult({
+		vendor: 'posthog',
+		packageSubpath: 'posthog',
+		label: 'PostHog',
+		ok: false,
+		phases: { load: { ok: false, detail: 'timeout' } },
+	});
+	const passing = makeResult({ vendor: 'microsoft-clarity' });
+
+	it('creates an issue for a failing vendor without an open issue', () => {
+		const plan = planMonitorIssueActions(makeReport([failing]), []);
+
+		expect(plan.create).toHaveLength(1);
+		expect(plan.create[0]?.title).toBe(buildMonitorIssueTitle('posthog'));
+		expect(plan.comment).toHaveLength(0);
+		expect(plan.close).toHaveLength(0);
+	});
+
+	it('comments instead of duplicating an open issue', () => {
+		const plan = planMonitorIssueActions(makeReport([failing]), [
+			{ number: 42, title: buildMonitorIssueTitle('posthog') },
+		]);
+
+		expect(plan.create).toHaveLength(0);
+		expect(plan.comment).toHaveLength(1);
+		expect(plan.comment[0]?.issueNumber).toBe(42);
+	});
+
+	it('closes the open issue when the vendor recovers', () => {
+		const plan = planMonitorIssueActions(makeReport([passing]), [
+			{ number: 7, title: buildMonitorIssueTitle('microsoft-clarity') },
+		]);
+
+		expect(plan.close).toHaveLength(1);
+		expect(plan.close[0]?.issueNumber).toBe(7);
+		expect(plan.create).toHaveLength(0);
+	});
+
+	it('leaves vendors outside the report untouched', () => {
+		const plan = planMonitorIssueActions(makeReport([passing]), [
+			{ number: 7, title: buildMonitorIssueTitle('microsoft-clarity') },
+			{ number: 8, title: buildMonitorIssueTitle('segment') },
+		]);
+
+		expect(plan.close).toHaveLength(1);
+		expect(plan.close[0]?.vendor).toBe('microsoft-clarity');
+	});
+
+	it('ignores skipped vendors and unrelated issues', () => {
+		const skipped = makeResult({
+			vendor: 'cloudflare-zaraz',
+			ok: true,
+			skipped: true,
+			skipReason: 'edge-injected',
+		});
+		const plan = planMonitorIssueActions(makeReport([skipped]), [
+			{ number: 1, title: 'Unrelated issue' },
+		]);
+
+		expect(plan.create).toHaveLength(0);
+		expect(plan.comment).toHaveLength(0);
+		expect(plan.close).toHaveLength(0);
+	});
+});

--- a/packages/scripts/live-vendors/report.ts
+++ b/packages/scripts/live-vendors/report.ts
@@ -30,6 +30,34 @@ export function buildMonitorIssueTitle(vendor: string): string {
 	return `${MONITOR_ISSUE_TITLE_PREFIX} ${vendor} live script contract failed`;
 }
 
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const MONITOR_ISSUE_TITLE_PATTERN = new RegExp(
+	`^${escapeRegExp(MONITOR_ISSUE_TITLE_PREFIX)} (\\S+) live script contract failed$`
+);
+
+const SIGNATURE_MARKER_PATTERN = /<!-- c15t-monitor-signature: ([a-z, ]*) -->/;
+
+/**
+ * Escapes third-party text (vendor URLs, error messages, probe details)
+ * before it is interpolated into GitHub-flavored Markdown, so a hostile or
+ * malformed vendor response cannot inject links, references, or formatting.
+ *
+ * @param value - Untrusted text destined for an issue body.
+ * @returns A single-line, backtick-free, length-capped string.
+ */
+function sanitizeInline(value: string): string {
+	const flattened = value.replaceAll('`', "'").replace(/\s+/g, ' ').trim();
+
+	if (flattened.length <= 300) {
+		return flattened;
+	}
+
+	return `${flattened.slice(0, 300)}…`;
+}
+
 /**
  * Extracts the vendor id from a monitor issue title.
  *
@@ -37,12 +65,33 @@ export function buildMonitorIssueTitle(vendor: string): string {
  * issue title.
  */
 export function vendorFromMonitorIssueTitle(title: string): string | undefined {
-	const match =
-		/^\[vendor-script-monitor\] (\S+) live script contract failed$/.exec(
-			title.trim()
-		);
+	const match = MONITOR_ISSUE_TITLE_PATTERN.exec(title.trim());
 
 	return match?.[1];
+}
+
+/**
+ * Builds the stable failure signature for a result — the ordered list of
+ * failing phases. Embedded in issue bodies so subsequent runs can tell
+ * "still failing the same way" apart from "failing differently".
+ */
+export function buildMonitorSignature(result: LiveVendorResult): string {
+	return failedPhases(result).join(',');
+}
+
+/**
+ * Reads the failure signature marker out of an existing issue body.
+ *
+ * @returns The signature, or `undefined` when the body has no marker.
+ */
+export function signatureFromIssueBody(
+	body: string | undefined
+): string | undefined {
+	if (!body) {
+		return undefined;
+	}
+
+	return SIGNATURE_MARKER_PATTERN.exec(body)?.[1]?.trim();
 }
 
 /**
@@ -57,7 +106,7 @@ function formatPhaseLines(result: LiveVendorResult): string {
 		.map((phase) => {
 			const check = result.phases[phase];
 			const status = check?.ok ? '✅' : '❌';
-			const detail = check?.detail ? ` — ${check.detail}` : '';
+			const detail = check?.detail ? ` — ${sanitizeInline(check.detail)}` : '';
 			return `- ${status} \`${phase}\`${detail}`;
 		})
 		.join('\n');
@@ -68,12 +117,16 @@ function formatErrorList(heading: string, errors: string[]): string {
 		return '';
 	}
 
-	const items = errors
-		.slice(0, 10)
-		.map((error) => `- \`${error.replaceAll('`', "'")}\``)
+	const shown = errors.slice(0, 10);
+	const items = shown
+		.map((error) => `- \`${sanitizeInline(error)}\``)
 		.join('\n');
+	let overflow = '';
+	if (errors.length > shown.length) {
+		overflow = `\n- …and ${errors.length - shown.length} more`;
+	}
 
-	return `\n### ${heading}\n\n${items}\n`;
+	return `\n### ${heading}\n\n${items}${overflow}\n`;
 }
 
 /**
@@ -86,10 +139,13 @@ export function buildMonitorIssueBody(
 	result: LiveVendorResult,
 	report: LiveVendorReport
 ): string {
+	const signature = buildMonitorSignature(result);
 	const failing = failedPhases(result).join(', ') || 'unknown';
 	const loaderLine = result.loader
-		? `\`${result.loader.url}\` → HTTP ${result.loader.status}${
-				result.loader.contentType ? ` (${result.loader.contentType})` : ''
+		? `\`${sanitizeInline(result.loader.url)}\` → HTTP ${result.loader.status}${
+				result.loader.contentType
+					? ` (${sanitizeInline(result.loader.contentType)})`
+					: ''
 			}`
 		: 'No loader response captured.';
 
@@ -109,9 +165,10 @@ export function buildMonitorIssueBody(
 		metadataLines.push(`- **Workflow run**: ${report.runUrl}`);
 	}
 
-	const notes = result.notes ? `\n> ${result.notes}\n` : '';
+	const notes = result.notes ? `\n> ${sanitizeInline(result.notes)}\n` : '';
 
-	return `The daily live vendor monitor detected a contract failure for **${result.label}**.
+	return `<!-- c15t-monitor-signature: ${signature} -->
+The daily live vendor monitor detected a contract failure for **${result.label}**.
 
 ${metadataLines.join('\n')}
 ${notes}
@@ -151,6 +208,8 @@ export interface ExistingMonitorIssue {
 	number: number;
 	/** Issue title, matched against the monitor title format. */
 	title: string;
+	/** Issue body, used to compare failure signatures across runs. */
+	body?: string;
 }
 
 /**
@@ -158,7 +217,7 @@ export interface ExistingMonitorIssue {
  */
 export interface MonitorIssueAction {
 	vendor: string;
-	/** Present for `comment` and `close` actions. */
+	/** Present for `update` and `close` actions. */
 	issueNumber?: number;
 	title?: string;
 	body: string;
@@ -170,8 +229,12 @@ export interface MonitorIssueAction {
 export interface MonitorIssuePlan {
 	/** New issues for failing vendors without an open monitor issue. */
 	create: MonitorIssueAction[];
-	/** Follow-up comments for failing vendors with an open monitor issue. */
-	comment: MonitorIssueAction[];
+	/**
+	 * Body edits for vendors that are still failing but whose failure
+	 * signature changed. Sustained identical failures produce no action, so
+	 * long-running incidents do not accumulate daily comment noise.
+	 */
+	update: MonitorIssueAction[];
 	/** Close actions for recovered vendors with an open monitor issue. */
 	close: MonitorIssueAction[];
 }
@@ -196,7 +259,7 @@ export function planMonitorIssueActions(
 		}
 	}
 
-	const plan: MonitorIssuePlan = { create: [], comment: [], close: [] };
+	const plan: MonitorIssuePlan = { create: [], update: [], close: [] };
 
 	for (const result of report.results) {
 		if (result.skipped) {
@@ -209,11 +272,16 @@ export function planMonitorIssueActions(
 			const body = buildMonitorIssueBody(result, report);
 
 			if (openIssue) {
-				plan.comment.push({
-					vendor: result.vendor,
-					issueNumber: openIssue.number,
-					body,
-				});
+				// Sustained failures with an unchanged signature stay silent —
+				// only a different failure shape is worth a fresh notification.
+				const previousSignature = signatureFromIssueBody(openIssue.body);
+				if (previousSignature !== buildMonitorSignature(result)) {
+					plan.update.push({
+						vendor: result.vendor,
+						issueNumber: openIssue.number,
+						body,
+					});
+				}
 			} else {
 				plan.create.push({
 					vendor: result.vendor,

--- a/packages/scripts/live-vendors/report.ts
+++ b/packages/scripts/live-vendors/report.ts
@@ -49,7 +49,13 @@ const SIGNATURE_MARKER_PATTERN = /<!-- c15t-monitor-signature: ([a-z, ]*) -->/;
  * @returns A single-line, backtick-free, length-capped string.
  */
 function sanitizeInline(value: string): string {
-	const flattened = value.replaceAll('`', "'").replace(/\s+/g, ' ').trim();
+	const flattened = value
+		.replaceAll('`', "'")
+		// Neutralize Markdown/HTML syntax that would render outside code spans:
+		// links, images, autolinks, mentions, and issue references.
+		.replace(/[[\]<>*_~#@!\\]/g, (match) => `\\${match}`)
+		.replace(/\s+/g, ' ')
+		.trim();
 
 	if (flattened.length <= 300) {
 		return flattened;

--- a/packages/scripts/live-vendors/report.ts
+++ b/packages/scripts/live-vendors/report.ts
@@ -1,0 +1,238 @@
+import type {
+	LiveProbePhase,
+	LiveVendorReport,
+	LiveVendorResult,
+} from './types';
+
+/**
+ * Title prefix used to dedupe monitor issues on GitHub.
+ */
+export const MONITOR_ISSUE_TITLE_PREFIX = '[vendor-script-monitor]';
+
+const PHASE_ORDER: LiveProbePhase[] = [
+	'consent',
+	'bootstrap',
+	'load',
+	'runtime',
+	'network',
+];
+
+/**
+ * Builds the canonical monitor issue title for a vendor.
+ *
+ * @example
+ * ```ts
+ * buildMonitorIssueTitle('microsoft-clarity');
+ * // "[vendor-script-monitor] microsoft-clarity live script contract failed"
+ * ```
+ */
+export function buildMonitorIssueTitle(vendor: string): string {
+	return `${MONITOR_ISSUE_TITLE_PREFIX} ${vendor} live script contract failed`;
+}
+
+/**
+ * Extracts the vendor id from a monitor issue title.
+ *
+ * @returns The vendor id, or `undefined` when the title is not a monitor
+ * issue title.
+ */
+export function vendorFromMonitorIssueTitle(title: string): string | undefined {
+	const match =
+		/^\[vendor-script-monitor\] (\S+) live script contract failed$/.exec(
+			title.trim()
+		);
+
+	return match?.[1];
+}
+
+/**
+ * Lists the phases that failed for a probe result, in probe order.
+ */
+export function failedPhases(result: LiveVendorResult): LiveProbePhase[] {
+	return PHASE_ORDER.filter((phase) => result.phases[phase]?.ok === false);
+}
+
+function formatPhaseLines(result: LiveVendorResult): string {
+	return PHASE_ORDER.filter((phase) => result.phases[phase] !== undefined)
+		.map((phase) => {
+			const check = result.phases[phase];
+			const status = check?.ok ? '✅' : '❌';
+			const detail = check?.detail ? ` — ${check.detail}` : '';
+			return `- ${status} \`${phase}\`${detail}`;
+		})
+		.join('\n');
+}
+
+function formatErrorList(heading: string, errors: string[]): string {
+	if (errors.length === 0) {
+		return '';
+	}
+
+	const items = errors
+		.slice(0, 10)
+		.map((error) => `- \`${error.replaceAll('`', "'")}\``)
+		.join('\n');
+
+	return `\n### ${heading}\n\n${items}\n`;
+}
+
+/**
+ * Builds the monitor issue body for a failing vendor probe.
+ *
+ * Includes the failing phases, expected vs actual detail, loader status, page
+ * errors, run metadata, and a local reproduction command.
+ */
+export function buildMonitorIssueBody(
+	result: LiveVendorResult,
+	report: LiveVendorReport
+): string {
+	const failing = failedPhases(result).join(', ') || 'unknown';
+	const loaderLine = result.loader
+		? `\`${result.loader.url}\` → HTTP ${result.loader.status}${
+				result.loader.contentType ? ` (${result.loader.contentType})` : ''
+			}`
+		: 'No loader response captured.';
+
+	const metadataLines = [
+		`- **Vendor**: \`${result.vendor}\` (\`@c15t/scripts/${result.packageSubpath}\`)`,
+		`- **Probe tier**: \`${result.tier}\``,
+		`- **Failed phase(s)**: ${failing}`,
+		`- **Attempts**: ${result.attempts}`,
+		`- **Loader**: ${loaderLine}`,
+	];
+
+	if (report.commitSha) {
+		metadataLines.push(`- **Commit**: ${report.commitSha}`);
+	}
+
+	if (report.runUrl) {
+		metadataLines.push(`- **Workflow run**: ${report.runUrl}`);
+	}
+
+	const notes = result.notes ? `\n> ${result.notes}\n` : '';
+
+	return `The daily live vendor monitor detected a contract failure for **${result.label}**.
+
+${metadataLines.join('\n')}
+${notes}
+### Phase results
+
+${formatPhaseLines(result)}
+${formatErrorList('Console errors', result.consoleErrors)}${formatErrorList(
+	'Page errors',
+	result.pageErrors
+)}
+### Reproduce locally
+
+\`\`\`sh
+bun run --filter @c15t/scripts test:live-vendors -- --vendor ${result.vendor}
+\`\`\`
+
+<sub>Opened automatically by the script vendor monitor. This issue closes automatically once the vendor passes again.</sub>`;
+}
+
+/**
+ * Comment body posted when a previously failing vendor recovers.
+ */
+export function buildMonitorRecoveryComment(
+	result: LiveVendorResult,
+	report: LiveVendorReport
+): string {
+	const runLine = report.runUrl ? ` in ${report.runUrl}` : '';
+
+	return `\`${result.vendor}\` passed the live vendor probes again${runLine}. Closing this monitor issue automatically.`;
+}
+
+/**
+ * Open GitHub issue candidate considered during dedupe planning.
+ */
+export interface ExistingMonitorIssue {
+	/** GitHub issue number. */
+	number: number;
+	/** Issue title, matched against the monitor title format. */
+	title: string;
+}
+
+/**
+ * One planned GitHub issue mutation.
+ */
+export interface MonitorIssueAction {
+	vendor: string;
+	/** Present for `comment` and `close` actions. */
+	issueNumber?: number;
+	title?: string;
+	body: string;
+}
+
+/**
+ * Issue mutations required to reconcile GitHub with a monitor report.
+ */
+export interface MonitorIssuePlan {
+	/** New issues for failing vendors without an open monitor issue. */
+	create: MonitorIssueAction[];
+	/** Follow-up comments for failing vendors with an open monitor issue. */
+	comment: MonitorIssueAction[];
+	/** Close actions for recovered vendors with an open monitor issue. */
+	close: MonitorIssueAction[];
+}
+
+/**
+ * Plans issue actions from a monitor report and the currently open issues.
+ *
+ * Only vendors present in the report are reconciled, so focused runs
+ * (`--vendor`) never close issues for vendors they did not probe. Skipped
+ * vendors are left untouched.
+ */
+export function planMonitorIssueActions(
+	report: LiveVendorReport,
+	existingIssues: ExistingMonitorIssue[]
+): MonitorIssuePlan {
+	const openIssueByVendor = new Map<string, ExistingMonitorIssue>();
+
+	for (const issue of existingIssues) {
+		const vendor = vendorFromMonitorIssueTitle(issue.title);
+		if (vendor && !openIssueByVendor.has(vendor)) {
+			openIssueByVendor.set(vendor, issue);
+		}
+	}
+
+	const plan: MonitorIssuePlan = { create: [], comment: [], close: [] };
+
+	for (const result of report.results) {
+		if (result.skipped) {
+			continue;
+		}
+
+		const openIssue = openIssueByVendor.get(result.vendor);
+
+		if (!result.ok) {
+			const body = buildMonitorIssueBody(result, report);
+
+			if (openIssue) {
+				plan.comment.push({
+					vendor: result.vendor,
+					issueNumber: openIssue.number,
+					body,
+				});
+			} else {
+				plan.create.push({
+					vendor: result.vendor,
+					title: buildMonitorIssueTitle(result.vendor),
+					body,
+				});
+			}
+
+			continue;
+		}
+
+		if (openIssue) {
+			plan.close.push({
+				vendor: result.vendor,
+				issueNumber: openIssue.number,
+				body: buildMonitorRecoveryComment(result, report),
+			});
+		}
+	}
+
+	return plan;
+}

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -31,6 +31,7 @@ import type {
 import { liveVendorProbeConfigs } from './vendors';
 
 const MAX_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 2_000;
 const LOADER_TIMEOUT_MS = 20_000;
 const RUNTIME_TIMEOUT_MS = 10_000;
 const RUNTIME_POLL_MS = 250;
@@ -55,6 +56,14 @@ interface CliOptions {
 	reportPath: string;
 }
 
+/**
+ * Parses runner CLI arguments.
+ *
+ * @param argv - Arguments after the script path (`--vendor id`, `--report path`).
+ * @returns The parsed vendor filter and report path.
+ * @throws `Error` when `--vendor`/`--report` is missing its value or an
+ * unknown argument is passed.
+ */
 function parseArgs(argv: string[]): CliOptions {
 	const options: CliOptions = { reportPath: 'live-vendors-report.json' };
 
@@ -84,6 +93,12 @@ function parseArgs(argv: string[]): CliOptions {
 	return options;
 }
 
+/**
+ * Bundles the browser-side harness with `Bun.build`.
+ *
+ * @returns The bundled harness JavaScript served to the probe page.
+ * @throws `Error` with the collected build logs when bundling fails.
+ */
 async function buildHarnessBundle(): Promise<string> {
 	const entrypoint = new URL('./harness/entry.ts', import.meta.url).pathname;
 	const result = await Bun.build({
@@ -177,6 +192,12 @@ async function probeVendorAttempt(
 			return route.fulfill({ status: 204, body: '' });
 		});
 
+		// HTTP routing does not cover WebSockets; refuse every WS connection so
+		// realtime vendor channels cannot bypass the network guard.
+		await context.routeWebSocket('**', () => {
+			// Never connect to the remote server.
+		});
+
 		const page = await context.newPage();
 		page.on('console', (message) => {
 			if (message.type() === 'error') {
@@ -256,9 +277,13 @@ async function probeVendorAttempt(
 				};
 			}
 
-			// Reset to a fresh document before the granted-consent probe.
+			// Reset to a fresh document before the granted-consent probe, and
+			// clear every loader observation so denied-phase network events can
+			// never feed the granted-phase load assertions.
 			await page.reload({ waitUntil: 'load' });
 			sawLoaderRequest = false;
+			loaderRequestUrl = undefined;
+			loaderFailure = undefined;
 		}
 
 		const loaderResponsePromise = config.loaderUrlSubstring
@@ -331,7 +356,7 @@ async function probeVendorAttempt(
 				}
 			} else if (
 				config.tier === 'loader-only' &&
-				loaderFailure?.includes('ERR_BLOCKED_BY_ORB') &&
+				loaderFailure?.toUpperCase().includes('ERR_BLOCKED_BY_ORB') &&
 				loaderRequestUrl
 			) {
 				// Chromium ORB-filters cross-origin error pages before the renderer
@@ -453,6 +478,12 @@ async function probeVendor(
 	let lastError: string | undefined;
 
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		if (attempt > 1) {
+			// Retries exist to absorb transient third-party failures; give the
+			// vendor endpoint a moment before hitting it again.
+			await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+		}
+
 		try {
 			lastOutcome = await probeVendorAttempt(
 				browser,
@@ -503,6 +534,13 @@ async function probeVendor(
 	};
 }
 
+/**
+ * Resolves the probe configs for a `--vendor` filter.
+ *
+ * @param vendors - Vendor ids from the CLI, or `undefined` for all vendors.
+ * @returns The matching probe configs, in filter order.
+ * @throws `Error` listing the known vendors when an id has no probe config.
+ */
 function resolveConfigs(
 	vendors: string[] | undefined
 ): LiveVendorProbeConfig[] {

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -1,0 +1,621 @@
+/**
+ * Live vendor monitor runner.
+ *
+ * Builds the browser harness with `Bun.build`, serves it locally, and drives
+ * real Chromium (Playwright) probes against every configured vendor:
+ *
+ * 1. `consent`   — the script must not load while consent is denied.
+ * 2. `bootstrap` — queue stubs must exist after `loadScripts`, before the
+ *                  remote loader executes.
+ * 3. `load`      — the real vendor loader URL must respond.
+ * 4. `runtime`   — the vendor runtime must initialize (full tier only).
+ * 5. `network`   — every non-allowlisted third-party request is answered with
+ *                  an empty 204 so no real analytics data is sent.
+ *
+ * Usage:
+ *   bun run --filter @c15t/scripts test:live-vendors
+ *   bun run --filter @c15t/scripts test:live-vendors -- --vendor microsoft-clarity
+ *   bun run --filter @c15t/scripts test:live-vendors -- --report ./report.json
+ */
+import { type Browser, chromium, type Response } from 'playwright';
+import { getBuiltInScriptIntegrationByVendor } from '../src/registry';
+import { failedPhases } from './report';
+import type {
+	LiveProbeCheckResult,
+	LiveProbeLoadOutcome,
+	LiveVendorProbeConfig,
+	LiveVendorProbeHarness,
+	LiveVendorReport,
+	LiveVendorResult,
+} from './types';
+import { liveVendorProbeConfigs } from './vendors';
+
+const MAX_ATTEMPTS = 2;
+const LOADER_TIMEOUT_MS = 20_000;
+const RUNTIME_TIMEOUT_MS = 10_000;
+const RUNTIME_POLL_MS = 250;
+const CONSENT_QUIET_MS = 750;
+
+const PAGE_HTML = `<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>c15t live vendor probe</title>
+		<script type="module" src="/harness.js"></script>
+	</head>
+	<body></body>
+</html>`;
+
+type ProbeWindow = {
+	__c15tLiveVendorProbe?: LiveVendorProbeHarness;
+};
+
+interface CliOptions {
+	vendors?: string[];
+	reportPath: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+	const options: CliOptions = { reportPath: 'live-vendors-report.json' };
+
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+
+		if (arg === '--vendor') {
+			const value = argv[++index];
+			if (!value) {
+				throw new Error('--vendor requires a vendor id');
+			}
+			options.vendors = [
+				...(options.vendors ?? []),
+				...value.split(',').map((vendor) => vendor.trim()),
+			];
+		} else if (arg === '--report') {
+			const value = argv[++index];
+			if (!value) {
+				throw new Error('--report requires a file path');
+			}
+			options.reportPath = value;
+		} else {
+			throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+async function buildHarnessBundle(): Promise<string> {
+	const entrypoint = new URL('./harness/entry.ts', import.meta.url).pathname;
+	const result = await Bun.build({
+		entrypoints: [entrypoint],
+		target: 'browser',
+		format: 'esm',
+	});
+
+	if (!result.success || !result.outputs[0]) {
+		const details = result.logs.map((log) => String(log)).join('\n');
+		throw new Error(`Failed to build live probe harness:\n${details}`);
+	}
+
+	return result.outputs[0].text();
+}
+
+interface ProbeAttemptOutcome {
+	phases: LiveVendorResult['phases'];
+	loader?: LiveVendorResult['loader'];
+	blockedRequests: number;
+	consoleErrors: string[];
+	pageErrors: string[];
+}
+
+async function loaderResponseDetails(
+	response: Response
+): Promise<NonNullable<LiveVendorResult['loader']>> {
+	const headers: Record<string, string> = await response
+		.allHeaders()
+		.catch(() => ({}));
+
+	return {
+		url: response.url(),
+		status: response.status(),
+		contentType: headers['content-type'],
+	};
+}
+
+/**
+ * Fetches loader details from Node when the browser never surfaced a
+ * response (for example when Chromium ORB-filters a non-script error page).
+ */
+async function fetchLoaderDetails(
+	url: string
+): Promise<LiveVendorResult['loader']> {
+	try {
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(LOADER_TIMEOUT_MS),
+		});
+		await response.body?.cancel();
+
+		return {
+			url,
+			status: response.status,
+			contentType: response.headers.get('content-type') ?? undefined,
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+async function probeVendorAttempt(
+	browser: Browser,
+	baseUrl: string,
+	config: LiveVendorProbeConfig,
+	alwaysLoad: boolean
+): Promise<ProbeAttemptOutcome> {
+	const blocked: string[] = [];
+	const consoleErrors: string[] = [];
+	const pageErrors: string[] = [];
+	const allow = [
+		config.loaderUrlSubstring,
+		...(config.allowUrlSubstrings ?? []),
+	].filter((value): value is string => Boolean(value));
+
+	const context = await browser.newContext();
+
+	try {
+		await context.route('**/*', (route) => {
+			const url = route.request().url();
+
+			if (url.startsWith(baseUrl)) {
+				return route.continue();
+			}
+
+			if (allow.some((substring) => url.includes(substring))) {
+				return route.continue();
+			}
+
+			blocked.push(url);
+			return route.fulfill({ status: 204, body: '' });
+		});
+
+		const page = await context.newPage();
+		page.on('console', (message) => {
+			if (message.type() === 'error') {
+				consoleErrors.push(message.text());
+			}
+		});
+		page.on('pageerror', (error) => {
+			pageErrors.push(String(error));
+		});
+
+		let sawLoaderRequest = false;
+		let loaderRequestUrl: string | undefined;
+		let loaderFailure: string | undefined;
+		if (config.loaderUrlSubstring) {
+			const loaderUrlSubstring = config.loaderUrlSubstring;
+			page.on('request', (request) => {
+				if (request.url().includes(loaderUrlSubstring)) {
+					sawLoaderRequest = true;
+					loaderRequestUrl = request.url();
+				}
+			});
+			page.on('requestfailed', (request) => {
+				if (request.url().includes(loaderUrlSubstring)) {
+					loaderFailure = request.failure()?.errorText;
+				}
+			});
+		}
+
+		await page.goto(baseUrl, { waitUntil: 'load' });
+
+		const hasHarness = await page.evaluate(() =>
+			Boolean((globalThis as unknown as ProbeWindow).__c15tLiveVendorProbe)
+		);
+		if (!hasHarness) {
+			throw new Error('probe harness did not initialize in the page');
+		}
+
+		const phases: LiveVendorResult['phases'] = {};
+
+		// Phase: consent — load with denied consent; nothing should hit the wire.
+		// alwaysLoad scripts manage consent internally and load regardless, so
+		// probing them here would only warm the browser cache and swallow the
+		// network events the load phase waits for.
+		if (alwaysLoad) {
+			phases.consent = {
+				ok: true,
+				detail:
+					'script declares alwaysLoad and manages consent internally; denied-consent gating not asserted',
+			};
+		} else {
+			const deniedOutcome = await page.evaluate<LiveProbeLoadOutcome, string>(
+				(vendor) => {
+					const harness = (globalThis as unknown as ProbeWindow)
+						.__c15tLiveVendorProbe;
+					if (!harness) {
+						throw new Error('harness missing');
+					}
+					return harness.load(vendor, false);
+				},
+				config.vendor
+			);
+
+			await page.waitForTimeout(CONSENT_QUIET_MS);
+
+			if (deniedOutcome.error) {
+				phases.consent = {
+					ok: false,
+					detail: `harness error: ${deniedOutcome.error}`,
+				};
+			} else {
+				const leaked = deniedOutcome.requested || sawLoaderRequest;
+				phases.consent = {
+					ok: !leaked,
+					detail: leaked
+						? 'script loaded despite denied consent'
+						: 'script did not load while consent was denied',
+				};
+			}
+
+			// Reset to a fresh document before the granted-consent probe.
+			await page.reload({ waitUntil: 'load' });
+			sawLoaderRequest = false;
+		}
+
+		const loaderResponsePromise = config.loaderUrlSubstring
+			? page
+					.waitForResponse(
+						(response) =>
+							response.url().includes(config.loaderUrlSubstring as string),
+						{ timeout: LOADER_TIMEOUT_MS }
+					)
+					.catch(() => undefined)
+			: Promise.resolve(undefined);
+
+		// Phase: bootstrap — granted consent; stub checks run synchronously
+		// inside the harness before the remote loader can respond.
+		const grantedOutcome = await page.evaluate<LiveProbeLoadOutcome, string>(
+			(vendor) => {
+				const harness = (globalThis as unknown as ProbeWindow)
+					.__c15tLiveVendorProbe;
+				if (!harness) {
+					throw new Error('harness missing');
+				}
+				return harness.load(vendor, true);
+			},
+			config.vendor
+		);
+
+		if (grantedOutcome.error) {
+			phases.bootstrap = {
+				ok: false,
+				detail: `harness error: ${grantedOutcome.error}`,
+			};
+		} else if (!grantedOutcome.requested) {
+			phases.bootstrap = {
+				ok: false,
+				detail: 'script did not load with granted consent',
+			};
+		} else {
+			phases.bootstrap = grantedOutcome.bootstrap;
+		}
+
+		// Phase: load — the real vendor loader must answer.
+		let loader: LiveVendorResult['loader'];
+		if (config.loaderUrlSubstring) {
+			const loaderResponse = await loaderResponsePromise;
+
+			if (loaderResponse) {
+				loader = await loaderResponseDetails(loaderResponse);
+				const detail = `loader responded with HTTP ${loader.status}${
+					loader.contentType ? ` (${loader.contentType})` : ''
+				}`;
+
+				if (config.tier === 'loader-only') {
+					// Any HTTP response proves the endpoint is reachable; placeholder
+					// ids often return 404/204 instead of real container JS.
+					phases.load = { ok: true, detail };
+				} else {
+					// Full tier requires actual JavaScript, not an empty 2xx. Clarity
+					// answers unknown project ids with an empty 204 that would
+					// otherwise pass as "loaded".
+					const servedScript =
+						loaderResponse.ok() &&
+						loader.status !== 204 &&
+						(loader.contentType?.includes('javascript') ?? false);
+					phases.load = {
+						ok: servedScript,
+						detail: servedScript
+							? detail
+							: `${detail} — expected a 2xx JavaScript response`,
+					};
+				}
+			} else if (
+				config.tier === 'loader-only' &&
+				loaderFailure?.includes('ERR_BLOCKED_BY_ORB') &&
+				loaderRequestUrl
+			) {
+				// Chromium ORB-filters cross-origin error pages before the renderer
+				// sees them, so no response event fires — but an ORB block proves
+				// the endpoint answered. Fetch from Node to record the real status.
+				loader = await fetchLoaderDetails(loaderRequestUrl);
+				phases.load = {
+					ok: true,
+					detail: `loader answered but Chromium ORB-filtered the non-script response${
+						loader ? ` (HTTP ${loader.status})` : ''
+					} — expected for placeholder ids`,
+				};
+			} else {
+				let detail = 'loader request was never sent';
+				if (loaderFailure) {
+					detail = `loader request failed: ${loaderFailure}`;
+				} else if (sawLoaderRequest) {
+					detail = `loader request sent but no response within ${LOADER_TIMEOUT_MS}ms`;
+				}
+
+				phases.load = { ok: false, detail };
+			}
+		} else {
+			phases.load = {
+				ok: true,
+				detail: 'no external loader for this vendor',
+			};
+		}
+
+		// Phase: runtime — full tier only; poll until the vendor runtime is up.
+		if (config.tier === 'full' && phases.load.ok) {
+			const deadline = Date.now() + RUNTIME_TIMEOUT_MS;
+			let runtime: LiveProbeCheckResult = {
+				ok: false,
+				detail: 'runtime check never ran',
+			};
+
+			for (;;) {
+				runtime = await page.evaluate<LiveProbeCheckResult, string>(
+					(vendor) => {
+						const harness = (globalThis as unknown as ProbeWindow)
+							.__c15tLiveVendorProbe;
+						if (!harness) {
+							throw new Error('harness missing');
+						}
+						return harness.check(vendor);
+					},
+					config.vendor
+				);
+
+				if (runtime.ok || Date.now() >= deadline) {
+					break;
+				}
+
+				await page.waitForTimeout(RUNTIME_POLL_MS);
+			}
+
+			phases.runtime = runtime;
+		}
+
+		// Phase: network — informational; the route handler guarantees blocking.
+		phases.network = {
+			ok: true,
+			detail: `${blocked.length} third-party request(s) answered with an empty 204`,
+		};
+
+		return {
+			phases,
+			loader,
+			blockedRequests: blocked.length,
+			consoleErrors,
+			pageErrors,
+		};
+	} finally {
+		await context.close();
+	}
+}
+
+function buildSkippedResult(config: LiveVendorProbeConfig): LiveVendorResult {
+	const integration = getBuiltInScriptIntegrationByVendor(config.vendor);
+
+	return {
+		vendor: config.vendor,
+		packageSubpath: integration?.packageSubpath ?? config.vendor,
+		label: integration?.label ?? config.vendor,
+		tier: config.tier,
+		ok: true,
+		skipped: true,
+		skipReason: config.skipReason ?? 'skipped without a reason',
+		attempts: 0,
+		phases: {},
+		blockedRequests: 0,
+		consoleErrors: [],
+		pageErrors: [],
+		notes: config.notes,
+	};
+}
+
+async function probeVendor(
+	browser: Browser,
+	baseUrl: string,
+	config: LiveVendorProbeConfig
+): Promise<LiveVendorResult> {
+	const integration = getBuiltInScriptIntegrationByVendor(config.vendor);
+	const base = {
+		vendor: config.vendor,
+		packageSubpath: integration?.packageSubpath ?? config.vendor,
+		label: integration?.label ?? config.vendor,
+		tier: config.tier,
+		notes: config.notes,
+	};
+
+	// Inspect the script node-side so the probe knows about alwaysLoad before
+	// touching the page. Factories only build config objects, so this is safe
+	// outside a browser.
+	const alwaysLoad = config.createScript?.().alwaysLoad === true;
+
+	let lastOutcome: ProbeAttemptOutcome | undefined;
+	let lastError: string | undefined;
+
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		try {
+			lastOutcome = await probeVendorAttempt(
+				browser,
+				baseUrl,
+				config,
+				alwaysLoad
+			);
+			lastError = undefined;
+		} catch (error) {
+			lastOutcome = undefined;
+			lastError = String(error);
+		}
+
+		const phaseValues = lastOutcome ? Object.values(lastOutcome.phases) : [];
+		const ok =
+			lastOutcome !== undefined && phaseValues.every((phase) => phase.ok);
+
+		if (ok) {
+			return {
+				...base,
+				ok: true,
+				attempts: attempt,
+				phases: lastOutcome?.phases ?? {},
+				loader: lastOutcome?.loader,
+				blockedRequests: lastOutcome?.blockedRequests ?? 0,
+				consoleErrors: lastOutcome?.consoleErrors ?? [],
+				pageErrors: lastOutcome?.pageErrors ?? [],
+			};
+		}
+	}
+
+	return {
+		...base,
+		ok: false,
+		attempts: MAX_ATTEMPTS,
+		phases: lastOutcome?.phases ?? {
+			load: {
+				ok: false,
+				detail: lastError ?? 'probe failed before any phase completed',
+			},
+		},
+		loader: lastOutcome?.loader,
+		blockedRequests: lastOutcome?.blockedRequests ?? 0,
+		consoleErrors: lastOutcome?.consoleErrors ?? [],
+		pageErrors: lastError
+			? [...(lastOutcome?.pageErrors ?? []), lastError]
+			: (lastOutcome?.pageErrors ?? []),
+	};
+}
+
+function resolveConfigs(
+	vendors: string[] | undefined
+): LiveVendorProbeConfig[] {
+	if (!vendors || vendors.length === 0) {
+		return liveVendorProbeConfigs;
+	}
+
+	return vendors.map((vendor) => {
+		const config = liveVendorProbeConfigs.find(
+			(candidate) => candidate.vendor === vendor
+		);
+
+		if (!config) {
+			const known = liveVendorProbeConfigs
+				.map((candidate) => candidate.vendor)
+				.join(', ');
+			throw new Error(`Unknown vendor "${vendor}". Known vendors: ${known}`);
+		}
+
+		return config;
+	});
+}
+
+function summarizeResult(result: LiveVendorResult): string {
+	if (result.skipped) {
+		return `⏭️  ${result.vendor} skipped — ${result.skipReason}`;
+	}
+
+	if (result.ok) {
+		return `✅ ${result.vendor} (${result.tier}, ${result.attempts} attempt(s))`;
+	}
+
+	return `❌ ${result.vendor} failed phase(s): ${failedPhases(result).join(', ')}`;
+}
+
+async function main(): Promise<void> {
+	const options = parseArgs(Bun.argv.slice(2));
+	const configs = resolveConfigs(options.vendors);
+
+	console.log(
+		`Probing ${configs.length} vendor(s) with live browser contracts...`
+	);
+
+	const harnessJs = await buildHarnessBundle();
+	const server = Bun.serve({
+		port: 0,
+		fetch(request) {
+			const { pathname } = new URL(request.url);
+
+			if (pathname === '/harness.js') {
+				return new Response(harnessJs, {
+					headers: { 'content-type': 'text/javascript; charset=utf-8' },
+				});
+			}
+
+			return new Response(PAGE_HTML, {
+				headers: { 'content-type': 'text/html; charset=utf-8' },
+			});
+		},
+	});
+	const baseUrl = `http://localhost:${server.port}`;
+
+	const browser = await chromium.launch();
+	const results: LiveVendorResult[] = [];
+
+	try {
+		for (const config of configs) {
+			if (config.tier === 'skip') {
+				const result = buildSkippedResult(config);
+				results.push(result);
+				console.log(summarizeResult(result));
+				continue;
+			}
+
+			const result = await probeVendor(browser, baseUrl, config);
+			results.push(result);
+			console.log(summarizeResult(result));
+		}
+	} finally {
+		await browser.close();
+		server.stop(true);
+	}
+
+	const report: LiveVendorReport = {
+		generatedAt: new Date().toISOString(),
+		commitSha: Bun.env.GITHUB_SHA,
+		runUrl:
+			Bun.env.GITHUB_SERVER_URL &&
+			Bun.env.GITHUB_REPOSITORY &&
+			Bun.env.GITHUB_RUN_ID
+				? `${Bun.env.GITHUB_SERVER_URL}/${Bun.env.GITHUB_REPOSITORY}/actions/runs/${Bun.env.GITHUB_RUN_ID}`
+				: undefined,
+		vendorFilter: options.vendors,
+		results,
+	};
+
+	await Bun.write(
+		options.reportPath,
+		`${JSON.stringify(report, null, '\t')}\n`
+	);
+
+	const failed = results.filter((result) => !result.ok);
+	const skipped = results.filter((result) => result.skipped);
+
+	console.log(
+		`\nReport written to ${options.reportPath}: ${
+			results.length - failed.length - skipped.length
+		} passed, ${failed.length} failed, ${skipped.length} skipped.`
+	);
+
+	if (failed.length > 0) {
+		process.exitCode = 1;
+	}
+}
+
+await main();

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -193,9 +193,11 @@ async function probeVendorAttempt(
 		});
 
 		// HTTP routing does not cover WebSockets; refuse every WS connection so
-		// realtime vendor channels cannot bypass the network guard.
-		await context.routeWebSocket('**', () => {
-			// Never connect to the remote server.
+		// realtime vendor channels cannot bypass the network guard. Closing the
+		// routed socket refuses it outright — an empty handler would mock an
+		// open socket instead.
+		await context.routeWebSocket('**', (ws) => {
+			ws.close();
 		});
 
 		const page = await context.newPage();

--- a/packages/scripts/live-vendors/tsconfig.json
+++ b/packages/scripts/live-vendors/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@c15t/typescript-config/base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"types": ["bun"]
+	},
+	"include": ["."],
+	"exclude": ["node_modules"]
+}

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -73,6 +73,14 @@ export interface LiveVendorProbeConfig {
 	 * the real vendor runtime replaced or initialized the bootstrap stub.
 	 */
 	runtimeCheck?: () => LiveProbeCheckResult;
+	/**
+	 * Globals whose pre-load stub identity must be replaced by the vendor
+	 * runtime for the runtime phase to pass. Stronger than a `typeof` check in
+	 * `runtimeCheck`, which a still-unreplaced stub can satisfy. The harness
+	 * snapshots these references at load time and compares identities during
+	 * the runtime phase, before any custom `runtimeCheck` runs.
+	 */
+	runtimeReplacedGlobals?: string[];
 	/** Free-form caveats surfaced in reports. */
 	notes?: string;
 }

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -1,0 +1,163 @@
+import type { Script } from 'c15t';
+
+/**
+ * Depth of a live vendor probe.
+ *
+ * - `full`: the vendor loader must respond successfully and the runtime check
+ *   must pass after the remote script executes.
+ * - `loader-only`: the loader request must complete with an HTTP response, but
+ *   no runtime behavior is asserted. Use this for vendors whose loader rejects
+ *   placeholder account ids (for example with a 404) so the probe still proves
+ *   bootstrap and consent gating against the real endpoint.
+ * - `skip`: the vendor cannot be probed live (for example edge-injected
+ *   scripts). Skipped vendors are reported with `skipReason` so coverage gaps
+ *   stay visible instead of silently disappearing.
+ */
+export type LiveProbeTier = 'full' | 'loader-only' | 'skip';
+
+/**
+ * Ordered probe phases reported for every vendor.
+ */
+export type LiveProbePhase =
+	| 'consent'
+	| 'bootstrap'
+	| 'load'
+	| 'runtime'
+	| 'network';
+
+/**
+ * Result of a single in-page or runner-side assertion.
+ */
+export interface LiveProbeCheckResult {
+	/** Whether the assertion passed. */
+	ok: boolean;
+	/** Human-readable expected vs actual context for reports. */
+	detail?: string;
+}
+
+/**
+ * Live probe definition for one built-in `@c15t/scripts` integration.
+ *
+ * The same config object is imported by the Playwright runner (Node side) and
+ * bundled into the browser harness, so `createScript` and the check callbacks
+ * execute inside the probed page while the URL fields drive network routing
+ * from the runner.
+ */
+export interface LiveVendorProbeConfig {
+	/** Vendor id matching the registry `vendor` field and emitted `Script.id`. */
+	vendor: string;
+	/** Probe depth for this vendor. */
+	tier: LiveProbeTier;
+	/** Required when `tier` is `skip`; explains the coverage gap. */
+	skipReason?: string;
+	/**
+	 * Builds the vendor script with safe placeholder configuration. Required
+	 * unless `tier` is `skip`. Must not send real account identifiers.
+	 */
+	createScript?: () => Script;
+	/** Substring identifying the vendor loader request URL. */
+	loaderUrlSubstring?: string;
+	/**
+	 * Additional URL substrings the loader is allowed to fetch (chained vendor
+	 * bundles). Every other third-party request is answered with an empty 204 so
+	 * no real analytics data leaves the probe.
+	 */
+	allowUrlSubstrings?: string[];
+	/**
+	 * Runs in the page synchronously after `loadScripts`, before the remote
+	 * loader executes. Assert queue stubs and globals seeded by bootstrap steps.
+	 */
+	bootstrapCheck?: () => LiveProbeCheckResult;
+	/**
+	 * Runs in the page (polled) after the loader response arrives. Assert that
+	 * the real vendor runtime replaced or initialized the bootstrap stub.
+	 */
+	runtimeCheck?: () => LiveProbeCheckResult;
+	/** Free-form caveats surfaced in reports. */
+	notes?: string;
+}
+
+/**
+ * Outcome returned by the in-page harness for one `loadScripts` invocation.
+ */
+export interface LiveProbeLoadOutcome {
+	/** Whether the script loader actually injected/executed the script. */
+	requested: boolean;
+	/** Whether the script declares `alwaysLoad` (manages consent internally). */
+	alwaysLoad: boolean;
+	/** Bootstrap assertion captured immediately after `loadScripts`. */
+	bootstrap: LiveProbeCheckResult;
+	/** Serialized error when the harness itself failed. */
+	error?: string;
+}
+
+/**
+ * Browser-side API installed by the live probe harness bundle.
+ */
+export interface LiveVendorProbeHarness {
+	/** Vendor ids available in this harness build. */
+	vendors: string[];
+	/** Loads one vendor with granted or denied consent and checks bootstrap. */
+	load(vendor: string, granted: boolean): LiveProbeLoadOutcome;
+	/** Runs the vendor's runtime check. */
+	check(vendor: string): LiveProbeCheckResult;
+}
+
+/**
+ * Loader response details captured by the runner.
+ */
+export interface LiveLoaderResponse {
+	url: string;
+	status: number;
+	contentType?: string;
+}
+
+/**
+ * Full probe outcome for one vendor.
+ */
+export interface LiveVendorResult {
+	/** Vendor id matching the registry `vendor` field. */
+	vendor: string;
+	/** Public package subpath, e.g. `microsoft-clarity`. */
+	packageSubpath: string;
+	/** Human-readable integration label. */
+	label: string;
+	/** Probe depth used for this vendor. */
+	tier: LiveProbeTier;
+	/** Whether every asserted phase passed. */
+	ok: boolean;
+	/** True when the vendor was skipped instead of probed. */
+	skipped?: boolean;
+	/** Reason the vendor was skipped. */
+	skipReason?: string;
+	/** Number of probe attempts performed (failed probes retry once). */
+	attempts: number;
+	/** Per-phase assertion results. */
+	phases: Partial<Record<LiveProbePhase, LiveProbeCheckResult>>;
+	/** Loader response captured during the load phase, when one arrived. */
+	loader?: LiveLoaderResponse;
+	/** Count of third-party requests answered with an empty 204. */
+	blockedRequests: number;
+	/** Console error messages emitted by the probed page. */
+	consoleErrors: string[];
+	/** Uncaught page errors emitted by the probed page. */
+	pageErrors: string[];
+	/** Config caveats copied from the probe definition. */
+	notes?: string;
+}
+
+/**
+ * JSON report produced by one live vendor monitor run.
+ */
+export interface LiveVendorReport {
+	/** ISO timestamp when the report was generated. */
+	generatedAt: string;
+	/** Commit SHA the probes ran against, when available. */
+	commitSha?: string;
+	/** GitHub Actions run URL, when available. */
+	runUrl?: string;
+	/** Vendor filter used for a focused run, absent for full runs. */
+	vendorFilter?: string[];
+	/** Per-vendor probe outcomes. */
+	results: LiveVendorResult[];
+}

--- a/packages/scripts/live-vendors/vendors.test.ts
+++ b/packages/scripts/live-vendors/vendors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { builtInScriptIntegrations } from '../src/registry';
+import type { LiveVendorProbeConfig } from './types';
+import { liveVendorProbeConfigs } from './vendors';
+
+function configsForVendor(vendor: string): LiveVendorProbeConfig[] {
+	return liveVendorProbeConfigs.filter((config) => config.vendor === vendor);
+}
+
+describe('live vendor probe configs', () => {
+	it('covers every built-in script integration exactly once', () => {
+		for (const integration of builtInScriptIntegrations) {
+			expect(configsForVendor(integration.vendor)).toHaveLength(1);
+		}
+
+		expect(liveVendorProbeConfigs).toHaveLength(
+			builtInScriptIntegrations.length
+		);
+	});
+
+	it('defines loader construction for every non-skip config', () => {
+		for (const config of liveVendorProbeConfigs) {
+			if (config.tier === 'skip') {
+				continue;
+			}
+
+			expect(config.createScript, config.vendor).toBeTypeOf('function');
+			expect(config.loaderUrlSubstring, config.vendor).toBeTypeOf('string');
+			expect(config.loaderUrlSubstring, config.vendor).not.toBe('');
+		}
+	});
+
+	it('documents every skip config', () => {
+		for (const config of liveVendorProbeConfigs) {
+			if (config.tier !== 'skip') {
+				continue;
+			}
+
+			expect(config.skipReason, config.vendor).toBeTypeOf('string');
+			expect(config.skipReason, config.vendor).not.toBe('');
+		}
+	});
+
+	it('constructs scripts whose ids match the configured vendor', () => {
+		for (const config of liveVendorProbeConfigs) {
+			if (config.tier === 'skip') {
+				continue;
+			}
+
+			const script = config.createScript?.();
+
+			expect(script, config.vendor).toBeDefined();
+			expect(script?.id).toBe(config.vendor);
+		}
+	});
+});

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -1,0 +1,694 @@
+/**
+ * Live probe definitions for built-in `@c15t/scripts` integrations.
+ *
+ * Each entry pairs a registry vendor with safe placeholder configuration and
+ * the checks used by the live monitor. This module is imported by the Node
+ * runner and bundled into the browser harness, so check callbacks run inside
+ * the probed page.
+ *
+ * Placeholder ids must be obviously fake and must never point at a real
+ * account. Collection endpoints are blocked by the runner, so probes cannot
+ * send real analytics data even when a vendor runtime initializes.
+ */
+
+import { linkedinInsights } from '../src/vendors/ads-and-pixels/linkedin-insights';
+import { metaPixel } from '../src/vendors/ads-and-pixels/meta-pixel';
+import { microsoftUet } from '../src/vendors/ads-and-pixels/microsoft-uet';
+import { redditPixel } from '../src/vendors/ads-and-pixels/reddit-pixel';
+import { snapchatPixel } from '../src/vendors/ads-and-pixels/snapchat-pixel';
+import { tiktokPixel } from '../src/vendors/ads-and-pixels/tiktok-pixel';
+import { xPixel } from '../src/vendors/ads-and-pixels/x-pixel';
+import { ahrefsAnalytics } from '../src/vendors/analytics/ahrefs-analytics';
+import { cloudflareWebAnalytics } from '../src/vendors/analytics/cloudflare-web-analytics';
+import { databuddy } from '../src/vendors/analytics/databuddy';
+import { fathomAnalytics } from '../src/vendors/analytics/fathom-analytics';
+import { gtag } from '../src/vendors/analytics/google-tag';
+import { hotjar } from '../src/vendors/analytics/hotjar';
+import { matomoAnalytics } from '../src/vendors/analytics/matomo-analytics';
+import { clarity } from '../src/vendors/analytics/microsoft-clarity';
+import { mixpanelAnalytics } from '../src/vendors/analytics/mixpanel-analytics';
+import { plausibleAnalytics } from '../src/vendors/analytics/plausible-analytics';
+import { posthog } from '../src/vendors/analytics/posthog';
+import { promptwatch } from '../src/vendors/analytics/promptwatch';
+import { rybbitAnalytics } from '../src/vendors/analytics/rybbit-analytics';
+import { segment } from '../src/vendors/analytics/segment';
+import { umamiAnalytics } from '../src/vendors/analytics/umami-analytics';
+import { vercelAnalytics } from '../src/vendors/analytics/vercel-analytics';
+import { crisp } from '../src/vendors/functional/crisp';
+import { intercom } from '../src/vendors/functional/intercom';
+import { googleTagManager } from '../src/vendors/tag-managers/google-tag-manager';
+import type { LiveProbeCheckResult, LiveVendorProbeConfig } from './types';
+
+function check(ok: boolean, detail: string): LiveProbeCheckResult {
+	return { ok, detail };
+}
+
+type PromptwatchWindow = Window & {
+	pwc?: unknown;
+};
+
+type MatomoWindow = Window & {
+	Matomo?: {
+		getTracker?: unknown;
+	};
+};
+
+type GoogleTagWindow = Window & {
+	google_tag_data?: {
+		ics?: {
+			usedDefault?: boolean;
+		};
+	};
+};
+
+type MetaPixelRuntime = Window['fbq'] & {
+	callMethod?: unknown;
+	loaded?: boolean;
+	version?: string;
+};
+
+type TikTokWindow = Window & {
+	TiktokAnalyticsObject?: string;
+};
+
+type UetWindow = Window & {
+	UET?: unknown;
+};
+
+type XPixelRuntime = Window['twq'] & {
+	exe?: unknown;
+	queue?: unknown[];
+};
+
+/**
+ * Probe configs for every built-in integration, ordered by registry vendor id.
+ */
+export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
+	{
+		vendor: 'google-tag-manager',
+		// GTM only serves container JS for real container ids, so a placeholder
+		// id proves bootstrap and endpoint reachability but not runtime behavior.
+		tier: 'loader-only',
+		createScript: () => googleTagManager({ id: 'GTM-C15TFAKE' }),
+		loaderUrlSubstring: 'googletagmanager.com/gtm.js',
+		bootstrapCheck: () => {
+			const dataLayer = window.dataLayer;
+
+			if (!Array.isArray(dataLayer)) {
+				return check(false, 'expected window.dataLayer array before load');
+			}
+
+			return check(
+				dataLayer.length > 0,
+				`dataLayer seeded with ${dataLayer.length} entries before load`
+			);
+		},
+		notes:
+			'Placeholder container ids return HTTP 404 from googletagmanager.com; runtime is not asserted.',
+	},
+	{
+		vendor: 'gtag',
+		tier: 'full',
+		createScript: () => gtag({ id: 'G-C15TFAKE', category: 'measurement' }),
+		loaderUrlSubstring: 'googletagmanager.com/gtag/js',
+		bootstrapCheck: () => {
+			const dataLayer = window.dataLayer;
+
+			if (!Array.isArray(dataLayer)) {
+				return check(false, 'expected window.dataLayer array before load');
+			}
+
+			return check(
+				dataLayer.length >= 3,
+				`dataLayer seeded with ${dataLayer.length} entries before load`
+			);
+		},
+		runtimeCheck: () => {
+			const consentState = (window as GoogleTagWindow).google_tag_data?.ics;
+
+			return check(
+				consentState?.usedDefault === true,
+				'google_tag_data consent state observed after gtag loader executed'
+			);
+		},
+	},
+	{
+		vendor: 'ahrefs-analytics',
+		tier: 'full',
+		createScript: () => ahrefsAnalytics({ key: 'C15TFAKE' }),
+		loaderUrlSubstring: 'analytics.ahrefs.com/analytics.js',
+		runtimeCheck: () =>
+			check(
+				typeof window.AhrefsAnalytics?.sendEvent === 'function',
+				'window.AhrefsAnalytics.sendEvent present after loader executed'
+			),
+	},
+	{
+		vendor: 'cloudflare-web-analytics',
+		tier: 'full',
+		createScript: () =>
+			cloudflareWebAnalytics({
+				token: 'c15tfake000000000000000000000000',
+			}),
+		loaderUrlSubstring: 'static.cloudflareinsights.com/beacon.min.js',
+		runtimeCheck: () =>
+			check(
+				window.__cfBeacon?.token === 'c15tfake000000000000000000000000',
+				'window.__cfBeacon token present after loader executed'
+			),
+	},
+	{
+		vendor: 'microsoft-clarity',
+		// clarity.ms answers unknown project ids with an empty 204, so runtime
+		// behavior can only be asserted with a real project id (planned as a
+		// repo-secret follow-up). Bootstrap and consent gating still run against
+		// the live endpoint.
+		tier: 'loader-only',
+		createScript: () =>
+			clarity({
+				id: 'c15tfake00',
+				defaultConsent: {
+					ad_storage: 'denied',
+					analytics_storage: 'denied',
+				},
+			}),
+		loaderUrlSubstring: 'clarity.ms/tag/',
+		allowUrlSubstrings: ['clarity.ms/s/'],
+		bootstrapCheck: () => {
+			const stub = window.clarity;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.clarity stub function');
+			}
+
+			if (stub.v !== '0.7.0') {
+				return check(false, `expected stub version 0.7.0, got ${stub.v}`);
+			}
+
+			return check(
+				Array.isArray(stub.q) && stub.q.length > 0,
+				'clarity queue seeded with default consent before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.clarity === 'function',
+				'window.clarity callable after loader executed'
+			),
+	},
+	{
+		vendor: 'databuddy',
+		tier: 'full',
+		createScript: () =>
+			databuddy({
+				clientId: 'db_c15tfake',
+				configWhenGranted: {
+					clientId: 'db_c15tfake',
+					disabled: false,
+				},
+				configWhenDenied: {
+					clientId: 'db_c15tfake',
+					disabled: true,
+				},
+			}),
+		loaderUrlSubstring: 'cdn.databuddy.cc/databuddy.js',
+		bootstrapCheck: () =>
+			check(
+				window.databuddyConfig?.clientId === 'db_c15tfake',
+				'databuddyConfig seeded before load'
+			),
+		runtimeCheck: () =>
+			check(
+				typeof window.databuddy?.track === 'function',
+				'window.databuddy.track present after loader executed'
+			),
+	},
+	{
+		vendor: 'fathom-analytics',
+		tier: 'full',
+		createScript: () => fathomAnalytics({ site: 'C15TFAKE' }),
+		loaderUrlSubstring: 'cdn.usefathom.com/script.js',
+		runtimeCheck: () =>
+			check(
+				typeof window.fathom?.trackPageview === 'function',
+				'window.fathom.trackPageview present after loader executed'
+			),
+	},
+	{
+		vendor: 'mixpanel-analytics',
+		// Mixpanel serves the public SDK for fake tokens, but that SDK rejects
+		// this manifest queue stub with a snippet version mismatch before init.
+		tier: 'loader-only',
+		createScript: () =>
+			mixpanelAnalytics({
+				token: 'c15fc15fc15fc15fc15fc15fc15fc15f',
+				initOptions: {
+					api_host: 'https://api-js.mixpanel.com',
+					opt_out_tracking_by_default: true,
+				},
+			}),
+		loaderUrlSubstring: 'cdn.mxpnl.com/libs/mixpanel-2-latest.min.js',
+		bootstrapCheck: () => {
+			const mixpanel = window.mixpanel;
+
+			if (!Array.isArray(mixpanel)) {
+				return check(false, 'expected window.mixpanel queue array');
+			}
+
+			return check(
+				typeof mixpanel.track === 'function' &&
+					typeof mixpanel.opt_out_tracking === 'function',
+				'mixpanel queue methods present before load'
+			);
+		},
+		runtimeCheck: () => {
+			const runtime = window.mixpanel as
+				| (Window['mixpanel'] & {
+						__loaded?: boolean;
+				  })
+				| undefined;
+
+			return check(
+				runtime?.__loaded === true || typeof runtime?.init === 'function',
+				'mixpanel SDK API present after loader executed'
+			);
+		},
+		notes:
+			"The SDK returns HTTP 200 JavaScript for fake tokens, but logs Mixpanel's snippet version mismatch and does not initialize against the current manifest stub.",
+	},
+	{
+		vendor: 'hotjar',
+		// Hotjar answers unknown site ids with an empty JavaScript response, so
+		// the probe verifies the account-keyed endpoint but cannot assert runtime.
+		tier: 'loader-only',
+		createScript: () => hotjar({ siteId: '123456789', version: 6 }),
+		loaderUrlSubstring: 'static.hotjar.com/c/hotjar-123456789.js',
+		bootstrapCheck: () => {
+			const stub = window.hj;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.hj stub function');
+			}
+
+			return check(
+				window._hjSettings?.hjid === '123456789',
+				'hotjar settings seeded before load'
+			);
+		},
+		notes:
+			'Placeholder site ids return an empty 200 JavaScript response from static.hotjar.com; runtime is not asserted.',
+	},
+	{
+		vendor: 'matomo-analytics',
+		// Matomo is self-hosted or account-hosted; the default public-cloud path
+		// for a fake cloud id returns 404, so this only proves the derived loader.
+		tier: 'loader-only',
+		createScript: () =>
+			matomoAnalytics({
+				cloudId: 'c15t-live-probe',
+				defaultConsent: 'required',
+				disableCookies: true,
+				enableLinkTracking: true,
+				siteId: '999999',
+			}),
+		loaderUrlSubstring: 'cdn.matomo.cloud/c15t-live-probe/matomo.js',
+		bootstrapCheck: () =>
+			check(
+				Array.isArray(window._paq) && window._paq.length >= 5,
+				`matomo queue seeded with ${window._paq?.length ?? 0} entries before load`
+			),
+		runtimeCheck: () => {
+			const matomo = (window as MatomoWindow).Matomo;
+
+			return check(
+				typeof matomo?.getTracker === 'function',
+				'window.Matomo.getTracker present after loader executed'
+			);
+		},
+		notes:
+			'Placeholder Matomo Cloud ids return HTTP 404 from cdn.matomo.cloud; runtime is not asserted.',
+	},
+	{
+		vendor: 'posthog',
+		tier: 'full',
+		createScript: () =>
+			posthog({
+				id: 'phc_c15tliveprobe000000000000000000000000000000000',
+				loadMode: 'after-consent',
+			}),
+		loaderUrlSubstring: 'assets.i.posthog.com/static/array.js',
+		// array.js chain-loads versioned SDK bundles from the same assets host.
+		allowUrlSubstrings: ['assets.i.posthog.com/static/'],
+		bootstrapCheck: () => {
+			const stub = window.posthog;
+
+			if (!stub || typeof stub.init !== 'function') {
+				return check(false, 'expected window.posthog stub with init()');
+			}
+
+			return check(
+				stub.get_explicit_consent_status() === 'pending',
+				'posthog stub reports pending consent before load'
+			);
+		},
+		runtimeCheck: () => {
+			const sdk = window.posthog as
+				| (Window['posthog'] & { __loaded?: boolean })
+				| undefined;
+
+			return check(
+				sdk?.__loaded === true,
+				'posthog SDK reports __loaded after init'
+			);
+		},
+	},
+	{
+		vendor: 'promptwatch',
+		tier: 'full',
+		createScript: () =>
+			promptwatch({
+				projectId: '00000000-0000-4000-8000-c15c15c15c15',
+			}),
+		loaderUrlSubstring: 'ingest.promptwatch.com/js/client.min.js',
+		runtimeCheck: () =>
+			check(
+				typeof (window as PromptwatchWindow).pwc === 'object' &&
+					(window as PromptwatchWindow).pwc !== null,
+				'window.pwc present after loader executed'
+			),
+	},
+	{
+		vendor: 'segment',
+		// Segment keys are embedded in the loader URL and fake write keys return
+		// HTTP 404, so this probe stops at bootstrap plus endpoint reachability.
+		tier: 'loader-only',
+		createScript: () => segment({ writeKey: 'C15TFAKE' }),
+		loaderUrlSubstring:
+			'cdn.segment.com/analytics.js/v1/C15TFAKE/analytics.min.js',
+		bootstrapCheck: () => {
+			const analytics = window.analytics;
+
+			if (!Array.isArray(analytics)) {
+				return check(false, 'expected window.analytics queue array');
+			}
+
+			return check(
+				typeof analytics.track === 'function' &&
+					typeof analytics.page === 'function',
+				'segment queue methods present before load'
+			);
+		},
+		notes:
+			'Placeholder write keys return HTTP 404 from cdn.segment.com; runtime is not asserted.',
+	},
+	{
+		vendor: 'rybbit-analytics',
+		tier: 'full',
+		createScript: () =>
+			rybbitAnalytics({
+				siteId: 'c15t-live-probe',
+				trackSpa: true,
+			}),
+		loaderUrlSubstring: 'app.rybbit.io/api/script.js',
+		runtimeCheck: () =>
+			check(
+				typeof window.rybbit?.pageview === 'function',
+				'window.rybbit.pageview present after loader executed'
+			),
+	},
+	{
+		vendor: 'plausible-analytics',
+		tier: 'full',
+		createScript: () =>
+			plausibleAnalytics({ domain: 'c15t-live-probe.invalid' }),
+		loaderUrlSubstring: 'plausible.io/js/script.js',
+		bootstrapCheck: () => {
+			const stub = window.plausible;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.plausible stub function');
+			}
+
+			return check(
+				Array.isArray(stub.q),
+				'plausible stub queue present before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.plausible === 'function',
+				'window.plausible callable after loader executed'
+			),
+	},
+	{
+		vendor: 'umami-analytics',
+		tier: 'full',
+		createScript: () =>
+			umamiAnalytics({
+				websiteId: '00000000-0000-4000-8000-c15c15c15c15',
+			}),
+		loaderUrlSubstring: 'cloud.umami.is/script.js',
+		runtimeCheck: () =>
+			check(
+				typeof window.umami?.track === 'function',
+				'window.umami.track present after loader executed'
+			),
+	},
+	{
+		vendor: 'vercel-analytics',
+		tier: 'full',
+		createScript: () =>
+			vercelAnalytics({
+				dsn: 'https://c15t-live-probe.invalid',
+			}),
+		loaderUrlSubstring: 'va.vercel-scripts.com/v1/script.js',
+		bootstrapCheck: () => {
+			const va = window.va;
+
+			if (typeof va !== 'function') {
+				return check(false, 'expected window.va stub function');
+			}
+
+			return check(
+				Array.isArray(window.vaq),
+				'vercel queue present before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.va === 'function',
+				'window.va callable after loader executed'
+			),
+	},
+	{
+		vendor: 'crisp',
+		tier: 'full',
+		createScript: () =>
+			crisp({
+				safeMode: true,
+				websiteId: '00000000-0000-4000-8000-c15c15c15c15',
+			}),
+		loaderUrlSubstring: 'client.crisp.chat/l.js',
+		// Crisp chain-loads widget assets after the bootstrap client runs.
+		allowUrlSubstrings: ['client.crisp.chat/'],
+		bootstrapCheck: () =>
+			check(
+				Array.isArray(window.$crisp) &&
+					window.CRISP_WEBSITE_ID === '00000000-0000-4000-8000-c15c15c15c15',
+				'crisp queue and website id seeded before load'
+			),
+		runtimeCheck: () =>
+			check(
+				Array.isArray(window.$crisp),
+				'window.$crisp queue remains available after loader executed'
+			),
+	},
+	{
+		vendor: 'intercom',
+		tier: 'full',
+		createScript: () => intercom({ appId: 'c15tfake' }),
+		loaderUrlSubstring: 'widget.intercom.io/widget/c15tfake',
+		// The widget loader pulls its runtime from Intercom's CDN path.
+		allowUrlSubstrings: ['js.intercomcdn.com/'],
+		bootstrapCheck: () => {
+			const stub = window.Intercom;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.Intercom stub function');
+			}
+
+			return check(
+				window.intercomSettings?.app_id === 'c15tfake',
+				'intercomSettings seeded before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.Intercom === 'function',
+				'window.Intercom callable after loader executed'
+			),
+	},
+	{
+		vendor: 'meta-pixel',
+		tier: 'full',
+		createScript: () => metaPixel({ pixelId: '123456789012345' }),
+		loaderUrlSubstring: 'connect.facebook.net/en_US/fbevents.js',
+		bootstrapCheck: () => {
+			const stub = window.fbq as MetaPixelRuntime | undefined;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.fbq stub function');
+			}
+
+			return check(
+				stub.loaded === true && stub.version === '2.0',
+				'meta pixel stub metadata present before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof (window.fbq as MetaPixelRuntime | undefined)?.callMethod ===
+					'function',
+				'fbq.callMethod present after loader executed'
+			),
+	},
+	{
+		vendor: 'reddit-pixel',
+		tier: 'full',
+		createScript: () => redditPixel({ pixelId: 't2_c15tfake' }),
+		loaderUrlSubstring: 'redditstatic.com/ads/pixel.js',
+		bootstrapCheck: () => {
+			const stub = window.rdt;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.rdt stub function');
+			}
+
+			return check(
+				Array.isArray(stub.callQueue) && stub.callQueue.length >= 2,
+				'reddit pixel queue seeded before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.rdt?.sendEvent === 'function',
+				'rdt.sendEvent present after loader executed'
+			),
+	},
+	{
+		vendor: 'tiktok-pixel',
+		tier: 'full',
+		createScript: () => tiktokPixel({ pixelId: 'C15TFAKE' }),
+		loaderUrlSubstring: 'analytics.tiktok.com/i18n/pixel/events.js',
+		bootstrapCheck: () => {
+			const queue = window.ttq;
+
+			if (!Array.isArray(queue)) {
+				return check(false, 'expected window.ttq queue array');
+			}
+
+			return check(
+				(window as TikTokWindow).TiktokAnalyticsObject === 'ttq' &&
+					typeof queue.grantConsent === 'function',
+				'tiktok queue methods present before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.ttq?.page === 'function',
+				'window.ttq.page callable after loader executed'
+			),
+	},
+	{
+		vendor: 'linkedin-insights',
+		tier: 'full',
+		createScript: () => linkedinInsights({ id: '123456789' }),
+		loaderUrlSubstring: 'snap.licdn.com/li.lms-analytics/insight.min.js',
+		bootstrapCheck: () =>
+			check(
+				window._linkedin_partner_id === '123456789' &&
+					window._linkedin_data_partner_ids?.includes('123456789') === true &&
+					typeof window.lintrk === 'function',
+				'linkedin partner globals and lintrk stub seeded before load'
+			),
+		runtimeCheck: () =>
+			check(
+				typeof window.lintrk === 'function',
+				'window.lintrk callable after loader executed'
+			),
+	},
+	{
+		vendor: 'microsoft-uet',
+		tier: 'full',
+		createScript: () => microsoftUet({ id: '123456789' }),
+		loaderUrlSubstring: 'bat.bing.com/bat.js',
+		bootstrapCheck: () =>
+			check(
+				Array.isArray(window.uetq) && window.uetq.length > 0,
+				'microsoft uet consent queue seeded before load'
+			),
+		runtimeCheck: () =>
+			check(
+				typeof (window as UetWindow).UET === 'function' &&
+					typeof window.uetq?.push === 'function',
+				'UET constructor and queue push present after loader executed'
+			),
+	},
+	{
+		vendor: 'snapchat-pixel',
+		tier: 'full',
+		createScript: () => snapchatPixel({ pixelId: '123456789012345' }),
+		loaderUrlSubstring: 'sc-static.net/scevent.min.js',
+		bootstrapCheck: () => {
+			const stub = window.snaptr;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.snaptr stub function');
+			}
+
+			return check(
+				window._snaptr === stub &&
+					stub.loaded === true &&
+					stub.version === '1.0',
+				'snapchat pixel stub metadata present before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof window.snaptr?.handleRequest === 'function',
+				'snaptr.handleRequest present after loader executed'
+			),
+	},
+	{
+		vendor: 'x-pixel',
+		tier: 'full',
+		createScript: () => xPixel({ pixelId: 'o0000' }),
+		loaderUrlSubstring: 'static.ads-twitter.com/uwt.js',
+		bootstrapCheck: () => {
+			const stub = window.twq as XPixelRuntime | undefined;
+
+			if (typeof stub !== 'function') {
+				return check(false, 'expected window.twq stub function');
+			}
+
+			return check(
+				Array.isArray(stub.queue) && stub.queue.length > 0,
+				'x pixel queue seeded before load'
+			);
+		},
+		runtimeCheck: () =>
+			check(
+				typeof (window.twq as XPixelRuntime | undefined)?.exe === 'function',
+				'twq.exe present after loader executed'
+			),
+	},
+];
+
+/**
+ * Looks up the live probe config for a vendor id.
+ */
+export function getLiveVendorProbeConfig(
+	vendor: string
+): LiveVendorProbeConfig | undefined {
+	return liveVendorProbeConfigs.find((config) => config.vendor === vendor);
+}

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -422,6 +422,7 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		createScript: () =>
 			plausibleAnalytics({ domain: 'c15t-live-probe.invalid' }),
 		loaderUrlSubstring: 'plausible.io/js/script.js',
+		runtimeReplacedGlobals: ['plausible'],
 		bootstrapCheck: () => {
 			const stub = window.plausible;
 
@@ -456,7 +457,10 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	},
 	{
 		vendor: 'vercel-analytics',
-		tier: 'full',
+		// script.js serves real JS but leaves the va stub untouched outside a
+		// real Vercel deployment context; runtime is not observable with
+		// placeholder config.
+		tier: 'loader-only',
 		createScript: () =>
 			vercelAnalytics({
 				dsn: 'https://c15t-live-probe.invalid',
@@ -482,7 +486,10 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	},
 	{
 		vendor: 'crisp',
-		tier: 'full',
+		// l.js loads for any website id but the client keeps the $crisp queue
+		// untouched for placeholder ids; runtime needs a real website id
+		// (repo-secret follow-up).
+		tier: 'loader-only',
 		createScript: () =>
 			crisp({
 				safeMode: true,
@@ -505,7 +512,10 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	},
 	{
 		vendor: 'intercom',
-		tier: 'full',
+		// The widget bootstrap serves real JS for any app id but boots nothing
+		// observable for placeholder ids, so runtime cannot be asserted without
+		// a real workspace id (repo-secret follow-up).
+		tier: 'loader-only',
 		createScript: () => intercom({ appId: 'c15tfake' }),
 		loaderUrlSubstring: 'widget.intercom.io/widget/c15tfake',
 		// The widget loader pulls its runtime from Intercom's CDN path.
@@ -593,15 +603,26 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				'tiktok queue methods present before load'
 			);
 		},
-		runtimeCheck: () =>
-			check(
-				typeof window.ttq?.page === 'function',
-				'window.ttq.page callable after loader executed'
-			),
+		runtimeCheck: () => {
+			const queue = window.ttq as
+				| (Window['ttq'] & { _env?: unknown; _plugins?: unknown })
+				| undefined;
+
+			// events.js decorates the queue object with runtime metadata even for
+			// placeholder pixel ids — a marker the pre-load stub never has.
+			return check(
+				queue !== undefined &&
+					(queue._env !== undefined || queue._plugins !== undefined),
+				'ttq decorated with runtime metadata after events.js executed'
+			);
+		},
 	},
 	{
 		vendor: 'linkedin-insights',
-		tier: 'full',
+		// insight.min.js serves real JS but initializes nothing observable for
+		// placeholder partner ids; runtime needs a real partner id
+		// (repo-secret follow-up).
+		tier: 'loader-only',
 		createScript: () => linkedinInsights({ id: '123456789' }),
 		loaderUrlSubstring: 'snap.licdn.com/li.lms-analytics/insight.min.js',
 		bootstrapCheck: () =>

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -189,11 +189,12 @@
 	"scripts": {
 		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs && bun ../../scripts/generate-package-docs.ts @c15t/scripts",
 		"build:docs": "bun ../../scripts/generate-package-docs.ts @c15t/scripts",
-		"check-types": "tsc --noEmit",
+		"check-types": "tsc --noEmit && tsc -p live-vendors --noEmit",
 		"dev": "sh -c 'rslib build --no-dts --no-clean && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
-		"lint": "bun biome lint ./src",
+		"lint": "bun biome lint ./src ./live-vendors",
 		"test": "vitest run",
+		"test:live-vendors": "bun --tsconfig-override live-vendors/tsconfig.json live-vendors/runner.ts",
 		"test:watch": "vitest"
 	},
 	"browserslist": [
@@ -204,7 +205,8 @@
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",
-		"c15t": "workspace:*"
+		"c15t": "workspace:*",
+		"playwright": "1.58.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/scripts/vitest.config.ts
+++ b/packages/scripts/vitest.config.ts
@@ -22,6 +22,7 @@ export default mergeConfig(
 				'src/**/*.spec.ts',
 				'src/**/*.e2e.test.tsx',
 				'src/**/*.e2e.test.ts',
+				'live-vendors/**/*.test.ts',
 			],
 			exclude: [
 				'**/node_modules/**',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -125,7 +125,7 @@
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",
-		"@rslib/core": "0.20.2",
+		"@rslib/core": "0.23.2",
 		"typescript": "6.0.2",
 		"vitest": "4.1.2"
 	},


### PR DESCRIPTION
Closes #899

## Summary

Adds a Playwright-based **live vendor probe harness** for every built-in `@c15t/scripts` integration, plus a daily GitHub Actions monitor that opens/updates deduped issues when a vendor's live loader behavior breaks — the class of failure static jsdom tests can't see (like the Microsoft Clarity loader change).

### How it works

`packages/scripts/live-vendors/` contains a runner that bundles a browser harness with `Bun.build`, serves it locally, and drives real Chromium through five phases per vendor:

1. **consent** — with denied consent, the script must not load and no loader request may leave the page
2. **bootstrap** — queue stubs/globals seeded by the manifest must exist immediately after `loadScripts()`, before the network answers
3. **load** — the real vendor loader must respond (full tier requires a 2xx JavaScript response; `loader-only` accepts placeholder-id rejections, including Chromium ORB-filtered error pages)
4. **runtime** — the real vendor SDK must initialize (full tier, polled)
5. **network** — every third-party request outside the loader allowlist is answered with an empty 204, so probes never send real analytics data

Failed probes retry once; every run writes a JSON report. A registry coverage test makes CI fail if a vendor is added to the registry without a live probe config, so future integrations (#873–#881) must ship with live coverage.

### Workflow

`.github/workflows/script-vendor-monitor.yml` — daily at 06:30 UTC + `workflow_dispatch` with optional vendor filter. Separate from PR CI so transient third-party failures never block PRs. Opens one deduped issue per failing vendor (`[vendor-script-monitor] <vendor> live script contract failed`), comments while it keeps failing, auto-closes on recovery. Issue planning logic is pure and unit-tested. zizmor-clean.

### Results

Full sweep: **26/26 vendors pass** — 20 full tier (real SDKs boot from vendor CDNs: gtag, PostHog, Meta Pixel, TikTok, Intercom, …), 6 loader-only with documented placeholder-id limitations (GTM 404s fake containers, Clarity answers 204, etc.). Upgrading loader-only vendors to full tier needs real test-account ids as repo secrets — tracked as a follow-up.

**The first sweep found a real bug**: the live Mixpanel SDK rejects our stub with `Mixpanel error: Version mismatch` and never initializes (our manifest bootstrap lacks the snippet contract, e.g. `__SV`). Fix lands as a stacked PR.

### Local usage

```sh
bun run --filter @c15t/scripts test:live-vendors
bun run --filter @c15t/scripts test:live-vendors -- --vendor microsoft-clarity
```

## Test plan

- [x] `bun run --filter @c15t/scripts test` — 205 tests / 50 files pass (includes new report + registry-coverage tests)
- [x] `bun run --filter @c15t/scripts check-types` / `lint` — clean (4 pre-existing warnings in `src/engine/runtime.ts` untouched)
- [x] Full local live sweep: 26 passed, 0 failed, 0 skipped
- [x] Independent review (`codex review --uncommitted`) — no findings
- [ ] Manually trigger the workflow once after merge (needs the workflow on the default branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily **Script Vendor Monitor** GitHub workflow with manual start support.
  * Introduced browser-based live vendor probes that produce a JSON report (with retries, phase checks, and vendor filtering).
  * Added automatic reconciliation of monitor issues for failing and recovered vendors.
* **Documentation**
  * Documented how to run the live vendor monitor locally and interpret report output.
* **Tests**
  * Added test coverage for vendor probe configuration, report formatting, and issue-planning logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->