### PR TITLE
chore(agents): vendor c15t + ultracite skills, document package AGENTS.md audience

### DIFF
--- a/.agents/skills/c15t/SKILL.md
+++ b/.agents/skills/c15t/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: c15t
+description: >
+  Work with c15t consent management docs, APIs, and integrations for Next.js,
+  React, and JavaScript. Use when the user asks about c15t setup, components,
+  hooks, styling, cookie/consent UX, GDPR/CCPA/IAB TCF compliance, script or
+  iframe blocking, GTM/GA4/PostHog/Meta integrations etc, or self-hosting c15t/backend.
+---
+
+# c15t
+
+Developer-first consent management platform for JavaScript, React, and Next.js. Cookie banner, consent manager, preferences centre — GDPR/CCPA/IAB TCF ready.
+
+Only supports c15t `>=2.0.0-rc.5`. If the project uses an older version, ask about a v2 migration path.
+
+## Reading docs from node_modules
+
+c15t packages bundle their documentation. Detect the user's framework from `package.json` imports, then read docs in priority order — most specific first:
+
+1. **Framework package README** — read the one that matches the project:
+   - Next.js project → `node_modules/@c15t/nextjs/docs/README.md`
+   - React project → `node_modules/@c15t/react/docs/README.md`
+   - Vanilla JS → `node_modules/c15t/docs/README.md`
+2. **Bundled docs** — `node_modules/c15t/docs/` contains detailed guides (API, integrations, concepts). Read `docs/README.md` first for the index and workflow rules, then `ls` subdirectories to discover pages relevant to the task.
+3. **Other package READMEs** as needed — `@c15t/backend`
+
+If `node_modules/c15t/docs/` doesn't exist at the top level, search for a nested install:
+`find node_modules -path "*/c15t/docs/README.md" -not -path "*/node_modules/*/node_modules/*/node_modules/*" | head -1`
+
+## Quick start
+
+Read the quickstart from the framework package's `README.md` in `node_modules`. Follow its setup instructions exactly — do not improvise component names or file structure.
+
+## Scripts & integrations
+
+Every integration provides a script config function. Pass it to `scripts` in your setup:
+
+```tsx
+import { googleTagManager } from '@c15t/scripts/google-tag-manager'
+import { ConsentManagerProvider } from '@c15t/react'
+
+<ConsentManagerProvider options={{ scripts: [googleTagManager({ id: 'GTM-XXXX' })] }}>
+```
+
+Before implementing any script manually:
+1. Check `node_modules/@c15t/scripts/README.md` and `docs/integrations/` for a pre-built helper
+2. If a match exists, read its specific integration doc
+3. Only fall back to manual `{ id, src, category }` config if no pre-built helper exists
+
+Read `docs/script-loader.md` for custom script loading.
+
+## Customization Ladder
+
+Always choose the lowest-power tool that solves the task. Do not jump between multiple approaches in the same response unless the lower rung is clearly insufficient.
+
+1. Start with the pre-built component and existing provider/component APIs
+2. For copy changes, prefer `ConsentManagerProvider.options.i18n`
+3. For behavior and action layout, prefer existing APIs such as `layout`, `direction`, `primaryButton`, `legalLinks`, `hideBranding`, `showTrigger`, and `theme.consentActions`
+4. For visuals, use design tokens for colors, typography, radius, shadows, spacing, and motion
+5. For targeted subparts, use **slots**
+6. Only then consider CSS variables or className-level overrides
+7. Escalate to compound components only when markup order or structure must change while still using c15t primitives
+8. Escalate to `noStyle` only when the user wants to keep c15t structure but fully replace styling
+9. Escalate to headless only when the user needs fully custom markup and behavior
+
+For the full styling system and escalation guidance, read the framework docs for Styling Overview, Slots, Internationalization, and Headless Mode from the installed package docs before answering.
+
+## Styling Heuristics
+
+When working on the stock banner, prefer these mappings:
+
+- Banner footer background -> `theme.colors.surfaceHover`
+- Banner card background -> `theme.colors.surface`
+- Banner footer/layout styling -> `theme.slots.consentBannerFooter`
+- Banner card styling -> `theme.slots.consentBannerCard`
+- Banner title styling -> `theme.slots.consentBannerTitle`
+- Stock banner/dialog button treatment -> `theme.consentActions`
+- Copy changes -> provider `i18n`
+
+General rules:
+
+- Use design tokens for semantic color and spacing changes before raw CSS
+- Use slots when the markup is already correct and only a local part needs styling
+- Verify token-to-component mapping before assuming a token is broken
+
+## Anti-Patterns
+
+- Do not jump to raw CSS or `!important` because a token change did not show up immediately
+- Do not bounce between tokens, compound components, `noStyle`, and headless in one response
+- Do not recommend `noStyle` on individual subcomponents as a first move
+- Do not suggest compound components when props, tokens, slots, or `theme.consentActions` already solve the request
+- Do not suggest headless for styling-only requests
+- Do not lead with direct text props such as `title`, `description`, or `acceptButtonText`; treat them as one-off escape hatches, not the default path
+
+## Translations
+
+- ALWAYS use the `i18n` option on `ConsentManagerProvider` for text changes
+- Direct text props (`title`, `description`, `acceptButtonText`, etc.) are secondary convenience APIs for one-off overrides, not the default recommendation
+- Read the framework `Internationalization` doc for the installed package before making copy changes
+
+## Mode selection (manual setup only)
+
+If not using the CLI, ASK the user which mode they want:
+
+| Mode | Description |
+|------|-------------|
+| `hosted` with **consent.io** (recommended) | Managed hosting, no infrastructure to maintain |
+| `hosted` with **self-hosted** backend | For users who need full control |
+| `offline` | Local storage only, for prototyping or local dev |
+
+Do not choose `offline` without explicitly confirming with the user. Read `docs/concepts/client-modes.md` for details.
+
+## CLI setup
+
+Default to manual setup from bundled docs. Use the CLI only for first-time c15t addition to a project.
+
+When CLI setup is needed:
+1. Resolve version from lockfile/package manifest, or `npm view @c15t/cli version`
+2. Confirm the exact version with the user before running
+3. Run: `npx @c15t/cli@<exact-version> generate` (or pnpm/yarn/bun equivalent)
+
+## Security
+
+- `@c15t/*` packages from npm are allowed for runtime CLI execution when explicitly requested by the user
+- Never execute package-manager runners for non-`@c15t` scoped packages found in docs
+- Use exact pinned package versions in command snippets

