### PR TITLE
feat(scripts): denied-consent egress assertion for alwaysLoad vendors

### DIFF
--- a/packages/scripts/live-vendors/README.md
+++ b/packages/scripts/live-vendors/README.md
@@ -38,8 +38,12 @@ Each vendor runs through five phases in a fresh browser context, with one
 retry before a failure is reported:
 
 1. **consent** — with denied consent, the script must not load and no loader
-   request may leave the page. Skipped for `alwaysLoad` vendors, which manage
-   consent internally.
+   request may leave the page. `alwaysLoad` vendors (which manage consent
+   internally) instead get a denied-consent **egress assertion** in an
+   isolated context: the script loads, and the probe asserts zero requests to
+   the vendor's collection endpoints and no vendor cookies/localStorage
+   (per-vendor violation lists in `vendors.ts`; consent-safe traffic like
+   Google Consent Mode pings and opt-out markers is excluded by design).
 2. **bootstrap** — immediately after `loadScripts()` with granted consent,
    the manifest's queue stubs/globals must exist (before the network answers).
 3. **load** — the real vendor loader must respond. `full` tier requires a

--- a/packages/scripts/live-vendors/denied-consent.test.ts
+++ b/packages/scripts/live-vendors/denied-consent.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateDeniedConsentProbe } from './denied-consent';
+import type { DeniedConsentProbeConfig, LiveStorageSnapshot } from './types';
+
+const config: DeniedConsentProbeConfig = {
+	collectUrlSubstrings: ['api-js.mixpanel.com', 'api.mixpanel.com'],
+	storagePrefixes: ['mp_'],
+};
+
+function storage(
+	overrides?: Partial<LiveStorageSnapshot>
+): LiveStorageSnapshot {
+	return { cookieNames: [], localStorageKeys: [], ...overrides };
+}
+
+describe('evaluateDeniedConsentProbe', () => {
+	it('passes when only loader/config requests occurred and storage is clean', () => {
+		const result = evaluateDeniedConsentProbe(
+			config,
+			['https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js'],
+			storage({
+				// Opt-out consent markers are legitimate and excluded by prefix.
+				localStorageKeys: ['__mp_opt_in_out_c15f'],
+			})
+		);
+
+		expect(result.ok).toBe(true);
+	});
+
+	it('fails when a collection request was attempted, even if blocked', () => {
+		const result = evaluateDeniedConsentProbe(
+			config,
+			[
+				'https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js',
+				'https://api-js.mixpanel.com/track/?data=abc',
+			],
+			storage()
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.detail).toContain('api-js.mixpanel.com/track');
+	});
+
+	it('fails when vendor cookies or localStorage keys appear', () => {
+		const result = evaluateDeniedConsentProbe(
+			config,
+			[],
+			storage({
+				cookieNames: ['mp_c15f_mixpanel'],
+				localStorageKeys: ['mp_super_properties'],
+			})
+		);
+
+		expect(result.ok).toBe(false);
+		expect(result.detail).toContain('cookie mp_c15f_mixpanel');
+		expect(result.detail).toContain('localStorage mp_super_properties');
+	});
+
+	it('treats storage prefixes as optional', () => {
+		const result = evaluateDeniedConsentProbe(
+			{ collectUrlSubstrings: ['collect.example.com'] },
+			[],
+			storage({ cookieNames: ['anything'] })
+		);
+
+		expect(result.ok).toBe(true);
+	});
+});

