### PR TITLE
feat(v3): x-c15t-version header on all backend-bound requests

### DIFF
--- a/packages/backend/src/middleware/cors/cors.test.ts
+++ b/packages/backend/src/middleware/cors/cors.test.ts
@@ -32,6 +32,7 @@ describe('createCORSOptions (unit)', () => {
 				'x-request-id',
 				'x-c15t-country',
 				'x-c15t-region',
+				'x-c15t-version',
 				'sec-gpc',
 				'accept-language',
 			]);

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -46,6 +46,7 @@ const SUPPORTED_HEADERS = [
 	'x-request-id',
 	'x-c15t-country',
 	'x-c15t-region',
+	'x-c15t-version',
 	'sec-gpc',
 	'accept-language',
 ] as const;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
 		"directory": "packages/core"
 	},
 	"license": "Apache-2.0",
+	"sideEffects": false,
 	"type": "module",
 	"exports": {
 		".": {
@@ -130,6 +131,5 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	},
-	"sideEffects": false
+	}
 }

--- a/packages/core/src/v3/__tests__/transport.test.ts
+++ b/packages/core/src/v3/__tests__/transport.test.ts
@@ -981,7 +981,7 @@ describe('x-c15t-version header (issue #916)', () => {
 		}
 	});
 
-	test('manifest save carries the client version; manifest fetch does not', async () => {
+	test('manifest fetch and save both carry the client version', async () => {
 		const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
 			const s = String(url);
 			if (s.endsWith('/manifest')) {
@@ -1018,8 +1018,9 @@ describe('x-c15t-version header (issue #916)', () => {
 
 		const manifestHeaders = ((manifestCall?.[1] as RequestInit)?.headers ??
 			{}) as Record<string, string>;
-		// CDN-bound document fetch stays header-clean (third-party CORS).
-		expect(manifestHeaders['x-c15t-version']).toBeUndefined();
+		// The manifest/GVL hosts are c15t/tenant-controlled (IAB requires
+		// self-hosting the GVL), so version telemetry rides here too.
+		expect(manifestHeaders['x-c15t-version']).toMatch(/^\d+\.\d+\.\d+/);
 
 		const saveHeaders = (saveCall?.[1] as RequestInit).headers as Record<
 			string,

--- a/packages/core/src/v3/__tests__/transport.test.ts
+++ b/packages/core/src/v3/__tests__/transport.test.ts
@@ -696,6 +696,8 @@ describe('createHostedTransport: request shape', () => {
 			'sec-gpc': '1',
 			'x-c15t-country': 'DE',
 			'x-c15t-region': 'BE',
+			// Always attached by the transport itself, not consumer-forwarded.
+			'x-c15t-version': expect.stringMatching(/^\d+\.\d+\.\d+/),
 		});
 	});
 
@@ -941,5 +943,88 @@ describe('createManifestTransport: local init resolution', () => {
 		expect(body).not.toHaveProperty('region');
 		expect(body).not.toHaveProperty('language');
 		expect(body).not.toHaveProperty('gpc');
+	});
+});
+
+describe('x-c15t-version header (issue #916)', () => {
+	test('hosted init and save carry the client version', async () => {
+		const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
+			const s = String(url);
+			if (s.endsWith('/init')) {
+				return new Response(JSON.stringify(REALISTIC_INIT_OUTPUT), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
+			}
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		});
+		const kernel = createConsentKernel({
+			transport: createHostedTransport({
+				backendURL: 'https://backend.example',
+				fetch: fetchSpy as unknown as typeof fetch,
+			}),
+		});
+
+		await kernel.commands.init();
+		await kernel.commands.save('all');
+
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		for (const call of fetchSpy.mock.calls) {
+			const headers = (call[1] as RequestInit).headers as Record<
+				string,
+				string
+			>;
+			expect(headers['x-c15t-version']).toMatch(/^\d+\.\d+\.\d+/);
+		}
+	});
+
+	test('manifest save carries the client version; manifest fetch does not', async () => {
+		const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
+			const s = String(url);
+			if (s.endsWith('/manifest')) {
+				return new Response(JSON.stringify(MANIFEST_FIXTURE), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				});
+			}
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		});
+		const kernel = createConsentKernel({
+			transport: createManifestTransport({
+				backendURL: 'https://backend.example',
+				manifestURL: 'https://cdn.example/manifest',
+				inputs: { country: 'DE', region: 'BE', language: 'de' },
+				fetch: fetchSpy as unknown as typeof fetch,
+			}),
+		});
+
+		await kernel.commands.init();
+		await kernel.commands.save('all');
+
+		const manifestCall = fetchSpy.mock.calls.find((c) =>
+			String(c[0]).endsWith('/manifest')
+		);
+		const saveCall = fetchSpy.mock.calls.find((c) =>
+			String(c[0]).endsWith('/subjects')
+		);
+		expect(manifestCall).toBeDefined();
+		expect(saveCall).toBeDefined();
+
+		const manifestHeaders = ((manifestCall?.[1] as RequestInit)?.headers ??
+			{}) as Record<string, string>;
+		// CDN-bound document fetch stays header-clean (third-party CORS).
+		expect(manifestHeaders['x-c15t-version']).toBeUndefined();
+
+		const saveHeaders = (saveCall?.[1] as RequestInit).headers as Record<
+			string,
+			string
+		>;
+		expect(saveHeaders['x-c15t-version']).toMatch(/^\d+\.\d+\.\d+/);
 	});
 });

