### PR TITLE
docs: clarify consent subject identification

### DIFF
--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -24,43 +24,113 @@ function MyComponent() {
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#state-and-actions" />
 
-## identifyUser
+## User Identification
 
-The `identifyUser()` method links anonymous consent records to an authenticated user. Call it after a user logs in to associate their consent preferences with their account.
+You can link a consent subject to your own internal user ID or a non-secret anonymous visitor ID. c15t stores the identifier in the subject row's `externalId` field. Consent records remain associated with that subject through `subjectId`, so your backend can find the subject and its related consent records by external ID for GDPR Article 15 exports.
+
+### 1. Providing the Current User ID
+
+When using Clerk, prefer the Clerk `userId` whenever the visitor is signed in. Before sign-in, you can fall back to a non-secret visitor ID stored in a first-party cookie:
+
+<Callout type="warn">
+  `ConsentManagerProvider` runs on the client. Values passed through
+  `options.user` are therefore available to client-side JavaScript, even when
+  they were read from an HttpOnly cookie on the server. Pass only a non-secret
+  identifier, such as a Clerk `userId` or an opaque visitor ID. Never pass a
+  Clerk session token or a value returned by `getToken()`.
+</Callout>
+
+<Callout type="info">
+  Clerk's `auth()` helper requires `clerkMiddleware()` to be configured. This
+  example also uses the asynchronous `cookies()` API from **Next.js 15+**. For
+  **Next.js 14 and earlier**, use `const cookieStore = cookies();` without
+  `await`. Keep the layout asynchronous because Clerk's `auth()` is
+  asynchronous.
+</Callout>
 
 ```tsx
-import { useConsentManager } from '@c15t/nextjs';
+// app/layout.tsx
+import { ClerkProvider } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
+import { ConsentManagerProvider } from '@c15t/nextjs';
+import { cookies } from 'next/headers';
+import { ClerkConsentSync } from './clerk-consent-sync';
 
-function LoginForm() {
-  const { identifyUser } = useConsentManager();
-
-  async function handleLogin(email: string) {
-    // ... your login logic
-    const user = await api.login(email);
-
-    // Link consent to the authenticated user
-    await identifyUser({
-      id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0'
-    });
-  }
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const { userId } = await auth();
+  const cookieStore = await cookies();
+  const visitorId = cookieStore.get('consent_visitor_id')?.value;
+  const consentUser = userId
+    ? { id: userId, identityProvider: 'clerk' }
+    : visitorId
+      ? { id: visitorId, identityProvider: 'anonymous-visitor' }
+      : undefined;
 
   return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      handleLogin(new FormData(e.currentTarget).get('email') as string);
-    }}>
-      <input name="email" type="email" placeholder="Email" />
-      <button type="submit">Log in</button>
-    </form>
+    <html lang="en">
+      <body>
+        <ClerkProvider>
+          <ConsentManagerProvider
+            options={{
+              mode: 'hosted',
+              backendURL: '/api/c15t',
+              consentCategories: ['necessary', 'measurement', 'marketing'],
+              user: consentUser,
+            }}
+          >
+            <ClerkConsentSync />
+            {children}
+          </ConsentManagerProvider>
+        </ClerkProvider>
+      </body>
+    </html>
   );
 }
 ```
 
+### 2. Synchronizing Clerk Sign-ins
+
+Clerk can complete a sign-in without reloading the page. Add a client component inside `ConsentManagerProvider` to update the current consent subject as soon as Clerk exposes the authenticated `userId`:
+
+```tsx
+// app/clerk-consent-sync.tsx
+'use client';
+
+import { useAuth } from '@clerk/nextjs';
+import { useConsentManager } from '@c15t/nextjs';
+import { useEffect } from 'react';
+
+export function ClerkConsentSync() {
+  const { isLoaded, isSignedIn, userId } = useAuth();
+  const { identifyUser } = useConsentManager();
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !userId) {
+      return;
+    }
+
+    void identifyUser({
+      id: userId,
+      identityProvider: 'clerk',
+    }).then(() => {
+      // Prevent the old anonymous ID from replacing the Clerk ID after sign-out.
+      document.cookie =
+        'consent_visitor_id=; Max-Age=0; Path=/; SameSite=Lax';
+    });
+  }, [identifyUser, isLoaded, isSignedIn, userId]);
+
+  return null;
+}
+```
+
+`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, stop supplying the former visitor ID. The example clears its client-readable cookie only after `identifyUser()` succeeds so a later render cannot change the subject back to the anonymous ID.
+
 <Callout type="info">
-  `identifyUser` sends the user data to the c15t backend. It works in hosted
-  mode, including the legacy alias `mode: 'c15t'`. In `mode: 'offline'`, the
-  call is a no-op.
+  Backend subject identification requires hosted mode (`mode: 'hosted'`). In
+  offline mode, `identifyUser()` cannot update a backend subject. Identifiers
+  supplied through `options.user` can still be held in client state and
+  persisted with locally stored consent, so do not place sensitive values
+  there.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />

--- a/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
@@ -24,43 +24,94 @@ function MyComponent() {
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#state-and-actions" />
 
-## identifyUser
+## User Identification
 
-The `identifyUser()` method links anonymous consent records to an authenticated user. Call it after a user logs in to associate their consent preferences with their account.
+You can link a consent subject to your own internal user ID or a non-secret anonymous visitor ID. c15t stores the identifier in the subject row's `externalId` field. Consent records remain associated with that subject through `subjectId`, so your backend can find the subject and its related consent records by external ID for GDPR Article 15 exports.
+
+### 1. Providing the Current User ID
+
+When using Clerk, wait for Clerk to load and prefer its authenticated `userId`. Before sign-in, you can fall back to a non-secret visitor ID from your application:
+
+<Callout type="warn">
+  Values passed through `options.user` are available to client-side JavaScript.
+  Pass only a non-secret identifier, such as a Clerk `userId` or an opaque
+  visitor ID. Never pass a Clerk session token or a value returned by
+  `getToken()`.
+</Callout>
 
 ```tsx
-import { useConsentManager } from '@c15t/react';
+import { useAuth } from '@clerk/react';
+import { ConsentManagerProvider } from '@c15t/react';
 
-function LoginForm() {
-  const { identifyUser } = useConsentManager();
+function ConsentApp() {
+  // Render this component beneath your existing ClerkProvider.
+  const { isLoaded, isSignedIn, userId } = useAuth();
 
-  async function handleLogin(email: string) {
-    // ... your login logic
-    const user = await api.login(email);
-
-    // Link consent to the authenticated user
-    await identifyUser({
-      id: user.id,
-      identityProvider: 'your-auth-provider', // e.g. 'clerk', 'auth0'
-    });
+  if (!isLoaded) {
+    return null;
   }
 
+  const visitorId = getVisitorId();
+  const consentUser = isSignedIn && userId
+    ? { id: userId, identityProvider: 'clerk' }
+    : visitorId
+      ? { id: visitorId, identityProvider: 'anonymous-visitor' }
+      : undefined;
+
   return (
-    <form onSubmit={(e) => {
-      e.preventDefault();
-      handleLogin(new FormData(e.currentTarget).get('email') as string);
-    }}>
-      <input name="email" type="email" placeholder="Email" />
-      <button type="submit">Log in</button>
-    </form>
+    <ConsentManagerProvider
+      options={{
+        mode: 'hosted',
+        backendURL: 'https://your-instance.c15t.dev',
+        consentCategories: ['necessary', 'measurement', 'marketing'],
+        user: consentUser,
+      }}
+    >
+      <ClerkConsentSync />
+      <MyComponents />
+    </ConsentManagerProvider>
   );
 }
 ```
 
+### 2. Synchronizing Clerk Sign-ins
+
+Use a component inside `ConsentManagerProvider` to update the current consent subject when Clerk's authentication state changes:
+
+```tsx
+import { useAuth } from '@clerk/react';
+import { useConsentManager } from '@c15t/react';
+import { useEffect } from 'react';
+
+function ClerkConsentSync() {
+  const { isLoaded, isSignedIn, userId } = useAuth();
+  const { identifyUser } = useConsentManager();
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !userId) {
+      return;
+    }
+
+    void identifyUser({
+      id: userId,
+      identityProvider: 'clerk',
+    }).then(() => {
+      clearVisitorId();
+    });
+  }, [identifyUser, isLoaded, isSignedIn, userId]);
+
+  return null;
+}
+```
+
+`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, clear the previous visitor ID from the application state or storage used by `getVisitorId()` so it cannot replace the Clerk ID later.
+
 <Callout type="info">
-  `identifyUser` sends the user data to the c15t backend. It works in hosted
-  mode, including the legacy alias `mode: 'c15t'`. In `mode: 'offline'`, the
-  call is a no-op.
+  Backend subject identification requires hosted mode (`mode: 'hosted'`). In
+  offline mode, `identifyUser()` cannot update a backend subject. Identifiers
+  supplied through `options.user` can still be held in client state and
+  persisted with locally stored consent, so do not place sensitive values
+  there.
 </Callout>
 
 <import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#key-types" />


### PR DESCRIPTION
Moves the documentation changes from #869 onto the intended `canary` branch.

PR #869 was accidentally merged into `main`; a separate revert PR removes it there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for linking consent subjects to authenticated or anonymous visitor IDs.
  * Added Clerk integration examples for synchronizing consent identity after sign-in.
  * Clarified that user identifiers may be stored locally in offline mode and should not contain sensitive data.
  * Documented how `identifyUser()` replaces existing external IDs and how to prevent stale visitor IDs from overriding authenticated IDs.
  * Clarified hosted versus offline behavior for backend subject identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->