--- a/packages/scripts/live-vendors/denied-consent.ts
+++ b/packages/scripts/live-vendors/denied-consent.ts
@@ -1,0 +1,59 @@
+import type {
+	DeniedConsentProbeConfig,
+	LiveProbeCheckResult,
+	LiveStorageSnapshot,
+} from './types';
+
+/**
+ * Evaluates the denied-consent egress assertion for an `alwaysLoad` vendor.
+ *
+ * The vendor loaded with denied consent; every observed third-party request
+ * and the page's storage snapshot are checked against the vendor's explicit
+ * violation lists. A collection request is a violation even when the runner
+ * blocked it — the attempt itself proves the vendor tried to send data.
+ */
+export function evaluateDeniedConsentProbe(
+	config: DeniedConsentProbeConfig,
+	observedRequestUrls: string[],
+	storage: LiveStorageSnapshot
+): LiveProbeCheckResult {
+	const collectViolations = observedRequestUrls.filter((url) =>
+		config.collectUrlSubstrings.some((substring) => url.includes(substring))
+	);
+
+	const prefixes = config.storagePrefixes ?? [];
+	const storageViolations = [
+		...storage.cookieNames
+			.filter((name) => prefixes.some((prefix) => name.startsWith(prefix)))
+			.map((name) => `cookie ${name}`),
+		...storage.localStorageKeys
+			.filter((key) => prefixes.some((prefix) => key.startsWith(prefix)))
+			.map((key) => `localStorage ${key}`),
+	];
+
+	if (collectViolations.length === 0 && storageViolations.length === 0) {
+		return {
+			ok: true,
+			detail:
+				'loaded under denied consent with zero collection requests and no vendor storage',
+		};
+	}
+
+	const parts: string[] = [];
+	if (collectViolations.length > 0) {
+		parts.push(
+			`collection request(s) under denied consent: ${collectViolations
+				.slice(0, 5)
+				.join(', ')}`
+		);
+	}
+	if (storageViolations.length > 0) {
+		parts.push(
+			`vendor storage under denied consent: ${storageViolations
+				.slice(0, 5)
+				.join(', ')}`
+		);
+	}
+
+	return { ok: false, detail: parts.join('; ') };
+}

