### PR TITLE
fix(react): apply CSP nonce to injected styles and scripts

### DIFF
--- a/.changeset/wild-pugs-clap.md
+++ b/.changeset/wild-pugs-clap.md
@@ -1,0 +1,15 @@
+---
+'@c15t/react': patch
+'@c15t/ui': patch
+'c15t': patch
+---
+
+Add a `nonce` option for nonce-based Content Security Policies
+
+The injected `<style id="c15t-theme">` element previously carried no nonce, so a strict CSP blocked it unless you allowed `'unsafe-inline'`. Setting `nonce` on the provider options now applies it to that stylesheet and to every `<script>` element created by the script loader. A per-script `nonce` still takes precedence.
+
+```tsx
+<ConsentManagerProvider options={{ mode: 'offline', nonce }}>
+  {children}
+</ConsentManagerProvider>
+```

--- a/changelog/2.2.0.mdx
+++ b/changelog/2.2.0.mdx
@@ -2,7 +2,7 @@
 title: "v2.2.0 - Consent-Aware Embeds, Configurable Controls, and More Integrations"
 version: "2.2.0"
 date: 2026-07-29
-description: "Minor release adding consent-aware Google Maps and YouTube components, a configurable consent controls toolbar, eight script integrations, a reusable SDK hook, policy-aware action styling, reliability fixes, and new translations."
+description: "Minor release adding consent-aware Google Maps and YouTube components, a configurable consent controls toolbar, eight script integrations, a reusable SDK hook, policy-aware action styling, CSP nonce support, reliability fixes, and new translations."
 group: changelog
 tags:
   - release
@@ -33,6 +33,7 @@ This is a minor release with no breaking changes.
 - RudderStack pre-consent buffering with category-to-consent-ID mapping
 - Microsoft Clarity Consent V2 support and a corrected Mixpanel bootstrap
 - Policy-aware primary action styling, including IAB consent surfaces
+- New `nonce` option applying your CSP nonce to injected styles and scripts
 - Reliable offline IAB GVL loading and language refreshes
 - Stronger consent submission deduplication and timestamp handling
 - Hindi and Gujarati translations for the full consent experience
@@ -147,6 +148,24 @@ The core script loader also now preserves an explicit `async: false`, which is r
 Themes can now define `consentActions.primary` to style whichever action the active policy marks as primary. The policy continues to decide whether that action is accept, reject, or customize, while the theme controls how primary actions look.
 
 Explicit component props and per-action theme keys still take precedence. The IAB consent banner now uses the same resolution rules instead of bypassing `consentActions` with hard-coded button variants.
+
+## Content Security Policy support
+
+c15t injects a `<style>` element for your theme tokens and a `<script>` element for each consented vendor. Under a nonce-based Content Security Policy, browsers refused both unless the page allowed `'unsafe-inline'`.
+
+The provider now accepts a `nonce` and applies it to everything c15t injects:
+
+```tsx
+<ConsentManagerProvider options={{ mode: 'offline', nonce }}>
+  {children}
+</ConsentManagerProvider>
+```
+
+A `nonce` set on an individual script definition still takes precedence, so you can override a single vendor without changing the provider.
+
+This covers the elements c15t injects. Inline `style` attributes are governed by `style-src-attr`, a directive that ignores nonces entirely, so a policy that restricts it is unaffected by this option.
+
+→ [React ConsentManagerProvider](/docs/frameworks/react/components/consent-manager-provider) · [Next.js ConsentManagerProvider](/docs/frameworks/next/components/consent-manager-provider)
 
 ## IAB TCF reliability
 

--- a/changelog/2.2.0.mdx
+++ b/changelog/2.2.0.mdx
@@ -151,7 +151,7 @@ Explicit component props and per-action theme keys still take precedence. The IA
 
 ## Content Security Policy support
 
-c15t injects a `<style>` element for your theme tokens and a `<script>` element for each consented vendor. Under a nonce-based Content Security Policy, browsers refused both unless the page allowed `'unsafe-inline'`.
+c15t injects a `<style>` element for your theme tokens and a `<script>` element for each consented vendor. Neither carried a nonce, so a nonce-based Content Security Policy blocked both — and because a directive that specifies a nonce ignores `'unsafe-inline'`, the only escape was to abandon nonces for that directive.
 
 The provider now accepts a `nonce` and applies it to everything c15t injects:
 

--- a/docs/frameworks/next/components/consent-manager-provider.mdx
+++ b/docs/frameworks/next/components/consent-manager-provider.mdx
@@ -52,6 +52,55 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
 
 See [Client Modes](/docs/frameworks/next/concepts/client-modes) for a detailed comparison.
 
