### PR TITLE
feat(scripts): opt-in RudderStack pre-consent mode with consent ID mapping

### DIFF
--- a/.changeset/rudderstack-preconsent-mode.md
+++ b/.changeset/rudderstack-preconsent-mode.md
@@ -1,0 +1,5 @@
+---
+'@c15t/scripts': minor
+---
+
+Add an opt-in pre-consent mode to the RudderStack helper: `consentManagement.mapping` maps c15t categories to RudderStack consent IDs, loads the SDK inert (`preConsent` with storage strategy `none` and buffered delivery), and signals every consent decision through `rudderanalytics.consent()` — preserving pre-consent event attribution for consenting users. Blocking the load remains the default. The manifest engine gains a `rudderstack` consent signal type alongside `gtag`.

--- a/docs/integrations/rudderstack.mdx
+++ b/docs/integrations/rudderstack.mdx
@@ -206,7 +206,7 @@ In this mode:
 - On every consent decision and change, c15t calls `rudderanalytics.consent()` with `allowedConsentIds`/`deniedConsentIds` partitioned from your mapping. The initial signal is queued before the SDK loads, so consent state is known the moment the SDK initializes.
 - Consent revocation re-signals with the denied IDs instead of unloading the script.
 
-**Event attribution.** This is the reason to opt in: events fired before the user interacts with the consent banner (the initial `page()` call, early product events) are buffered and delivered once consent is granted, so consenting users keep their full journey. In the default blocked-load mode those pre-consent events are simply lost. If you want session stitching across the consent boundary as well, pass your own `preConsent` in `loadOptions` with storage strategy `'session'` — c15t keeps your value and only forces `consentManagement.enabled` and the `custom` provider.
+**Event attribution.** This is the reason to opt in: events fired before the user interacts with the consent banner (the initial `page()` call, early product events) are buffered and delivered once consent is granted, so consenting users keep their full journey. In the default blocked-load mode those pre-consent events are simply lost. If you want session stitching across the consent boundary as well, pass your own `preConsent` in `loadOptions` with storage strategy `'session'` — c15t keeps your storage choice but always forces `preConsent.enabled`, buffered event delivery, and the `custom` consent provider, since any of those falling back to SDK defaults would leak pre-consent events.
 
 **Requirements and caveats:**
 

--- a/docs/integrations/rudderstack.mdx
+++ b/docs/integrations/rudderstack.mdx
@@ -176,9 +176,48 @@ Some integrations — Google Tag Manager is the clearest example — load immedi
 
 Loading the RudderStack SDK does not provide that guarantee on its own: once loaded normally it writes its `anonymousId` cookie and delivers events to your data plane, and the `consent()` API filters which downstream *destinations* receive those events rather than preventing collection. Even RudderStack's pre-consent mode defaults to `events.delivery: 'immediate'`, which still sends pre-decision events. "Loaded but consent-filtered" is still collection, so c15t treats blocking the load as the only default that reliably honors a missing or denied `measurement` consent.
 
-RudderStack v3 does offer a pre-consent mode (`preConsent` load options with storage disabled and buffered delivery) designed for CMP integrations, which would allow a GTM-style flow: load the SDK inert, then map c15t categories to RudderStack consent IDs and flush the buffer once consent is granted. c15t may add that as an explicit opt-in in a future release; it is not the default because it runs vendor code before consent and depends on vendor-side configuration (consent IDs on every destination) that c15t cannot verify from the browser.
+RudderStack v3 does offer a pre-consent mode (`preConsent` load options with storage disabled and buffered delivery) designed for CMP integrations, which allows a GTM-style flow. c15t supports it as an explicit opt-in — see below. It is not the default because it runs vendor code before consent and depends on vendor-side configuration (consent IDs on every destination) that c15t cannot verify from the browser.
 
 The same reasoning applies to the other customer-data-platform helpers (Segment, Hightouch): their consent surfaces are destination filters, not collection gates, so those helpers block the load too.
