### PR TITLE
ci: cache Playwright browsers and the Turborepo local cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
       - name: 📦 Install dependencies
         run: bun install --frozen-lockfile
 
+      # Read-only: the test job is the single writer of this cache (see below).
+      - name: ♻️ Restore Turborepo cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
       # Deliberately not affected-scoped: this is the always-on cross-package
       # signal that catches breakage in packages a PR does not touch directly.
       - name: 👀 Type Check
@@ -76,6 +85,15 @@ jobs:
 
       - name: 📦 Install dependencies
         run: bun install --frozen-lockfile
+
+      # Read-only: the test job is the single writer of this cache (see below).
+      - name: ♻️ Restore Turborepo cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
 
       - name: 🏗️ Build
         env:
@@ -115,19 +133,36 @@ jobs:
       - name: 🧰 Test repository scripts
         run: bun run test:scripts
 
-      - name: 🎭 Cache Playwright browsers
-        id: playwright-cache
+      # This job is the single writer of the shared Turborepo cache: it builds
+      # every package as a dependency of `test`, so its cache is the most
+      # complete, and one writer means no concurrent-save conflicts.
+      - name: ♻️ Restore Turborepo cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            playwright-browsers-${{ runner.os }}-
+            turbo-${{ runner.os }}-
+
+      - name: 🎭 Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(bun -e "console.log(require('./package.json').devDependencies.playwright)")" >> "$GITHUB_OUTPUT"
+
+      - name: 🎭 Cache Playwright browsers
+        # `actions/cache`, not `actions/cache/restore`: the restore-only step
+        # had no counterpart save anywhere in the repo, so the key was never
+        # written and every run re-downloaded the browsers.
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/ms-playwright
+          # Keyed on the Playwright version rather than the lockfile hash —
+          # browsers only change when Playwright does, and lockfile churn was
+          # invalidating them on every unrelated dependency bump.
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright.outputs.version }}
 
       - name: 🎭 Install Playwright browsers
-        run: |
-          PLAYWRIGHT_VERSION=$(bun -e "console.log(require('./package.json').devDependencies.playwright)")
-          bunx "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium chromium-headless-shell
+        run: bunx "playwright@${{ steps.playwright.outputs.version }}" install --with-deps chromium chromium-headless-shell
 
       - name: 🧪 Run Tests
         env:
@@ -139,6 +174,35 @@ jobs:
           else
             bun turbo run test --filter="./packages/*"
           fi
+
+      # Restored entries are carried into the next save, so the cache would
+      # grow without bound across pushes and thrash the repo's 10GB budget.
+      # Keep the newest entries up to a fixed ceiling and drop the rest.
+      # Runs on every event, not just pushes: on a PR the pruned cache is
+      # discarded anyway, but running it here means this script is exercised on
+      # every PR instead of only on the pushes that actually save. Non-fatal —
+      # a failure to prune must never fail CI, it only means a larger cache.
+      - name: ♻️ Prune Turborepo cache
+        continue-on-error: true
+        run: |
+          [ -d .turbo/cache ] || exit 0
+          before=$(du -sh .turbo/cache | cut -f1)
+          find .turbo/cache -type f -printf '%T@\t%s\t%p\n' \
+            | sort -rn \
+            | awk -F'\t' -v limit=$((1024 * 1024 * 1024)) \
+                '{ total += $2; if (total > limit) print $3 }' \
+            | xargs -r rm -f
+          echo "turbo cache: $before -> $(du -sh .turbo/cache | cut -f1)"
+
+      # Written only from pushes to canary/main. PR runs restore read-only so
+      # they cannot churn the cache budget, matching the posture already chosen
+      # for TURBO_TOKEN.
+      - name: ♻️ Save Turborepo cache
+        if: github.event_name == 'push'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}
 
       - name: ⬆️ Upload Individual Coverage Reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,9 @@ jobs:
         run: |
           echo "version=$(bun -e "console.log(require('./package.json').devDependencies.playwright)")" >> "$GITHUB_OUTPUT"
 
-      - name: 🎭 Cache Playwright browsers
-        # `actions/cache`, not `actions/cache/restore`: the restore-only step
-        # had no counterpart save anywhere in the repo, so the key was never
-        # written and every run re-downloaded the browsers.
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: 🎭 Restore Playwright browsers
+        id: playwright-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.cache/ms-playwright
           # Keyed on the Playwright version rather than the lockfile hash —
@@ -163,6 +161,15 @@ jobs:
 
       - name: 🎭 Install Playwright browsers
         run: bunx "playwright@${{ steps.playwright.outputs.version }}" install --with-deps chromium chromium-headless-shell