+<import src="../../../shared/react/components/consent-manager-provider.mdx#csp-nonce" />
+
+### Reading the nonce in the App Router
+
+Next.js does not expose the request nonce to client components, so read it in a server component and pass it down. Generate the nonce in middleware, forward it on a request header, then hand it to the provider from your layout:
+
+```ts title="middleware.ts"
+import { NextResponse, type NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const nonce = crypto.randomUUID();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  response.headers.set(
+    'Content-Security-Policy',
+    `style-src 'self' 'nonce-${nonce}'; script-src 'self' 'nonce-${nonce}'`
+  );
+
+  return response;
+}
+```
+
+```tsx title="app/layout.tsx"
+import { headers } from 'next/headers';
+import { ConsentManagerProvider } from '@c15t/nextjs';
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+
+  return (
+    <html lang="en">
+      <body>
+        <ConsentManagerProvider options={{ mode: 'offline', nonce }}>
+          {children}
+        </ConsentManagerProvider>
+      </body>
+    </html>
+  );
+}
+```
+
 <import src="../../../shared/react/components/consent-manager-provider.mdx#legal-links" />
 
 <import src="../../../shared/react/components/consent-manager-provider.mdx#overrides" />

--- a/docs/frameworks/next/components/consent-manager-provider.mdx
+++ b/docs/frameworks/next/components/consent-manager-provider.mdx
@@ -63,20 +63,31 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
   const nonce = crypto.randomUUID();
+  const isDev = process.env.NODE_ENV === 'development';
+
+  const csp = [
+    `default-src 'self'`,
+    // Next.js dev tooling (React Refresh and HMR) requires 'unsafe-eval'.
+    `script-src 'self' 'nonce-${nonce}'${isDev ? " 'unsafe-eval'" : ''}`,
+    `style-src 'self' 'nonce-${nonce}'`,
+    // Nonces cannot authorize inline style attributes — see above.
+    `style-src-attr 'unsafe-inline'`,
+  ].join('; ');
 
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', csp);
 
   const response = NextResponse.next({ request: { headers: requestHeaders } });
-
-  response.headers.set(
-    'Content-Security-Policy',
-    `style-src 'self' 'nonce-${nonce}'; script-src 'self' 'nonce-${nonce}'`
-  );
+  response.headers.set('Content-Security-Policy', csp);
 
   return response;
 }
 ```
+
+<Callout type="warn">
+  Set the same policy on **both** the forwarded request headers and the response. Next.js reads the nonce for its own runtime and hydration scripts from the `Content-Security-Policy` request header during rendering. Setting it only on the response leaves those scripts without a nonce, and the enforced policy then blocks them, so the page never hydrates.
+</Callout>
 
 ```tsx title="app/layout.tsx"
 import { headers } from 'next/headers';

