### PR TITLE
fix(translations): translate consent storage refresh sentence in all locales

### DIFF
--- a/.changeset/fix-latvian-custom-vendors-notice.md
+++ b/.changeset/fix-latvian-custom-vendors-notice.md
@@ -1,0 +1,5 @@
+---
+'@c15t/translations': patch
+---
+
+Fix a stray German word in the Latvian IAB custom vendors notice: "pamatojoties auf jūsu piekrišanu" is now "pamatojoties uz jūsu piekrišanu".

--- a/.changeset/translate-consent-storage-refresh-sentence.md
+++ b/.changeset/translate-consent-storage-refresh-sentence.md
@@ -1,0 +1,5 @@
+---
+'@c15t/translations': patch
+---
+
+Translate the second sentence of the IAB preference-center consent storage notice (`iab.preferenceCenter.footer.consentStorage`) — "The storage duration may be refreshed when you update your preferences." — which was previously left in English in all 32 non-English locales.

--- a/packages/translations/src/translations/bg.ts
+++ b/packages/translations/src/translations/bg.ts
@@ -123,7 +123,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Предпочитанията за съгласие се съхраняват в бисквитка с име "euconsent-v2" за 13 месеца. The storage duration may be refreshed when you update your preferences.',
+					'Предпочитанията за съгласие се съхраняват в бисквитка с име "euconsent-v2" за 13 месеца. Срокът на съхранение може да бъде подновен, когато актуализирате вашите предпочитания.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/cs.ts
+++ b/packages/translations/src/translations/cs.ts
@@ -124,7 +124,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Předvolby souhlasu jsou uloženy v cookie s názvem "euconsent-v2" po dobu 13 měsíců. The storage duration may be refreshed when you update your preferences.',
+					'Předvolby souhlasu jsou uloženy v cookie s názvem "euconsent-v2" po dobu 13 měsíců. Doba uložení se může obnovit, když aktualizujete své předvolby.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/cy.ts
+++ b/packages/translations/src/translations/cy.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Mae dewisiadau cydsyniad yn cael eu storio mewn cwci o’r enw "euconsent-v2" am 13 mis. The storage duration may be refreshed when you update your preferences.',
+					'Mae dewisiadau cydsyniad yn cael eu storio mewn cwci o’r enw "euconsent-v2" am 13 mis. Gall y cyfnod storio gael ei adnewyddu pan fyddwch yn diweddaru eich dewisiadau.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/da.ts
+++ b/packages/translations/src/translations/da.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Samtykkepræferencer gemmes i en cookie med navnet "euconsent-v2" i 13 måneder. The storage duration may be refreshed when you update your preferences.',
+					'Samtykkepræferencer gemmes i en cookie med navnet "euconsent-v2" i 13 måneder. Opbevaringsperioden kan blive fornyet, når du opdaterer dine præferencer.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/de.ts
+++ b/packages/translations/src/translations/de.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Einwilligungspräferenzen werden in einem Cookie namens "euconsent-v2" für 13 Monate gespeichert. The storage duration may be refreshed when you update your preferences.',
+					'Einwilligungspräferenzen werden in einem Cookie namens "euconsent-v2" für 13 Monate gespeichert. Die Speicherdauer kann erneut beginnen, wenn du deine Präferenzen aktualisierst.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/el.ts
+++ b/packages/translations/src/translations/el.ts
@@ -123,7 +123,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Οι προτιμήσεις συγκατάθεσης αποθηκεύονται σε cookie με το όνομα "euconsent-v2" για 13 μήνες. The storage duration may be refreshed when you update your preferences.',
+					'Οι προτιμήσεις συγκατάθεσης αποθηκεύονται σε cookie με το όνομα "euconsent-v2" για 13 μήνες. Η διάρκεια αποθήκευσης ενδέχεται να ανανεωθεί όταν ενημερώνετε τις προτιμήσεις σας.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/es.ts
+++ b/packages/translations/src/translations/es.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Las preferencias de consentimiento se almacenan en una cookie llamada "euconsent-v2" durante 13 meses. The storage duration may be refreshed when you update your preferences.',
+					'Las preferencias de consentimiento se almacenan en una cookie llamada "euconsent-v2" durante 13 meses. La duración del almacenamiento puede renovarse cuando actualices tus preferencias.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/et.ts
+++ b/packages/translations/src/translations/et.ts
@@ -120,7 +120,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Nõusoleku eelistused salvestatakse küpsisesse nimega "euconsent-v2" 13 kuuks. The storage duration may be refreshed when you update your preferences.',
+					'Nõusoleku eelistused salvestatakse küpsisesse nimega "euconsent-v2" 13 kuuks. Salvestusaeg võib teie eelistuste uuendamisel uuesti alata.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/fi.ts
+++ b/packages/translations/src/translations/fi.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Suostumusasetukset tallennetaan evästeeseen nimeltä "euconsent-v2" 13 kuukaudeksi. The storage duration may be refreshed when you update your preferences.',
+					'Suostumusasetukset tallennetaan evästeeseen nimeltä "euconsent-v2" 13 kuukaudeksi. Säilytysaika voi alkaa alusta, kun päivität asetuksiasi.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/fr.ts
+++ b/packages/translations/src/translations/fr.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Les préférences de consentement sont stockées dans un cookie nommé « euconsent-v2 » pendant 13 mois. The storage duration may be refreshed when you update your preferences.',
+					'Les préférences de consentement sont stockées dans un cookie nommé « euconsent-v2 » pendant 13 mois. La durée de stockage peut être renouvelée lorsque vous mettez à jour vos préférences.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/ga.ts
+++ b/packages/translations/src/translations/ga.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Stóráiltear roghanna toilithe i bhfianán darb ainm "euconsent-v2" ar feadh 13 mhí. The storage duration may be refreshed when you update your preferences.',
+					'Stóráiltear roghanna toilithe i bhfianán darb ainm "euconsent-v2" ar feadh 13 mhí. D\'fhéadfaí an tréimhse stórála a athnuachan nuair a nuashonraíonn tú do roghanna.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/he.ts
+++ b/packages/translations/src/translations/he.ts
@@ -115,7 +115,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'העדפות הסכמה נשמרות בעוגייה בשם "euconsent-v2" למשך 13 חודשים. The storage duration may be refreshed when you update your preferences.',
+					'העדפות הסכמה נשמרות בעוגייה בשם "euconsent-v2" למשך 13 חודשים. משך השמירה עשוי להתחדש כאשר תעדכן את ההעדפות שלך.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/hr.ts
+++ b/packages/translations/src/translations/hr.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Postavke privole pohranjuju se u kolačiću pod nazivom "euconsent-v2" tijekom 13 mjeseci. The storage duration may be refreshed when you update your preferences.',
+					'Postavke privole pohranjuju se u kolačiću pod nazivom "euconsent-v2" tijekom 13 mjeseci. Trajanje pohrane može se obnoviti kada ažurirate svoje postavke.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/hu.ts
+++ b/packages/translations/src/translations/hu.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'A hozzájárulási beállításokat egy "euconsent-v2" nevű sütiben tároljuk 13 hónapig. The storage duration may be refreshed when you update your preferences.',
+					'A hozzájárulási beállításokat egy "euconsent-v2" nevű sütiben tároljuk 13 hónapig. A tárolási időtartam megújulhat, amikor Ön frissíti a beállításait.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/id.ts
+++ b/packages/translations/src/translations/id.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Preferensi persetujuan disimpan dalam cookie bernama "euconsent-v2" selama 13 bulan. The storage duration may be refreshed when you update your preferences.',
+					'Preferensi persetujuan disimpan dalam cookie bernama "euconsent-v2" selama 13 bulan. Masa penyimpanan tersebut dapat dimulai ulang saat Anda memperbarui preferensi Anda.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/is.ts
+++ b/packages/translations/src/translations/is.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Samþykkisstillingar eru geymdar í vafraköku sem heitir "euconsent-v2" í 13 mánuði. The storage duration may be refreshed when you update your preferences.',
+					'Samþykkisstillingar eru geymdar í vafraköku sem heitir "euconsent-v2" í 13 mánuði. Geymslutíminn kann að endurnýjast þegar þú uppfærir stillingar þínar.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/it.ts
+++ b/packages/translations/src/translations/it.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Le preferenze di consenso vengono memorizzate in un cookie denominato "euconsent-v2" per 13 mesi. The storage duration may be refreshed when you update your preferences.',
+					'Le preferenze di consenso vengono memorizzate in un cookie denominato "euconsent-v2" per 13 mesi. La durata di memorizzazione può essere rinnovata quando aggiorni le tue preferenze.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/lb.ts
+++ b/packages/translations/src/translations/lb.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Zoustëmmungsvirléiften ginn an engem Cookie mam Numm "euconsent-v2" fir 13 Méint gespäichert. The storage duration may be refreshed when you update your preferences.',
+					'Zoustëmmungsvirléiften ginn an engem Cookie mam Numm "euconsent-v2" fir 13 Méint gespäichert. D’Späicherdauer kann erneiert ginn, wann Dir Är Virléiften aktualiséiert.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/lt.ts
+++ b/packages/translations/src/translations/lt.ts
@@ -123,7 +123,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Sutikimo nuostatos saugomos slapuke pavadinimu „euconsent-v2“ 13 mėnesių. The storage duration may be refreshed when you update your preferences.',
+					'Sutikimo nuostatos saugomos slapuke pavadinimu „euconsent-v2“ 13 mėnesių. Kai atnaujinate savo nuostatas, saugojimo trukmė gali būti pradėta skaičiuoti iš naujo.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/lv.ts
+++ b/packages/translations/src/translations/lv.ts
@@ -103,7 +103,7 @@ export const translations: CompleteTranslations = {
 					'Šie partneri ir reģistrēti IAB Transparency & Consent Framework (TCF) — nozares standartā piekrišanas pārvaldībai',
 				customVendorsHeading: 'Pielāgoti partneri',
 				customVendorsNotice:
-					'Šie ir pielāgoti partneri, kas nav reģistrēti IAB Transparency & Consent Framework (TCF). Viņi apstrādā datus, pamatojoties auf jūsu piekrišanu, un viņiem var būt atšķirīga privātuma prakse nekā IAB reģistrētajiem piegādātājiem.',
+					'Šie ir pielāgoti partneri, kas nav reģistrēti IAB Transparency & Consent Framework (TCF). Viņi apstrādā datus, pamatojoties uz jūsu piekrišanu, un viņiem var būt atšķirīga privātuma prakse nekā IAB reģistrētajiem piegādātājiem.',
 				purposes: 'Mērķi',
 				specialPurposes: 'Īpašie mērķi',
 				specialFeatures: 'Īpašās funkcijas',

--- a/packages/translations/src/translations/lv.ts
+++ b/packages/translations/src/translations/lv.ts
@@ -120,7 +120,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Piekrišanas preferences tiek glabātas sīkdatnē ar nosaukumu "euconsent-v2" 13 mēnešus. Glabāšanas ilgums var tikt atjaunots, kad jūs atjaunināt savas preferences.',
+					'Piekrišanas iestatījumi tiek glabāti sīkdatnē ar nosaukumu "euconsent-v2" 13 mēnešus. Glabāšanas ilgums var tikt atjaunots, kad jūs atjaunināt savus iestatījumus.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/lv.ts
+++ b/packages/translations/src/translations/lv.ts
@@ -120,7 +120,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Piekrišanas preferences tiek glabātas sīkdatnē ar nosaukumu "euconsent-v2" 13 mēnešus. The storage duration may be refreshed when you update your preferences.',
+					'Piekrišanas preferences tiek glabātas sīkdatnē ar nosaukumu "euconsent-v2" 13 mēnešus. Glabāšanas ilgums var tikt atjaunots, kad jūs atjaunināt savas preferences.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/mt.ts
+++ b/packages/translations/src/translations/mt.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Il-preferenzi tal-kunsens huma maħżuna f’cookie msemmija "euconsent-v2" għal 13-il xahar. The storage duration may be refreshed when you update your preferences.',
+					'Il-preferenzi tal-kunsens huma maħżuna f’cookie msemmija "euconsent-v2" għal 13-il xahar. Il-perjodu tal-ħażna jista’ jiġġedded meta taġġorna l-preferenzi tiegħek.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/nb.ts
+++ b/packages/translations/src/translations/nb.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Samtykkepreferanser lagres i en informasjonskapsel kalt "euconsent-v2" i 13 måneder. The storage duration may be refreshed when you update your preferences.',
+					'Samtykkepreferanser lagres i en informasjonskapsel kalt "euconsent-v2" i 13 måneder. Lagringsperioden kan fornyes når du oppdaterer preferansene dine.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/nl.ts
+++ b/packages/translations/src/translations/nl.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Toestemmingsvoorkeuren worden gedurende 13 maanden opgeslagen in een cookie genaamd "euconsent-v2". The storage duration may be refreshed when you update your preferences.',
+					'Toestemmingsvoorkeuren worden gedurende 13 maanden opgeslagen in een cookie genaamd "euconsent-v2". De bewaartermijn kan opnieuw ingaan wanneer u uw voorkeuren aanpast.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/nn.ts
+++ b/packages/translations/src/translations/nn.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Samtykkepreferansar blir lagra i ein informasjonskapsel kalla "euconsent-v2" i 13 månader. The storage duration may be refreshed when you update your preferences.',
+					'Samtykkepreferansar blir lagra i ein informasjonskapsel kalla "euconsent-v2" i 13 månader. Lagringstida kan fornyast når du oppdaterer preferansane dine.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/pl.ts
+++ b/packages/translations/src/translations/pl.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Preferencje dotyczące zgody są przechowywane w pliku cookie o nazwie „euconsent-v2” przez 13 miesięcy. The storage duration may be refreshed when you update your preferences.',
+					'Preferencje dotyczące zgody są przechowywane w pliku cookie o nazwie „euconsent-v2” przez 13 miesięcy. Okres przechowywania może zostać odnowiony, gdy zaktualizujesz swoje preferencje.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/pt.ts
+++ b/packages/translations/src/translations/pt.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'As preferências de consentimento são armazenadas num cookie chamado "euconsent-v2" durante 13 meses. The storage duration may be refreshed when you update your preferences.',
+					'As preferências de consentimento são armazenadas num cookie chamado "euconsent-v2" durante 13 meses. O período de armazenamento pode ser renovado quando atualizar as suas preferências.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/rm.ts
+++ b/packages/translations/src/translations/rm.ts
@@ -122,7 +122,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Las preferenzas da consentiment vegnan memorisadas en in cookie numnà "euconsent-v2" per 13 mais. The storage duration may be refreshed when you update your preferences.',
+					'Las preferenzas da consentiment vegnan memorisadas en in cookie numnà "euconsent-v2" per 13 mais. La durada da memorisaziun po vegnir renovada, cur che vus actualisais vossas preferenzas.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/ro.ts
+++ b/packages/translations/src/translations/ro.ts
@@ -123,7 +123,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Preferințele de consimțământ sunt stocate într-un cookie numit „euconsent-v2” timp de 13 luni. The storage duration may be refreshed when you update your preferences.',
+					'Preferințele de consimțământ sunt stocate într-un cookie numit „euconsent-v2” timp de 13 luni. Durata de stocare poate fi reînnoită atunci când îți actualizezi preferințele.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/sk.ts
+++ b/packages/translations/src/translations/sk.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Predvoľby súhlasu sú uložené v cookie s názvom "euconsent-v2" po dobu 13 mesiacov. The storage duration may be refreshed when you update your preferences.',
+					'Predvoľby súhlasu sú uložené v cookie s názvom "euconsent-v2" po dobu 13 mesiacov. Doba uloženia sa môže obnoviť, keď aktualizujete svoje predvoľby.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/sl.ts
+++ b/packages/translations/src/translations/sl.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Preference glede soglasja so shranjene v piškotku z imenom "euconsent-v2" 13 mesecev. The storage duration may be refreshed when you update your preferences.',
+					'Preference glede soglasja so shranjene v piškotku z imenom "euconsent-v2" 13 mesecev. Obdobje hrambe se lahko obnovi, ko posodobite svoje preference.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/sv.ts
+++ b/packages/translations/src/translations/sv.ts
@@ -121,7 +121,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'Samtyckesinställningar lagras i en cookie med namnet "euconsent-v2" i 13 månader. The storage duration may be refreshed when you update your preferences.',
+					'Samtyckesinställningar lagras i en cookie med namnet "euconsent-v2" i 13 månader. Lagringstiden kan förnyas när du uppdaterar dina inställningar.',
 			},
 		},
 		common: {

--- a/packages/translations/src/translations/zh.ts
+++ b/packages/translations/src/translations/zh.ts
@@ -112,7 +112,7 @@ export const translations: CompleteTranslations = {
 			},
 			footer: {
 				consentStorage:
-					'同意偏好存储在名为 "euconsent-v2" 的 cookie 中，有效期为 13 个月。 The storage duration may be refreshed when you update your preferences.',
+					'同意偏好存储在名为 "euconsent-v2" 的 cookie 中，有效期为 13 个月。当您更新同意偏好时，该有效期可能会重新开始计算。',
 			},
 		},
 		common: {


### PR DESCRIPTION
## Summary

The IAB preference-center footer string `iab.preferenceCenter.footer.consentStorage` is two sentences; the second one — "The storage duration may be refreshed when you update your preferences." — was left in English in every non-English locale. This PR translates it into all 32 locales.

Each translation was written against the locale file's existing terminology and register (formal/informal address; how the file already renders "preferences", "stored/storage", "update"), then independently reviewed per language. Locale-specific details:

- `zh`: also removes the stray space after 。 (full-width punctuation takes no following space) and reuses 同意偏好 / 有效期 from the first sentence.
- `he`: uses משך השמירה to match the first sentence's נשמרות and the file's retention term שמירה.
- `it`: uses "durata di memorizzazione" (matching "vengono memorizzate" in the first sentence) rather than "conservazione", which the file reserves for the TCF retention concept.
- `nn`: uses the st-passive ("kan fornyast"), consistent with the file's "kan ikkje deaktiverast".

## Changes

- 32 locale files, one line each, in `packages/translations/src/translations/`.
- Changeset: patch bump for `@c15t/translations`.

`check-types`, `lint`, and `test` pass for `@c15t/translations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the consent storage notice across 32 non-English locales to ensure no untranslated English fragments remain.
  * Updated localized text so the IAB preference-center footer consistently explains the 13‑month storage period and that it can be refreshed/renewed when preferences are updated.
  * Fixed the Latvian “custom vendors notice” sentence to use the correct localized wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->