--- a/packages/core/src/v3/index.ts
+++ b/packages/core/src/v3/index.ts
@@ -56,6 +56,10 @@ export { createManifestTransport } from './transports/manifest';
 export type { OfflineTransportOptions } from './transports/offline';
 export { createOfflineTransport } from './transports/offline';
 export { buildSubjectPostBody } from './transports/subject-body';
+export {
+	C15T_VERSION_HEADER,
+	c15tVersionHeaders,
+} from './transports/version-header';
 export type {
 	ConsentKernel,
 	ConsentSnapshot,

--- a/packages/core/src/v3/transports/hosted.ts
+++ b/packages/core/src/v3/transports/hosted.ts
@@ -34,6 +34,7 @@ import type {
 } from '../types';
 import { mapInitOutputToInitResponse } from './init-output';
 import { buildSubjectPostBody } from './subject-body';
+import { c15tVersionHeaders } from './version-header';
 
 export interface HostedTransportOptions {
 	/**
@@ -143,6 +144,7 @@ export function createHostedTransport(
 				credentials,
 				headers: {
 					accept: 'application/json',
+					...c15tVersionHeaders,
 					...initHeaders,
 				},
 			});
@@ -164,6 +166,7 @@ export function createHostedTransport(
 				headers: {
 					'content-type': 'application/json',
 					accept: 'application/json',
+					...c15tVersionHeaders,
 				},
 				body: JSON.stringify(buildSubjectPostBody(payload, { domain })),
 			});

--- a/packages/core/src/v3/transports/index.ts
+++ b/packages/core/src/v3/transports/index.ts
@@ -29,3 +29,7 @@ export { createManifestTransport } from './manifest';
 export type { OfflineTransportOptions } from './offline';
 export { createOfflineTransport } from './offline';
 export { buildSubjectPostBody } from './subject-body';
+export {
+	C15T_VERSION_HEADER,
+	c15tVersionHeaders,
+} from './version-header';

--- a/packages/core/src/v3/transports/manifest.ts
+++ b/packages/core/src/v3/transports/manifest.ts
@@ -172,6 +172,7 @@ async function defaultFetchGvl(input: {
 		method: 'GET',
 		headers: {
 			'accept-language': input.language,
+			...c15tVersionHeaders,
 		},
 	});
 
@@ -235,6 +236,7 @@ export function createManifestTransport(
 					credentials,
 					headers: {
 						accept: 'application/json',
+						...c15tVersionHeaders,
 						...options.headers,
 					},
 				});

--- a/packages/core/src/v3/transports/manifest.ts
+++ b/packages/core/src/v3/transports/manifest.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types';
 import { mapInitOutputToInitResponse } from './init-output';
 import { buildSubjectPostBody } from './subject-body';
+import { c15tVersionHeaders } from './version-header';
 
 export interface ManifestTransportOptions {
 	/**
@@ -283,6 +284,7 @@ export function createManifestTransport(
 				headers: {
 					'content-type': 'application/json',
 					accept: 'application/json',
+					...c15tVersionHeaders,
 				},
 				body: JSON.stringify({
 					...buildSubjectPostBody(payload, { domain }),

--- a/packages/core/src/v3/transports/version-header.ts
+++ b/packages/core/src/v3/transports/version-header.ts
@@ -1,0 +1,25 @@
+/**
+ * `x-c15t-version` — client-version header on every c15t-backend-bound
+ * request (issue #916). Lets the backend attribute traffic to a client
+ * version for telemetry and compatibility gating.
+ *
+ * Scope: requests to the c15t BACKEND only (hosted `/init` + `/subjects`,
+ * manifest-mode `/subjects`). Deliberately NOT attached to manifest/GVL
+ * document fetches — those may target third-party CDNs whose CORS policy
+ * won't allow an unexpected custom header, and the backend can't read
+ * telemetry from a CDN hit anyway.
+ *
+ * CORS note: the backend allowlists this header (`SUPPORTED_HEADERS` in
+ * @c15t/backend cors middleware). On cross-origin hosted mode this turns
+ * the otherwise-simple `/init` GET into a preflighted request — one extra
+ * OPTIONS roundtrip per origin per `maxAge` window (600s). Same-origin and
+ * manifest modes are unaffected.
+ */
+import { version } from '../../version';
+
+export const C15T_VERSION_HEADER = 'x-c15t-version';
+
+/** Header record to spread into backend-bound request headers. */
+export const c15tVersionHeaders: Readonly<Record<string, string>> = {
+	[C15T_VERSION_HEADER]: version,
+};

--- a/packages/core/src/v3/transports/version-header.ts
+++ b/packages/core/src/v3/transports/version-header.ts
@@ -3,11 +3,12 @@
  * request (issue #916). Lets the backend attribute traffic to a client
  * version for telemetry and compatibility gating.
  *
- * Scope: requests to the c15t BACKEND only (hosted `/init` + `/subjects`,
- * manifest-mode `/subjects`). Deliberately NOT attached to manifest/GVL
- * document fetches — those may target third-party CDNs whose CORS policy
- * won't allow an unexpected custom header, and the backend can't read
- * telemetry from a CDN hit anyway.
+ * Scope: every c15t-bound request — hosted `/init` + `/subjects`,
+ * manifest-mode `/subjects`, the manifest document fetch, the GVL fetch,
+ * and the Next/Nuxt server proxies' upstream manifest calls. The manifest
+ * and GVL hosts are c15t/tenant-controlled infrastructure (IAB TCF policy
+ * requires CMPs to self-host the GVL rather than hotlink IAB's), so the
+ * header is safe and version-gated manifest serving stays possible.
  *
  * CORS note: the backend allowlists this header (`SUPPORTED_HEADERS` in
  * @c15t/backend cors middleware). On cross-origin hosted mode this turns

--- a/packages/nextjs/src/v3/api.ts
+++ b/packages/nextjs/src/v3/api.ts
@@ -5,6 +5,7 @@ import type {
 	InitOutput,
 } from '@c15t/schema/types';
 import { resolveBackendURL, resolveInitFromManifest } from '@c15t/schema/types';
+import { c15tVersionHeaders } from 'c15t/v3';
 import { extractConsentRequestInputs } from './headers';
 
 const DEFAULT_MANIFEST_REVALIDATE_SECONDS = 300;
@@ -156,7 +157,7 @@ export function createManifestFetchInit(
 	const revalidate = getManifestRevalidate(options);
 	return {
 		method: 'GET',
-		headers: { accept: 'application/json' },
+		headers: { accept: 'application/json', ...c15tVersionHeaders },
 		next: { revalidate },
 	};
 }

--- a/packages/svelte/src/__tests__/fixtures/conformance-fixture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/conformance-fixture.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import type { ConsentKernel } from 'c15t/v3';
 import ConsentBanner from '../../lib/components/consent-banner.svelte';
 import ConsentDialog from '../../lib/components/consent-dialog.svelte';
 import ConsentManagerProvider from '../../lib/components/consent-manager-provider.svelte';
 import ConsentWidget from '../../lib/components/consent-widget.svelte';
 import type { ConsentManagerOptions } from '../../lib/types';
-import type { ConsentKernel } from 'c15t/v3';
 import ConformanceKernelCapture from './conformance-kernel-capture.svelte';
 
 type MountableComponent =

--- a/packages/svelte/src/__tests__/fixtures/conformance-kernel-capture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/conformance-kernel-capture.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { getConsentKernel } from '../../lib/context.svelte';
 import type { ConsentKernel } from 'c15t/v3';
+import { getConsentKernel } from '../../lib/context.svelte';
 
 let {
 	onKernel,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -148,9 +148,9 @@
 		"@c15t/vitest-config": "workspace:*",
 		"@rslib/core": "0.20.2",
 		"postcss": "8.5.10",
+		"typed-css-modules": "0.9.1",
 		"typescript": "6.0.2",
-		"vitest": "4.1.2",
-		"typed-css-modules": "0.9.1"
+		"vitest": "4.1.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/ui/src/styles/v3/button.module.css
+++ b/packages/ui/src/styles/v3/button.module.css
@@ -430,7 +430,9 @@
 	}
 
 	/* Secondary aliases for consumers that use semantic variant names. */
-	.button:not(:global(.headless))[data-variant="secondary"][data-mode="filled"] {
+	.button:not(
+			:global(.headless)
+		)[data-variant="secondary"][data-mode="filled"] {
 		background-color: var(--button-neutral);
 		color: var(--button-background-color);
 	}
@@ -466,7 +468,9 @@
 		transition: var(--button-hover-transition-color);
 	}
 
-	.button:not(:global(.headless))[data-variant="secondary"][data-mode="stroke"] {
+	.button:not(
+			:global(.headless)
+		)[data-variant="secondary"][data-mode="stroke"] {
 		background-color: var(--button-background-color);
 		box-shadow: var(--button-shadow-neutral);
 	}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -52,12 +52,12 @@
 	},
 	"dependencies": {
 		"@c15t/schema": "workspace:*",
+		"@c15t/ui": "workspace:*",
 		"@vueuse/core": "^14.3.0",
 		"c15t": "workspace:*",
 		"defu": "^6.1.4",
 		"ufo": "^1.6.1",
-		"vue": "^3.5.13",
-		"@c15t/ui": "workspace:*"
+		"vue": "^3.5.13"
 	},
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",

--- a/packages/vue/src/__tests__/conformance.test.ts
+++ b/packages/vue/src/__tests__/conformance.test.ts
@@ -479,7 +479,8 @@ function createLifecycleTransport(opts: MountOptions) {
 				return {
 					location: init.location,
 					translations: init.translations,
-					branding: init.branding,
+					// InitOutput branding includes 'none'; InitResponse does not.
+					branding: init.branding === 'none' ? undefined : init.branding,
 					policy: init.policy,
 					policyDecision: init.policyDecision,
 					policySnapshotToken: init.policySnapshotToken,

--- a/packages/vue/src/runtime/server/manifest-mode.ts
+++ b/packages/vue/src/runtime/server/manifest-mode.ts
@@ -211,6 +211,13 @@ export function resolveManifestInit(input: {
 	const inputs = getResolverInputsFromHeaders(input.headers);
 	return {
 		...resolveInitFromManifest(input.manifest, inputs),
-		resolvedOverrides: consentInputsToOverrides(inputs),
+		// Resolver inputs use `null` for absent; the overrides record wants
+		// the fields dropped instead.
+		resolvedOverrides: consentInputsToOverrides({
+			country: inputs.country ?? undefined,
+			region: inputs.region ?? undefined,
+			language: inputs.language ?? undefined,
+			gpc: inputs.gpc,
+		}),
 	} as InitOutput;
 }

--- a/packages/vue/src/runtime/server/manifest-mode.ts
+++ b/packages/vue/src/runtime/server/manifest-mode.ts
@@ -8,6 +8,7 @@ import {
 	extractConsentRequestInputs,
 	resolveInitFromManifest,
 } from '@c15t/schema/types';
+import { c15tVersionHeaders } from 'c15t/v3';
 import type { ConsentConfig } from '../config';
 import { DEFAULT_MANIFEST_ROUTE, DEFAULT_NUXT_INIT_ROUTE } from '../manifest';
 
@@ -135,6 +136,7 @@ export async function fetchCachedManifest(input: {
 
 	const headers: Record<string, string> = {
 		accept: 'application/json',
+		...c15tVersionHeaders,
 	};
 	if (cached?.headers.etag) {
 		headers['if-none-match'] = cached.headers.etag;


### PR DESCRIPTION
Part of #916 — **v3 half only. Do not close the issue on merge**: the 2.x fix ships separately (@KayleeWilliams).

## What
Every v3 request to c15t infrastructure now carries `x-c15t-version` with the core package version, attached by the transports/proxies themselves (never consumer-forwardable):
- hosted transport: `GET /init` + `POST /subjects`
- manifest transport: manifest document fetch, GVL reference fetch, `POST /subjects`
- server proxies' upstream manifest calls: `@c15t/nextjs` api routes, `@c15t/vue` Nitro manifest mode

Vue/React/Svelte/Next all build on the core transports, so client-side coverage is structural — no per-framework wiring.

## Why manifest + GVL are included
The manifest endpoint and the GVL host are c15t/tenant-controlled infrastructure — IAB TCF policy requires CMPs to self-host the GVL rather than hotlink IAB's `vendor-list.json` — so version telemetry belongs there too, and it keeps version-gated manifest serving possible later. Pinned by test: manifest fetch and save both carry the header.

## CORS / perf note
Backend `SUPPORTED_HEADERS` now allowlists the header. Cross-origin requests that were previously "simple" (`/init` GET, manifest GET) become preflighted — one extra OPTIONS per origin per `maxAge` window (600s). Same-origin proxy modes (the recommended integrations) are unaffected. Operators serving the manifest from their own CDN must allow the `x-c15t-version` request header in that CDN's CORS config.

## Also in this branch
Two latent Vue typecheck fixes (null-bearing resolver inputs → overrides; conformance driver branding `'none'`) — cherry-picked to `v3` independently as `2b02db2b`, so this branch rebases/merges cleanly.

## Verification
core 872 · backend 527 (CORS test updated) · react 787 · vue 47 (vue-tsc + nuxt typecheck) · svelte 172 · nextjs 39 · `bun run e2e:consent` 10/10 (real Next+Nuxt manifest-SSR apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending an `x-c15t-version` header with backend-bound requests (including hosted init/save and manifest fetch flows).
  * Exposed the `x-c15t-version` header constant and default header set for version-aware integrations.

* **Bug Fixes**
  * Updated CORS configuration to allow `x-c15t-version`, preventing blocked cross-origin requests.
  * Improved manifest resolution behavior when optional fields are missing and aligned conformance output (e.g., `branding: "none"` → `undefined`).
  * Extended tests to verify header propagation across transports and request paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->