### PR TITLE
fix(backend): prioritize x-forwarded-for

### DIFF
--- a/.changeset/prioritize-forwarded-client-ip.md
+++ b/.changeset/prioritize-forwarded-client-ip.md
@@ -1,0 +1,5 @@
+---
+'@c15t/backend': patch
+---
+
+Prioritize `x-forwarded-for` over `x-client-ip` when resolving client IP addresses with the default header order.

--- a/changelog/2.2.0.mdx
+++ b/changelog/2.2.0.mdx
@@ -166,6 +166,7 @@ Legacy duplicate lookups are now scoped to the current tenant, and timestamps ou
 
 ## Backend, API, and compatibility improvements
 
+- The backend now prioritizes `x-forwarded-for` over `x-client-ip` when resolving client IP addresses with the default header order.
 - Browser, SSR, prefetch, and Node SDK requests now forward `x-c15t-version`, and the backend allows it through CORS preflight handling.
 - Custom `headers` configured for hosted clients are no longer dropped. They are included in the runtime cache key so differently configured clients cannot share an instance.
 - Explicit ports in `trustedOrigins` are now matched exactly, while host-only entries remain port-agnostic.

--- a/packages/backend/src/middleware/process-ip/index.test.ts
+++ b/packages/backend/src/middleware/process-ip/index.test.ts
@@ -102,6 +102,16 @@ describe('getIpAddress', () => {
 			expect(getIpAddress(headers, options)).toBe('192.168.1.0');
 		});
 
+		it('should prioritize x-forwarded-for over x-client-ip by default', () => {
+			const headers = createMockHeaders({
+				'x-client-ip': '10.0.0.1',
+				'x-forwarded-for': '192.168.1.100',
+			});
+			const options = createBaseOptions();
+
+			expect(getIpAddress(headers, options)).toBe('192.168.1.0');
+		});
+
 		it('should extract and mask IP from cf-connecting-ip header by default', () => {
 			const headers = createMockHeaders({
 				'cf-connecting-ip': '8.8.8.8',

--- a/packages/backend/src/middleware/process-ip/index.ts
+++ b/packages/backend/src/middleware/process-ip/index.ts
@@ -1,8 +1,8 @@
 import type { C15TOptions } from '~/types';
 
 const DEFAULT_IP_HEADERS = [
-	'x-client-ip',
 	'x-forwarded-for',
+	'x-client-ip',
 	'cf-connecting-ip',
 	'fastly-client-ip',
 	'x-real-ip',


### PR DESCRIPTION
## Summary

- prioritize `x-forwarded-for` over `x-client-ip` in the default client IP header order
- add regression coverage for conflicting headers
- add a patch changeset for `@c15t/backend`

## Testing

- `bun run --cwd packages/backend test src/middleware/process-ip/index.test.ts`
- `bun turbo run build --filter=@c15t/backend`
- `bun run --cwd packages/backend check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated client IP detection to prioritize `x-forwarded-for` over `x-client-ip` by default.
  * Continued masking the resolved IP address for privacy.

* **Tests**
  * Added coverage confirming the default header priority and IP masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->