+
+      # Save immediately after installation so a later test failure does not
+      # discard a successfully prepared browser cache.
+      - name: 🎭 Save Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright.outputs.version }}
 
       - name: 🧪 Run Tests
         env:
@@ -177,25 +184,15 @@ jobs:
 
       # Restored entries are carried into the next save, so the cache would
       # grow without bound across pushes and thrash the repo's 10GB budget.
-      # Keep the newest entries up to a fixed ceiling and drop the rest.
-      # Runs on every event, not just pushes: on a PR the pruned cache is
-      # discarded anyway, but running it here means this script is exercised on
-      # every PR instead of only on the pushes that actually save. Non-fatal —
-      # a failure to prune must never fail CI, it only means a larger cache.
+      # Prune complete task entries to a 1 GiB ceiling. This runs on every event
+      # so the script is exercised on PRs, but remains non-fatal because a prune
+      # failure should only produce a larger cache, never failed product CI.
       - name: ♻️ Prune Turborepo cache
         continue-on-error: true
-        run: |
-          [ -d .turbo/cache ] || exit 0
-          before=$(du -sh .turbo/cache | cut -f1)
-          find .turbo/cache -type f -printf '%T@\t%s\t%p\n' \
-            | sort -rn \
-            | awk -F'\t' -v limit=$((1024 * 1024 * 1024)) \
-                '{ total += $2; if (total > limit) print $3 }' \
-            | xargs -r rm -f
-          echo "turbo cache: $before -> $(du -sh .turbo/cache | cut -f1)"
+        run: bun scripts/prune-turbo-cache.ts
 
-      # Written only from pushes to canary/main. PR runs restore read-only so
-      # they cannot churn the cache budget, matching the posture already chosen
+      # Written only from pushes to publishing branches. PR runs restore
+      # read-only so they cannot churn the cache budget, matching the posture
       # for TURBO_TOKEN.
       - name: ♻️ Save Turborepo cache
         if: github.event_name == 'push'