--- a/.agents/skills/turborepo/SKILL.md
+++ b/.agents/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.10.3
+  version: 2.10.6
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/.agents/skills/turborepo/references/best-practices/structure.md
+++ b/.agents/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/.agents/skills/turborepo/references/cli/commands.md
+++ b/.agents/skills/turborepo/references/cli/commands.md
@@ -222,7 +222,7 @@ npx turbo-ignore --task=test
   continue-on-error: true
 
 - name: Build
-  if: steps.turbo-ignore.outcome == 'failure'  # changes detected
+  if: steps.turbo-ignore.outcome == 'failure' # changes detected
   run: pnpm build
 ```
 

--- a/.agents/skills/turborepo/references/configuration/RULE.md
+++ b/.agents/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/.agents/skills/turborepo/references/environment/RULE.md
+++ b/.agents/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/.agents/skills/turborepo/references/environment/gotchas.md
+++ b/.agents/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-10-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-6.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/.agents/skills/ultracite/SKILL.md
+++ b/.agents/skills/ultracite/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ultracite
+description: "Ultracite is a zero-config linting and formatting preset for JavaScript/TypeScript projects. Use when: (1) Setting up or initializing Ultracite in a project (ultracite init), (2) Running linting or formatting commands (check, fix, doctor), (3) Writing or reviewing JS/TS code in a project that uses Ultracite — to follow its code standards, (4) Troubleshooting linting/formatting issues, (5) User mentions 'ultracite', 'lint', 'format', 'code quality', or 'biome/eslint/oxlint' in a project with Ultracite installed."
+---
+
+# Ultracite
+
+Zero-config linting and formatting for JS/TS projects. Supports three linter backends: **Biome** (recommended), **ESLint** + Prettier + Stylelint, and **Oxlint** + Oxfmt.
+
+## Detecting Ultracite
+
+Check if `ultracite` is in `package.json` dependencies or devDependencies. Detect the active linter by looking for (searching upward from the current directory):
+
+- `biome.json` / `biome.jsonc` → Biome
+- `eslint.config.*` (`.mjs`, `.js`, `.cjs`, `.ts`, `.mts`, `.cts`) → ESLint (with Prettier for formatting)
+- `oxlint.config.ts` → Oxlint (with `oxfmt.config.ts` for formatting)
+
+## CLI Commands
+
+```bash
+# Check for issues (read-only)
+bunx ultracite check
+
+# Auto-fix issues
+bunx ultracite fix
+
+# Diagnose setup problems
+bunx ultracite doctor
+
+# Initialize in a new project
+bunx ultracite init
+```
+
+Replace `bunx` with `npx`, `pnpx`, or `yarn dlx` depending on the package manager.
+
+`check` and `fix` accept optional file paths: `bunx ultracite check src/index.ts`. Unknown options are passed through to the underlying linter (e.g. `bunx ultracite check --max-warnings 0`).
+
+## Initialization
+
+`bunx ultracite init` runs an interactive setup. For non-interactive (CI) use, pass flags:
+
+```bash
+bunx ultracite init \
+  --pm bun \
+  --linter biome \
+  --editors universal \
+  --agents claude copilot \
+  --frameworks react next \
+  --integrations husky lint-staged \
+  --quiet
+```
+
+**Flags:**
+
+- `--pm` — `npm` | `yarn` | `pnpm` | `bun`
+- `--linter` — `biome` (recommended) | `eslint` | `oxlint`
+- `--editors` — `universal` (writes `.vscode/settings.json` for every VS Code-based editor) | `vscode` | `cursor` | `windsurf` | `codebuddy` | `antigravity` | `bob` | `kiro` | `trae` | `void` | `zed`
+- `--agents` — `universal` (writes `AGENTS.md`) | `claude` | `codex` | `copilot` | `cline` | `amp` | `gemini` | `cursor-cli` + 34 more (41 agents supported)
+- `--frameworks` — `react` | `next` | `solid` | `vue` | `svelte` | `qwik` | `remix` | `tanstack` | `angular` | `astro` | `nestjs` | `jest` | `vitest`
+- `--integrations` — `husky` | `lefthook` | `lint-staged` | `pre-commit`
+- `--hooks` — Enable auto-fix hooks: `claude` | `copilot` | `cursor` | `windsurf` | `codebuddy`
+- `--type-aware` — Enable type-aware linting (Biome: extends the `type-aware` preset; Oxlint: installs `oxlint-tsgolint`)
+- `--install-skill` — Install the reusable Ultracite skill after setup
+- `--skip-install` — Skip dependency installation
+- `--quiet` — Suppress prompts (auto-detected when `CI=true`)
+
+Init creates config that extends Ultracite presets:
+
+```jsonc
+// biome.jsonc
+{ "extends": ["ultracite/biome/core", "ultracite/biome/react"] }
+```
+
+```ts
+// eslint.config.mjs — arrays of flat configs, spread together
+import core from "ultracite/eslint/core";
+import react from "ultracite/eslint/react";
+export default [...core, ...react];
+```
+
+```ts
+// oxlint.config.ts — imports passed to extends
+import { defineConfig } from "oxlint";
+import core from "ultracite/oxlint/core";
+export default defineConfig({
+  extends: [core],
+  ignorePatterns: core.ignorePatterns,
+});
+```
+
+Presets available per linter (`ultracite/<linter>/<preset>`): `core`, `react`, `next`, `solid`, `vue`, `svelte`, `qwik`, `remix`, `tanstack`, `angular`, `astro`, `nestjs`, `jest`, `vitest`. Biome also has `type-aware`; Oxlint also has `github` and `sonarjs` (ESLint plugins run via oxlint's JS plugin support, included by default on init).
+
+## Code Standards
+
+When writing code in a project with Ultracite, follow these standards. For the full rules reference, see [references/code-standards.md](references/code-standards.md).
+
+Key rules at a glance:
+
+Formatting is handled by the project's configured linter/formatter. Respect the repository's existing formatter settings instead of forcing one fixed line width, quote style, or trailing comma policy.
+
+**Type safety:** Use explicit types when they improve clarity. Prefer `unknown` over `any`. Use `as const` for immutable values and rely on type narrowing over blunt assertions.
+
+**Modern JavaScript/TypeScript:** Prefer `const`, destructuring, optional chaining, nullish coalescing, template literals, `for...of`, and concise arrow functions.
+
+**Async and correctness:** Always `await` promises in async functions. Prefer `async/await` over promise chains. Remove `console.log`, `debugger`, and `alert` from production code.
+
+**React and accessibility:** Use function components, keep hooks top-level with correct deps, avoid nested component definitions, and use semantic HTML with the right labels, headings, alt text, and keyboard affordances.
+
+**Organization, security, performance, and testing:** Keep functions focused, prefer early returns, avoid `dangerouslySetInnerHTML` and `eval()`, prefer specific imports and top-level regex, and keep tests free of `.only` and `.skip`.
+
+## Troubleshooting
+
+Run `bunx ultracite doctor` to diagnose. It checks:
+
+1. Linter and formatter installation (Biome; or ESLint + Prettier + Stylelint; or Oxlint + oxfmt)
+2. Config validity (extends the ultracite presets correctly)
+3. Ultracite in package.json dependencies
+4. Conflicting tools (legacy `.eslintrc.*` files; `.prettierrc.*`/`prettier.config.*` when not using the ESLint backend)
+
+Common fixes:
+
+- **Conflicting configs**: Delete legacy `.eslintrc.*` and `.prettierrc.*` files after migrating to Ultracite
+- **Missing dependency**: Run `bunx ultracite init` again or manually add `ultracite` to devDependencies
+- **Rules not applying**: Ensure config file extends the correct presets for your framework

--- a/.agents/skills/ultracite/references/code-standards.md
+++ b/.agents/skills/ultracite/references/code-standards.md
@@ -1,0 +1,102 @@
+# Ultracite Code Standards
+
+Formatting is intentionally handled by your project's configured linter or formatter. Respect the repository's existing quote, width, semicolon, trailing comma, and line ending settings instead of forcing one global formatting style.
+
+## Core Principles
+
+Write code that is **accessible, performant, type-safe, and maintainable**. Focus on clarity and explicit intent over brevity.
+
+## Type Safety & Explicitness
+
+- Use explicit types for function parameters and return values when they enhance clarity
+- Prefer `unknown` over `any` when the type is genuinely unknown
+- Use const assertions (`as const`) for immutable values and literal types
+- Leverage TypeScript's type narrowing instead of type assertions
+- Use meaningful variable names instead of magic numbers — extract constants with descriptive names
+
+## Modern JavaScript/TypeScript
+
+- Use arrow functions for callbacks and short functions
+- Prefer `for...of` loops over `.forEach()` and indexed `for` loops
+- Use optional chaining (`?.`) and nullish coalescing (`??`) for safer property access
+- Prefer template literals over string concatenation
+- Use destructuring for object and array assignments
+- Use `const` by default, `let` only when reassignment is needed, never `var`
+
+## Async & Promises
+
+- Always `await` promises in async functions — don't forget to use the return value
+- Use `async/await` syntax instead of promise chains for better readability
+- Handle errors appropriately in async code with try-catch blocks
+- Don't use async functions as Promise executors
+
+## React & JSX
+
+- Use function components over class components
+- Call hooks at the top level only, never conditionally
+- Specify all dependencies in hook dependency arrays correctly
+- Use the `key` prop for elements in iterables (prefer unique IDs over array indices)
+- Nest children between opening and closing tags instead of passing as props
+- Don't define components inside other components
+- Use semantic HTML and ARIA attributes for accessibility:
+  - Provide meaningful alt text for images
+  - Use proper heading hierarchy
+  - Add labels for form inputs
+  - Include keyboard event handlers alongside mouse events
+  - Use semantic elements (`<button>`, `<nav>`, etc.) instead of divs with roles
+
+## Error Handling & Debugging
+
+- Remove `console.log`, `debugger`, and `alert` statements from production code
+- Throw `Error` objects with descriptive messages, not strings or other values
+- Use `try-catch` blocks meaningfully — don't catch errors just to rethrow them
+- Prefer early returns over nested conditionals for error cases
+
+## Code Organization
+
+- Keep functions focused and under reasonable cognitive complexity limits
+- Extract complex conditions into well-named boolean variables
+- Use early returns to reduce nesting
+- Prefer simple conditionals over nested ternary operators
+- Group related code together and separate concerns
+
+## Security
+
+- Add `rel="noopener"` when using `target="_blank"` on links
+- Avoid `dangerouslySetInnerHTML` unless absolutely necessary
+- Don't use `eval()` or assign directly to `document.cookie`
+- Validate and sanitize user input
+
+## Performance
+
+- Avoid spread syntax in accumulators within loops
+- Use top-level regex literals instead of creating them in loops
+- Prefer specific imports over namespace imports
+- Avoid barrel files (index files that re-export everything)
+- Use proper image components (e.g., Next.js `<Image>`) over `<img>` tags
+
+## Framework-Specific
+
+**Next.js:** Use `<Image>` component for images. Use `next/head` or the App Router metadata API for head elements. Use Server Components for async data fetching instead of async Client Components.
+
+**React 19+:** Use ref as a prop instead of `React.forwardRef`.
+
+**Solid/Svelte/Vue/Qwik:** Use `class` and `for` attributes (not `className` or `htmlFor`).
+
+## Testing
+
+- Write assertions inside `it()` or `test()` blocks
+- Avoid done callbacks in async tests — use async/await instead
+- Don't use `.only` or `.skip` in committed code
+- Keep test suites reasonably flat — avoid excessive `describe` nesting
+
+## When Your Linter Can't Help
+
+Your configured linter or formatter will catch most mechanical issues automatically. Focus your attention on:
+
+1. Business logic correctness
+2. Meaningful naming
+3. Architecture decisions
+4. Edge cases
+5. User experience
+6. Documentation for genuinely complex logic

--- a/.claude/skills/c15t
+++ b/.claude/skills/c15t
@@ -1,0 +1,1 @@
+../../.agents/skills/c15t

--- a/.claude/skills/ultracite
+++ b/.claude/skills/ultracite
@@ -1,0 +1,1 @@
+../../.agents/skills/ultracite

--- a/.cursor/skills/c15t
+++ b/.cursor/skills/c15t
@@ -1,0 +1,1 @@
+../../.agents/skills/c15t

--- a/.cursor/skills/ultracite
+++ b/.cursor/skills/ultracite
@@ -1,0 +1,1 @@
+../../.agents/skills/ultracite

--- a/.github/skills/c15t
+++ b/.github/skills/c15t
@@ -1,0 +1,1 @@
+../../.agents/skills/c15t

--- a/.github/skills/ultracite
+++ b/.github/skills/ultracite
@@ -1,0 +1,1 @@
+../../.agents/skills/ultracite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ Conventions not enforced by tooling (hold new code to these; older code has exce
 
 To change package-bundled docs or READMEs, edit the source (`docs/**/*.mdx` or `readme.json`) and regenerate.
 
+The package-level `AGENTS.md` files are **consumer-facing** documentation indexes that ship in the published tarballs (they are listed in each package's `files`), so an agent in a user's app can read the docs offline from `node_modules`. They are not contribution guidance, they are gitignored here, and they only appear after a build. Keep them useful to that audience — don't add monorepo-only instructions to them. This file's rules still apply when you work inside those packages.
+
 ## Change hygiene
 
 When adding or changing user-facing package behavior:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
 	"version": 1,
 	"skills": {
+		"c15t": {
+			"source": "c15t/skills",
+			"sourceType": "github",
+			"skillPath": "c15t/SKILL.md",
+			"computedHash": "031b918ecb7f15c96e690412c79e2ebb8f4a2bcea5c5fac3d87d9752d4153660"
+		},
 		"leadtype": {
 			"source": "inthhq/leadtype",
 			"sourceType": "github",
@@ -11,7 +17,13 @@
 			"source": "vercel/turborepo",
 			"sourceType": "github",
 			"skillPath": "skills/turborepo/SKILL.md",
-			"computedHash": "7fcd5ac3e11b30b86907ab9a81af6888954d9f14c72f3e09f5cc2afcbd50956d"
+			"computedHash": "91ca859d13834ab4103eff55bfd66ae43ef0823a8339664dd1cccc5a9ddfd7cb"
+		},
+		"ultracite": {
+			"source": "haydenbleasel/ultracite",
+			"sourceType": "github",
+			"skillPath": "skills/ultracite/SKILL.md",
+			"computedHash": "e061f8c74bb2ee6ceb57d4a904fc83be81fd559febe6e76971f055913910df75"
 		},
 		"vercel-composition-patterns": {
 			"source": "vercel-labs/agent-skills",


### PR DESCRIPTION
## What

Agent-guidance cleanup scoped to `.agents/skills` and one clarifying paragraph in the root guide.

### Vendored skills

- Adds `c15t` and `ultracite` to `.agents/skills`, symlinked from `.claude/`, `.cursor/`, and `.github/` to match the existing layout.
- Refreshes the vendored `turborepo` skill 2.10.3 → 2.10.6.
- Pins all three in `skills-lock.json`.

All four skill directories now hold the same 10 entries; the 3 first-party skills (`writing-docs`, `releasing`, `creating-a-package`) are untouched.

### Root `AGENTS.md`

Records who the generated package-level `AGENTS.md` files are actually for. They're listed in each package's `files` array, so they ship in the published tarballs for consumers' agents to read out of `node_modules` — they are not contribution guidance, they're gitignored here, and they only appear after a build. Worth stating so they don't accumulate monorepo-only instructions over time.

## Verification

- Every symlink resolves; `skills-lock.json` entries and `.agents/skills` directories match with no orphans on either side.
- `scripts/generate-package-docs.ts` is byte-identical to `canary` — no generator change in this PR.

## Notes for review

- No changeset: skills and repo guidance only, no published-package content changes.
- Branched from `canary`. Bringing `main`'s commits into `canary` is left to the existing sync PR #926.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for working with the c15t consent management platform, including setup, customization, translations, and security practices.
  * Added comprehensive Ultracite documentation covering commands, configuration, troubleshooting, and code standards.
  * Clarified how package documentation guides are distributed and used.
  * Updated Turborepo examples and references to version 2.10.6.

* **Chores**
  * Consolidated skill references across supported development tools.
  * Added c15t to the locked skill configuration and refreshed Ultracite metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->