### PR TITLE
fix(backend): prevent subject list database timeouts

### DIFF
--- a/.changeset/fix-subject-list-db-pressure.md
+++ b/.changeset/fix-subject-list-db-pressure.md
@@ -1,0 +1,5 @@
+---
+'@c15t/backend': patch
+---
+
+Fix database timeouts when listing subjects with `GET /subjects`.

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Patch Changes
 
-- Fix database timeouts when listing subjects with `GET /subjects`.
 - 8c004cf: Improve generated OpenAPI request schemas for consent, subject, and legal-document endpoints.
 - 16a1f82: Dependency audit for the next release: remove unused `@orpc/*` dependencies from `@c15t/backend` and `@c15t/node-sdk`, update runtime dependencies (hono 4.12.27, valibot 1.4.2, defu 6.1.7, jose 6.2.3, zod 4.4.3, zustand 5.0.14, xstate 5.32.4, and more), and force security floors for kysely (SQL injection fixes) and protobufjs via workspace overrides. Builds now use TypeScript 7 (native compiler) with rslib 0.23 for type checking and declaration emit; emitted types are semantically unchanged.
 - c7e53ff: Forward `x-c15t-version` on backend-bound requests from browser, SSR, prefetch, and Node SDK clients, and allow the header through backend CORS preflight handling.

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Fix database timeouts when listing subjects with `GET /subjects`.
 - 8c004cf: Improve generated OpenAPI request schemas for consent, subject, and legal-document endpoints.
 - 16a1f82: Dependency audit for the next release: remove unused `@orpc/*` dependencies from `@c15t/backend` and `@c15t/node-sdk`, update runtime dependencies (hono 4.12.27, valibot 1.4.2, defu 6.1.7, jose 6.2.3, zod 4.4.3, zustand 5.0.14, xstate 5.32.4, and more), and force security floors for kysely (SQL injection fixes) and protobufjs via workspace overrides. Builds now use TypeScript 7 (native compiler) with rslib 0.23 for type checking and declaration emit; emitted types are semantically unchanged.
 - c7e53ff: Forward `x-c15t-version` on backend-bound requests from browser, SSR, prefetch, and Node SDK clients, and allow the header through backend CORS preflight handling.

