### PR TITLE
fix(scripts): implement Mixpanel snippet contract so the SDK initializes

### DIFF
--- a/.changeset/mixpanel-snippet-contract.md
+++ b/.changeset/mixpanel-snippet-contract.md
@@ -1,0 +1,5 @@
+---
+'@c15t/scripts': patch
+---
+
+Fix Mixpanel integration: implement the official snippet contract (`__SV` version marker and `_i` init registry) so `mixpanel-2-latest.min.js` initializes from the stub instead of logging "Mixpanel error: Version mismatch" and silently dropping queued events.

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -236,9 +236,7 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	},
 	{
 		vendor: 'mixpanel-analytics',
-		// Mixpanel serves the public SDK for fake tokens, but that SDK rejects
-		// this manifest queue stub with a snippet version mismatch before init.
-		tier: 'loader-only',
+		tier: 'full',
 		createScript: () =>
 			mixpanelAnalytics({
 				token: 'c15fc15fc15fc15fc15fc15fc15fc15f',
@@ -255,10 +253,17 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				return check(false, 'expected window.mixpanel queue array');
 			}
 
+			if (mixpanel.__SV !== 1.2 || !Array.isArray(mixpanel._i)) {
+				return check(
+					false,
+					'expected snippet contract (__SV and _i) on the stub before load'
+				);
+			}
+
 			return check(
 				typeof mixpanel.track === 'function' &&
 					typeof mixpanel.opt_out_tracking === 'function',
-				'mixpanel queue methods present before load'
+				'mixpanel snippet contract and queue methods present before load'
 			);
 		},
 		runtimeCheck: () => {
@@ -269,12 +274,10 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				| undefined;
 
 			return check(
-				runtime?.__loaded === true || typeof runtime?.init === 'function',
-				'mixpanel SDK API present after loader executed'
+				runtime?.__loaded === true,
+				'mixpanel SDK reports __loaded after init_from_snippet'
 			);
 		},
-		notes:
-			"The SDK returns HTTP 200 JavaScript for fake tokens, but logs Mixpanel's snippet version mismatch and does not initialize against the current manifest stub.",
 	},
 	{
 		vendor: 'hotjar',

--- a/packages/scripts/src/analytics-queues.e2e.test.ts
+++ b/packages/scripts/src/analytics-queues.e2e.test.ts
@@ -100,9 +100,10 @@ describe('analytics queue contracts', () => {
 		]);
 	});
 