--- a/docs/frameworks/next/script-loader.mdx
+++ b/docs/frameworks/next/script-loader.mdx
@@ -194,6 +194,6 @@ For iframe-only embeds, use the [iframe blocking](/docs/frameworks/next/iframe-b
 - The provider and any component that calls `useConsentManager()` must be client components.
 - Keep vendor ids out of static examples when they differ per environment — read them from `process.env.NEXT_PUBLIC_*` or runtime config.
 - If a script must be available before a page becomes interactive, prefer a built-in helper that models denied-consent defaults rather than adding a separate `next/script` tag.
-- If you use CSP nonces, pass the nonce through the `Script` object so c15t applies it to the generated script element.
+- If you use CSP nonces, set `nonce` on the provider options so c15t applies it to every injected script element and the theme stylesheet. See [Content Security Policy](/docs/frameworks/next/components/consent-manager-provider#content-security-policy) for reading the nonce in the App Router.
 
 <import src="../../shared/react/guides/script-loader.mdx#api-reference" />

--- a/docs/frameworks/react/components/consent-manager-provider.mdx
+++ b/docs/frameworks/react/components/consent-manager-provider.mdx
@@ -52,6 +52,8 @@ export default function ConsentManager({ children }: { children: ReactNode }) {
 
 See [Client Modes](/docs/frameworks/react/concepts/client-modes) for a detailed comparison.
 
+<import src="../../../shared/react/components/consent-manager-provider.mdx#csp-nonce" />
+
 <import src="../../../shared/react/components/consent-manager-provider.mdx#legal-links" />
 
 <import src="../../../shared/react/components/consent-manager-provider.mdx#overrides" />

--- a/docs/shared/react/components/consent-manager-provider.mdx
+++ b/docs/shared/react/components/consent-manager-provider.mdx
@@ -25,7 +25,7 @@ group: reference
 <section id="csp-nonce">
   ## Content Security Policy
 
-  c15t injects a `<style id="c15t-theme">` element for your theme tokens, and the [script loader](/docs/frameworks/react/script-loader) injects a `<script>` element per consented vendor. Under a nonce-based Content Security Policy, both are blocked unless they carry your nonce.
+  c15t injects a `<style id="c15t-theme">` element for your theme tokens, and the script loader injects a `<script>` element per consented vendor. Under a nonce-based Content Security Policy, both are blocked unless they carry your nonce.
 
   Pass it once through the `nonce` option and c15t applies it to everything it injects:
 
@@ -64,7 +64,7 @@ group: reference
   ```
 
   <Callout type="warn">
-    `'unsafe-inline'` on `style-src-attr` permits any inline style attribute on the page. That is weaker than a nonce, but far narrower than putting `'unsafe-inline'` on `style-src`, which would additionally authorize arbitrary injected `<style>` elements. If your threat model does not allow it, expect components that use inline styles to render unstyled.
+    `'unsafe-inline'` on `style-src-attr` permits any inline style attribute on the page. That is weaker than a nonce, but far narrower than replacing your nonce-based `style-src` with `'unsafe-inline'`, which would additionally authorize arbitrary injected `<style>` elements. Note that adding `'unsafe-inline'` *alongside* a nonce achieves nothing — a directive that specifies a nonce ignores it. If your threat model does not allow this, expect components that use inline styles to render unstyled.
   </Callout>
 </section>
 

--- a/docs/shared/react/components/consent-manager-provider.mdx
+++ b/docs/shared/react/components/consent-manager-provider.mdx
@@ -22,6 +22,35 @@ group: reference
   <AutoTypeTable path="./packages/ui/src/theme/types.ts" name="UIOptions" />
 </section>
 
+<section id="csp-nonce">
+  ## Content Security Policy
+
+  c15t injects a `<style id="c15t-theme">` element for your theme tokens, and the [script loader](/docs/frameworks/react/script-loader) injects a `<script>` element per consented vendor. Under a nonce-based Content Security Policy, both are blocked unless they carry your nonce.
+
+  Pass it once through the `nonce` option and c15t applies it to everything it injects:
+
+  ```tsx
+  <ConsentManagerProvider
+    options={{
+      mode: 'offline',
+      nonce: yourRequestNonce,
+    }}
+  >
+    {children}
+  </ConsentManagerProvider>
+  ```
+
+  A `nonce` set on an individual script definition still wins, so you can override a single vendor without changing the provider.
+
+  <Callout type="note">
+    Browsers hide the `nonce` content attribute once a policy is active. Inspecting the element shows no `nonce=""`, but `element.nonce` still returns the value — this is expected and not a sign that c15t dropped it.
+  </Callout>
+
+  ### Inline style attributes
+
+  The `nonce` option covers elements c15t injects. It does not cover inline `style="..."` attributes, which CSP governs through `style-src-attr` — a directive that ignores nonces entirely. If your policy sets `style-src-attr` without `'unsafe-inline'`, some component styling is affected regardless of the nonce.
+</section>
+
 <section id="legal-links">
   ## Legal Links
 

--- a/docs/shared/react/components/consent-manager-provider.mdx
+++ b/docs/shared/react/components/consent-manager-provider.mdx
@@ -48,7 +48,24 @@ group: reference
 
   ### Inline style attributes
 
-  The `nonce` option covers elements c15t injects. It does not cover inline `style="..."` attributes, which CSP governs through `style-src-attr` — a directive that ignores nonces entirely. If your policy sets `style-src-attr` without `'unsafe-inline'`, some component styling is affected regardless of the nonce.
+  The `nonce` option covers the elements c15t injects. It cannot cover inline `style="..."` attributes, which several components rely on — a nonce never authorizes a style attribute, because nonces apply to elements only.
+
+  Style attributes are governed by `style-src-attr`, and when that directive is absent CSP falls back to `style-src`. A nonce-based style policy therefore blocks them:
+
+  ```http
+  style-src 'self' 'nonce-abc123';
+  ```
+
+  To keep the nonce requirement for stylesheets while still allowing style attributes, set `style-src-attr` explicitly:
+
+  ```http
+  style-src 'self' 'nonce-abc123';
+  style-src-attr 'unsafe-inline';
+  ```
+
+  <Callout type="warn">
+    `'unsafe-inline'` on `style-src-attr` permits any inline style attribute on the page. That is weaker than a nonce, but far narrower than putting `'unsafe-inline'` on `style-src`, which would additionally authorize arbitrary injected `<style>` elements. If your threat model does not allow it, expect components that use inline styles to render unstyled.
+  </Callout>
 </section>
 
 <section id="legal-links">

--- a/docs/shared/react/guides/script-loader.mdx
+++ b/docs/shared/react/guides/script-loader.mdx
@@ -239,6 +239,8 @@ group: reference
 
   Set `anonymizeId: false` only when another script or test needs a stable DOM id. Pass `nonce` when your CSP requires it; c15t applies it directly to the generated `<script>` element.
 
+  You usually do not need a per-script `nonce`. Setting `nonce` once on the provider covers every injected script (and the theme stylesheet); a per-script value overrides it for that script alone.
+
   ## Dynamic Management
 
   Framework packages expose script-manager methods so integrations can be added, removed, or inspected at runtime. Use this for tenant-specific tools, feature-flagged scripts, or vendors that are configured after sign-in:

--- a/packages/core/src/__tests__/store-script-loader.test.ts
+++ b/packages/core/src/__tests__/store-script-loader.test.ts
@@ -707,5 +707,16 @@ describe('Store Script Loader Integration', () => {
 
 			expect(lastCreatedScriptElement()?.nonce).toBe('');
 		});
+
+		it('applies the store-level nonce when reloading a script', () => {
+			const store = createStoreWithNonce('store-nonce');
+
+			store.getState().setScripts([scripts[0]]);
+			store.getState().reloadScript('necessary-script');
+
+			// reloadScript recreates the element, so the most recent one must
+			// still carry the nonce.
+			expect(lastCreatedScriptElement()?.nonce).toBe('store-nonce');
+		});
 	});
 });

--- a/packages/core/src/__tests__/store-script-loader.test.ts
+++ b/packages/core/src/__tests__/store-script-loader.test.ts
@@ -658,4 +658,54 @@ describe('Store Script Loader Integration', () => {
 			expect(store.getState().isScriptLoaded('analytics-script')).toBe(false);
 		});
 	});
+
+	describe('CSP nonce', () => {
+		function createStoreWithNonce(nonce?: string) {
+			const store = createConsentManagerStore(mockConsentManager, {
+				config: { pkg: 'test', version: '1.0.0', mode: 'test' },
+				nonce,
+			});
+
+			store.setState((state) => ({
+				...state,
+				consents: { ...state.consents, necessary: true },
+				selectedConsents: { ...state.selectedConsents, necessary: true },
+			}));
+
+			return store;
+		}
+
+		function lastCreatedScriptElement() {
+			const mockCreateElement = document.createElement as unknown as {
+				mock: { results: Array<{ value: HTMLScriptElement }> };
+			};
+			const results = mockCreateElement.mock.results;
+
+			return results[results.length - 1]?.value;
+		}
+
+		it('applies the store-level nonce to injected script elements', () => {
+			const store = createStoreWithNonce('store-nonce');
+
+			store.getState().setScripts([scripts[0]]);
+
+			expect(lastCreatedScriptElement()?.nonce).toBe('store-nonce');
+		});
+
+		it('lets a per-script nonce override the store-level nonce', () => {
+			const store = createStoreWithNonce('store-nonce');
+
+			store.getState().setScripts([{ ...scripts[0], nonce: 'script-nonce' }]);
+
+			expect(lastCreatedScriptElement()?.nonce).toBe('script-nonce');
+		});
+
+		it('leaves the nonce unset when the store has none', () => {
+			const store = createStoreWithNonce();
+
+			store.getState().setScripts([scripts[0]]);
+
+			expect(lastCreatedScriptElement()?.nonce).toBe('');
+		});
+	});
 });

--- a/packages/core/src/libs/script-loader/__tests__/core.test.ts
+++ b/packages/core/src/libs/script-loader/__tests__/core.test.ts
@@ -204,6 +204,71 @@ fbq('track', 'PageView');
 			);
 		});
 
+		it('should apply the loader-level nonce to scripts without their own', () => {
+			loadScripts(
+				[
+					{
+						id: 'default-nonce-script',
+						src: 'https://example.com/test.js',
+						category: 'necessary',
+					},
+				],
+				sampleConsents,
+				{},
+				{ nonce: 'provider-nonce' }
+			);
+
+			const mockCreateElement = document.createElement as unknown as {
+				mock: { results: Array<{ value: HTMLScriptElement }> };
+			};
+			const scriptElement = mockCreateElement.mock.results[0].value;
+
+			expect(scriptElement.nonce).toBe('provider-nonce');
+		});
+
+		it('should let a per-script nonce override the loader-level nonce', () => {
+			loadScripts(
+				[
+					{
+						id: 'own-nonce-script',
+						src: 'https://example.com/test.js',
+						category: 'necessary',
+						nonce: 'script-nonce',
+					},
+				],
+				sampleConsents,
+				{},
+				{ nonce: 'provider-nonce' }
+			);
+
+			const mockCreateElement = document.createElement as unknown as {
+				mock: { results: Array<{ value: HTMLScriptElement }> };
+			};
+			const scriptElement = mockCreateElement.mock.results[0].value;
+
+			expect(scriptElement.nonce).toBe('script-nonce');
+		});
+
+		it('should leave the nonce unset when neither source provides one', () => {
+			loadScripts(
+				[
+					{
+						id: 'no-nonce-script',
+						src: 'https://example.com/test.js',
+						category: 'necessary',
+					},
+				],
+				sampleConsents
+			);
+
+			const mockCreateElement = document.createElement as unknown as {
+				mock: { results: Array<{ value: HTMLScriptElement }> };
+			};
+			const scriptElement = mockCreateElement.mock.results[0].value;
+
+			expect(scriptElement.nonce).toBe('');
+		});
+
 		it('should use anonymized IDs by default', () => {
 			// Mock the generateRandomScriptId function to return a predictable value
 			mockRandomForTesting();

--- a/packages/core/src/libs/script-loader/core.ts
+++ b/packages/core/src/libs/script-loader/core.ts
@@ -41,6 +41,14 @@ export interface ScriptLoaderOptions {
 	model?: Model;
 	/** IAB consent state (required when model is 'iab') */
 	iabConsent?: IABConsentState;
+	/**
+	 * Default Content Security Policy nonce for injected script elements.
+	 *
+	 * @remarks
+	 * Applied to every generated `<script>` that does not declare its own
+	 * {@link Script.nonce}. A per-script value always takes precedence.
+	 */
+	nonce?: string;
 }
 
 /**
@@ -471,9 +479,11 @@ export function loadScripts(
 			scriptElement.defer = true;
 		}
 
-		// Add CSP nonce if provided
-		if (script.nonce) {
-			scriptElement.nonce = script.nonce;
+		// Add CSP nonce if provided. A per-script nonce wins over the
+		// provider-level default so individual scripts stay overridable.
+		const nonce = script.nonce ?? options?.nonce;
+		if (nonce) {
+			scriptElement.nonce = nonce;
 		}
 
 		// Add any additional attributes

--- a/packages/core/src/libs/script-loader/store.ts
+++ b/packages/core/src/libs/script-loader/store.ts
@@ -40,6 +40,7 @@ export function createScriptManager(
 			scriptIdMap,
 			model,
 			iab,
+			nonce,
 			policyCategories,
 			policyScopeMode,
 		} = getState();
@@ -62,6 +63,7 @@ export function createScriptManager(
 		const result = updateScripts(scripts, runtimeConsents, scriptIdMap, {
 			model,
 			iabConsent,
+			nonce,
 		});
 
 		// Update loadedScripts state
@@ -189,6 +191,7 @@ export function createScriptManager(
 				{
 					model: state.model,
 					iabConsent,
+					nonce: state.nonce,
 				}
 			);
 		},

--- a/packages/core/src/runtime/__tests__/index.test.ts
+++ b/packages/core/src/runtime/__tests__/index.test.ts
@@ -36,9 +36,21 @@ describe('runtime', () => {
 		configureConsentManagerMock.mockImplementation(() => ({
 			id: `manager-${++managerCount}`,
 		}));
-		createConsentManagerStoreMock.mockImplementation(() => ({
-			id: `store-${++storeCount}`,
-		}));
+		// Minimal stateful store stub: the runtime reads and writes state on
+		// cached stores, so an inert object would not exercise that path.
+		createConsentManagerStoreMock.mockImplementation(
+			(_manager: unknown, storeOptions: unknown) => {
+				let state = { ...(storeOptions as Record<string, unknown>) };
+
+				return {
+					id: `store-${++storeCount}`,
+					getState: () => state,
+					setState: (partial: Record<string, unknown>) => {
+						state = { ...state, ...partial };
+					},
+				};
+			}
+		);
 	});
 
 	afterEach(() => {
@@ -82,6 +94,29 @@ describe('runtime', () => {
 			} satisfies ConsentRuntimeOptions);
 
 			expect(storeOptions.nonce).toBe('top-level');
+		});
+
+		it('refreshes the nonce on a cached store instead of reusing a stale one', () => {
+			const first = getOrCreateConsentRuntime(
+				{
+					mode: 'offline',
+					nonce: 'nonce-request-a',
+				} satisfies ConsentRuntimeOptions,
+				pkgInfo
+			);
+			const second = getOrCreateConsentRuntime(
+				{
+					mode: 'offline',
+					nonce: 'nonce-request-b',
+				} satisfies ConsentRuntimeOptions,
+				pkgInfo
+			);
+
+			// The nonce is deliberately not part of the cache key — see the runtime
+			// comment — so the same store must be handed back with a fresh nonce.
+			expect(second.consentStore).toBe(first.consentStore);
+			expect(createConsentManagerStoreMock).toHaveBeenCalledTimes(1);
+			expect(second.consentStore.getState().nonce).toBe('nonce-request-b');
 		});
 
 		it('leaves the nonce undefined when neither form is set', () => {

--- a/packages/core/src/runtime/__tests__/index.test.ts
+++ b/packages/core/src/runtime/__tests__/index.test.ts
@@ -45,6 +45,54 @@ describe('runtime', () => {
 		vi.unstubAllGlobals();
 	});
 
+	describe('nonce resolution', () => {
+		const pkgInfo = { pkg: '@c15t/react', version: '2.0.0' };
+
+		function storeOptionsFor(options: ConsentRuntimeOptions) {
+			getOrCreateConsentRuntime(options, pkgInfo);
+
+			return createConsentManagerStoreMock.mock.calls[0]?.[1] as {
+				nonce?: string;
+			};
+		}
+
+		it('passes a top-level nonce to the store', () => {
+			const storeOptions = storeOptionsFor({
+				mode: 'offline',
+				nonce: 'top-level',
+			} satisfies ConsentRuntimeOptions);
+
+			expect(storeOptions.nonce).toBe('top-level');
+		});
+
+		it('falls back to a nonce nested under store', () => {
+			const storeOptions = storeOptionsFor({
+				mode: 'offline',
+				store: { nonce: 'nested-store' },
+			} satisfies ConsentRuntimeOptions);
+
+			expect(storeOptions.nonce).toBe('nested-store');
+		});
+
+		it('prefers the top-level nonce over a nested one', () => {
+			const storeOptions = storeOptionsFor({
+				mode: 'offline',
+				nonce: 'top-level',
+				store: { nonce: 'nested-store' },
+			} satisfies ConsentRuntimeOptions);
+
+			expect(storeOptions.nonce).toBe('top-level');
+		});
+
+		it('leaves the nonce undefined when neither form is set', () => {
+			const storeOptions = storeOptionsFor({
+				mode: 'offline',
+			} satisfies ConsentRuntimeOptions);
+
+			expect(storeOptions.nonce).toBeUndefined();
+		});
+	});
+
 	it('reuses runtime instances for the same cache key', () => {
 		const options = {
 			mode: 'offline',

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -145,6 +145,7 @@ export function getOrCreateConsentRuntime(
 		consentCategories,
 		debug,
 		headers,
+		nonce,
 		customFetch: _unusedCustomFetch,
 		retryConfig: _unusedRetryConfig,
 		endpointHandlers: _unusedEndpointHandlers,
@@ -187,6 +188,9 @@ export function getOrCreateConsentRuntime(
 	const resolvedStorageConfig =
 		storageConfig ?? storeWithoutTranslationInputs.storageConfig;
 	const resolvedEnabled = enabled ?? storeWithoutTranslationInputs.enabled;
+	// A top-level `nonce` wins over `store.nonce` so the value the provider
+	// applies to the theme stylesheet always matches the one scripts receive.
+	const resolvedNonce = nonce ?? storeWithoutTranslationInputs.nonce;
 	const resolvedBackendURL = backendURL || DEFAULT_BACKEND_URL;
 	const explicitSSRData = topLevelSSRData ?? storeSSRData;
 
@@ -284,6 +288,7 @@ export function getOrCreateConsentRuntime(
 			offlinePolicy: resolvedOfflinePolicy,
 			storageConfig: resolvedStorageConfig,
 			enabled: resolvedEnabled,
+			nonce: resolvedNonce,
 			initialTranslationConfig: normalizedInitialTranslationConfig,
 			initialConsentCategories: consentCategories,
 			ssrData: resolvedSSRData,

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -303,6 +303,13 @@ export function getOrCreateConsentRuntime(
 		} as InternalStoreOptions);
 
 		storeCache.set(cacheKey, consentStore);
+	} else if (consentStore.getState().nonce !== resolvedNonce) {
+		// A nonce is per-request, so a cached store can outlive the one it was
+		// created with. Sync it rather than adding the nonce to the cache key:
+		// keying on it would allocate a fresh manager and store for every request
+		// during SSR, and neither cache evicts. Leaving it stale would let the
+		// theme stylesheet and injected scripts carry different nonces.
+		consentStore.setState({ nonce: resolvedNonce });
 	}
 
 	return {

--- a/packages/core/src/store/type.ts
+++ b/packages/core/src/store/type.ts
@@ -436,6 +436,20 @@ export interface StoreConfig {
 	 * Array of script configurations to manage.
 	 */
 	scripts: Script[];
+
+	/**
+	 * Content Security Policy nonce applied to DOM nodes c15t injects.
+	 *
+	 * @remarks
+	 * Set this when your CSP uses a nonce-based policy instead of
+	 * `'unsafe-inline'`. c15t forwards it to the injected theme `<style>`
+	 * element and to every `<script>` element created by the script loader.
+	 *
+	 * A per-script {@link Script.nonce} still takes precedence over this value.
+	 *
+	 * @see https://c15t.com/docs/frameworks/react/components/consent-manager-provider
+	 */
+	nonce?: string;
 }
 
 /**

--- a/packages/react/src/providers/__tests__/provider-nonce.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-nonce.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentManagerProvider } from '~/index';
 import { clearConsentRuntimeCache } from '../consent-manager-provider';
@@ -16,6 +16,12 @@ describe('ConsentManagerProvider CSP nonce', () => {
 
 	afterEach(() => {
 		clearConsentRuntimeCache();
+		// Scripts injected by these tests outlive the React tree.
+		for (const el of document.querySelectorAll(
+			'script[src^="data:text/javascript"]'
+		)) {
+			el.remove();
+		}
 	});
 
 	it('applies the provided nonce to the injected theme stylesheet', async () => {
@@ -44,6 +50,82 @@ describe('ConsentManagerProvider CSP nonce', () => {
 		// Read the IDL property rather than the content attribute: browsers hide
 		// the `nonce` attribute once a real CSP is in force.
 		expect(styleEl?.nonce).toBe('test-nonce-value');
+	});
+
+	it('falls back to a nonce nested under store', async () => {
+		const { getByText } = await render(
+			<ConsentManagerProvider
+				options={{
+					mode: 'offline',
+					store: { nonce: 'nested-store-nonce' },
+				}}
+			>
+				<div>Test Component</div>
+			</ConsentManagerProvider>
+		);
+
+		await expect.element(getByText('Test Component')).toBeInTheDocument();
+
+		const styleEl = document.querySelector<HTMLStyleElement>('#c15t-theme');
+
+		expect(styleEl?.nonce).toBe('nested-store-nonce');
+	});
+
+	it('prefers the top-level nonce over a nested one', async () => {
+		const { getByText } = await render(
+			<ConsentManagerProvider
+				options={{
+					mode: 'offline',
+					nonce: 'top-level-nonce',
+					store: { nonce: 'nested-store-nonce' },
+				}}
+			>
+				<div>Test Component</div>
+			</ConsentManagerProvider>
+		);
+
+		await expect.element(getByText('Test Component')).toBeInTheDocument();
+
+		const styleEl = document.querySelector<HTMLStyleElement>('#c15t-theme');
+
+		expect(styleEl?.nonce).toBe('top-level-nonce');
+	});
+
+	it('applies the same nonce to scripts the provider injects', async () => {
+		// A data: URL keeps this entirely off the network. A fetched src leaves a
+		// pending request that destabilizes timing-sensitive tests in other files
+		// sharing the browser run.
+		const src = 'data:text/javascript,0';
+		const { getByText } = await render(
+			<ConsentManagerProvider
+				options={{
+					mode: 'offline',
+					nonce: 'shared-nonce',
+					scripts: [
+						{
+							id: 'nonce-e2e',
+							src,
+							category: 'necessary',
+							alwaysLoad: true,
+						},
+					],
+				}}
+			>
+				<div>Test Component</div>
+			</ConsentManagerProvider>
+		);
+
+		await expect.element(getByText('Test Component')).toBeInTheDocument();
+
+		const styleEl = document.querySelector<HTMLStyleElement>('#c15t-theme');
+		const scriptEl = await vi.waitUntil(() =>
+			document.querySelector<HTMLScriptElement>(`script[src="${src}"]`)
+		);
+
+		// The stylesheet and the injected script must agree, otherwise a CSP
+		// authorizes only one of them.
+		expect(styleEl?.nonce).toBe('shared-nonce');
+		expect(scriptEl?.nonce).toBe('shared-nonce');
 	});
 
 	it('omits the nonce attribute when no nonce is configured', async () => {

--- a/packages/react/src/providers/__tests__/provider-nonce.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-nonce.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { ConsentManagerProvider } from '~/index';
+import { clearConsentRuntimeCache } from '../consent-manager-provider';
+
+/**
+ * Regression coverage for the injected theme stylesheet under a nonce-based
+ * Content Security Policy.
+ *
+ * @see https://github.com/c15t/c15t/issues/948
+ */
+describe('ConsentManagerProvider CSP nonce', () => {
+	beforeEach(() => {
+		clearConsentRuntimeCache();
+	});
+
+	afterEach(() => {
+		clearConsentRuntimeCache();
+	});
+
+	it('applies the provided nonce to the injected theme stylesheet', async () => {
+		const { getByText } = await render(
+			<ConsentManagerProvider
+				options={{
+					mode: 'offline',
+					nonce: 'test-nonce-value',
+					theme: {
+						colors: {
+							primary: '#6366f1',
+						},
+					},
+				}}
+			>
+				<div>Test Component</div>
+			</ConsentManagerProvider>
+		);
+
+		await expect.element(getByText('Test Component')).toBeInTheDocument();
+
+		const styleEl = document.querySelector<HTMLStyleElement>('#c15t-theme');
+
+		expect(styleEl).not.toBeNull();
+		expect(styleEl?.textContent).toContain('#6366f1');
+		// Read the IDL property rather than the content attribute: browsers hide
+		// the `nonce` attribute once a real CSP is in force.
+		expect(styleEl?.nonce).toBe('test-nonce-value');
+	});
+
+	it('omits the nonce attribute when no nonce is configured', async () => {
+		const { getByText } = await render(
+			<ConsentManagerProvider options={{ mode: 'offline' }}>
+				<div>Test Component</div>
+			</ConsentManagerProvider>
+		);
+
+		await expect.element(getByText('Test Component')).toBeInTheDocument();
+
+		const styleEl = document.querySelector<HTMLStyleElement>('#c15t-theme');
+
+		expect(styleEl).not.toBeNull();
+		expect(styleEl?.hasAttribute('nonce')).toBe(false);
+	});
+});

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -245,6 +245,7 @@ export function ConsentManagerProvider({
 				{themeCSS ? (
 					<style
 						id="c15t-theme"
+						nonce={options.nonce}
 						// biome-ignore lint/security/noDangerouslySetInnerHtml: It's safe to set innerHTML here
 						dangerouslySetInnerHTML={{ __html: themeCSS }}
 					/>

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -223,6 +223,11 @@ export function ConsentManagerProvider({
 		return generateThemeCSS(themeContextValue.theme);
 	}, [themeContextValue.theme]);
 
+	// `nonce` is accepted at the top level and via the `store` escape hatch.
+	// Resolve it with the same precedence the core runtime uses, so the theme
+	// stylesheet and injected scripts never end up with different nonces.
+	const nonce = options.nonce ?? options.store?.nonce;
+
 	useColorScheme(options.colorScheme);
 
 	// Create consent context value - without theme properties
@@ -245,7 +250,7 @@ export function ConsentManagerProvider({
 				{themeCSS ? (
 					<style
 						id="c15t-theme"
-						nonce={options.nonce}
+						nonce={nonce}
 						// biome-ignore lint/security/noDangerouslySetInnerHtml: It's safe to set innerHTML here
 						dangerouslySetInnerHTML={{ __html: themeCSS }}
 					/>

--- a/packages/ui/src/theme/options.ts
+++ b/packages/ui/src/theme/options.ts
@@ -47,6 +47,20 @@ export interface CommonInlineStoreOptions {
 	scripts?: Script[];
 
 	/**
+	 * Content Security Policy nonce applied to DOM nodes c15t injects.
+	 *
+	 * @remarks
+	 * Set this when your CSP uses a nonce-based policy instead of
+	 * `'unsafe-inline'`. c15t forwards it to the injected theme `<style>`
+	 * element and to every `<script>` element created by the script loader.
+	 *
+	 * A per-script `nonce` still takes precedence over this value.
+	 *
+	 * @see https://c15t.com/docs/frameworks/react/components/consent-manager-provider
+	 */
+	nonce?: string;
+
+	/**
 	 * Configuration for the legal links.
 	 *
 	 * @remarks


### PR DESCRIPTION
Closes #948

## Problem

c15t injects its theme tokens as `<style id="c15t-theme">`, and that element carried no nonce. Under a nonce-based Content Security Policy the browser refuses it:

```
Refused to apply inline style because it violates the following Content Security Policy directive: "style-src-elem ..."
```

The only workaround was allowing `'unsafe-inline'`.

It was worse than a missed prop: `nonce` was not part of the provider options at all — not in `CoreOptions`, `UIOptions`, `CommonInlineStoreOptions`, or `ConsentManagerContentOptions` — so a value passed there was dropped at the type boundary before it could reach a DOM node.

## Fix

A single top-level `nonce` option, forwarded to everything c15t injects.

```tsx
<ConsentManagerProvider options={{ mode: 'offline', nonce }}>
  {children}
</ConsentManagerProvider>
```

**Theme stylesheet**
- `nonce?: string` on `CommonInlineStoreOptions` (public, framework-facing — the options reference table renders from it) and on `StoreConfig` in core. The core declaration is enough on its own for three things: `StoreOptions extends Partial<StoreConfig>` accepts it, `StoreRuntimeState extends StoreConfig` exposes it in state, and the existing `...storeConfigOptions` spread populates it with no extra wiring.
- The provider passes it to the `<style>` element.

**Script loader**
- `nonce` added to the shared `ScriptLoaderOptions` bag and resolved at the single element-creation site as `script.nonce ?? options?.nonce`, so a per-script value still wins.
- Threaded from state at both call sites (`updateScripts` and `reloadScript`), which covers scripts declared in provider options *and* scripts registered later via `setScripts`.

Without this second part a strict-CSP app hits the identical wall on `script-src` the moment it uses the script loader, and today's only answer is repeating the nonce on every script entry.

## Tests

- `provider-nonce.test.tsx` — the original issue repro (verified failing before the fix) plus a negative case. Asserts via `styleEl.nonce` rather than `getAttribute`, since browsers hide the content attribute once a policy is live.
- 6 script-loader tests: 3 unit (loader default, per-script override, neither set) and 3 store-level integration proving `options.nonce` reaches the injected element.

`check-types` passes repo-wide. Full suites green: core 519, react 397, plus ui and nextjs.

## Docs

A shared "Content Security Policy" section imported into the React and Next provider pages, including a Next-specific middleware → `headers()` → provider example. The stale per-script CSP advice in `next/script-loader.mdx` now points at the provider option.

## Notes for review

- The `nonce` option covers elements c15t injects. It does not cover inline `style="..."` attributes, which CSP governs through `style-src-attr` — a directive that ignores nonces entirely. Documented as a caveat, since the reporter's policy sets `style-src-attr 'self'`.
- Unrelated and not addressed here: `noStyle: true` does not currently suppress the theme `<style>` element; the provider renders it unconditionally. Happy to file that separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a global CSP nonce for injected scripts and theme styles.
  - Per-script nonces override the global provider nonce.
  - Nonce attributes are omitted when no nonce is configured.

- **Documentation**
  - Added CSP nonce setup guidance for React and Next.js App Router integrations.
  - Documented nonce behavior, browser inspection, and inline-style limitations.

- **Bug Fixes**
  - Ensured configured nonces remain synchronized and are correctly applied to dynamically injected elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->