### PR TITLE
feat(v3): window.c15t debug object installed on client hydration by every adapter

### DIFF
--- a/.changeset/quiet-windows-debug.md
+++ b/.changeset/quiet-windows-debug.md
@@ -1,0 +1,9 @@
+---
+"c15t": minor
+"@c15t/react": minor
+"@c15t/nextjs": minor
+"@c15t/vue": minor
+"@c15t/svelte": minor
+---
+
+Expose a v3 `window.c15t` debug object from client-side framework adapter mounts with the c15t version, adapter package, and transport mode.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -87,6 +87,11 @@
 			"types": "./dist-types/v3/modules/persistence/index.d.ts",
 			"import": "./dist/v3-persistence.js",
 			"require": "./dist/v3-persistence.cjs"
+		},
+		"./v3/modules/window-debug": {
+			"types": "./dist-types/v3/modules/window-debug/index.d.ts",
+			"import": "./dist/v3-window-debug.js",
+			"require": "./dist/v3-window-debug.cjs"
 		}
 	},
 	"main": "dist/index.cjs",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 			'v3-network-blocker': ['./src/v3/modules/network-blocker/index.ts'],
 			'v3-iframe-blocker': ['./src/v3/modules/iframe-blocker/index.ts'],
 			'v3-persistence': ['./src/v3/modules/persistence/index.ts'],
