### PR TITLE
fix(build): raise Node heap for leadtype docs generation at the spawn site

### DIFF
--- a/scripts/generate-package-docs.ts
+++ b/scripts/generate-package-docs.ts
@@ -123,6 +123,14 @@ async function runLeadtype(config: PackageDocsConfig) {
 		cwd: ROOT_DIR,
 		stderr: 'inherit',
 		stdout: 'inherit',
+		env: {
+			...process.env,
+			// leadtype's MDX bundling exceeds Node's default heap on the larger
+			// packages (core, react); raise it here so every caller — all CI
+			// workflows and local builds — gets the fix in one place.
+			NODE_OPTIONS:
+				`${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=6144`.trim(),
+		},
 	});
 	const exitCode = await proc.exited;
 	if (exitCode !== 0) {


### PR DESCRIPTION
The script-vendor-monitor's first manual dispatch ([run](https://github.com/c15t/c15t/actions/runs/28842389483)) failed with the same leadtype heap OOM that #908/#909 patched in three workflows via `NODE_OPTIONS` — the monitor workflow was the fourth caller building `packages/core` on a cache miss.

Rather than a fourth per-workflow env copy, this sets `NODE_OPTIONS: --max-old-space-size=6144` where the leadtype child process is spawned (`scripts/generate-package-docs.ts`), fixing every caller at once: all workflows, local builds, and anything added later. Verified locally with an empty `NODE_OPTIONS` and a forced cache-miss core build.

The per-workflow env lines from #908/#909 become redundant but harmless; happy to remove them here or in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation generation process to carry forward the existing environment and apply a higher Node memory limit during builds.
  * This helps larger documentation packages complete more reliably in local and CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->