-	it('boots Mixpanel queue methods and load-time consent handoff', () => {
-		const initCalls: unknown[][] = [];
+	it('boots Mixpanel snippet contract and load-time consent handoff', () => {
 		let methodTypes: Record<string, string> | undefined;
+		let snippetVersion: number | undefined;
+		let pendingInits: unknown[][] | undefined;
 		let queueBeforeLoad: unknown[] | undefined;
 		let queueAfterLoad: unknown[] | undefined;
 
@@ -111,7 +112,12 @@ describe('analytics queue contracts', () => {
 				return;
 			}
 
-			const mixpanel = win.mixpanel;
+			const mixpanel = win.mixpanel as
+				| (NonNullable<TestWindow['mixpanel']> & {
+						__SV?: number;
+						_i?: unknown[][];
+				  })
+				| undefined;
 			methodTypes = {
 				identify: typeof mixpanel?.identify,
 				init: typeof mixpanel?.init,
@@ -122,13 +128,10 @@ describe('analytics queue contracts', () => {
 				track: typeof mixpanel?.track,
 			};
 
+			snippetVersion = mixpanel?.__SV;
+			pendingInits = mixpanel?._i?.map((entry) => [...entry]);
 			mixpanel?.track?.('Signup', { plan: 'pro' });
 			queueBeforeLoad = Array.from(mixpanel ?? []);
-			if (mixpanel) {
-				mixpanel.init = (...args: unknown[]) => {
-					initCalls.push(args);
-				};
-			}
 			node.dispatchEvent(new Event('load'));
 			queueAfterLoad = Array.from(mixpanel ?? []);
 		});
@@ -156,8 +159,9 @@ describe('analytics queue contracts', () => {
 			track: 'function',
 		});
 		expect(queueBeforeLoad).toEqual([['track', 'Signup', { plan: 'pro' }]]);
-		expect(initCalls).toEqual([
-			['1234567890abcdef1234567890abcdef', { debug: true }],
+		expect(snippetVersion).toBe(1.2);
+		expect(pendingInits).toEqual([
+			['1234567890abcdef1234567890abcdef', { debug: true }, 'mixpanel'],
 		]);
 		expect(queueAfterLoad).toEqual([
 			['track', 'Signup', { plan: 'pro' }],

--- a/packages/scripts/src/analytics-queues.e2e.test.ts
+++ b/packages/scripts/src/analytics-queues.e2e.test.ts
@@ -113,10 +113,7 @@ describe('analytics queue contracts', () => {
 			}
 
 			const mixpanel = win.mixpanel as
-				| (NonNullable<TestWindow['mixpanel']> & {
-						__SV?: number;
-						_i?: unknown[][];
-				  })
+				| NonNullable<TestWindow['mixpanel']>
 				| undefined;
 			methodTypes = {
 				identify: typeof mixpanel?.identify,

--- a/packages/scripts/src/vendors/analytics/mixpanel-analytics.test.ts
+++ b/packages/scripts/src/vendors/analytics/mixpanel-analytics.test.ts
@@ -26,26 +26,22 @@ describe('mixpanelAnalytics', () => {
 		});
 	});
 
-	it('trims valid tokens before resolving the manifest', () => {
+	it('seeds the snippet contract with the trimmed token before load', () => {
 		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		globalRef.mixpanel = {
-			init,
-			opt_in_tracking: vi.fn(),
-			opt_out_tracking: vi.fn(),
-		};
 		const script = mixpanelAnalytics({
 			token: ` ${MOCK_MIXPANEL_TOKEN} `,
 		});
 
-		script.onLoad?.(
+		script.onBeforeLoad?.(
 			createCallbackInfo({
 				id: script.id,
 				consents: deniedConsentState,
 			})
 		);
 
-		expect(init).toHaveBeenCalledWith(MOCK_MIXPANEL_TOKEN, {});
+		const mixpanel = globalRef.mixpanel as Window['mixpanel'];
+		expect(mixpanel?.__SV).toBe(1.2);
+		expect(mixpanel?._i).toEqual([[MOCK_MIXPANEL_TOKEN, {}, 'mixpanel']]);
 	});
 
 	it('throws for blank or malformed tokens', () => {
@@ -57,13 +53,30 @@ describe('mixpanelAnalytics', () => {
 		);
 	});
 
-	it('initializes mixpanel and syncs consent state through opt methods', () => {
+	it('registers init options in _i for the snippet init registry', () => {
 		const globalRef = getTestGlobal();
-		const init = vi.fn();
+		const script = mixpanelAnalytics({
+			token: MOCK_MIXPANEL_TOKEN,
+			initOptions: { debug: true },
+		});
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: deniedConsentState,
+			})
+		);
+
+		expect((globalRef.mixpanel as Window['mixpanel'])?._i).toEqual([
+			[MOCK_MIXPANEL_TOKEN, { debug: true }, 'mixpanel'],
+		]);
+	});
+
+	it('syncs consent state through the SDK opt methods', () => {
+		const globalRef = getTestGlobal();
 		const optIn = vi.fn();
 		const optOut = vi.fn();
 		globalRef.mixpanel = {
-			init,
 			opt_in_tracking: optIn,
 			opt_out_tracking: optOut,
 		};
@@ -79,9 +92,6 @@ describe('mixpanelAnalytics', () => {
 				consents: deniedConsentState,
 			})
 		);
-		expect(init).toHaveBeenCalledWith(MOCK_MIXPANEL_TOKEN, {
-			debug: true,
-		});
 		expect(optOut).toHaveBeenCalledTimes(1);
 
 		script.onConsentChange?.(

--- a/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
@@ -12,12 +12,22 @@ declare global {
 			register: (properties: Record<string, unknown>) => void;
 			opt_in_tracking: () => void;
 			opt_out_tracking: () => void;
+			/** Snippet version marker consumed by `init_from_snippet`. */
+			__SV?: number;
+			/** Pending `[token, config]` init tuples consumed at SDK load. */
+			_i?: unknown[][];
 		};
 	}
 }
 
 /**
  * Mixpanel vendor manifest.
+ *
+ * Implements the official snippet contract: the stub array carries the
+ * snippet version marker (`__SV`) and the pending `[token, config]` init
+ * tuple in `_i`, which `mixpanel-2-latest.min.js` consumes at load time via
+ * `init_from_snippet`. Without `__SV` the SDK logs "Mixpanel error: Version
+ * mismatch" and never initializes, silently dropping queued calls.
  *
  * Mixpanel can stay loaded across consent changes and toggle tracking with its
  * own opt-in and opt-out APIs.
@@ -35,6 +45,19 @@ export const mixpanelAnalyticsManifest = {
 			ifUndefined: true,
 		},
 		{
+			type: 'setGlobalPath',
+			path: ['mixpanel', '__SV'],
+			value: 1.2,
+		},
+		{
+			// The official snippet always pushes an explicit instance name; the
+			// SDK's create_mplib resolves the queue stub through that name, so a
+			// two-element tuple would leave the queue unreplayed.
+			type: 'setGlobalPath',
+			path: ['mixpanel', '_i'],
+			value: [['{{token}}', '{{initOptions}}', 'mixpanel']],
+		},
+		{
 			type: 'defineQueueMethods',
 			target: 'mixpanel',
 			methods: [
@@ -50,14 +73,6 @@ export const mixpanelAnalyticsManifest = {
 			type: 'loadScript',
 			src: '{{scriptUrl}}',
 			async: true,
-		},
-	],
-	afterLoad: [
-		{
-			type: 'callGlobal',
-			global: 'mixpanel',
-			method: 'init',
-			args: ['{{token}}', '{{initOptions}}'],
 		},
 	],
 	onLoadGranted: [

--- a/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
@@ -14,7 +14,7 @@ declare global {
 			opt_out_tracking: () => void;
 			/** Snippet version marker consumed by `init_from_snippet`. */
 			__SV?: number;
-			/** Pending `[token, config]` init tuples consumed at SDK load. */
+			/** Pending `[token, config, instanceName]` init tuples consumed at SDK load. */
 			_i?: unknown[][];
 		};
 	}
@@ -24,8 +24,8 @@ declare global {
  * Mixpanel vendor manifest.
  *
  * Implements the official snippet contract: the stub array carries the
- * snippet version marker (`__SV`) and the pending `[token, config]` init
- * tuple in `_i`, which `mixpanel-2-latest.min.js` consumes at load time via
+ * snippet version marker (`__SV`) and the pending `[token, config, 'mixpanel']`
+ * init tuple in `_i`, which `mixpanel-2-latest.min.js` consumes at load time via
  * `init_from_snippet`. Without `__SV` the SDK logs "Mixpanel error: Version
  * mismatch" and never initializes, silently dropping queued calls.
  *


### PR DESCRIPTION
Fixes #904. Stacked on #903 (the live vendor monitor that found this bug).

## Summary

The `mixpanel-analytics` manifest seeded `window.mixpanel = []` with queue methods but never implemented Mixpanel's snippet contract. The live SDK checks the snippet version marker and bails with:

```
Mixpanel error: Version mismatch; please ensure you're using the latest version of the Mixpanel code snippet.
```

…so in production the SDK loaded but **never initialized, and queued `track`/`identify` calls were silently dropped**.

### Fix

The manifest bootstrap now reproduces the official snippet contract (verified against the unminified `mixpanel-2-latest.js` source):

- `mixpanel.__SV = 1.2` — without it `init_from_snippet` refuses to boot
- `mixpanel._i = [[token, initOptions, 'mixpanel']]` — the pending init tuple `init_from_snippet` consumes at load. The explicit `'mixpanel'` instance name is load-bearing: `create_mplib` resolves the queue stub through `mixpanel_master[name]`, so a two-element tuple makes the SDK create an orphan instance and leave the stub in place (silently — no console error)
- the `afterLoad` `mixpanel.init(...)` call is removed; init happens through the snippet registry like the official snippet

Queued calls already used the right format (`[method, ...args]` arrays), so they replay correctly via `_execute_array` once init actually runs.

The live probe for mixpanel is upgraded back to **full tier** with a runtime assertion that the real SDK reports `__loaded` — the monitor now guards this contract daily.

## Test plan

- [x] `bun run --filter @c15t/scripts test` — 206 tests / 50 files pass (unit + e2e contract tests updated to assert the snippet contract)
- [x] `bun run --filter @c15t/scripts check-types` / `lint` — clean
- [x] Live probe against the real CDN: `test:live-vendors -- --vendor mixpanel-analytics` → ✅ full tier, SDK reports `__loaded`, no version-mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mixpanel integration to use the official snippet contract, preventing version mismatch errors and ensuring queued events initialize correctly.
  * Strengthened Mixpanel readiness verification and adjusted runtime success detection to avoid false positives.
  * Preserved consent-driven tracking behavior with the updated Mixpanel bootstrap flow.
* **Tests**
  * Updated Mixpanel unit and e2e contract tests to validate the snippet interface and queued init registry, rather than intercepting SDK `init` calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->