+			'v3-window-debug': ['./src/v3/modules/window-debug/index.ts'],
 		},
 		exclude: [
 			'**/__tests__/**',

--- a/packages/core/src/v3/index.ts
+++ b/packages/core/src/v3/index.ts
@@ -46,9 +46,13 @@ export type {
 	C15tWindowDebug,
 	WindowDebugHandle,
 	WindowDebugMode,
+	WindowDebugModeInput,
 	WindowDebugOptions,
 } from './modules/window-debug';
-export { createWindowDebug } from './modules/window-debug';
+export {
+	createWindowDebug,
+	resolveWindowDebugMode,
+} from './modules/window-debug';
 export type { HostedTransportOptions } from './transports/hosted';
 export { createHostedTransport } from './transports/hosted';
 export {

--- a/packages/core/src/v3/index.ts
+++ b/packages/core/src/v3/index.ts
@@ -42,6 +42,13 @@ export {
 	generateSubjectId,
 	isValidSubjectId,
 } from './libs/generate-subject-id';
+export type {
+	C15tWindowDebug,
+	WindowDebugHandle,
+	WindowDebugMode,
+	WindowDebugOptions,
+} from './modules/window-debug';
+export { createWindowDebug } from './modules/window-debug';
 export type { HostedTransportOptions } from './transports/hosted';
 export { createHostedTransport } from './transports/hosted';
 export {

--- a/packages/core/src/v3/modules/window-debug/__tests__/window-debug.test.ts
+++ b/packages/core/src/v3/modules/window-debug/__tests__/window-debug.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { version } from '../../../../version';
-import { createWindowDebug } from '../index';
+import { createWindowDebug, resolveWindowDebugMode } from '../index';
 
 type WindowWithC15t = Window & {
 	c15t?: {
@@ -17,6 +17,24 @@ afterEach(() => {
 	if (typeof window !== 'undefined') {
 		delete (window as WindowWithC15t).c15t;
 	}
+});
+
+describe('resolveWindowDebugMode', () => {
+	test('maps provider options to the reported transport kind', () => {
+		expect(resolveWindowDebugMode({})).toBe('offline');
+		expect(resolveWindowDebugMode({ backendURL: '/api/c15t' })).toBe('hosted');
+		expect(resolveWindowDebugMode({ mode: 'hosted' })).toBe('hosted');
+		expect(resolveWindowDebugMode({ mode: 'c15t' })).toBe('hosted');
+		expect(
+			resolveWindowDebugMode({ mode: 'offline', backendURL: '/api/c15t' })
+		).toBe('offline');
+		expect(resolveWindowDebugMode({ transport: {} })).toBe('custom');
+		expect(
+			resolveWindowDebugMode({ mode: 'custom', endpointHandlers: {} })
+		).toBe('custom');
+		// `mode: 'custom'` without handlers falls back to the offline transport.
+		expect(resolveWindowDebugMode({ mode: 'custom' })).toBe('offline');
+	});
 });
 
 describe('window-debug', () => {
@@ -66,6 +84,31 @@ describe('window-debug', () => {
 		expect((window as WindowWithC15t).c15t?.pkg).toBe('@c15t/nextjs');
 
 		second.dispose();
+	});
+
+	test('degrades to an inert handle when window.c15t is non-writable', () => {
+		Object.defineProperty(window, 'c15t', {
+			value: 'host-owned',
+			writable: false,
+			configurable: true,
+		});
+
+		try {
+			let handle: { dispose(): void } | undefined;
+			expect(() => {
+				handle = createWindowDebug({ pkg: '@c15t/vue', mode: 'hosted' });
+			}).not.toThrow();
+			expect((window as WindowWithC15t).c15t).toBe('host-owned');
+			expect(() => handle?.dispose()).not.toThrow();
+			expect((window as WindowWithC15t).c15t).toBe('host-owned');
+		} finally {
+			Object.defineProperty(window, 'c15t', {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			});
+			delete (window as WindowWithC15t).c15t;
+		}
 	});
 
 	test('returns an inert handle when window is undefined', () => {

--- a/packages/core/src/v3/modules/window-debug/__tests__/window-debug.test.ts
+++ b/packages/core/src/v3/modules/window-debug/__tests__/window-debug.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for c15t/v3/modules/window-debug.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { version } from '../../../../version';
+import { createWindowDebug } from '../index';
+
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
+afterEach(() => {
+	if (typeof window !== 'undefined') {
+		delete (window as WindowWithC15t).c15t;
+	}
+});
+
+describe('window-debug', () => {
+	test('installs a frozen window.c15t object with static metadata', () => {
+		const handle = createWindowDebug({
+			pkg: '@c15t/react',
+			mode: 'hosted',
+		});
+
+		const debug = (window as WindowWithC15t).c15t;
+		expect(debug).toBeTruthy();
+		expect(debug).toEqual({
+			version,
+			pkg: '@c15t/react',
+			mode: 'hosted',
+		});
+		expect(Object.isFrozen(debug)).toBe(true);
+
+		handle.dispose();
+	});
+
+	test('dispose removes the installed object', () => {
+		const handle = createWindowDebug({
+			pkg: '@c15t/svelte',
+			mode: 'offline',
+		});
+
+		expect((window as WindowWithC15t).c15t).toBeTruthy();
+		handle.dispose();
+		expect((window as WindowWithC15t).c15t).toBeUndefined();
+	});
+
+	test('dispose does not remove a newer install', () => {
+		const first = createWindowDebug({
+			pkg: '@c15t/react',
+			mode: 'hosted',
+		});
+		const second = createWindowDebug({
+			pkg: '@c15t/nextjs',
+			mode: 'hosted',
+		});
+		const latest = (window as WindowWithC15t).c15t;
+
+		first.dispose();
+
+		expect((window as WindowWithC15t).c15t).toBe(latest);
+		expect((window as WindowWithC15t).c15t?.pkg).toBe('@c15t/nextjs');
+
+		second.dispose();
+	});
+
+	test('returns an inert handle when window is undefined', () => {
+		const previousWindow = (
+			globalThis as typeof globalThis & { window?: Window }
+		).window;
+		vi.stubGlobal('window', undefined);
+		try {
+			const handle = createWindowDebug({
+				pkg: '@c15t/react',
+				mode: 'offline',
+			});
+
+			expect(() => handle.dispose()).not.toThrow();
+		} finally {
+			vi.stubGlobal('window', previousWindow);
+		}
+	});
+});

--- a/packages/core/src/v3/modules/window-debug/index.ts
+++ b/packages/core/src/v3/modules/window-debug/index.ts
@@ -13,6 +13,10 @@
  *
  * Invariants:
  * - Isomorphic-safe: in non-browser environments the handle is inert.
+ * - Best-effort: if a host page defined `window.c15t` as non-writable,
+ *   install/dispose degrade to no-ops instead of throwing — this hook
+ *   must never take the consent provider down with it. Adapters that
+ *   call it synchronously during mount (Vue, Svelte) rely on this.
  * - Last writer wins: mounting a newer provider replaces `window.c15t`.
  * - Dispose is identity-checked so an older handle cannot remove a newer
  *   provider's debug object.
@@ -22,6 +26,8 @@ import { version } from '../../../version';
 import type {
 	C15tWindowDebug,
 	WindowDebugHandle,
+	WindowDebugMode,
+	WindowDebugModeInput,
 	WindowDebugOptions,
 } from './types';
 
@@ -29,8 +35,35 @@ export type {
 	C15tWindowDebug,
 	WindowDebugHandle,
 	WindowDebugMode,
+	WindowDebugModeInput,
 	WindowDebugOptions,
 } from './types';
+
+/**
+ * Resolves the {@link WindowDebugMode} to report for a provider-style
+ * adapter (React, Svelte, Next.js). Shared so adapters cannot drift:
+ * an explicit transport (or `mode: 'custom'` with endpoint handlers)
+ * reports `custom`; `'c15t'` is the hosted platform alias; a
+ * `backendURL` with no explicit mode implies hosted.
+ *
+ * Vue resolves its own mode (`manifest` vs `hosted`) — its config has
+ * no provider-mode concept.
+ *
+ * @param input - The adapter's provider options (structural subset).
+ * @returns The transport kind to report on `window.c15t`.
+ */
+export function resolveWindowDebugMode(
+	input: WindowDebugModeInput
+): WindowDebugMode {
+	const mode = input.mode ?? (input.backendURL ? 'hosted' : 'offline');
+	if (input.transport || (mode === 'custom' && input.endpointHandlers)) {
+		return 'custom';
+	}
+	if (mode === 'hosted' || mode === 'c15t') {
+		return 'hosted';
+	}
+	return 'offline';
+}
 
 type WindowWithC15tDebug = Window & {
 	c15t?: C15tWindowDebug;
@@ -40,6 +73,23 @@ const inertHandle: WindowDebugHandle = {
 	dispose() {},
 };
 
+/**
+ * Installs a frozen `window.c15t` debug object describing the mounted
+ * c15t adapter: `{ version, pkg, mode }`.
+ *
+ * @param options - The adapter identity to report: `pkg` (installed
+ * adapter package name) and `mode` (resolved transport kind).
+ * @returns A handle whose `dispose()` removes `window.c15t` — only if it
+ * still is the object this call installed. Inert outside the browser or
+ * when the page blocks the write.
+ *
+ * @example
+ * ```ts
+ * const handle = createWindowDebug({ pkg: '@c15t/react', mode: 'hosted' });
+ * // window.c15t -> { version: '2.1.0', pkg: '@c15t/react', mode: 'hosted' }
+ * handle.dispose();
+ * ```
+ */
 export function createWindowDebug(
 	options: WindowDebugOptions
 ): WindowDebugHandle {
@@ -54,12 +104,23 @@ export function createWindowDebug(
 		mode: options.mode,
 	});
 
-	target.c15t = installed;
+	try {
+		target.c15t = installed;
+	} catch {
+		// A host page defined `window.c15t` as non-writable — strict-mode
+		// assignment throws. The debug hook is best-effort; never let it
+		// abort a provider that installs it synchronously during mount.
+		return inertHandle;
+	}
 
 	return {
 		dispose() {
 			if (target.c15t === installed) {
-				delete target.c15t;
+				try {
+					delete target.c15t;
+				} catch {
+					// Non-configurable property — leave it in place.
+				}
 			}
 		},
 	};

--- a/packages/core/src/v3/modules/window-debug/index.ts
+++ b/packages/core/src/v3/modules/window-debug/index.ts
@@ -1,0 +1,66 @@
+/**
+ * c15t/v3/modules/window-debug
+ *
+ * Client-only debug and adapter identification module. Installs a tiny,
+ * read-only `window.c15t` object for browser inspection after a framework
+ * adapter has mounted. This is the v3 successor to v2's `window.c15tStore`
+ * exposure, but intentionally exposes only static public metadata
+ * (`version`, `pkg`, `mode`) instead of the mutable store.
+ *
+ * Concerns are split across siblings:
+ * - `types.ts` — public type definitions.
+ * - `index.ts` — this file: installation + lifecycle.
+ *
+ * Invariants:
+ * - Isomorphic-safe: in non-browser environments the handle is inert.
+ * - Last writer wins: mounting a newer provider replaces `window.c15t`.
+ * - Dispose is identity-checked so an older handle cannot remove a newer
+ *   provider's debug object.
+ * - The installed object is frozen.
+ */
+import { version } from '../../../version';
+import type {
+	C15tWindowDebug,
+	WindowDebugHandle,
+	WindowDebugOptions,
+} from './types';
+
+export type {
+	C15tWindowDebug,
+	WindowDebugHandle,
+	WindowDebugMode,
+	WindowDebugOptions,
+} from './types';
+
+type WindowWithC15tDebug = Window & {
+	c15t?: C15tWindowDebug;
+};
+
+const inertHandle: WindowDebugHandle = {
+	dispose() {},
+};
+
+export function createWindowDebug(
+	options: WindowDebugOptions
+): WindowDebugHandle {
+	if (typeof window === 'undefined') {
+		return inertHandle;
+	}
+
+	const target = window as WindowWithC15tDebug;
+	const installed: C15tWindowDebug = Object.freeze({
+		version,
+		pkg: options.pkg,
+		mode: options.mode,
+	});
+
+	target.c15t = installed;
+
+	return {
+		dispose() {
+			if (target.c15t === installed) {
+				delete target.c15t;
+			}
+		},
+	};
+}

--- a/packages/core/src/v3/modules/window-debug/types.ts
+++ b/packages/core/src/v3/modules/window-debug/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared types for the window-debug module.
+ */
+
+export type WindowDebugMode = 'hosted' | 'offline' | 'custom' | 'manifest';
+
+export interface WindowDebugOptions {
+	/** Adapter package name, e.g. `@c15t/react`. */
+	pkg: string;
+	mode: WindowDebugMode;
+}
+
+export interface WindowDebugHandle {
+	dispose(): void;
+}
+
+export interface C15tWindowDebug {
+	readonly version: string;
+	readonly pkg: string;
+	readonly mode: WindowDebugMode;
+}

--- a/packages/core/src/v3/modules/window-debug/types.ts
+++ b/packages/core/src/v3/modules/window-debug/types.ts
@@ -2,20 +2,61 @@
  * Shared types for the window-debug module.
  */
 
+/**
+ * The transport kind reported on `window.c15t`. Reflects what the
+ * adapter actually built, not what the consumer wrote in config —
+ * e.g. React's `mode: 'c15t'` reports as `'hosted'`.
+ */
 export type WindowDebugMode = 'hosted' | 'offline' | 'custom' | 'manifest';
 
+/**
+ * Options for {@link createWindowDebug}.
+ */
 export interface WindowDebugOptions {
 	/** Adapter package name, e.g. `@c15t/react`. */
 	pkg: string;
+	/** Resolved transport kind the adapter is running with. */
 	mode: WindowDebugMode;
 }
 
+/**
+ * Lifecycle handle returned by {@link createWindowDebug}.
+ */
 export interface WindowDebugHandle {
+	/**
+	 * Removes `window.c15t` — only when it is still the exact object this
+	 * handle installed, so an unmounting older provider cannot clobber a
+	 * newer provider's debug object.
+	 */
 	dispose(): void;
 }
 
+/**
+ * The frozen object installed at `window.c15t`. Public, read-only
+ * metadata for debugging and for detecting c15t on a page — never the
+ * store, consent state, or backend configuration.
+ */
 export interface C15tWindowDebug {
+	/** The `c15t` core package version. */
 	readonly version: string;
+	/** The installed adapter package name, e.g. `@c15t/nextjs`. */
 	readonly pkg: string;
+	/** The resolved transport kind. */
 	readonly mode: WindowDebugMode;
+}
+
+/**
+ * Provider options common to the React/Svelte-style adapters, as far as
+ * {@link resolveWindowDebugMode} needs them. Kept structural so each
+ * adapter can pass its own options object directly.
+ */
+export interface WindowDebugModeInput {
+	/** The consumer-facing provider mode, if set. */
+	mode?: 'hosted' | 'offline' | 'custom' | 'c15t';
+	/** Backend URL — its presence implies hosted when `mode` is unset. */
+	backendURL?: string;
+	/** A consumer-supplied transport object, reported as `custom`. */
+	transport?: unknown;
+	/** Custom endpoint handlers — with `mode: 'custom'`, reported as `custom`. */
+	endpointHandlers?: unknown;
 }

--- a/packages/nextjs/src/v3/__tests__/end-to-end.test.tsx
+++ b/packages/nextjs/src/v3/__tests__/end-to-end.test.tsx
@@ -15,6 +15,14 @@ import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentBoundary } from '../boundary';
 
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
 const POLICY = {
 	id: 'gdpr',
 	model: 'opt-in',
@@ -22,6 +30,42 @@ const POLICY = {
 } as const;
 
 describe('ConsentBoundary: backendURL triggers auto-init', () => {
+	test('boundary reports Next.js adapter identity on window.c15t', async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ policy: POLICY }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			})
+		);
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+		delete (window as WindowWithC15t).c15t;
+
+		try {
+			const { unmount } = await render(
+				<ConsentBoundary
+					config={{}}
+					backendURL="/api/c15t"
+					persistence={false}
+				>
+					<div data-testid="probe">ready</div>
+				</ConsentBoundary>
+			);
+
+			await vi.waitFor(() => {
+				expect((window as WindowWithC15t).c15t).toMatchObject({
+					pkg: '@c15t/nextjs',
+					mode: 'hosted',
+				});
+			});
+			expect(typeof (window as WindowWithC15t).c15t?.version).toBe('string');
+			unmount();
+		} finally {
+			globalThis.fetch = originalFetch;
+			delete (window as WindowWithC15t).c15t;
+		}
+	});
+
 	test('boundary with backendURL fires kernel.commands.init on mount', async () => {
 		const fetchSpy = vi.fn().mockResolvedValue(
 			new Response(

--- a/packages/nextjs/src/v3/boundary.tsx
+++ b/packages/nextjs/src/v3/boundary.tsx
@@ -66,6 +66,7 @@ export interface ConsentBoundaryProps {
 		| 'prefetch'
 		| 'scriptLoader'
 		| 'scripts'
+		| '__debugPkg'
 	>;
 
 	children: ReactNode;
@@ -92,6 +93,7 @@ export function ConsentBoundary({
 				scriptLoader,
 				networkBlocker,
 				persistence,
+				__debugPkg: '@c15t/nextjs',
 			}}
 		>
 			{children}

--- a/packages/nextjs/vitest.config.ts
+++ b/packages/nextjs/vitest.config.ts
@@ -27,6 +27,10 @@ export default mergeConfig(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
+				'c15t/v3/modules/window-debug': resolve(
+					__dirname,
+					'../core/src/v3/modules/window-debug/index.ts'
+				),
 				'c15t/v3': resolve(__dirname, '../core/src/v3/index.ts'),
 				c15t: resolve(__dirname, '../core/src/index.ts'),
 				'@c15t/react/v3/provider': resolve(

--- a/packages/react/src/v3/__tests__/provider.test.tsx
+++ b/packages/react/src/v3/__tests__/provider.test.tsx
@@ -20,6 +20,14 @@ import { useUIConfig } from '../ui-config-context';
 
 const STORAGE_KEY = 'c15t-provider-test';
 
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
 function hostedInitOutput(
 	policy: InitOutput['policy'] = {
 		id: 'gdpr',
@@ -55,12 +63,83 @@ function withProvider(options = {}) {
 }
 
 beforeEach(() => {
+	delete (window as WindowWithC15t).c15t;
 	localStorage.clear();
 	clearCookies();
 	vi.restoreAllMocks();
 });
 
 describe('v3 ConsentProvider options API', () => {
+	test('installs window.c15t after mount with React adapter identity', async () => {
+		const { unmount } = await render(
+			<ConsentProvider
+				options={{
+					mode: 'c15t',
+					backendURL: '/api/c15t',
+					persistence: false,
+				}}
+			>
+				<div data-testid="child">ready</div>
+			</ConsentProvider>
+		);
+
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toMatchObject({
+				pkg: '@c15t/react',
+				mode: 'hosted',
+			});
+		});
+		expect(typeof (window as WindowWithC15t).c15t?.version).toBe('string');
+
+		unmount();
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toBeUndefined();
+		});
+	});
+
+	test('reports offline mode when no backend is configured', async () => {
+		const { unmount } = await render(
+			<ConsentProvider options={{ persistence: false }}>
+				<div data-testid="child">ready</div>
+			</ConsentProvider>
+		);
+
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toMatchObject({
+				pkg: '@c15t/react',
+				mode: 'offline',
+			});
+		});
+
+		unmount();
+	});
+
+	test('reports custom mode when endpointHandlers select the custom transport', async () => {
+		const { unmount } = await render(
+			<ConsentProvider
+				options={{
+					mode: 'custom',
+					endpointHandlers: {
+						init: async () => ({ ok: true, data: hostedInitOutput() }),
+						setConsent: async () => ({ ok: true, data: {} }),
+					},
+					persistence: false,
+				}}
+			>
+				<div data-testid="child">ready</div>
+			</ConsentProvider>
+		);
+
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toMatchObject({
+				pkg: '@c15t/react',
+				mode: 'custom',
+			});
+		});
+
+		unmount();
+	});
+
 	test('keeps one kernel instance across provider rerenders', async () => {
 		function Probe() {
 			const marketing = useConsent('marketing');

--- a/packages/react/src/v3/provider.tsx
+++ b/packages/react/src/v3/provider.tsx
@@ -36,7 +36,11 @@ import {
 	type TranslationsResponse,
 } from 'c15t/v3';
 import type { Script } from 'c15t/v3/modules/script-loader';
-import type { WindowDebugMode } from 'c15t/v3/modules/window-debug';
+import {
+	createWindowDebug,
+	resolveWindowDebugMode,
+	type WindowDebugMode,
+} from 'c15t/v3/modules/window-debug';
 import type { ReactNode } from 'react';
 import {
 	lazy,
@@ -487,20 +491,6 @@ function createProviderKernel(options: ConsentProviderOptions): ConsentKernel {
 	});
 }
 
-function resolveWindowDebugMode(
-	options: ConsentProviderOptions
-): WindowDebugMode {
-	const mode: ProviderMode =
-		options.mode ?? (options.backendURL ? 'hosted' : 'offline');
-	if (options.transport || (mode === 'custom' && options.endpointHandlers)) {
-		return 'custom';
-	}
-	if (mode === 'hosted' || mode === 'c15t') {
-		return 'hosted';
-	}
-	return 'offline';
-}
-
 function snapshotConsentsChanged(
 	previous: ConsentSnapshot,
 	next: ConsentSnapshot
@@ -857,22 +847,10 @@ function WindowDebugMount({
 	mode: WindowDebugMode;
 }) {
 	useEffect(() => {
-		let disposed = false;
-		let handle: { dispose(): void } | null = null;
-		import('c15t/v3/modules/window-debug')
-			.then(({ createWindowDebug }) => {
-				if (disposed) return;
-				handle = createWindowDebug({ pkg, mode });
-			})
-			.catch(() => {
-				// The debug hook is best-effort — a failed chunk load must not
-				// surface as an unhandled rejection or affect consent behavior.
-			});
-		return () => {
-			disposed = true;
-			handle?.dispose();
-			handle = null;
-		};
+		// The module is tiny and dependency-free; `createWindowDebug` itself
+		// guards against pages that made `window.c15t` non-writable.
+		const handle = createWindowDebug({ pkg, mode });
+		return () => handle.dispose();
 	}, [mode, pkg]);
 
 	return null;

--- a/packages/react/src/v3/provider.tsx
+++ b/packages/react/src/v3/provider.tsx
@@ -36,6 +36,7 @@ import {
 	type TranslationsResponse,
 } from 'c15t/v3';
 import type { Script } from 'c15t/v3/modules/script-loader';
+import type { WindowDebugMode } from 'c15t/v3/modules/window-debug';
 import type { ReactNode } from 'react';
 import {
 	lazy,
@@ -133,6 +134,8 @@ export interface ConsentProviderOptions
 	 * compatibility and bridged through a minimal custom transport.
 	 */
 	endpointHandlers?: CustomClientOptions['endpointHandlers'];
+	/** @internal Adapter package name reported by `window.c15t`. */
+	__debugPkg?: string;
 }
 
 export interface ConsentProviderProps {
@@ -484,6 +487,20 @@ function createProviderKernel(options: ConsentProviderOptions): ConsentKernel {
 	});
 }
 
+function resolveWindowDebugMode(
+	options: ConsentProviderOptions
+): WindowDebugMode {
+	const mode: ProviderMode =
+		options.mode ?? (options.backendURL ? 'hosted' : 'offline');
+	if (options.transport || (mode === 'custom' && options.endpointHandlers)) {
+		return 'custom';
+	}
+	if (mode === 'hosted' || mode === 'c15t') {
+		return 'hosted';
+	}
+	return 'offline';
+}
+
 function snapshotConsentsChanged(
 	previous: ConsentSnapshot,
 	next: ConsentSnapshot
@@ -832,6 +849,35 @@ function PersistenceMount({ options }: { options?: UsePersistenceOptions }) {
 	return null;
 }
 
+function WindowDebugMount({
+	pkg,
+	mode,
+}: {
+	pkg: string;
+	mode: WindowDebugMode;
+}) {
+	useEffect(() => {
+		let disposed = false;
+		let handle: { dispose(): void } | null = null;
+		import('c15t/v3/modules/window-debug')
+			.then(({ createWindowDebug }) => {
+				if (disposed) return;
+				handle = createWindowDebug({ pkg, mode });
+			})
+			.catch(() => {
+				// The debug hook is best-effort — a failed chunk load must not
+				// surface as an unhandled rejection or affect consent behavior.
+			});
+		return () => {
+			disposed = true;
+			handle?.dispose();
+			handle = null;
+		};
+	}, [mode, pkg]);
+
+	return null;
+}
+
 function ThemeStyleMount({ theme }: { theme?: Theme }) {
 	const [themeCSS, setThemeCSS] = useState('');
 
@@ -957,6 +1003,8 @@ export function ConsentProvider({ options, children }: ConsentProviderProps) {
 	const iabOptions = normalizeIabOptions(getProviderIab(options));
 	const scripts = getProviderScripts(options);
 	const networkBlocker = getProviderNetworkBlocker(options);
+	const windowDebugPkg = options.__debugPkg ?? '@c15t/react';
+	const windowDebugMode = resolveWindowDebugMode(options);
 
 	useProviderCallbacks(
 		kernel,
@@ -1002,6 +1050,10 @@ export function ConsentProvider({ options, children }: ConsentProviderProps) {
 				enabled={enabled}
 				kernel={kernel}
 				eagerInit={eagerInit}
+			/>
+			<WindowDebugMount
+				pkg={windowDebugPkg}
+				mode={windowDebugMode}
 			/>
 			{enabled && persistenceOptions ? (
 				<PersistenceMount options={persistenceOptions} />

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -38,6 +38,10 @@ export default mergeConfig(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
+				'c15t/v3/modules/window-debug': resolve(
+					__dirname,
+					'../core/src/v3/modules/window-debug/index.ts'
+				),
 				'c15t/v3': resolve(__dirname, '../core/src/v3/index.ts'),
 				c15t: resolve(__dirname, '../core/src/index.ts'),
 				'@c15t/schema/types': resolve(__dirname, '../schema/src/types.ts'),

--- a/packages/svelte/src/components/__tests__/provider-basic.test.ts
+++ b/packages/svelte/src/components/__tests__/provider-basic.test.ts
@@ -14,8 +14,17 @@ import ConsentManagerProvider from '../../lib/components/consent-manager-provide
 const mockFetch = vi.fn();
 window.fetch = mockFetch;
 
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
 describe('ConsentManagerProvider Basic Request Behavior', () => {
 	beforeEach(() => {
+		delete (window as WindowWithC15t).c15t;
 		vi.resetAllMocks();
 		clearConsentRuntimeCache();
 
@@ -35,6 +44,43 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		delete (window as WindowWithC15t).c15t;
+	});
+
+	test('should install window.c15t with Svelte offline identity', async () => {
+		const result = render(ProviderOnlyFixture, {
+			options: {
+				mode: 'offline',
+			},
+		});
+
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toMatchObject({
+				pkg: '@c15t/svelte',
+				mode: 'offline',
+			});
+		});
+		expect(typeof (window as WindowWithC15t).c15t?.version).toBe('string');
+
+		result.unmount();
+		expect((window as WindowWithC15t).c15t).toBeUndefined();
+	});
+
+	test('should report hosted mode on window.c15t when backendURL is set', async () => {
+		const result = render(ProviderOnlyFixture, {
+			options: {
+				backendURL: '/api/c15t',
+			},
+		});
+
+		await vi.waitFor(() => {
+			expect((window as WindowWithC15t).c15t).toMatchObject({
+				pkg: '@c15t/svelte',
+				mode: 'hosted',
+			});
+		});
+
+		result.unmount();
 	});
 
 	test('should not make fetch calls in offline mode', async () => {

--- a/packages/svelte/src/lib/components/consent-manager-provider.svelte
+++ b/packages/svelte/src/lib/components/consent-manager-provider.svelte
@@ -29,6 +29,10 @@ import { createIframeBlocker } from 'c15t/v3/modules/iframe-blocker';
 import { createNetworkBlocker } from 'c15t/v3/modules/network-blocker';
 import { createPersistence } from 'c15t/v3/modules/persistence';
 import { createScriptLoader } from 'c15t/v3/modules/script-loader';
+import {
+	createWindowDebug,
+	type WindowDebugMode,
+} from 'c15t/v3/modules/window-debug';
 import type { Snippet } from 'svelte';
 import { onDestroy, onMount, untrack } from 'svelte';
 import {
@@ -252,6 +256,16 @@ function createProviderKernel(
 		initialPolicyDecision: prefetch.initialPolicyDecision,
 		initialPolicySnapshotToken: prefetch.initialPolicySnapshotToken,
 	});
+}
+
+function resolveWindowDebugMode(
+	providerOptions: ConsentManagerOptions
+): WindowDebugMode {
+	const mode: ProviderMode =
+		providerOptions.mode ?? (providerOptions.backendURL ? 'hosted' : 'offline');
+	if (providerOptions.transport) return 'custom';
+	if (mode === 'hosted' || mode === 'c15t') return 'hosted';
+	return 'offline';
 }
 
 const kernel = untrack(() => createProviderKernel(options));
@@ -481,6 +495,12 @@ onMount(() => {
 	const disposers: Array<() => void> = [];
 	const enabled = getEnabled(options);
 	const persistenceOptions = normalizePersistenceOptions();
+
+	const windowDebug = createWindowDebug({
+		pkg: '@c15t/svelte',
+		mode: resolveWindowDebugMode(options),
+	});
+	disposers.push(() => windowDebug.dispose());
 
 	if (enabled && persistenceOptions) {
 		const persistence =

--- a/packages/svelte/src/lib/components/consent-manager-provider.svelte
+++ b/packages/svelte/src/lib/components/consent-manager-provider.svelte
@@ -31,7 +31,7 @@ import { createPersistence } from 'c15t/v3/modules/persistence';
 import { createScriptLoader } from 'c15t/v3/modules/script-loader';
 import {
 	createWindowDebug,
-	type WindowDebugMode,
+	resolveWindowDebugMode,
 } from 'c15t/v3/modules/window-debug';
 import type { Snippet } from 'svelte';
 import { onDestroy, onMount, untrack } from 'svelte';
@@ -256,16 +256,6 @@ function createProviderKernel(
 		initialPolicyDecision: prefetch.initialPolicyDecision,
 		initialPolicySnapshotToken: prefetch.initialPolicySnapshotToken,
 	});
-}
-
-function resolveWindowDebugMode(
-	providerOptions: ConsentManagerOptions
-): WindowDebugMode {
-	const mode: ProviderMode =
-		providerOptions.mode ?? (providerOptions.backendURL ? 'hosted' : 'offline');
-	if (providerOptions.transport) return 'custom';
-	if (mode === 'hosted' || mode === 'c15t') return 'hosted';
-	return 'offline';
 }
 
 const kernel = untrack(() => createProviderKernel(options));

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -41,6 +41,13 @@ export default mergeConfig(
 					),
 				},
 				{
+					find: 'c15t/v3/modules/window-debug',
+					replacement: resolve(
+						__dirname,
+						'../core/src/v3/modules/window-debug/index.ts'
+					),
+				},
+				{
 					find: '@c15t/iab/v3',
 					replacement: resolve(__dirname, '../iab/src/v3/index.ts'),
 				},

--- a/packages/vue/src/__tests__/kernel-runtime.test.ts
+++ b/packages/vue/src/__tests__/kernel-runtime.test.ts
@@ -23,6 +23,14 @@ import {
 	symbolSnapshot,
 } from '../runtime/utils/symbols';
 
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
 const initFixture: InitOutput = {
 	jurisdiction: 'GDPR',
 	location: {
@@ -238,6 +246,7 @@ async function renderRootToString(cookieHeader?: string) {
 }
 
 beforeEach(() => {
+	delete (window as WindowWithC15t).c15t;
 	document.body.innerHTML = '';
 	window.localStorage.clear();
 	document.cookie = 'c15t=; max-age=0; path=/';
@@ -246,12 +255,26 @@ beforeEach(() => {
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+	delete (window as WindowWithC15t).c15t;
 	document.body.innerHTML = '';
 	window.localStorage.clear();
 	document.cookie = 'c15t=; max-age=0; path=/';
 });
 
 describe('@c15t/vue kernel runtime', () => {
+	test('installs window.c15t with Vue hosted identity', async () => {
+		const { wrapper } = await mountRoot();
+
+		expect((window as WindowWithC15t).c15t).toMatchObject({
+			pkg: '@c15t/vue',
+			mode: 'hosted',
+		});
+		expect(typeof (window as WindowWithC15t).c15t?.version).toBe('string');
+
+		wrapper.unmount();
+		expect((window as WindowWithC15t).c15t).toBeUndefined();
+	});
+
 	test('renders the banner from kernel init state', async () => {
 		const { wrapper } = await mountRoot();
 

--- a/packages/vue/src/__tests__/manifest-mode.test.ts
+++ b/packages/vue/src/__tests__/manifest-mode.test.ts
@@ -15,6 +15,14 @@ import {
 	resolveManifestInit,
 } from '../runtime/server/manifest-mode';
 
+type WindowWithC15t = Window & {
+	c15t?: {
+		version: string;
+		pkg: string;
+		mode: string;
+	};
+};
+
 function createManifestFixture(): ConsentManifest {
 	return {
 		schemaVersion: 1,
@@ -82,6 +90,7 @@ afterEach(() => {
 	clearManifestRouteCache();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
+	delete (window as WindowWithC15t).c15t;
 });
 
 describe('@c15t/vue Nuxt manifest mode', () => {
@@ -301,6 +310,10 @@ describe('@c15t/vue Nuxt manifest mode', () => {
 			expect(context.snapshot.value.policy?.id).toBe('ca-opt-out');
 		});
 
+		expect((window as WindowWithC15t).c15t).toMatchObject({
+			pkg: '@c15t/vue',
+			mode: 'manifest',
+		});
 		expect(seenPolicyIds[0]).toBe('eu-opt-in');
 		expect(seenPolicyIds.at(-1)).toBe('ca-opt-out');
 		expect(context.snapshot.value.policyDecision).toMatchObject({
@@ -311,6 +324,7 @@ describe('@c15t/vue Nuxt manifest mode', () => {
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		dispose();
+		expect((window as WindowWithC15t).c15t).toBeUndefined();
 	});
 
 	test('prefetched manifest init seeds decision inputs for save', async () => {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,6 +35,7 @@ export const c15tVue: Plugin<[Partial<ConsentConfig>?]> = {
 		app.provide(symbolInit, context.init);
 		app.provide(symbolActiveUI, context.activeUI);
 		app.provide(symbolConsent, context.storedConsent);
-		startVueConsentRuntime(context, config);
+		const disposeRuntime = startVueConsentRuntime(context, config);
+		app.onUnmount(disposeRuntime);
 	},
 };

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -36,6 +36,10 @@ export const c15tVue: Plugin<[Partial<ConsentConfig>?]> = {
 		app.provide(symbolActiveUI, context.activeUI);
 		app.provide(symbolConsent, context.storedConsent);
 		const disposeRuntime = startVueConsentRuntime(context, config);
-		app.onUnmount(disposeRuntime);
+		// `app.onUnmount` is Vue 3.5+. On older runtimes skip cleanup
+		// registration rather than throwing during plugin install.
+		if (typeof app.onUnmount === 'function') {
+			app.onUnmount(disposeRuntime);
+		}
 	},
 };

--- a/packages/vue/src/runtime/kernel.ts
+++ b/packages/vue/src/runtime/kernel.ts
@@ -23,6 +23,7 @@ import {
 	type StoredPayload,
 } from 'c15t/v3/modules/persistence';
 import { createScriptLoader, type Script } from 'c15t/v3/modules/script-loader';
+import { createWindowDebug } from 'c15t/v3/modules/window-debug';
 import { computed, type Ref, shallowRef } from 'vue';
 import type { ConsentConfig } from './config';
 import {
@@ -370,6 +371,18 @@ export function startVueConsentRuntime(
 	options: { runInit?: boolean } = {}
 ): () => void {
 	const disposers: Array<() => void> = [];
+
+	if (typeof document !== 'undefined') {
+		const windowDebug = createWindowDebug({
+			pkg: '@c15t/vue',
+			mode:
+				isClientManifestModeEnabled(config) ||
+				isServerManifestModeEnabled(config)
+					? 'manifest'
+					: 'hosted',
+		});
+		disposers.push(() => windowDebug.dispose());
+	}
 
 	if (typeof document !== 'undefined' && typeof localStorage !== 'undefined') {
 		const persistence = createPersistence({

--- a/packages/vue/src/runtime/plugin.nuxt.ts
+++ b/packages/vue/src/runtime/plugin.nuxt.ts
@@ -90,6 +90,9 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 	);
 	// A Nuxt app normally lives until page unload, but hosts that unmount the
 	// Vue app explicitly (tests, microfrontends) should tear the runtime down
-	// with it — mirrors the plain Vue plugin in src/index.ts.
-	nuxtApp.vueApp.onUnmount(disposeRuntime);
+	// with it — mirrors the plain Vue plugin in src/index.ts. `onUnmount` is
+	// Vue 3.5+; Nuxt 3 apps on older Vue runtimes skip cleanup registration.
+	if (typeof nuxtApp.vueApp.onUnmount === 'function') {
+		nuxtApp.vueApp.onUnmount(disposeRuntime);
+	}
 });

--- a/packages/vue/src/runtime/plugin.nuxt.ts
+++ b/packages/vue/src/runtime/plugin.nuxt.ts
@@ -79,9 +79,17 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 	nuxtApp.vueApp.provide(symbolInit, context.init);
 	nuxtApp.vueApp.provide(symbolActiveUI, context.activeUI);
 	nuxtApp.vueApp.provide(symbolConsent, context.storedConsent);
-	startVueConsentRuntime(context, config.value as ConsentConfig, {
-		runInit:
-			!prefetch &&
-			!(manifestMode === 'client' && typeof window === 'undefined'),
-	});
+	const disposeRuntime = startVueConsentRuntime(
+		context,
+		config.value as ConsentConfig,
+		{
+			runInit:
+				!prefetch &&
+				!(manifestMode === 'client' && typeof window === 'undefined'),
+		}
+	);
+	// A Nuxt app normally lives until page unload, but hosts that unmount the
+	// Vue app explicitly (tests, microfrontends) should tear the runtime down
+	// with it — mirrors the plain Vue plugin in src/index.ts.
+	nuxtApp.vueApp.onUnmount(disposeRuntime);
 });

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -43,6 +43,10 @@ export default mergeConfig(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
+				'c15t/v3/modules/window-debug': resolve(
+					__dirname,
+					'../core/src/v3/modules/window-debug/index.ts'
+				),
 				'c15t/v3/consent-record': resolve(
 					__dirname,
 					'../core/src/v3/consent-record/index.ts'


### PR DESCRIPTION
## What

v3 successor to v2's `window.c15tStore`. Every framework adapter installs a tiny, frozen `window.c15t` object on client-side hydration so anyone can validate c15t is on a site and see what it's running:

```js
window.c15t
// { version: "2.1.0", pkg: "@c15t/vue", mode: "manifest" }
```

- `version` — c15t core version (same source as the `x-c15t-version` header, #920)
- `pkg` — installed adapter package: `@c15t/react`, `@c15t/nextjs`, `@c15t/vue`, `@c15t/svelte`
- `mode` — resolved transport: `hosted | offline | custom | manifest`

Deliberately **not** exposed: the store/kernel (unlike v2), backend URL, or any consent state.

## How

The v3 kernel must stay pure (window exposure is pinned as an opt-in adapter concern by the correctness gate in `v3-correctness-gates.test.ts`), so this is a new core module — `c15t/v3/modules/window-debug` — following the persistence/script-loader create→dispose pattern:

- inert handle on SSR, identity-checked `dispose()` (an unmounting old provider can't clobber a newer one's object), last-writer-wins
- no global `Window` type augmentation (exported `C15tWindowDebug` type instead)

Adapter wiring at each client-boot spot:

- **React**: `WindowDebugMount` — `useEffect` + dynamic import (zero SSR bytes, off the hydration path; chunk-load failure caught as best-effort). `mode: 'c15t'` reports `hosted`; `transport`/`endpointHandlers` report `custom`
- **Next.js**: `ConsentBoundary` passes internal `__debugPkg: '@c15t/nextjs'`
- **Vue/Nuxt**: wired in `startVueConsentRuntime` behind the existing `typeof document` gate; reports `manifest` vs `hosted`. Nuxt reports `@c15t/vue` because that is the package users actually install — there is no `@c15t/nuxt`
- **Svelte**: `onMount` disposer chain
- **Vanilla**: exported from `c15t/v3` + the new subpath for self-composition

Also in this branch: the Nuxt plugin now registers the runtime disposer via `nuxtApp.vueApp.onUnmount(...)`, mirroring the plain Vue plugin (matters for hosts that explicitly unmount the app — tests, microfrontends).

## SSR impact

None. All wiring is effect/mount/document-gated and the module itself is inert without `window`; client cost is a single frozen 3-field object assignment (no kernel subscription, no network).

## Verification

- window-debug module unit tests at 100% stmt/branch/func/line coverage (install shape, frozen, dispose identity, SSR no-op)
- per-framework mount/mode/unmount assertions: react 18 · nextjs e2e 5 · vue 48 (incl. Nuxt manifest plugin path) · svelte 7; core v3 suite 374 + purity gates still green
- typechecks clean: core/react/nextjs (tsc), vue (vue-tsc + nuxt typecheck), svelte (svelte-check)
- verified live in `examples/nuxt`: `window.c15t` → `{ version: "2.1.0", pkg: "@c15t/vue", mode: "manifest" }`, `Object.isFrozen` → `true`

## Follow-ups

- `@c15t/dev-tools` still reads v2's `window.c15tStore`; plan is to deprecate the standalone package in favor of per-framework entry points (`@c15t/react/dev-tools` etc.) which can use this hook for detection — separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser debug object (`window.c15t`) that exposes runtime metadata like version, package, and resolved mode.
  * Enabled this debug info across React, Next.js, Svelte, and Vue, including manifest mode where applicable.
* **Bug Fixes**
  * Improved lifecycle cleanup so the debug object is reliably removed on unmount/dispose.
  * Hardened behavior for edge cases (e.g., non-writable `window.c15t`) to avoid runtime errors.
* **Tests**
  * Expanded test coverage to verify installation, mode resolution, and proper teardown/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->