### PR TITLE
fix(backend): revert x-forwarded-for header priority

### DIFF
--- a/.changeset/revert-prioritize-forwarded-client-ip.md
+++ b/.changeset/revert-prioritize-forwarded-client-ip.md
@@ -1,0 +1,5 @@
+---
+'@c15t/backend': patch
+---
+
+Revert prioritizing `x-forwarded-for` over `x-client-ip` in the default client IP header order.

--- a/changelog/2.2.0.mdx
+++ b/changelog/2.2.0.mdx
@@ -185,7 +185,6 @@ Legacy duplicate lookups are now scoped to the current tenant, and timestamps ou
 
 ## Backend, API, and compatibility improvements
 
-- The backend now prioritizes `x-forwarded-for` over `x-client-ip` when resolving client IP addresses with the default header order.
 - Browser, SSR, prefetch, and Node SDK requests now forward `x-c15t-version`, and the backend allows it through CORS preflight handling.
 - Custom `headers` configured for hosted clients are no longer dropped. They are included in the runtime cache key so differently configured clients cannot share an instance.
 - Explicit ports in `trustedOrigins` are now matched exactly, while host-only entries remain port-agnostic.

--- a/packages/backend/src/middleware/process-ip/index.test.ts
+++ b/packages/backend/src/middleware/process-ip/index.test.ts
@@ -102,16 +102,6 @@ describe('getIpAddress', () => {
 			expect(getIpAddress(headers, options)).toBe('192.168.1.0');
 		});
 
-		it('should prioritize x-forwarded-for over x-client-ip by default', () => {
-			const headers = createMockHeaders({
-				'x-client-ip': '10.0.0.1',
-				'x-forwarded-for': '192.168.1.100',
-			});
-			const options = createBaseOptions();
-
-			expect(getIpAddress(headers, options)).toBe('192.168.1.0');
-		});
-
 		it('should extract and mask IP from cf-connecting-ip header by default', () => {
 			const headers = createMockHeaders({
 				'cf-connecting-ip': '8.8.8.8',

--- a/packages/backend/src/middleware/process-ip/index.ts
+++ b/packages/backend/src/middleware/process-ip/index.ts
@@ -1,8 +1,8 @@
 import type { C15TOptions } from '~/types';
 
 const DEFAULT_IP_HEADERS = [
-	'x-forwarded-for',
 	'x-client-ip',
+	'x-forwarded-for',
 	'cf-connecting-ip',
 	'fastly-client-ip',
 	'x-real-ip',


### PR DESCRIPTION
Reverts #951, which reordered `DEFAULT_IP_HEADERS` in the backend's `process-ip` middleware to prefer `x-forwarded-for` over `x-client-ip`.

`DEFAULT_IP_HEADERS` returns to its prior order:

```ts
const DEFAULT_IP_HEADERS = [
	'x-client-ip',
	'x-forwarded-for',
	'cf-connecting-ip',
	'fastly-client-ip',
	'x-real-ip',
	...
];
```

The 10 assertions added by #951 are removed along with the changelog entry.

### Note on the changeset

The original changeset (`prioritize-forwarded-client-ip.md`) was already consumed by the canary snapshot publish in #950, which landed after #951 — so `git revert` had nothing to undo there and touched 3 files rather than 4. That also means the header-order change already shipped in a published canary snapshot, so this PR carries its own patch changeset for `@c15t/backend` to revert it.

### Verification

`packages/backend` `process-ip` suite: 24/24 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted client IP header prioritization order; `x-client-ip` now takes precedence over `x-forwarded-for`.

* **Tests**
  * Removed outdated test case for IP header precedence.

* **Documentation**
  * Updated changelog to reflect IP header priority changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->