### PR TITLE
fix: unblock canary changeset release

### DIFF
--- a/.changeset/dependency-audit-ts7.md
+++ b/.changeset/dependency-audit-ts7.md
@@ -5,9 +5,6 @@
 "c15t": patch
 "@c15t/dev-tools": patch
 "@c15t/schema": patch
-"@c15t/solid": patch
-"@c15t/svelte": patch
-"@c15t/vue": patch
 "@c15t/react": patch
 "@c15t/nextjs": patch
 "@c15t/translations": patch


### PR DESCRIPTION
## Summary

- remove `@c15t/solid`, `@c15t/svelte`, and `@c15t/vue` from the dependency audit changeset
- keep the changeset limited to publishable packages so canary snapshot versioning can proceed

## Root cause

The three framework packages are private and unversioned. Changesets treats them as ignored and rejects a changeset that mixes them with publishable packages.

## Verification

- `bunx changeset status`
- `bun run version:canary` in a disposable worktree
- full Agent CI was unavailable because the local Docker socket is not present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upcoming release configuration so selected Solid, Svelte, and Vue packages do not receive an unnecessary patch version bump.
  * Retained dependency-audit guidance for removing unused dependencies, updating runtime packages, enforcing security versions, and maintaining the TypeScript toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->