--- a/packages/backend/src/handlers/subject/list.handler.test.ts
+++ b/packages/backend/src/handlers/subject/list.handler.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it, vi } from 'vitest';
+import { listSubjectsHandler } from './list.handler';
+
+const CREATED_AT = new Date('2026-07-28T00:00:00.000Z');
+const GIVEN_AT = new Date('2026-07-28T01:00:00.000Z');
+
+interface SubjectRow {
+	id: string;
+	externalId: string;
+	createdAt: Date;
+}
+
+interface ConsentRow {
+	id: string;
+	subjectId: string;
+	policyId: string;
+	purposeIds: string[];
+	givenAt: Date;
+}
+
+interface TestData {
+	subjects: SubjectRow[];
+	consents: ConsentRow[];
+}
+
+function createTestData(
+	subjectCount: number,
+	consentsPerSubject: number
+): TestData {
+	const subjects = Array.from({ length: subjectCount }, (_, subjectIndex) => ({
+		id: `sub_${subjectIndex}`,
+		externalId: 'user_123',
+		createdAt: CREATED_AT,
+	}));
+	const consents = subjects.flatMap((subject) =>
+		Array.from({ length: consentsPerSubject }, (_, consentIndex) => ({
+			id: `con_${subject.id}_${consentIndex}`,
+			subjectId: subject.id,
+			policyId: 'pol_1',
+			purposeIds: ['pur_1'],
+			givenAt: GIVEN_AT,
+		}))
+	);
+
+	return { subjects, consents };
+}
+
+function tableResult(table: string, data: TestData) {
+	switch (table) {
+		case 'subject':
+			return data.subjects;
+		case 'consent':
+			return data.consents;
+		case 'consentPolicy':
+			return [
+				{
+					id: 'pol_1',
+					type: 'privacy_policy',
+					version: '1.0.0',
+					effectiveDate: CREATED_AT,
+				},
+			];
+		case 'consentPurpose':
+			return [{ id: 'pur_1', code: 'analytics' }];
+		default:
+			return [];
+	}
+}
+
+function createContext(data: TestData) {
+	const db = {
+		findMany: vi.fn((table: string) =>
+			Promise.resolve(tableResult(table, data))
+		),
+		transaction: vi.fn(),
+	};
+	const registry = {
+		findLatestPolicyByType: vi.fn().mockResolvedValue({ id: 'pol_1' }),
+	};
+	const logger = {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	};
+	const context = {
+		get: (key: string) =>
+			key === 'c15tContext'
+				? {
+						apiKeyAuthenticated: true,
+						db,
+						registry,
+						logger,
+					}
+				: undefined,
+		req: {
+			query: (key: string) => (key === 'externalId' ? 'user_123' : undefined),
+		},
+		json: vi.fn((value) => value),
+	};
+
+	return { context, db, registry };
+}
+
+class ConstrainedPool {
+	readonly max: number;
+	readonly acquisitionTimeoutMs: number;
+	readonly queryMs: number;
+
+	active = 0;
+	acquired = 0;
+	released = 0;
+	timedOut = 0;
+	maxActive = 0;
+	maxWaiting = 0;
+
+	private readonly waiters: Array<{
+		resolve: () => void;
+		reject: (error: Error) => void;
+		timer: ReturnType<typeof setTimeout>;
+	}> = [];
+	private readonly outstandingByRequest = new Map<string, number>();
+	private readonly maxOutstandingByRequest = new Map<string, number>();
+
+	constructor(options: {
+		max: number;
+		acquisitionTimeoutMs: number;
+		queryMs: number;
+	}) {
+		this.max = options.max;
+		this.acquisitionTimeoutMs = options.acquisitionTimeoutMs;
+		this.queryMs = options.queryMs;
+	}
+
+	get waiting() {
+		return this.waiters.length;
+	}
+
+	maxOutstanding(requestId: string) {
+		return this.maxOutstandingByRequest.get(requestId) ?? 0;
+	}
+
+	async query<ResultType>(
+		requestId: string,
+		run: () => ResultType
+	): Promise<ResultType> {
+		this.incrementOutstanding(requestId);
+		let acquired = false;
+
+		try {
+			await this.acquire();
+			acquired = true;
+			await new Promise((resolve) => setTimeout(resolve, this.queryMs));
+			return run();
+		} finally {
+			if (acquired) this.release();
+			this.decrementOutstanding(requestId);
+		}
+	}
+
+	private incrementOutstanding(requestId: string) {
+		const outstanding = (this.outstandingByRequest.get(requestId) ?? 0) + 1;
+		this.outstandingByRequest.set(requestId, outstanding);
+		this.maxOutstandingByRequest.set(
+			requestId,
+			Math.max(this.maxOutstanding(requestId), outstanding)
+		);
+	}
+
+	private decrementOutstanding(requestId: string) {
+		const outstanding = (this.outstandingByRequest.get(requestId) ?? 1) - 1;
+		if (outstanding === 0) {
+			this.outstandingByRequest.delete(requestId);
+			return;
+		}
+		this.outstandingByRequest.set(requestId, outstanding);
+	}
+
+	private acquire(): Promise<void> {
+		if (this.active < this.max) {
+			this.checkout();
+			return Promise.resolve();
+		}
+
+		return new Promise((resolve, reject) => {
+			const waiter = {
+				resolve: () => {
+					clearTimeout(waiter.timer);
+					this.checkout();
+					resolve();
+				},
+				reject,
+				timer: setTimeout(() => {
+					const index = this.waiters.indexOf(waiter);
+					if (index >= 0) this.waiters.splice(index, 1);
+					this.timedOut++;
+					reject(new Error('timeout exceeded when trying to connect'));
+				}, this.acquisitionTimeoutMs),
+			};
+			this.waiters.push(waiter);
+			this.maxWaiting = Math.max(this.maxWaiting, this.waiting);
+		});
+	}
+
+	private checkout() {
+		this.active++;
+		this.acquired++;
+		this.maxActive = Math.max(this.maxActive, this.active);
+	}
+
+	private release() {
+		this.active--;
+		this.released++;
+		const waiter = this.waiters.shift();
+		waiter?.resolve();
+	}
+}
+
+function createPooledContext(
+	data: TestData,
+	pool: ConstrainedPool,
+	requestId: string,
+	failTable?: string
+) {
+	const db = {
+		findMany: vi.fn((table: string) =>
+			pool.query(requestId, () => {
+				if (table === failTable) throw new Error('forced query failure');
+				return tableResult(table, data);
+			})
+		),
+		transaction: vi.fn(),
+	};
+	const registry = {
+		findLatestPolicyByType: vi.fn(() =>
+			pool.query(requestId, () => ({ id: 'pol_1' }))
+		),
+	};
+	const logger = {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	};
+	const context = {
+		get: (key: string) =>
+			key === 'c15tContext'
+				? {
+						apiKeyAuthenticated: true,
+						db,
+						registry,
+						logger,
+					}
+				: undefined,
+		req: {
+			query: (key: string) => (key === 'externalId' ? 'user_123' : undefined),
+		},
+		json: vi.fn((value) => value),
+	};
+
+	return { context, db };
+}
+
+describe('listSubjectsHandler', () => {
+	it('skips consent and enrichment queries when no subjects match', async () => {
+		const { context, db, registry } = createContext(createTestData(0, 0));
+
+		await expect(listSubjectsHandler(context as never)).resolves.toEqual({
+			subjects: [],
+		});
+		expect(db.findMany).toHaveBeenCalledTimes(1);
+		expect(db.findMany).toHaveBeenCalledWith(
+			'subject',
+			expect.objectContaining({ where: expect.any(Function) })
+		);
+		expect(registry.findLatestPolicyByType).not.toHaveBeenCalled();
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ subjectCount: 2, consentsPerSubject: 1 },
+		{ subjectCount: 100, consentsPerSubject: 3 },
+	])('batches $subjectCount subjects with $consentsPerSubject consents each into five queries', async ({
+		subjectCount,
+		consentsPerSubject,
+	}) => {
+		const data = createTestData(subjectCount, consentsPerSubject);
+		const { context, db, registry } = createContext(data);
+
+		const result = (await listSubjectsHandler(context as never)) as {
+			subjects: Array<{ id: string; consents: unknown[] }>;
+		};
+
+		expect(db.findMany.mock.calls.map(([table]) => table)).toEqual([
+			'subject',
+			'consent',
+			'consentPolicy',
+			'consentPurpose',
+		]);
+		expect(registry.findLatestPolicyByType).toHaveBeenCalledTimes(1);
+		expect(db.findMany.mock.calls.length + 1).toBe(5);
+		expect(result.subjects).toHaveLength(subjectCount);
+		expect(
+			result.subjects.every(
+				(subject) => subject.consents.length === consentsPerSubject
+			)
+		).toBe(true);
+
+		const consentWhere = db.findMany.mock.calls.find(
+			([table]) => table === 'consent'
+		)?.[1].where;
+		const builder = vi.fn();
+		consentWhere?.(builder);
+		expect(builder).toHaveBeenCalledWith(
+			'subjectId',
+			'in',
+			data.subjects.map((subject) => subject.id)
+		);
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
+	it('bounds concurrent GET workload to one acquisition per request', async () => {
+		const requestCount = 4;
+		const pool = new ConstrainedPool({
+			max: 2,
+			acquisitionTimeoutMs: 250,
+			queryMs: 5,
+		});
+		const requests = Array.from({ length: requestCount }, (_, index) => {
+			const requestId = `request_${index}`;
+			const { context } = createPooledContext(
+				createTestData(50, 2),
+				pool,
+				requestId
+			);
+			return { requestId, response: listSubjectsHandler(context as never) };
+		});
+
+		const responses = await Promise.all(
+			requests.map(({ response }) => response)
+		);
+
+		expect(responses).toHaveLength(requestCount);
+		expect(pool.maxActive).toBe(2);
+		expect(pool.maxWaiting).toBeLessThanOrEqual(requestCount - pool.max);
+		expect(pool.timedOut).toBe(0);
+		expect(pool.active).toBe(0);
+		expect(pool.waiting).toBe(0);
+		expect(pool.acquired).toBe(pool.released);
+		for (const { requestId } of requests) {
+			expect(pool.maxOutstanding(requestId)).toBe(1);
+		}
+	});
+
+	it('has no checked-out or queued work after a query fails', async () => {
+		const pool = new ConstrainedPool({
+			max: 1,
+			acquisitionTimeoutMs: 250,
+			queryMs: 5,
+		});
+		const { context, db } = createPooledContext(
+			createTestData(50, 2),
+			pool,
+			'failing_request',
+			'consentPolicy'
+		);
+
+		await expect(listSubjectsHandler(context as never)).rejects.toMatchObject({
+			status: 500,
+		});
+		expect(pool.active).toBe(0);
+		expect(pool.waiting).toBe(0);
+		expect(pool.acquired).toBe(pool.released);
+		expect(pool.maxOutstanding('failing_request')).toBe(1);
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+});

--- a/packages/backend/src/handlers/subject/list.handler.test.ts
+++ b/packages/backend/src/handlers/subject/list.handler.test.ts
@@ -23,6 +23,16 @@ interface TestData {
 	consents: ConsentRow[];
 }
 
+type TestWhereBuilder = (
+	column: string,
+	operator: string,
+	value: unknown
+) => unknown;
+
+interface TestFindManyOptions {
+	where?: (builder: TestWhereBuilder) => unknown;
+}
+
 function createTestData(
 	subjectCount: number,
 	consentsPerSubject: number
@@ -45,12 +55,32 @@ function createTestData(
 	return { subjects, consents };
 }
 
-function tableResult(table: string, data: TestData) {
+function subjectIdsFromWhere(options?: TestFindManyOptions) {
+	let subjectIds: string[] | undefined;
+	options?.where?.((column, operator, value) => {
+		if (column === 'subjectId' && operator === 'in' && Array.isArray(value)) {
+			subjectIds = value as string[];
+		}
+	});
+	return subjectIds;
+}
+
+function tableResult(
+	table: string,
+	data: TestData,
+	options?: TestFindManyOptions
+) {
 	switch (table) {
 		case 'subject':
 			return data.subjects;
-		case 'consent':
-			return data.consents;
+		case 'consent': {
+			const subjectIds = subjectIdsFromWhere(options);
+			return subjectIds
+				? data.consents.filter((consent) =>
+						subjectIds.includes(consent.subjectId)
+					)
+				: data.consents;
+		}
 		case 'consentPolicy':
 			return [
 				{
@@ -69,8 +99,8 @@ function tableResult(table: string, data: TestData) {
 
 function createContext(data: TestData) {
 	const db = {
-		findMany: vi.fn((table: string) =>
-			Promise.resolve(tableResult(table, data))
+		findMany: vi.fn((table: string, options?: TestFindManyOptions) =>
+			Promise.resolve(tableResult(table, data, options))
 		),
 		transaction: vi.fn(),
 	};
@@ -222,10 +252,10 @@ function createPooledContext(
 	failTable?: string
 ) {
 	const db = {
-		findMany: vi.fn((table: string) =>
+		findMany: vi.fn((table: string, options?: TestFindManyOptions) =>
 			pool.query(requestId, () => {
 				if (table === failTable) throw new Error('forced query failure');
-				return tableResult(table, data);
+				return tableResult(table, data, options);
 			})
 		),
 		transaction: vi.fn(),
@@ -296,7 +326,7 @@ describe('listSubjectsHandler', () => {
 			'consentPurpose',
 		]);
 		expect(registry.findLatestPolicyByType).toHaveBeenCalledTimes(1);
-		expect(db.findMany.mock.calls.length + 1).toBe(5);
+		expect(db.findMany).toHaveBeenCalledTimes(4);
 		expect(result.subjects).toHaveLength(subjectCount);
 		expect(
 			result.subjects.every(
@@ -317,6 +347,26 @@ describe('listSubjectsHandler', () => {
 		expect(db.transaction).not.toHaveBeenCalled();
 	});
 
+	it('queries large subject lists in bounded batches', async () => {
+		const data = createTestData(501, 1);
+		const { context, db } = createContext(data);
+
+		const result = (await listSubjectsHandler(context as never)) as {
+			subjects: Array<{ consents: unknown[] }>;
+		};
+
+		const consentCalls = db.findMany.mock.calls.filter(
+			([table]) => table === 'consent'
+		);
+		expect(
+			consentCalls.map(([, options]) => subjectIdsFromWhere(options)?.length)
+		).toEqual([500, 1]);
+		expect(
+			result.subjects.every((subject) => subject.consents.length === 1)
+		).toBe(true);
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
 	it('bounds concurrent GET workload to one acquisition per request', async () => {
 		const requestCount = 4;
 		const pool = new ConstrainedPool({
@@ -327,7 +377,7 @@ describe('listSubjectsHandler', () => {
 		const requests = Array.from({ length: requestCount }, (_, index) => {
 			const requestId = `request_${index}`;
 			const { context } = createPooledContext(
-				createTestData(50, 2),
+				createTestData(501, 2),
 				pool,
 				requestId
 			);

--- a/packages/backend/src/handlers/subject/list.handler.ts
+++ b/packages/backend/src/handlers/subject/list.handler.ts
@@ -48,23 +48,48 @@ export const listSubjectsHandler = async (c: Context) => {
 			where: (b) => b('externalId', '=', externalId),
 		});
 
-		// Get consents for each subject
-		const subjectItems = await Promise.all(
-			subjects.map(async (subject) => {
-				const consents = await db.findMany('consent', {
-					where: (b) => b('subjectId', '=', subject.id),
-				});
+		if (subjects.length === 0) {
+			logger.info('Found subjects for externalId', {
+				externalId,
+				count: 0,
+			});
 
-				const consentItems = await enrichConsents(consents, { db, registry });
+			return c.json({ subjects: [] });
+		}
 
-				return {
-					id: subject.id,
-					externalId: subject.externalId ?? externalId,
-					createdAt: subject.createdAt,
-					consents: consentItems,
-				};
-			})
-		);
+		// Batch the remaining work so this request has at most one outstanding
+		// database acquisition, regardless of the number of matching subjects.
+		const consents = await db.findMany('consent', {
+			where: (b) =>
+				b(
+					'subjectId',
+					'in',
+					subjects.map((subject) => subject.id)
+				),
+		});
+		const consentItems = await enrichConsents(consents, { db, registry });
+
+		const consentsBySubjectId = new Map<
+			string,
+			(typeof consentItems)[number][]
+		>();
+		for (const [index, consent] of consents.entries()) {
+			const consentItem = consentItems[index];
+			if (!consentItem) {
+				throw new Error('Consent enrichment returned an incomplete result');
+			}
+
+			const subjectConsents = consentsBySubjectId.get(consent.subjectId) ?? [];
+			subjectConsents.push(consentItem);
+			consentsBySubjectId.set(consent.subjectId, subjectConsents);
+		}
+
+		const subjectItems = subjects.map((subject) => ({
+			id: subject.id,
+			externalId: subject.externalId ?? externalId,
+			createdAt: subject.createdAt,
+			consents: consentsBySubjectId.get(subject.id) ?? [],
+		}));
 
 		logger.info('Found subjects for externalId', {
 			externalId,

--- a/packages/backend/src/handlers/subject/list.handler.ts
+++ b/packages/backend/src/handlers/subject/list.handler.ts
@@ -10,6 +10,8 @@ import type { C15TContext } from '~/types';
 import { extractErrorMessage } from '~/utils/extract-error-message';
 import { enrichConsents } from '../utils/consent-enrichment';
 
+const SUBJECT_ID_BATCH_SIZE = 500;
+
 /**
  * Handles listing all subjects linked to an external ID.
  *
@@ -59,14 +61,24 @@ export const listSubjectsHandler = async (c: Context) => {
 
 		// Batch the remaining work so this request has at most one outstanding
 		// database acquisition, regardless of the number of matching subjects.
-		const consents = await db.findMany('consent', {
-			where: (b) =>
-				b(
-					'subjectId',
-					'in',
-					subjects.map((subject) => subject.id)
-				),
-		});
+		const subjectIds = subjects.map((subject) => subject.id);
+		const findConsents = (batch: string[]) =>
+			db.findMany('consent', {
+				where: (b) => b('subjectId', 'in', batch),
+			});
+		const consents = await findConsents(
+			subjectIds.slice(0, SUBJECT_ID_BATCH_SIZE)
+		);
+		for (
+			let index = SUBJECT_ID_BATCH_SIZE;
+			index < subjectIds.length;
+			index += SUBJECT_ID_BATCH_SIZE
+		) {
+			const batch = await findConsents(
+				subjectIds.slice(index, index + SUBJECT_ID_BATCH_SIZE)
+			);
+			consents.push(...batch);
+		}
 		const consentItems = await enrichConsents(consents, { db, registry });
 
 		const consentsBySubjectId = new Map<


### PR DESCRIPTION
## Overview

Fix database connection timeouts in GET /subjects by loading and enriching matching consents in sequential batches of up to 500. This keeps each request to one database query at a time.

## Related Issue

Production bug report; no public issue.

## Type of Change

- [x] Bug fix
- [x] Performance

## Testing

- [x] Tested small and large subject lists
- [x] Tested the 500-subject batch boundary
- [x] Tested concurrent requests with a constrained pool
- [x] Verified connections are released after success and failure
- [x] Backend build, 552 tests, type check, and lint pass

## Checklist

- [x] Tests added
- [x] Changeset added to generate the release changelog
- [x] Tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subject listing performance by batching consent lookups, reducing database pressure and helping prevent timeouts.
  * Added a fast response for requests that match no subjects.
  * Preserved correct consent associations and handling for large subject lists.
  * Improved cleanup and error handling when database operations fail.

* **Tests**
  * Added coverage for empty results, batching, concurrency limits, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->