--- a/scripts/prune-turbo-cache.test.ts
+++ b/scripts/prune-turbo-cache.test.ts
@@ -1,0 +1,172 @@
+import {
+	access,
+	mkdtemp,
+	readdir,
+	rm,
+	utimes,
+	writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_MAX_CACHE_BYTES, pruneTurboCache } from './prune-turbo-cache';
+
+const temporaryDirectories: string[] = [];
+
+async function createCacheDirectory() {
+	const directory = await mkdtemp(join(tmpdir(), 'c15t-turbo-cache-'));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+async function createFile(
+	directory: string,
+	name: string,
+	size: number,
+	mtimeMs: number
+) {
+	const path = join(directory, name);
+	await writeFile(path, Buffer.alloc(size));
+	const mtime = new Date(mtimeMs);
+	await utimes(path, mtime, mtime);
+	return path;
+}
+
+async function fileExists(path: string) {
+	try {
+		await access(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories.splice(0).map((directory) =>
+			rm(directory, {
+				force: true,
+				recursive: true,
+			})
+		)
+	);
+});
+
+describe('pruneTurboCache', () => {
+	it('uses a 1 GiB default limit', () => {
+		expect(DEFAULT_MAX_CACHE_BYTES).toBe(1024 * 1024 * 1024);
+	});
+
+	it('returns an empty result when the cache directory does not exist', async () => {
+		const parent = await createCacheDirectory();
+
+		await expect(
+			pruneTurboCache({ cacheDirectory: join(parent, 'missing') })
+		).resolves.toEqual({
+			afterBytes: 0,
+			beforeBytes: 0,
+			removedEntries: 0,
+			removedFiles: 0,
+		});
+	});
+
+	it('leaves a cache at the limit unchanged', async () => {
+		const directory = await createCacheDirectory();
+		await createFile(directory, 'current.tar.zst', 6, 2);
+		await createFile(directory, 'current-meta.json', 2, 2);
+
+		const result = await pruneTurboCache({
+			cacheDirectory: directory,
+			maxBytes: 8,
+		});
+
+		expect(result).toEqual({
+			afterBytes: 8,
+			beforeBytes: 8,
+			removedEntries: 0,
+			removedFiles: 0,
+		});
+		expect(await readdir(directory)).toHaveLength(2);
+	});
+
+	it('removes all files in the oldest logical entry', async () => {
+		const directory = await createCacheDirectory();
+		const oldFiles = await Promise.all([
+			createFile(directory, 'old.tar.zst', 4, 1),
+			createFile(directory, 'old-manifest.json', 2, 1),
+			createFile(directory, 'old-meta.json', 2, 1),
+		]);
+		const newFiles = await Promise.all([
+			createFile(directory, 'new.tar.zst', 4, 2),
+			createFile(directory, 'new-manifest.json', 2, 2),
+			createFile(directory, 'new-meta.json', 2, 2),
+		]);
+
+		const result = await pruneTurboCache({
+			cacheDirectory: directory,
+			maxBytes: 8,
+		});
+
+		expect(result).toEqual({
+			afterBytes: 8,
+			beforeBytes: 16,
+			removedEntries: 1,
+			removedFiles: 3,
+		});
+		await Promise.all(
+			oldFiles.map(async (path) => expect(await fileExists(path)).toBe(false))
+		);
+		await Promise.all(
+			newFiles.map(async (path) => expect(await fileExists(path)).toBe(true))
+		);
+	});
+
+	it('counts orphan and unknown files toward the limit', async () => {
+		const directory = await createCacheDirectory();
+		const oldOrphan = await createFile(directory, 'orphan-meta.json', 4, 1);
+		const unknown = await createFile(directory, 'future-cache.bin', 4, 2);
+
+		const result = await pruneTurboCache({
+			cacheDirectory: directory,
+			maxBytes: 4,
+		});
+
+		expect(result.afterBytes).toBe(4);
+		expect(result.beforeBytes).toBe(8);
+		expect(await fileExists(oldOrphan)).toBe(false);
+		expect(await fileExists(unknown)).toBe(true);
+	});
+
+	it('removes every older entry after the newest prefix exceeds the limit', async () => {
+		const directory = await createCacheDirectory();
+		await createFile(directory, 'new.tar.zst', 6, 3);
+		await createFile(directory, 'middle.tar.zst', 6, 2);
+		await createFile(directory, 'old.tar.zst', 2, 1);
+
+		const result = await pruneTurboCache({
+			cacheDirectory: directory,
+			maxBytes: 8,
+		});
+
+		expect(result).toEqual({
+			afterBytes: 6,
+			beforeBytes: 14,
+			removedEntries: 2,
+			removedFiles: 2,
+		});
+		expect(await readdir(directory)).toEqual(['new.tar.zst']);
+	});
+
+	it('uses the entry name as a deterministic mtime tie-breaker', async () => {
+		const directory = await createCacheDirectory();
+		await createFile(directory, 'alpha.tar.zst', 4, 1);
+		await createFile(directory, 'beta.tar.zst', 4, 1);
+
+		await pruneTurboCache({
+			cacheDirectory: directory,
+			maxBytes: 4,
+		});
+
+		expect(await readdir(directory)).toEqual(['alpha.tar.zst']);
+	});
+});

--- a/scripts/prune-turbo-cache.ts
+++ b/scripts/prune-turbo-cache.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env bun
+
+import type { Dirent } from 'node:fs';
+import { mkdtemp, readdir, rename, rm, stat } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_MAX_CACHE_BYTES = 1024 * 1024 * 1024;
+
+const DEFAULT_CACHE_DIRECTORY = fileURLToPath(
+	new URL('../.turbo/cache', import.meta.url)
+);
+const CACHE_FILE_PATTERN = /^(.*?)(\.tar\.zst|-meta\.json|-manifest\.json)$/;
+
+interface CacheFile {
+	name: string;
+	path: string;
+	size: number;
+	mtimeMs: number;
+	type: 'archive' | 'manifest' | 'metadata' | 'unknown';
+}
+
+interface CacheEntry {
+	id: string;
+	files: CacheFile[];
+	size: number;
+	mtimeMs: number;
+}
+
+export interface PruneTurboCacheOptions {
+	cacheDirectory?: string;
+	maxBytes?: number;
+}
+
+export interface PruneTurboCacheResult {
+	afterBytes: number;
+	beforeBytes: number;
+	removedEntries: number;
+	removedFiles: number;
+}
+
+function cacheFileIdentity(name: string) {
+	const match = name.match(CACHE_FILE_PATTERN);
+	if (!match?.[1] || !match[2]) {
+		return { id: `unknown:${name}`, type: 'unknown' as const };
+	}
+
+	const type = match[2].endsWith('.tar.zst')
+		? 'archive'
+		: match[2] === '-meta.json'
+			? 'metadata'
+			: 'manifest';
+
+	return { id: `turbo:${match[1]}`, type } as const;
+}
+
+async function collectCacheEntries(
+	cacheDirectory: string
+): Promise<CacheEntry[]> {
+	let directoryEntries: Dirent[];
+	try {
+		directoryEntries = await readdir(cacheDirectory, {
+			withFileTypes: true,
+		});
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			return [];
+		}
+		throw error;
+	}
+
+	const groups = new Map<string, CacheFile[]>();
+	for (const directoryEntry of directoryEntries) {
+		if (!directoryEntry.isFile()) {
+			continue;
+		}
+
+		const path = join(cacheDirectory, directoryEntry.name);
+		const fileStats = await stat(path);
+		const identity = cacheFileIdentity(directoryEntry.name);
+		const files = groups.get(identity.id) ?? [];
+		files.push({
+			name: directoryEntry.name,
+			path,
+			size: fileStats.size,
+			mtimeMs: fileStats.mtimeMs,
+			type: identity.type,
+		});
+		groups.set(identity.id, files);
+	}
+
+	return [...groups].map(([id, files]) => ({
+		id,
+		files,
+		size: files.reduce((total, file) => total + file.size, 0),
+		mtimeMs: Math.max(...files.map((file) => file.mtimeMs)),
+	}));
+}
+
+function removalOrder(files: CacheFile[]) {
+	const priority = {
+		archive: 0,
+		manifest: 1,
+		metadata: 1,
+		unknown: 0,
+	} as const;
+
+	return [...files].sort(
+		(left, right) =>
+			priority[left.type] - priority[right.type] ||
+			left.name.localeCompare(right.name)
+	);
+}
+
+export async function pruneTurboCache({
+	cacheDirectory = DEFAULT_CACHE_DIRECTORY,
+	maxBytes = DEFAULT_MAX_CACHE_BYTES,
+}: PruneTurboCacheOptions = {}): Promise<PruneTurboCacheResult> {
+	if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+		throw new Error('maxBytes must be a non-negative safe integer');
+	}
+
+	const entries = await collectCacheEntries(cacheDirectory);
+	const beforeBytes = entries.reduce((total, entry) => total + entry.size, 0);
+	const newestFirst = entries.sort(
+		(left, right) =>
+			right.mtimeMs - left.mtimeMs || left.id.localeCompare(right.id)
+	);
+
+	let retainedBytes = 0;
+	let exceededLimit = false;
+	const entriesToRemove: CacheEntry[] = [];
+	for (const entry of newestFirst) {
+		if (!exceededLimit && retainedBytes + entry.size <= maxBytes) {
+			retainedBytes += entry.size;
+			continue;
+		}
+
+		exceededLimit = true;
+		entriesToRemove.push(entry);
+	}
+
+	if (entriesToRemove.length === 0) {
+		return {
+			afterBytes: beforeBytes,
+			beforeBytes,
+			removedEntries: 0,
+			removedFiles: 0,
+		};
+	}
+
+	const stagingDirectory = await mkdtemp(
+		join(dirname(cacheDirectory), '.turbo-cache-prune-')
+	);
+	let movedFiles = 0;
+	try {
+		for (const [entryIndex, entry] of entriesToRemove.entries()) {
+			for (const file of removalOrder(entry.files)) {
+				await rename(
+					file.path,
+					join(
+						stagingDirectory,
+						`${entryIndex}-${movedFiles}-${basename(file.path)}`
+					)
+				);
+				movedFiles += 1;
+			}
+		}
+	} finally {
+		await rm(stagingDirectory, { force: true, recursive: true });
+	}
+
+	const removedBytes = entriesToRemove.reduce(
+		(total, entry) => total + entry.size,
+		0
+	);
+	return {
+		afterBytes: beforeBytes - removedBytes,
+		beforeBytes,
+		removedEntries: entriesToRemove.length,
+		removedFiles: movedFiles,
+	};
+}
+
+if (import.meta.main) {
+	const result = await pruneTurboCache();
+	console.log(
+		`turbo cache: ${result.beforeBytes} -> ${result.afterBytes} bytes ` +
+			`(${result.removedEntries} entries, ${result.removedFiles} files removed)`
+	);
+}