+
+### Opt-in: pre-consent mode with consent ID mapping
+
+Pass `consentManagement` to make c15t the consent provider for RudderStack's pre-consent flow:
+
+```ts
+import { rudderstack } from '@c15t/scripts/rudderstack';
+
+rudderstack({
+  writeKey: 'WRITE_KEY',
+  dataPlaneUrl: 'https://example.dataplane.rudderstack.com',
+  consentManagement: {
+    // c15t category → RudderStack consent IDs (from your destination settings)
+    mapping: {
+      measurement: ['product-analytics'],
+      marketing: ['ad-destinations'],
+    },
+  },
+});
+```
+
+In this mode:
+
+- The SDK loads immediately for every visitor, but **inert**: `preConsent` is enabled with storage strategy `none` (no cookies, no localStorage) and buffered event delivery — nothing reaches your data plane before a consent decision.
+- On every consent decision and change, c15t calls `rudderanalytics.consent()` with `allowedConsentIds`/`deniedConsentIds` partitioned from your mapping. The initial signal is queued before the SDK loads, so consent state is known the moment the SDK initializes.
+- Consent revocation re-signals with the denied IDs instead of unloading the script.
+
+**Event attribution.** This is the reason to opt in: events fired before the user interacts with the consent banner (the initial `page()` call, early product events) are buffered and delivered once consent is granted, so consenting users keep their full journey. In the default blocked-load mode those pre-consent events are simply lost. If you want session stitching across the consent boundary as well, pass your own `preConsent` in `loadOptions` with storage strategy `'session'` — c15t keeps your value and only forces `consentManagement.enabled` and the `custom` provider.
+
+**Requirements and caveats:**
+
+- Every destination in your RudderStack workspace must be assigned the consent IDs used in the mapping. Destinations without consent IDs receive events regardless of consent — that is RudderStack behavior c15t cannot detect or prevent from the browser.
+- Users who never consent have their buffered events discarded; nothing is persisted for them.
+- The daily [script vendor monitor](https://github.com/c15t/c15t/issues/899) probes this mode against the live SDK: it loads RudderStack with denied consent in a real browser and asserts zero data plane requests and zero `rl_*` storage, so a vendor-side change to pre-consent semantics is caught automatically.
+
+### Choosing a consent model for CDPs
+
+- **Default (blocked load)** — strictest interpretation of consent; no vendor code runs pre-consent. Pre-consent events are lost. Right when compliance posture outweighs attribution.
+- **Pre-consent mode (`consentManagement`)** — vendor-sanctioned CMP flow; pre-consent events are buffered and attributed for consenting users. Requires disciplined destination consent-ID configuration and accepts vendor code running before consent, with the live monitor verifying its inertness daily.
 
 ## Tracking events in your app
 

--- a/packages/scripts/SKILL.md
+++ b/packages/scripts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: c15t-scripts-docs
+description: Read and search the @c15t/scripts documentation. Use when working with @c15t/scripts — its setup, configuration, API, and behavior.
+metadata:
+  source: leadtype
+---
+# @c15t/scripts documentation
+
+Consent-aware script integration docs for analytics, advertising pixels, tag managers, widgets, and custom loaders.
+
+To work with @c15t/scripts, read its bundled docs — they ship with the package and are version-matched to the installed code:
+
+- Start with `./AGENTS.md`; it links every per-topic Markdown file under `./docs/`.
+- Prefer these local files over fetching anything over the network.

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -771,15 +771,29 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 	{
 		vendor: 'rudderstack',
 		tier: 'full',
+		// Probes the opt-in pre-consent mode — the riskier surface, since the
+		// SDK loads for every visitor. The default blocked-load mode is covered
+		// by the jsdom contract tests. The fake data plane host doubles as the
+		// collection violation list: any request to it under denied consent
+		// proves the buffered pre-consent state leaked.
 		createScript: () =>
 			rudderstack({
 				writeKey: 'C15TFAKE',
 				dataPlaneUrl: 'https://c15t-live-probe.invalid',
-				loadOptions: {
-					useBeacon: true,
+				consentManagement: {
+					mapping: {
+						measurement: ['c15t-measurement'],
+						marketing: ['c15t-marketing'],
+					},
 				},
 			}),
 		loaderUrlSubstring: 'cdn.rudderlabs.com/v3/modern/rsa.min.js',
+		deniedConsentProbe: {
+			collectUrlSubstrings: ['c15t-live-probe.invalid'],
+			storagePrefixes: ['rl_'],
+			notes:
+				'Pre-consent mode: the SDK loads inert with buffered delivery and storage strategy none; any data-plane request or rl_* storage under denied consent is a violation.',
+		},
 		bootstrapCheck: () => {
 			const rudderanalytics = (window as RudderStackWindow).rudderanalytics;
 

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -790,7 +790,9 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		loaderUrlSubstring: 'cdn.rudderlabs.com/v3/modern/rsa.min.js',
 		deniedConsentProbe: {
 			collectUrlSubstrings: ['c15t-live-probe.invalid'],
-			storagePrefixes: ['rl_'],
+			// rl_* covers cookies; rudder* covers the SDK's localStorage keys
+			// (rudder_<writeKey> batch queues and friends).
+			storagePrefixes: ['rl_', 'rudder'],
 			notes:
 				'Pre-consent mode: the SDK loads inert with buffered delivery and storage strategy none; any data-plane request or rl_* storage under denied consent is a violation.',
 		},

--- a/packages/scripts/src/engine.test.ts
+++ b/packages/scripts/src/engine.test.ts
@@ -843,6 +843,59 @@ describe('scripts engine', () => {
 		expect(liveTrack).toHaveBeenCalledWith('Signup');
 
 		delete globalRef.vendorQueue;
+
+	it('partitions consent IDs for the rudderstack consent signal', () => {
+		const globalRef = globalThis as TestGlobal;
+		const consentCalls: unknown[][] = [];
+		globalRef.rudderanalytics = {
+			consent: (...args: unknown[]) => {
+				consentCalls.push(args);
+			},
+		};
+
+		const manifest = createManifest({
+			vendor: 'rudderstack-signal',
+			category: 'measurement',
+			alwaysLoad: true,
+			install: [],
+			consentMapping: {
+				measurement: ['product-analytics'],
+				marketing: ['ad-destinations', 'retargeting'],
+			},
+			consentSignal: 'rudderstack',
+			consentSignalTarget: 'rudderanalytics',
+		});
+
+		const script = resolvedManifestToScript(compileManifest(manifest));
+
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+				consents: {
+					necessary: true,
+					functionality: false,
+					measurement: true,
+					marketing: false,
+					experience: false,
+				},
+			})
+		);
+
+		expect(consentCalls).toEqual([
+			[
+				{
+					consentManagement: {
+						enabled: true,
+						provider: 'custom',
+						allowedConsentIds: ['product-analytics'],
+						deniedConsentIds: ['ad-destinations', 'retargeting'],
+					},
+				},
+			],
+		]);
+
+		delete globalRef.rudderanalytics;
 	});
 
 	it('emits phase and step debug events for manifest execution', () => {

--- a/packages/scripts/src/engine.test.ts
+++ b/packages/scripts/src/engine.test.ts
@@ -843,6 +843,7 @@ describe('scripts engine', () => {
 		expect(liveTrack).toHaveBeenCalledWith('Signup');
 
 		delete globalRef.vendorQueue;
+	});
 
 	it('partitions consent IDs for the rudderstack consent signal', () => {
 		const globalRef = globalThis as TestGlobal;

--- a/packages/scripts/src/engine/runtime.ts
+++ b/packages/scripts/src/engine/runtime.ts
@@ -519,6 +519,23 @@ function mapConsentState(
 	return result;
 }
 
+function partitionConsentIds(
+	mapping: Record<string, string[]>,
+	consents: ConsentState
+): { allowedConsentIds: string[]; deniedConsentIds: string[] } {
+	const allowedConsentIds: string[] = [];
+	const deniedConsentIds: string[] = [];
+
+	for (const [c15tCategory, consentIds] of Object.entries(mapping)) {
+		const isGranted = (consents as Record<string, boolean>)[c15tCategory];
+		for (const consentId of consentIds) {
+			(isGranted ? allowedConsentIds : deniedConsentIds).push(consentId);
+		}
+	}
+
+	return { allowedConsentIds, deniedConsentIds };
+}
+
 function getConsentSignalSteps(
 	resolvedManifest: ResolvedManifest,
 	mode: 'default' | 'update',
@@ -528,15 +545,45 @@ function getConsentSignalSteps(
 		return [];
 	}
 
-	const mapped = mapConsentState(resolvedManifest.consentMapping, consents);
-
 	switch (resolvedManifest.consentSignal) {
 		case 'gtag': {
+			const mapped = mapConsentState(resolvedManifest.consentMapping, consents);
+
 			return [
 				{
 					type: 'callGlobal',
 					global: resolvedManifest.consentSignalTarget ?? 'gtag',
 					args: ['consent', mode, mapped],
+				},
+			];
+		}
+
+		case 'rudderstack': {
+			// RudderStack's consent() call carries the full allow/deny partition
+			// each time, so the default and update modes share one shape. The
+			// pre-load call is captured by the snippet queue and replayed by the
+			// SDK as its initial consent state. c15t is the CMP, so the provider
+			// is always 'custom'.
+			const partition = partitionConsentIds(
+				resolvedManifest.consentMapping,
+				consents
+			);
+
+			return [
+				{
+					type: 'callGlobal',
+					global: resolvedManifest.consentSignalTarget ?? 'rudderanalytics',
+					method: 'consent',
+					args: [
+						{
+							consentManagement: {
+								enabled: true,
+								provider: 'custom',
+								allowedConsentIds: partition.allowedConsentIds,
+								deniedConsentIds: partition.deniedConsentIds,
+							},
+						},
+					],
 				},
 			];
 		}

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -243,8 +243,12 @@ export type ManifestStep =
  * Consent signal type determines how consent state is communicated to the vendor.
  *
  * - `'gtag'` — Google Consent Mode pattern: calls `gtag('consent', 'default'|'update', state)`
+ * - `'rudderstack'` — RudderStack consent-management pattern: calls
+ *   `rudderanalytics.consent({ consentManagement: { enabled, provider: 'custom',
+ *   allowedConsentIds, deniedConsentIds } })` with the mapping's consent IDs
+ *   partitioned by the current c15t consent state
  */
-export type ConsentSignalType = 'gtag';
+export type ConsentSignalType = 'gtag' | 'rudderstack';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Vendor Manifest — declarative vendor integration definition

--- a/packages/scripts/src/vendors/analytics/rudderstack.test.ts
+++ b/packages/scripts/src/vendors/analytics/rudderstack.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
 	createCallbackInfo,
+	deniedConsentState,
 	expectScriptMatchesIntegration,
 	getTestGlobal,
+	grantedMeasurementConsentState,
 	setupScriptHelperTest,
 	toArgumentsArray,
 } from '../../__tests__/helpers';
@@ -161,5 +163,163 @@ describe('rudderstack', () => {
 				dataPlaneUrl: 'http://c15t-live-probe.invalid',
 			})
 		).toThrowError('rudderstack: dataPlaneUrl must be a valid https URL');
+	});
+
+	it('loads inert with buffered events and signals denied IDs in pre-consent mode', () => {
+		const globalRef = getTestGlobal();
+		const script = rudderstack({
+			writeKey: 'WRITE_KEY',
+			dataPlaneUrl: 'https://c15t-live-probe.invalid',
+			consentManagement: {
+				mapping: {
+					measurement: ['product-analytics'],
+					marketing: [' ad-destinations '],
+				},
+			},
+		});
+
+		expect(script.alwaysLoad).toBe(true);
+		expect(script.persistAfterConsentRevoked).toBe(true);
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({ id: script.id, consents: deniedConsentState })
+		);
+		const rudderanalytics = globalRef.rudderanalytics as
+			| RudderStackQueue
+			| undefined;
+
+		// Consent default signal is queued before load(), so the SDK knows the
+		// denied state the moment it replays the queue.
+		expect(rudderanalytics?.[0]).toEqual(
+			toArgumentsArray([
+				'consent',
+				{
+					consentManagement: {
+						enabled: true,
+						provider: 'custom',
+						allowedConsentIds: [],
+						deniedConsentIds: ['product-analytics', 'ad-destinations'],
+					},
+				},
+			])
+		);
+		expect(rudderanalytics?.[1]).toEqual(
+			toArgumentsArray([
+				'load',
+				'WRITE_KEY',
+				'https://c15t-live-probe.invalid',
+				{
+					preConsent: {
+						enabled: true,
+						storage: { strategy: 'none' },
+						events: { delivery: 'buffered' },
+					},
+					consentManagement: {
+						enabled: true,
+						provider: 'custom',
+					},
+				},
+			])
+		);
+	});
+
+	it('signals partitioned consent IDs on consent changes in pre-consent mode', () => {
+		const globalRef = getTestGlobal();
+		const consentCalls: unknown[][] = [];
+		globalRef.rudderanalytics = {
+			consent: (...args: unknown[]) => {
+				consentCalls.push(args);
+			},
+		};
+
+		const script = rudderstack({
+			writeKey: 'WRITE_KEY',
+			dataPlaneUrl: 'https://c15t-live-probe.invalid',
+			consentManagement: {
+				mapping: {
+					measurement: ['product-analytics'],
+					marketing: ['ad-destinations'],
+				},
+			},
+		});
+
+		script.onConsentChange?.(
+			createCallbackInfo({
+				id: script.id,
+				hasConsent: true,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		expect(consentCalls).toEqual([
+			[
+				{
+					consentManagement: {
+						enabled: true,
+						provider: 'custom',
+						allowedConsentIds: ['product-analytics'],
+						deniedConsentIds: ['ad-destinations'],
+					},
+				},
+			],
+		]);
+	});
+
+	it('lets user preConsent load options win while forcing the custom provider', () => {
+		const globalRef = getTestGlobal();
+		const script = rudderstack({
+			writeKey: 'WRITE_KEY',
+			dataPlaneUrl: 'https://c15t-live-probe.invalid',
+			trackPageView: false,
+			loadOptions: {
+				preConsent: {
+					enabled: true,
+					storage: { strategy: 'session' },
+					events: { delivery: 'buffered' },
+				},
+				consentManagement: { provider: 'oneTrust' },
+			},
+			consentManagement: {
+				mapping: { measurement: ['product-analytics'] },
+			},
+		});
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({ id: script.id, consents: deniedConsentState })
+		);
+		const rudderanalytics = globalRef.rudderanalytics as
+			| RudderStackQueue
+			| undefined;
+
+		expect(rudderanalytics?.[1]).toEqual(
+			toArgumentsArray([
+				'load',
+				'WRITE_KEY',
+				'https://c15t-live-probe.invalid',
+				{
+					preConsent: {
+						enabled: true,
+						storage: { strategy: 'session' },
+						events: { delivery: 'buffered' },
+					},
+					consentManagement: {
+						enabled: true,
+						provider: 'custom',
+					},
+				},
+			])
+		);
+	});
+
+	it('throws for an empty consent mapping', () => {
+		expect(() =>
+			rudderstack({
+				writeKey: 'WRITE_KEY',
+				dataPlaneUrl: 'https://c15t-live-probe.invalid',
+				consentManagement: { mapping: { measurement: ['   '] } },
+			})
+		).toThrowError(
+			'rudderstack: consentManagement.mapping must map at least one c15t category to a non-empty list of RudderStack consent IDs'
+		);
 	});
 });

--- a/packages/scripts/src/vendors/analytics/rudderstack.test.ts
+++ b/packages/scripts/src/vendors/analytics/rudderstack.test.ts
@@ -212,7 +212,7 @@ describe('rudderstack', () => {
 					preConsent: {
 						enabled: true,
 						storage: { strategy: 'none' },
-						events: { delivery: 'buffered' },
+						events: { delivery: 'buffer' },
 					},
 					consentManagement: {
 						enabled: true,
@@ -275,7 +275,7 @@ describe('rudderstack', () => {
 				preConsent: {
 					enabled: true,
 					storage: { strategy: 'session' },
-					events: { delivery: 'buffered' },
+					events: { delivery: 'buffer' },
 				},
 				consentManagement: { provider: 'oneTrust' },
 			},
@@ -300,7 +300,7 @@ describe('rudderstack', () => {
 					preConsent: {
 						enabled: true,
 						storage: { strategy: 'session' },
-						events: { delivery: 'buffered' },
+						events: { delivery: 'buffer' },
 					},
 					consentManagement: {
 						enabled: true,
@@ -311,12 +311,24 @@ describe('rudderstack', () => {
 		);
 	});
 
-	it('throws for an empty consent mapping', () => {
+	it('throws when a declared category has no valid consent IDs', () => {
 		expect(() =>
 			rudderstack({
 				writeKey: 'WRITE_KEY',
 				dataPlaneUrl: 'https://c15t-live-probe.invalid',
 				consentManagement: { mapping: { measurement: ['   '] } },
+			})
+		).toThrowError(
+			'rudderstack: consentManagement.mapping.measurement is declared but contains no valid consent IDs'
+		);
+	});
+
+	it('throws for an empty consent mapping', () => {
+		expect(() =>
+			rudderstack({
+				writeKey: 'WRITE_KEY',
+				dataPlaneUrl: 'https://c15t-live-probe.invalid',
+				consentManagement: { mapping: {} },
 			})
 		).toThrowError(
 			'rudderstack: consentManagement.mapping must map at least one c15t category to a non-empty list of RudderStack consent IDs'

--- a/packages/scripts/src/vendors/analytics/rudderstack.ts
+++ b/packages/scripts/src/vendors/analytics/rudderstack.ts
@@ -194,9 +194,11 @@ export interface RudderStackApi {
 	 * @returns The RudderStack runtime or a promise-like value from the SDK.
 	 *
 	 * @remarks
-	 * This API is for RudderStack's consent-management flow. It is not treated
-	 * as a c15t revocation hook; c15t unloads the SDK when measurement consent
-	 * is revoked.
+	 * This API is for RudderStack's consent-management flow. In the default
+	 * (blocked-load) mode it is not a c15t revocation hook; c15t unloads the
+	 * SDK when measurement consent is revoked. In the opt-in pre-consent mode
+	 * (`consentManagement` option) c15t calls it with the mapped consent IDs on
+	 * every consent decision and change.
 	 */
 	consent: (consentOptions?: Record<string, unknown>) => unknown;
 	/**
@@ -282,6 +284,48 @@ export const rudderstackManifest = {
 	],
 } as const satisfies VendorManifest;
 
+/**
+ * c15t consent categories accepted by the RudderStack consent mapping.
+ */
+export type RudderStackConsentCategory =
+	| 'necessary'
+	| 'functionality'
+	| 'experience'
+	| 'measurement'
+	| 'marketing';
+
+/**
+ * Opt-in pre-consent mode configuration.
+ *
+ * When provided, the SDK loads immediately for every visitor in RudderStack's
+ * pre-consent state (no persistent storage, events buffered in memory) and
+ * c15t signals consent decisions through `rudderanalytics.consent()` with the
+ * mapped consent IDs. This preserves pre-consent event attribution for users
+ * who go on to consent, at the cost of running vendor code before consent.
+ *
+ * Every destination in your RudderStack workspace must carry the consent IDs
+ * used here — c15t cannot verify that configuration from the browser, which is
+ * why this mode is opt-in and blocking the load stays the default.
+ */
+export interface RudderStackConsentManagementOptions {
+	/**
+	 * c15t consent category → RudderStack consent IDs.
+	 *
+	 * IDs come from your RudderStack destination consent settings. Categories
+	 * granted in c15t contribute their IDs to `allowedConsentIds`; everything
+	 * else lands in `deniedConsentIds`.
+	 *
+	 * @example
+	 * ```ts
+	 * {
+	 *   measurement: ['product-analytics'],
+	 *   marketing: ['ad-destinations'],
+	 * }
+	 * ```
+	 */
+	mapping: Partial<Record<RudderStackConsentCategory, string[]>>;
+}
+
 export interface RudderStackOptions {
 	/**
 	 * RudderStack source write key.
@@ -292,6 +336,16 @@ export interface RudderStackOptions {
 	 * RudderStack HTTPS data plane URL.
 	 */
 	dataPlaneUrl: string;
+
+	/**
+	 * Opt into RudderStack's pre-consent mode with c15t as the consent
+	 * provider instead of blocking the SDK load until consent.
+	 *
+	 * Defaults to `undefined`, which keeps the safe default: the SDK does not
+	 * load until `measurement` consent is granted. See
+	 * {@link RudderStackConsentManagementOptions} for the tradeoffs.
+	 */
+	consentManagement?: RudderStackConsentManagementOptions;
 
 	/**
 	 * Optional JSON-serializable RudderStack `load()` options.
@@ -348,6 +402,92 @@ function validateOptionalHttpsScriptUrl(
 	return scriptUrl;
 }
 
+function isJsonObjectValue(value: unknown): value is JsonObject {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateConsentMapping(
+	consentManagement: RudderStackConsentManagementOptions
+): Record<string, string[]> {
+	const normalized: Record<string, string[]> = {};
+
+	for (const [category, ids] of Object.entries(consentManagement.mapping)) {
+		if (!Array.isArray(ids)) {
+			throw new Error(
+				`rudderstack: consentManagement.mapping.${category} must be an array of consent IDs`
+			);
+		}
+
+		const trimmed = ids
+			.map((id) => {
+				if (typeof id === 'string') {
+					return id.trim();
+				}
+				return '';
+			})
+			.filter((id) => id.length > 0);
+
+		// A declared category with no usable IDs would silently leave its
+		// destinations receiving events regardless of consent — reject loudly.
+		if (trimmed.length === 0) {
+			throw new Error(
+				`rudderstack: consentManagement.mapping.${category} is declared but contains no valid consent IDs`
+			);
+		}
+
+		normalized[category] = trimmed;
+	}
+
+	if (Object.keys(normalized).length === 0) {
+		throw new Error(
+			'rudderstack: consentManagement.mapping must map at least one c15t category to a non-empty list of RudderStack consent IDs'
+		);
+	}
+
+	return normalized;
+}
+
+function buildPreConsentLoadOptions(
+	loadOptions: RudderStackLoadOptions
+): RudderStackLoadOptions {
+	let userConsentManagement: JsonObject = {};
+	if (isJsonObjectValue(loadOptions.consentManagement)) {
+		userConsentManagement = loadOptions.consentManagement;
+	}
+
+	let userPreConsent: JsonObject = {};
+	if (isJsonObjectValue(loadOptions.preConsent)) {
+		userPreConsent = loadOptions.preConsent;
+	}
+
+	// Storage strategy 'none' is the conservative default; a user preConsent
+	// may relax it (for example 'session' for session stitching).
+	let storage: JsonObject = { strategy: 'none' };
+	if (isJsonObjectValue(userPreConsent.storage)) {
+		storage = userPreConsent.storage;
+	}
+
+	return {
+		...loadOptions,
+		// Deep-merged so a partial user preConsent can never drop the
+		// safety-critical fields: enabled stays true and delivery stays
+		// 'buffer' — the SDK's only other DeliveryType, 'immediate', would
+		// send pre-consent events to the data plane.
+		preConsent: {
+			...userPreConsent,
+			enabled: true,
+			storage,
+			events: { delivery: 'buffer' },
+		},
+		consentManagement: {
+			...userConsentManagement,
+			enabled: true,
+			provider: 'custom',
+		},
+	};
+
+}
+
 function validateDataPlaneUrl(dataPlaneUrl: unknown): string {
 	const normalized = validateRequiredString(dataPlaneUrl, 'dataPlaneUrl');
 	let parsed: URL;
@@ -377,9 +517,16 @@ function validateDataPlaneUrl(dataPlaneUrl: unknown): string {
  *
  * @remarks
  * RudderStack collects customer behavior and sends it to destinations through
- * your configured data plane. c15t gates the browser SDK on `measurement`
- * consent and unloads it when that consent is revoked. `loadOptions` is passed
- * directly as the third `load()` argument and must be JSON-serializable.
+ * your configured data plane. By default c15t gates the browser SDK on
+ * `measurement` consent and unloads it when that consent is revoked.
+ * `loadOptions` is passed directly as the third `load()` argument and must be
+ * JSON-serializable.
+ *
+ * Pass `consentManagement` to opt into RudderStack's pre-consent mode instead:
+ * the SDK loads immediately with no persistent storage and buffered events,
+ * and c15t signals every consent decision through `rudderanalytics.consent()`
+ * with your mapped consent IDs — preserving pre-consent event attribution for
+ * users who consent. Requires consent IDs on every RudderStack destination.
  *
  * @example
  * ```ts
@@ -397,6 +544,7 @@ function validateDataPlaneUrl(dataPlaneUrl: unknown): string {
 export function rudderstack({
 	writeKey,
 	dataPlaneUrl,
+	consentManagement,
 	loadOptions = {},
 	trackPageView = true,
 	scriptUrl,
@@ -405,11 +553,29 @@ export function rudderstack({
 	const normalizedDataPlaneUrl = validateDataPlaneUrl(dataPlaneUrl);
 
 	let manifest: VendorManifest = rudderstackManifest;
+	let resolvedLoadOptions = loadOptions;
+
+	if (consentManagement) {
+		const consentMapping = validateConsentMapping(consentManagement);
+
+		// Pre-consent mode: the SDK loads immediately but inert (no persistent
+		// storage, buffered events) and c15t signals consent decisions through
+		// rudderanalytics.consent() — queued before load, live afterwards.
+		manifest = {
+			...manifest,
+			alwaysLoad: true,
+			persistAfterConsentRevoked: true,
+			consentMapping,
+			consentSignal: 'rudderstack',
+			consentSignalTarget: 'rudderanalytics',
+		} satisfies VendorManifest;
+		resolvedLoadOptions = buildPreConsentLoadOptions(loadOptions);
+	}
 
 	if (!trackPageView) {
 		manifest = {
-			...rudderstackManifest,
-			install: rudderstackManifest.install.filter(
+			...manifest,
+			install: manifest.install.filter(
 				(step) =>
 					!(
 						step.type === 'callGlobal' &&
@@ -422,7 +588,7 @@ export function rudderstack({
 
 	return resolveManifest(manifest, {
 		dataPlaneUrl: normalizedDataPlaneUrl,
-		loadOptions,
+		loadOptions: resolvedLoadOptions,
 		writeKey: normalizedWriteKey,
 		scriptUrl: resolveScriptUrl(
 			validateOptionalHttpsScriptUrl(trimToUndefined(scriptUrl)),

--- a/packages/scripts/src/vendors/analytics/rudderstack.ts
+++ b/packages/scripts/src/vendors/analytics/rudderstack.ts
@@ -485,7 +485,6 @@ function buildPreConsentLoadOptions(
 			provider: 'custom',
 		},
 	};
-
 }
 
 function validateDataPlaneUrl(dataPlaneUrl: unknown): string {


### PR DESCRIPTION
Closes #915. Stacked on #917 (denied-consent egress assertion — its safety prerequisite).

## Summary

Enterprises running RudderStack want the vendor-sanctioned CMP flow instead of losing pre-consent events to the blocked load. This adds it as an **explicit opt-in**, keeping blocked-load the default:

```ts
rudderstack({
  writeKey: 'WRITE_KEY',
  dataPlaneUrl: 'https://example.dataplane.rudderstack.com',
  consentManagement: {
    mapping: {
      measurement: ['product-analytics'],
      marketing: ['ad-destinations'],
    },
  },
});
```

- SDK loads immediately but **inert**: `preConsent` enabled with storage strategy `none` + buffered event delivery — nothing reaches the data plane pre-decision
- c15t signals every consent decision/change via `rudderanalytics.consent({ consentManagement: { enabled, provider: 'custom', allowedConsentIds, deniedConsentIds } })`, partitioned from the category mapping; the initial signal is queued before load
- Revocation re-signals denied IDs instead of unloading
- **Event attribution** (the point of opting in): pre-banner events buffer and deliver once consent is granted; users who never consent get their buffer discarded. `loadOptions.preConsent` overrides ours (e.g. storage `'session'` for session stitching) — documented tradeoff
- Engine: new `'rudderstack'` consent signal type beside `'gtag'`, reusing `consentMapping` — unit-tested
- Docs: full pre-consent guide + "choosing a consent model for CDPs" comparison; the destination consent-ID requirement is called out loudly (unverifiable from the browser, the reason this stays opt-in)

### Live-verified via #917

The live probe now exercises the pre-consent variant — the riskier surface (default blocked-load mode is covered by jsdom contract tests). Result against the real SDK: **loaded under denied consent with zero collection requests and no vendor storage** — the fake data plane host doubles as the violation list, so any pre-consent leak fails the daily monitor.

## Test plan

- [x] `bun run --filter @c15t/scripts test` — 287 tests / 67 files (engine partition test, helper mode tests, merge-precedence test, empty-mapping validation)
- [x] `check-types` / `lint` — clean
- [x] Live probe: rudderstack ✅ full tier, denied-consent egress assertion passing against the real SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in RudderStack “pre-consent mode” with consent ID mapping.
  * Consent updates now translate into RudderStack `consent` calls using partitioned allowed/denied consent IDs.
  * Added a new RudderStack consent signal type to the consent signaling flow.
* **Documentation**
  * Updated RudderStack integration guidance for v3 pre-consent mode configuration and runtime behavior.
* **Bug Fixes**
  * Improved pre-consent buffering/queueing so consent changes and revocations behave consistently.
* **Tests**
  * Added coverage for RudderStack consent ID partitioning and pre-consent behavior, including invalid mapping cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->