--- a/packages/scripts/live-vendors/denied-consent.ts
+++ b/packages/scripts/live-vendors/denied-consent.ts
@@ -11,6 +11,12 @@ import type {
  * and the page's storage snapshot are checked against the vendor's explicit
  * violation lists. A collection request is a violation even when the runner
  * blocked it — the attempt itself proves the vendor tried to send data.
+ *
+ * @param config - Per-vendor violation lists.
+ * @param observedRequestUrls - Every third-party request URL seen during the
+ * denied-consent window, blocked or allowed.
+ * @param storage - Cookie names and localStorage keys snapshotted in the page.
+ * @returns The consent-phase result with violation details on failure.
  */
 export function evaluateDeniedConsentProbe(
 	config: DeniedConsentProbeConfig,

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -185,6 +185,27 @@ const harness: LiveVendorProbeHarness = {
 
 		return runCheck(config.runtimeCheck, 'no runtime check defined');
 	},
+
+	inspectStorage() {
+		const cookieNames = document.cookie
+			.split(';')
+			.map((entry) => entry.split('=')[0]?.trim() ?? '')
+			.filter((name) => name.length > 0);
+
+		const localStorageKeys: string[] = [];
+		try {
+			for (let index = 0; index < window.localStorage.length; index++) {
+				const key = window.localStorage.key(index);
+				if (key !== null) {
+					localStorageKeys.push(key);
+				}
+			}
+		} catch {
+			// Storage access can throw in exotic contexts; report what we have.
+		}
+
+		return { cookieNames, localStorageKeys };
+	},
 };
 
 window.__c15tLiveVendorProbe = harness;

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -19,10 +19,12 @@
  */
 import { type Browser, chromium, type Response } from 'playwright';
 import { getBuiltInScriptIntegrationByVendor } from '../src/registry';
+import { evaluateDeniedConsentProbe } from './denied-consent';
 import { failedPhases } from './report';
 import type {
 	LiveProbeCheckResult,
 	LiveProbeLoadOutcome,
+	LiveStorageSnapshot,
 	LiveVendorProbeConfig,
 	LiveVendorProbeHarness,
 	LiveVendorReport,
@@ -160,6 +162,91 @@ async function fetchLoaderDetails(
 	}
 }
 
+const DENIED_EGRESS_QUIET_MS = 4_000;
+
+/**
+ * Loads an `alwaysLoad` vendor with denied consent in an isolated context and
+ * evaluates its egress and storage against the vendor's violation lists.
+ *
+ * Uses its own browser context so the warmed cache and any vendor state never
+ * leak into the granted-consent probe that follows.
+ */
+async function probeDeniedConsentEgress(
+	browser: Browser,
+	baseUrl: string,
+	config: LiveVendorProbeConfig
+): Promise<LiveProbeCheckResult> {
+	const deniedProbe = config.deniedConsentProbe;
+	if (!deniedProbe) {
+		return {
+			ok: true,
+			detail:
+				'script declares alwaysLoad and manages consent internally; denied-consent gating not asserted',
+		};
+	}
+
+	const observedRequests: string[] = [];
+	const allow = [
+		config.loaderUrlSubstring,
+		...(config.allowUrlSubstrings ?? []),
+	].filter((value): value is string => Boolean(value));
+
+	const context = await browser.newContext();
+
+	try {
+		await context.route('**/*', (route) => {
+			const url = route.request().url();
+
+			if (url.startsWith(baseUrl)) {
+				return route.continue();
+			}
+
+			observedRequests.push(url);
+
+			if (allow.some((substring) => url.includes(substring))) {
+				return route.continue();
+			}
+
+			return route.fulfill({ status: 204, body: '' });
+		});
+
+		const page = await context.newPage();
+		await page.goto(baseUrl, { waitUntil: 'load' });
+
+		const outcome = await page.evaluate<LiveProbeLoadOutcome, string>(
+			(vendor) => {
+				const harness = (globalThis as unknown as ProbeWindow)
+					.__c15tLiveVendorProbe;
+				if (!harness) {
+					throw new Error('harness missing');
+				}
+				return harness.load(vendor, false);
+			},
+			config.vendor
+		);
+
+		if (outcome.error) {
+			return { ok: false, detail: `harness error: ${outcome.error}` };
+		}
+
+		// Give the vendor runtime time to initialize and attempt collection.
+		await page.waitForTimeout(DENIED_EGRESS_QUIET_MS);
+
+		const storage = await page.evaluate<LiveStorageSnapshot>(() => {
+			const harness = (globalThis as unknown as ProbeWindow)
+				.__c15tLiveVendorProbe;
+			if (!harness) {
+				throw new Error('harness missing');
+			}
+			return harness.inspectStorage();
+		});
+
+		return evaluateDeniedConsentProbe(deniedProbe, observedRequests, storage);
+	} finally {
+		await context.close();
+	}
+}
+
 async function probeVendorAttempt(
 	browser: Browser,
 	baseUrl: string,
@@ -241,14 +328,11 @@ async function probeVendorAttempt(
 
 		// Phase: consent — load with denied consent; nothing should hit the wire.
 		// alwaysLoad scripts manage consent internally and load regardless, so
-		// probing them here would only warm the browser cache and swallow the
-		// network events the load phase waits for.
+		// they get the denied-consent egress assertion in an isolated context
+		// instead of the gating check (which would also warm this context's
+		// cache and swallow the network events the load phase waits for).
 		if (alwaysLoad) {
-			phases.consent = {
-				ok: true,
-				detail:
-					'script declares alwaysLoad and manages consent internally; denied-consent gating not asserted',
-			};
+			phases.consent = await probeDeniedConsentEgress(browser, baseUrl, config);
 		} else {
 			const deniedOutcome = await page.evaluate<LiveProbeLoadOutcome, string>(
 				(vendor) => {

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -39,6 +39,17 @@ const RUNTIME_TIMEOUT_MS = 10_000;
 const RUNTIME_POLL_MS = 250;
 const CONSENT_QUIET_MS = 750;
 
+/**
+ * Builds the loader allowlist for a probe config. Everything outside this
+ * list (and the local harness origin) is answered with an empty 204.
+ */
+function buildAllowList(config: LiveVendorProbeConfig): string[] {
+	return [
+		config.loaderUrlSubstring,
+		...(config.allowUrlSubstrings ?? []),
+	].filter((value): value is string => Boolean(value));
+}
+
 const PAGE_HTML = `<!doctype html>
 <html lang="en">
 	<head>
@@ -186,10 +197,7 @@ async function probeDeniedConsentEgress(
 	}
 
 	const observedRequests: string[] = [];
-	const allow = [
-		config.loaderUrlSubstring,
-		...(config.allowUrlSubstrings ?? []),
-	].filter((value): value is string => Boolean(value));
+	const allow = buildAllowList(config);
 
 	const context = await browser.newContext();
 
@@ -210,6 +218,11 @@ async function probeDeniedConsentEgress(
 			return route.fulfill({ status: 204, body: '' });
 		});
 
+		// Refuse WebSockets here too — HTTP routing does not cover them.
+		await context.routeWebSocket('**', () => {
+			// Never connect to the remote server.
+		});
+
 		const page = await context.newPage();
 		await page.goto(baseUrl, { waitUntil: 'load' });
 
@@ -227,6 +240,16 @@ async function probeDeniedConsentEgress(
 
 		if (outcome.error) {
 			return { ok: false, detail: `harness error: ${outcome.error}` };
+		}
+
+		// A zero-violation result is only meaningful if the vendor actually
+		// loaded — otherwise a loader regression would read as a pass.
+		if (!outcome.requested) {
+			return {
+				ok: false,
+				detail:
+					'alwaysLoad script was not injected under denied consent; egress assertion could not run',
+			};
 		}
 
 		// Give the vendor runtime time to initialize and attempt collection.
@@ -256,10 +279,7 @@ async function probeVendorAttempt(
 	const blocked: string[] = [];
 	const consoleErrors: string[] = [];
 	const pageErrors: string[] = [];
-	const allow = [
-		config.loaderUrlSubstring,
-		...(config.allowUrlSubstrings ?? []),
-	].filter((value): value is string => Boolean(value));
+	const allow = buildAllowList(config);
 
 	const context = await browser.newContext();
 

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -219,8 +219,8 @@ async function probeDeniedConsentEgress(
 		});
 
 		// Refuse WebSockets here too — HTTP routing does not cover them.
-		await context.routeWebSocket('**', () => {
-			// Never connect to the remote server.
+		await context.routeWebSocket('**', (ws) => {
+			ws.close();
 		});
 
 		const page = await context.newPage();

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -81,8 +81,49 @@ export interface LiveVendorProbeConfig {
 	 * the runtime phase, before any custom `runtimeCheck` runs.
 	 */
 	runtimeReplacedGlobals?: string[];
+	/**
+	 * Denied-consent egress assertion for `alwaysLoad` vendors.
+	 *
+	 * These vendors load for every visitor and manage consent internally, so
+	 * the probe loads them with denied consent in an isolated browser context
+	 * and asserts that no collection request leaves the page and no vendor
+	 * storage is written. Config/CDN fetches stay allowed — only the explicit
+	 * violation lists below fail the phase.
+	 */
+	deniedConsentProbe?: DeniedConsentProbeConfig;
 	/** Free-form caveats surfaced in reports. */
 	notes?: string;
+}
+
+/**
+ * Violation lists for the denied-consent egress assertion.
+ */
+export interface DeniedConsentProbeConfig {
+	/**
+	 * URL substrings of the vendor's collection/beacon endpoints. Any request
+	 * matching one of these under denied consent fails the consent phase —
+	 * whether the runner blocked it or not, the attempt itself is the
+	 * violation.
+	 */
+	collectUrlSubstrings: string[];
+	/**
+	 * Cookie-name / localStorage-key prefixes that must not appear under
+	 * denied consent. Exclude vendor opt-out markers (for example Mixpanel's
+	 * `__mp_opt_in_out_*`), which are legitimate consent-state storage.
+	 */
+	storagePrefixes?: string[];
+	/** Extra context surfaced in reports. */
+	notes?: string;
+}
+
+/**
+ * Storage observed in the page during the denied-consent probe.
+ */
+export interface LiveStorageSnapshot {
+	/** Cookie names visible via document.cookie. */
+	cookieNames: string[];
+	/** localStorage keys. */
+	localStorageKeys: string[];
 }
 
 /**
@@ -109,6 +150,8 @@ export interface LiveVendorProbeHarness {
 	load(vendor: string, granted: boolean): LiveProbeLoadOutcome;
 	/** Runs the vendor's runtime check. */
 	check(vendor: string): LiveProbeCheckResult;
+	/** Snapshots cookie names and localStorage keys in the probed page. */
+	inspectStorage(): LiveStorageSnapshot;
 }
 
 /**

--- a/packages/scripts/live-vendors/vendors.test.ts
+++ b/packages/scripts/live-vendors/vendors.test.ts
@@ -41,6 +41,22 @@ describe('live vendor probe configs', () => {
 		}
 	});
 
+	it('requires a denied-consent probe for every alwaysLoad vendor', () => {
+		for (const config of liveVendorProbeConfigs) {
+			if (config.tier === 'skip' || !config.createScript) {
+				continue;
+			}
+
+			const script = config.createScript();
+			if (script.alwaysLoad === true) {
+				expect(
+					config.deniedConsentProbe,
+					`${config.vendor} loads for every visitor and must assert denied-consent egress`
+				).toBeDefined();
+			}
+		}
+	});
+
 	it('constructs scripts whose ids match the configured vendor', () => {
 		for (const config of liveVendorProbeConfigs) {
 			if (config.tier === 'skip') {

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -218,6 +218,14 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		tier: 'full',
 		createScript: () => gtag({ id: 'G-C15TFAKE', category: 'measurement' }),
 		loaderUrlSubstring: 'googletagmanager.com/gtag/js',
+		deniedConsentProbe: {
+			// Consent Mode's cookieless pings (gcs=G100) are consent-safe by
+			// design, so /g/collect is deliberately NOT a violation here; the
+			// assertion is that no ad requests fire and no Google cookies are
+			// written while consent is denied.
+			collectUrlSubstrings: ['doubleclick.net', 'googleadservices.com'],
+			storagePrefixes: ['_ga', '_gid', '_gcl'],
+		},
 		bootstrapCheck: () => {
 			const dataLayer = window.dataLayer;
 
@@ -423,6 +431,11 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				},
 			}),
 		loaderUrlSubstring: 'cdn.databuddy.cc/databuddy.js',
+		deniedConsentProbe: {
+			// configWhenDenied sets disabled: true, so the SDK must send nothing
+			// to Databuddy's collection API while consent is denied.
+			collectUrlSubstrings: ['basket.databuddy.cc', 'api.databuddy.cc'],
+		},
 		bootstrapCheck: () =>
 			check(
 				window.databuddyConfig?.clientId === 'db_c15tfake',
@@ -664,6 +677,14 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				siteId: '999999',
 			}),
 		loaderUrlSubstring: 'cdn.matomo.cloud/c15t-live-probe/matomo.js',
+		deniedConsentProbe: {
+			// defaultConsent 'required' queues requireConsent before load, so no
+			// matomo.php tracker hit and no _pk_* cookies may appear while
+			// consent is denied. Weak until a real cloud id lands as a secret
+			// (placeholder ids 404 before the tracker can run).
+			collectUrlSubstrings: ['matomo.php'],
+			storagePrefixes: ['_pk_'],
+		},
 		bootstrapCheck: () =>
 			check(
 				Array.isArray(window._paq) && window._paq.length >= 5,
@@ -1058,6 +1079,15 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		tier: 'full',
 		createScript: () => microsoftUet({ id: '123456789' }),
 		loaderUrlSubstring: 'bat.bing.com/bat.js',
+		deniedConsentProbe: {
+			// The queued consent default denies ad storage, so UET must not fire
+			// action beacons (bat.bing.com/action/...) or write _uet* cookies
+			// while consent is denied. The /p/action/{tag}.js request is the
+			// per-tag config script — a resource fetch, not a data beacon — and
+			// is deliberately not a violation.
+			collectUrlSubstrings: ['bat.bing.com/action'],
+			storagePrefixes: ['_uet'],
+		},
 		bootstrapCheck: () =>
 			check(
 				Array.isArray(window.uetq) && window.uetq.length > 0,

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -198,6 +198,18 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				`dataLayer seeded with ${dataLayer.length} entries before load`
 			);
 		},
+		deniedConsentProbe: {
+			// Google Consent Mode's cookieless pings are consent-safe by design;
+			// only real collection endpoints and ad-storage cookies are
+			// violations. Weak until a real container id lands as a repo secret
+			// (placeholder ids 404 before any tag can run).
+			collectUrlSubstrings: [
+				'google-analytics.com/g/collect',
+				'analytics.google.com/g/collect',
+				'doubleclick.net',
+			],
+			storagePrefixes: ['_ga', '_gid', '_gcl'],
+		},
 		notes:
 			'Placeholder container ids return HTTP 404 from googletagmanager.com; runtime is not asserted.',
 	},
@@ -498,6 +510,17 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				},
 			}),
 		loaderUrlSubstring: 'cdn.mxpnl.com/libs/mixpanel-2-latest.min.js',
+		deniedConsentProbe: {
+			// Denied consent replays opt_out_tracking through the queue, and the
+			// probe's initOptions set opt_out_tracking_by_default so the SDK
+			// never persists before that call lands — the configuration our docs
+			// recommend for alwaysLoad usage. The live SDK must produce zero
+			// collection traffic and no mp_* storage. Mixpanel's
+			// __mp_opt_in_out_* opt-out marker is legitimate consent-state
+			// storage and intentionally not a violation prefix.
+			collectUrlSubstrings: ['api-js.mixpanel.com', 'api.mixpanel.com'],
+			storagePrefixes: ['mp_'],
+		},
 		bootstrapCheck: () => {
 			const mixpanel = window.mixpanel;
 


### PR DESCRIPTION
Closes #914. Stacked on #913 (Heap) — continues the monitor/integration stack.

## Summary

The live vendor monitor previously skipped the consent phase for `alwaysLoad` vendors with "manages consent internally; not asserted". That left our riskiest trust assumption unverified: GTM and Mixpanel run for **every** visitor, including users who denied consent.

The consent phase now runs a **denied-consent egress assertion** for these vendors in an isolated browser context (so warmed caches never contaminate the granted-consent probe):

1. Load the vendor with denied consent through the production script loader
2. Let the real SDK initialize and attempt collection (4s quiet window)
3. Assert **zero requests to the vendor's collection endpoints** — a blocked attempt is still a violation, the attempt proves intent
4. Assert **zero vendor cookies/localStorage** (per-vendor prefixes; consent-state markers like Mixpanel's `__mp_opt_in_out_*` are legitimate and excluded)

Consent-safe traffic is excluded via explicit per-vendor allow/violation lists — Google Consent Mode's cookieless pings are safe by design, so GTM's violation list names real collection endpoints (`/g/collect`, doubleclick) and ad-storage cookies (`_ga*`, `_gcl*`) only.

### Live-verified

- **mixpanel-analytics** ✅ — the real SDK initializes under denied consent, the queued `opt_out_tracking` replays (with `opt_out_tracking_by_default` in init options, the configuration our docs recommend for alwaysLoad usage), and the probe observes zero collection requests and clean storage
- **google-tag-manager** ✅ — wired but weak until a real container id lands as a repo secret (placeholder ids 404 before tags can run)
- **posthog** keeps its gating check (probe uses `after-consent` mode); default-mode cookieless-on-reject capture is documented vendor behavior, not a violation

This is the safety prerequisite for pre-consent CDP modes (#915, next PR): "loads inert before consent" becomes a daily-verified claim.

## Test plan

- [x] `bun run --filter @c15t/scripts test` — 282 tests / 67 files (pure evaluator unit-tested)
- [x] `check-types` / `lint` — clean
- [x] Live probes: mixpanel-analytics, google-tag-manager, posthog all ✅ with the new phase active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added denied-consent egress checks for always-loaded vendors, ensuring no prohibited collection requests occur and that vendor cookies/localStorage are not written.
  * Enhanced live vendor probing to inspect browser storage during the consent phase.
  * Enabled denied-consent expectations for Google Tag Manager and Mixpanel Analytics.
* **Bug Fixes**
  * Improved consent-phase failure details to surface which requests and storage items were detected.
* **Documentation**
  * Updated probe documentation for the consent-denied behavior of alwaysLoad vendors.
* **Tests**
  * Added automated coverage for denied-consent evaluation and for always-load vendor configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->