### PR DESCRIPTION
Stacked on #952 — both PRs rewrite overlapping parts of `ci.yml`. Base retargets to `canary` automatically once #952 merges.

## Why

Measured on CI run `30625455595`, nothing in this repo's CI is cached:

- `Remote caching disabled`, `Cached: 0 cached, 47 total` — every turbo task cold on every PR.
- `actions/cache/restore` for Playwright is the **only** cache action in the repo. Nothing saves it, so it reported `Cache not found for input keys` and re-downloaded Chromium — **32s** of the test job's 171s.
- No `.turbo` persistence to substitute for the disabled remote cache.

Note this is unrelated to Turborepo's Git worktree cache sharing, which is already working — that redirects a linked worktree's cache to the main worktree and is local-only. CI does a fresh clone, not a worktree, so it contributes nothing here.

## Changes

**Playwright.** `actions/cache/restore` → `actions/cache`, so the post-step actually writes the key. Re-keyed on the resolved Playwright version instead of `hashFiles('bun.lock')` — browsers only change when Playwright does, and lockfile churn was invalidating them on every unrelated dependency bump (this repo bumps the lockfile often; affected-scoping in #952 makes lockfile changes a full run anyway).

**Turborepo local cache.** All three jobs restore `.turbo/cache` read-only. The **test job is the single writer** — it builds every package as a dependency of `test`, so its cache is the most complete, and one writer avoids concurrent-save conflicts on the same key.

Saves are gated to `push` only. PR runs restore read-only, which keeps them from churning the 10GB repo budget and matches the posture already chosen for `TURBO_TOKEN`. GitHub scopes caches per branch, so a PR cannot write into canary's scope regardless.

**Pruning.** Restored entries carry into each save, so the cache would grow without bound across pushes and evict everything else. It's pruned newest-first to a 1GB ceiling before saving.

## Testing

- actionlint clean, including its shellcheck pass over the prune script.
- Prune pipeline tested against real files: 20 x 100KB with staggered mtimes and a 1MB limit → exactly 10 survivors, the 10 newest. Correct ordering and cutoff.
- Verified the resolved step graph: 3 read-only restores, save gated to `push`, prune non-fatal.

**Not verified locally:** the prune uses `find -printf` and `xargs -r`, which are GNU-only — no GNU findutils or working container runtime on this machine, so only the `sort | awk | xargs` half ran here. Two deliberate mitigations: the prune runs on **every** event rather than only on pushes, so this PR's own CI exercises it; and it is `continue-on-error: true`, so a failure means a larger cache, never a failed build. Worth reading its log line on this PR before merge.

The **save** path still cannot be exercised until this is on a push to `canary` — check the first post-merge run.

## Expected effect

~32s from Playwright plus cold-build savings on the test job. Roughly 3 min → ~2 min. Modest, because the repo is already fast; the point is that both were straightforward gaps.

## Separately

`Failed to restore: Cache service responded with 400` appears in **Setup Bun** on all three jobs. That is `oven-sh/setup-bun`'s own bundled cache, not `actions/cache` — the pinned `actions/cache` v4.3.0 reported a clean miss with no 400. Not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration performance by reusing build, test, and lint caches.
  * Improved browser test setup with version-matched browser installation and caching.
  * Added automated cache size management to limit storage use and keep workflows efficient.
  * Added safeguards for missing, outdated, orphaned, and grouped cache entries during cleanup.
  * Improved cache cleanup reporting, validation, and deterministic handling of older entries.
* **Tests**
  * Expanded automated coverage for cache management, boundary conditions, and filesystem cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Verified on CI (run `30630285555`)

**Playwright cache now works — this was the whole bug.**

| | Result |
|---|---|
| First run | `Cache not found for input keys: playwright-browsers-Linux-1.61.1` → install → **`Cache saved with key: playwright-browsers-Linux-1.61.1`** |
| Re-run | **`Cache restored from key: playwright-browsers-Linux-1.61.1`** |

The save had never happened before this change. Install step: **32s (baseline) → 12s**, plus 2s restore — about **18s saved per test run**, not the full 32s I projected: `--with-deps` still does uncached apt work on a hit. Splitting `install-deps` from `install` could reclaim more; not worth it for 12s.

Note the key is now the Playwright version (`1.61.1`) rather than a lockfile hash, so dependency bumps no longer evict the browsers.

**Prune script verified on ubuntu.** The GNU-only `find -printf` / `xargs -r` form I could not test locally ran clean: `turbo cache: 4.0K -> 4.0K`. Small cache because `--affected` selected 0 packages against the stacked base, so this exercised the syntax, not pruning at scale.

**Gating confirmed.** `♻️ Save Turborepo cache` reported `skipped` on the PR run, as intended. All three restores succeeded.

**Still unproven:** the turbo cache *save* path, which by design only runs on pushes to `canary`/`main`. Check the first post-merge run — expect a `Cache saved with key: turbo-Linux-<sha>` line and a sane prune figure.