### PR TITLE
chore(ci): disable Benchmark Regression on pull requests

### DIFF
--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -1,20 +1,23 @@
 name: Benchmark Regression
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'packages/core/**'
-      - 'packages/react/**'
-      - 'packages/nextjs/**'
-      - 'packages/translations/**'
-      - 'packages/ui/**'
-      - 'benchmarks/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'bun.lockb'
-      - 'turbo.json'
-      - 'internals/bundle-analysis-action/**'
+  # TODO: re-enable the pull_request trigger once the report is less noisy.
+  # Disabled for now — the per-PR comparison comment is too spammy.
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+  #   paths:
+  #     - 'packages/core/**'
+  #     - 'packages/react/**'
+  #     - 'packages/nextjs/**'
+  #     - 'packages/translations/**'
+  #     - 'packages/ui/**'
+  #     - 'benchmarks/**'
+  #     - 'package.json'
+  #     - 'bun.lock'
+  #     - 'bun.lockb'
+  #     - 'turbo.json'
+  #     - 'internals/bundle-analysis-action/**'
+  workflow_dispatch:
   push:
     branches: ['main', 'canary']
     paths:


### PR DESCRIPTION
## What

Stops the **Benchmark Regression** workflow from running on pull requests. The per-PR comparison comment is too spammy; disabling it for now, to be revisited.

## How

- Commented out the `pull_request:` trigger in `.github/workflows/benchmark-regression.yml`, with a `TODO` noting it is temporary.
- Added `workflow_dispatch:` so the suite can still be run manually when benchmark numbers are needed (e.g. for perf PRs).
- Left the `push:` trigger on `main`/`canary` untouched, so the `benchmark-current` baseline artifact keeps being produced.

`benchmark-comment.yml` needs no change — its job is already gated on `github.event.workflow_run.event == 'pull_request'`, so with no PR runs it never posts.

## Notes

- No changeset: CI-only change, no published-package behaviour affected.
- Bundle Analysis still comments on every PR; that is intentionally left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic benchmark regression checks for pull requests to reduce noisy reporting.
  * Benchmark checks remain available through manual runs and pushes to the main development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->