### PR TITLE
test(migration-fixtures): capture database shapes from published releases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -503,6 +503,15 @@
         "typescript": "6.0.3",
       },
     },
+    "internals/migration-fixtures": {
+      "name": "@c15t/migration-fixtures",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@c15t/typescript-config": "workspace:*",
+        "@types/node": "^24.10.1",
+        "typescript": "6.0.3",
+      },
+    },
     "internals/typescript-config": {
       "name": "@c15t/typescript-config",
       "version": "0.0.1",
@@ -1082,6 +1091,8 @@
     "@c15t/iab": ["@c15t/iab@workspace:packages/iab"],
 
     "@c15t/logger": ["@c15t/logger@workspace:packages/logger"],
+
+    "@c15t/migration-fixtures": ["@c15t/migration-fixtures@workspace:internals/migration-fixtures"],
 
     "@c15t/next-bundle-bench": ["@c15t/next-bundle-bench@workspace:benchmarks/bundle-test-app"],
 
@@ -5179,6 +5190,8 @@
 
     "@c15t/logger/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "@c15t/migration-fixtures/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
     "@c15t/next-bundle-bench/next": ["next@16.2.10", "", { "dependencies": { "@next/env": "16.2.10", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.10", "@next/swc-darwin-x64": "16.2.10", "@next/swc-linux-arm64-gnu": "16.2.10", "@next/swc-linux-arm64-musl": "16.2.10", "@next/swc-linux-x64-gnu": "16.2.10", "@next/swc-linux-x64-musl": "16.2.10", "@next/swc-win32-arm64-msvc": "16.2.10", "@next/swc-win32-x64-msvc": "16.2.10", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA=="],
 
     "@c15t/nextjs/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -6732,6 +6745,8 @@
     "@c15t/example-demo/next/@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@c15t/example-demo/next/baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
+
+    "@c15t/migration-fixtures/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@c15t/next-bundle-bench/next/@next/env": ["@next/env@16.2.10", "", {}, "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA=="],
 

--- a/internals/migration-fixtures/README.md
+++ b/internals/migration-fixtures/README.md
@@ -1,0 +1,95 @@
+# @c15t/migration-fixtures
+
+Ground-truth database shapes captured from **published** `@c15t/backend`
+releases, used to test that the v3 migrator upgrades real databases correctly.
+
+Supports RFC 0004 §3. Not published; not part of any build.
+
+## Why these are generated from npm
+
+The shapes a user's database can be in are determined by the release that
+created it, not by the schema definitions in this repo. For the fumadb eras
+those two happen to agree, but for the legacy era there is no schema
+definition here at all — that code was replaced in 2.0. Generating fixtures
+from anything other than the real releases would test our understanding of
+history rather than history itself.
+
+Each fixture is produced by installing the release into a throwaway workspace,
+running **that release's own migrator** against a blank database, and
+capturing the result.
+
+## Shapes
+
+| Shape | Released by | Migrator entry | Marker table |
+| --- | --- | --- | --- |
+| `legacy-fresh-1.0` | `1.0.0` | `pkgs/migrations` (root) | none |
+| `legacy-fresh-1.8` | `1.8.6` | `pkgs/migrations` (root) | none |
+| `legacy-upgraded` | `1.0.0` → `1.4.2` → `1.8.6` | `pkgs/migrations` (root) | none |
+| `fumadb-1.0.0` | `1.8.6` | `v2/db/migrator` (opt-in subpath) | `private_c15t_settings` = `1.0.0` |
+| `fumadb-2.0.0` | `2.1.0` | `db/migrator` (root) | `private_c15t_settings` = `2.0.0` |
+
+## Findings
+
+**There is one legacy shape, not a family.** RFC §3.2 reasoned that because the
+legacy migrator was strictly additive with no ledger, a database created at 1.0
+and upgraded to 1.8 could retain columns a fresh 1.8 install never had.
+Measured, that does not happen: `legacy-fresh-1.0`, `legacy-fresh-1.8` and
+`legacy-upgraded` are **identical** in tables and columns on both sqlite and
+postgres. The legacy schema simply never changed across the 1.x line, so an
+additive migrator converges on the same result either way.
+
+`legacy-upgraded` is kept anyway — it is the regression test for that claim,
+and it costs nothing to keep generating.
+
+**Scope of that claim.** Captured metadata is tables and columns (name, data
+type, nullability, auto-increment, default presence). **Indexes, foreign keys
+and check constraints are not yet captured**, so drift could still hide there.
+Treat "one legacy shape" as established for columns and unproven for
+constraints until that gap is closed.
+
+## Regenerating
+
+```bash
+# every in-process shape (sqlite + postgres)
+bun run generate
+
+# narrow it down
+bun run generate --shape legacy-upgraded
+bun run generate --engine sqlite
+
+# keep the throwaway workspace to debug a failure
+bun run generate --shape fumadb-1.0.0 --keep-workspace
+```
+
+MySQL needs a real server, so it is opt-in and generated locally rather than in
+CI (RFC §7 keeps Docker off CI's critical path — CI verifies against the
+committed dumps instead):
+
+```bash
+docker run --rm -d -p 3399:3306 \
+  -e MYSQL_ROOT_PASSWORD=c15t -e MYSQL_DATABASE=c15t \
+  --name c15t-fixtures mysql:8
+
+bun run generate --engine mysql --mysql-url mysql://root:c15t@127.0.0.1:3399/c15t
+
+docker stop c15t-fixtures
+```
+
+## Implementation notes
+
+Things that are load-bearing and non-obvious:
+
+- **Releases are installed on demand**, not declared as dependencies.
+  Generation is rare and the old releases drag native drivers and a MongoDB
+  client behind them; nobody running `bun install` should pay for that.
+- **The driver runs under Node, not Bun.** `better-sqlite3`'s NAPI module hard
+  crashes the Bun runtime (`NAPI FATAL ERROR: Error::New`). Bun still performs
+  the install.
+- **The driver hands its result back through a file**, not stdout. 1.8.6's
+  legacy migrator logs to stdout, which corrupts a stdout handoff.
+- **kysely is pinned to the range each release declares**, not `latest`.
+  kysely 0.29 dropped the `Migrator` export that `kysely-pglite` still imports,
+  and a release should be exercised against its own dependency anyway.
+- **`migrator()` returns a plan, not a result.** Nothing touches the database
+  until `plan.execute()` — the CLI does the same thing at
+  `packages/cli/src/commands/self-host/migrate/migrator-result.ts:51`.

--- a/internals/migration-fixtures/README.md
+++ b/internals/migration-fixtures/README.md
@@ -68,11 +68,31 @@ of the rewrite.
 Those cells are committed as `mysql.unsupported.json` so the absence is a
 recorded finding rather than a coverage gap.
 
-**Scope of these claims.** Captured metadata is tables and columns (name, data
-type, nullability, auto-increment, default presence). **Indexes, foreign keys
-and check constraints are not yet captured**, so drift could still hide there.
-Treat "one legacy shape" as established for columns and unproven for
-constraints until that gap is closed.
+**No foreign key column is indexed, in any shipped version.** Across both
+eras, the only non-primary indexes that exist anywhere are `domain.name`
+(legacy) and `runtimePolicyDecision.dedupeKey` (2.0.0). Postgres does not
+create an index on the referencing side of a foreign key, so
+`consent.subjectId`, `consent.domainId`, `consent.policyId` and
+`auditLog.subjectId` are all unindexed.
+
+That is likely the dominant scaling problem, ahead of the join-less query
+surface: the chunked `subjectId in (…)` fan-out in `list.handler.ts` is a
+sequential scan of `consent` per chunk. Adding those indexes is a
+post-cutover change (the baseline has to reproduce the shipped shape, not
+improve on it), but it belongs in the benchmark story — RFC §7 measures query
+count and latency precisely so this shows up as a number.
+
+**Foreign keys exist on Postgres and SQLite but not on MySQL.** The legacy
+migrator emits 6 foreign keys on Postgres and SQLite and **zero** on MySQL, so
+referential integrity in shipped c15t depends on which engine you chose. The
+adoption step has to treat adding foreign keys to a MySQL database as a
+migration that can *fail* on pre-existing data, not as a formality.
+
+**Scope of these claims.** Captured metadata is tables, columns (name, data
+type, nullability, auto-increment, default presence), indexes and foreign
+keys. Check constraints and column defaults' actual expressions are still not
+captured. The "one legacy shape" finding now holds **including indexes and
+foreign keys** on all three engines.
 
 ## Regenerating
 

--- a/internals/migration-fixtures/README.md
+++ b/internals/migration-fixtures/README.md
@@ -41,7 +41,28 @@ additive migrator converges on the same result either way.
 `legacy-upgraded` is kept anyway — it is the regression test for that claim,
 and it costs nothing to keep generating.
 
-**Scope of that claim.** Captured metadata is tables and columns (name, data
+Verified on sqlite, postgres **and** mysql.
+
+**fumadb cannot migrate MySQL at all.** Both `fumadb-1.0.0` and `fumadb-2.0.0`
+fail on a blank MySQL database with:
+
+> ID columns must not be updated, not every database supports updating primary
+> keys and often requires workarounds.
+
+The failure is inside `plan.execute()`, not merely SQL rendering, and it
+reproduces against the exact dependency each release pins — 2.1.0 pins
+`fumadb@0.2.2` — so it is released behaviour, not a resolution artifact.
+MySQL is advertised in `docs/self-host/guides/database-setup.mdx`, so the
+practical implication is that **fumadb-managed MySQL databases most likely do
+not exist in the wild**: the documented migrator could never have created one.
+Those cells are committed as `mysql.unsupported.json` so the absence is a
+recorded finding rather than a coverage gap.
+
+Not yet checked: whether `fumadb@0.3.0`, which this repo pins on the v3 line,
+still has the bug. If it does, MySQL is broken on the current shipping line
+too — worth confirming independently of the rewrite.
+
+**Scope of these claims.** Captured metadata is tables and columns (name, data
 type, nullability, auto-increment, default presence). **Indexes, foreign keys
 and check constraints are not yet captured**, so drift could still hide there.
 Treat "one legacy shape" as established for columns and unproven for

--- a/internals/migration-fixtures/README.md
+++ b/internals/migration-fixtures/README.md
@@ -41,26 +41,32 @@ additive migrator converges on the same result either way.
 `legacy-upgraded` is kept anyway — it is the regression test for that claim,
 and it costs nothing to keep generating.
 
-Verified on sqlite, postgres **and** mysql.
+Verified on sqlite, postgres **and** mysql, each shape against a genuinely
+blank database.
 
-**fumadb cannot migrate MySQL at all.** Both `fumadb-1.0.0` and `fumadb-2.0.0`
-fail on a blank MySQL database with:
+**fumadb cannot migrate MySQL at all, and it is not fixed on the v3 line.**
+Both `fumadb-1.0.0` and `fumadb-2.0.0` fail on a blank MySQL database with:
 
-> ID columns must not be updated, not every database supports updating primary
-> keys and often requires workarounds.
+> BLOB/TEXT column '…' used in key specification without a key length
 
-The failure is inside `plan.execute()`, not merely SQL rendering, and it
-reproduces against the exact dependency each release pins — 2.1.0 pins
-`fumadb@0.2.2` — so it is released behaviour, not a resolution artifact.
-MySQL is advertised in `docs/self-host/guides/database-setup.mdx`, so the
-practical implication is that **fumadb-managed MySQL databases most likely do
-not exist in the wild**: the documented migrator could never have created one.
+fumadb maps a `string` column to MySQL `TEXT` and then indexes it; MySQL
+requires a prefix length to index TEXT/BLOB. Different eras trip over
+different columns — `domain.name` at schema 1.0.0,
+`runtimePolicyDecision.dedupeKey` at 2.0.0 — but the cause is the same.
+
+Reproduced against **both** `fumadb@0.2.2` (pinned by the released 2.1.0) and
+`fumadb@0.3.0` (pinned by this repo on the v3 line), using the real c15t
+schema. A minimal schema with an `idColumn` migrates fine on both versions, so
+this is specific to c15t's schema rather than a blanket fumadb defect.
+
+MySQL is advertised in `docs/self-host/guides/database-setup.mdx`. Two
+implications: fumadb-managed MySQL databases most likely **do not exist in the
+wild**, since the documented migrator could never have created one; and MySQL
+self-hosting is broken on the current v3 line, which is a live bug independent
+of the rewrite.
+
 Those cells are committed as `mysql.unsupported.json` so the absence is a
 recorded finding rather than a coverage gap.
-
-Not yet checked: whether `fumadb@0.3.0`, which this repo pins on the v3 line,
-still has the bug. If it does, MySQL is broken on the current shipping line
-too — worth confirming independently of the rewrite.
 
 **Scope of these claims.** Captured metadata is tables and columns (name, data
 type, nullability, auto-increment, default presence). **Indexes, foreign keys
@@ -114,3 +120,9 @@ Things that are load-bearing and non-obvious:
 - **`migrator()` returns a plan, not a result.** Nothing touches the database
   until `plan.execute()` — the CLI does the same thing at
   `packages/cli/src/commands/self-host/migrate/migrator-result.ts:51`.
+- **MySQL is dropped to a blank schema before every shape.** sqlite and
+  postgres get a fresh in-process database per run; MySQL is a shared server,
+  so without this each shape migrates whatever the previous one left behind.
+  That changes the migration *path*, not just the result — an earlier version
+  of this tool reused one database and produced both a spurious failure mode
+  and a spurious "all legacy shapes are identical" result.

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/mysql.unsupported.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/mysql.unsupported.json
@@ -3,5 +3,5 @@
 	"engine": "mysql",
 	"versions": ["1.8.6"],
 	"era": "fumadb-v2-subpath",
-	"unsupported": "fumadb migration fails on MySQL: \"ID columns must not be updated, not every database supports updating primary keys and often requires workarounds.\" Fails inside execute(), not just SQL rendering."
+	"unsupported": "fumadb migration fails on MySQL: \"BLOB/TEXT column used in key specification without a key length\". fumadb maps string columns to TEXT and indexes them; MySQL needs a prefix length. Trips on domain.name at schema 1.0.0 and runtimePolicyDecision.dedupeKey at 2.0.0. Reproduced on fumadb 0.2.2 and 0.3.0."
 }

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/mysql.unsupported.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/mysql.unsupported.json
@@ -1,0 +1,7 @@
+{
+	"shape": "fumadb-1.0.0",
+	"engine": "mysql",
+	"versions": ["1.8.6"],
+	"era": "fumadb-v2-subpath",
+	"unsupported": "fumadb migration fails on MySQL: \"ID columns must not be updated, not every database supports updating primary keys and often requires workarounds.\" Fails inside execute(), not just SQL rendering."
+}

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/postgres.json
@@ -1,0 +1,1058 @@
+{
+	"shape": "fumadb-1.0.0",
+	"engine": "postgres",
+	"versions": ["1.8.6"],
+	"era": "fumadb-v2-subpath",
+	"rationale": "The opt-in /v2 path shipped inside 1.8.x. Writes c15t_settings = 1.0.0.",
+	"applied": [
+		{
+			"version": "1.8.6",
+			"era": "fumadb-v2-subpath",
+			"sql": "create table \"subject\" (\"id\" varchar(255) not null primary key, \"isIdentified\" boolean not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"subjectTimezone\" text, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null);\n\ncreate table \"domain\" (\"id\" varchar(255) not null primary key, \"name\" text not null, \"description\" text, \"allowedOrigins\" json, \"isVerified\" boolean not null, \"isActive\" boolean not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null);\n\nalter table \"domain\" add constraint \"unique_c_domain_name\" unique (\"name\");\n\ncreate table \"consentPolicy\" (\"id\" varchar(255) not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" timestamp not null, \"expirationDate\" timestamp, \"content\" text not null, \"contentHash\" text not null, \"isActive\" boolean not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null);\n\ncreate table \"consentPurpose\" (\"id\" varchar(255) not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" boolean not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" boolean not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null);\n\ncreate table \"consent\" (\"id\" varchar(255) not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" json not null, \"metadata\" json, \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" timestamp default CURRENT_TIMESTAMP not null, \"validUntil\" timestamp, \"isActive\" boolean not null, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"auditLog\" (\"id\" varchar(255) not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" json, \"metadata\" json, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"eventTimezone\" text not null, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"consentRecord\" (\"id\" varchar(255) not null primary key, \"subjectId\" text not null, \"consentId\" text, \"actionType\" text not null, \"details\" json, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, constraint \"consentRecord_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consentRecord_consent_consent_fk\" foreign key (\"consentId\") references \"consent\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"private_c15t_settings\" (\"key\" varchar(255) primary key, \"value\" text not null);\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('version', '1.0.0');\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('name-variants', '{\"subject\":{\"convex\":\"subject\",\"drizzle\":\"subject\",\"prisma\":\"subject\",\"mongodb\":\"subject\",\"sql\":\"subject\"},\"subject.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"subject.isIdentified\":{\"convex\":\"isIdentified\",\"drizzle\":\"isIdentified\",\"prisma\":\"isIdentified\",\"mongodb\":\"isIdentified\",\"sql\":\"isIdentified\"},\"subject.externalId\":{\"convex\":\"externalId\",\"drizzle\":\"externalId\",\"prisma\":\"externalId\",\"mongodb\":\"externalId\",\"sql\":\"externalId\"},\"subject.identityProvider\":{\"convex\":\"identityProvider\",\"drizzle\":\"identityProvider\",\"prisma\":\"identityProvider\",\"mongodb\":\"identityProvider\",\"sql\":\"identityProvider\"},\"subject.lastIpAddress\":{\"convex\":\"lastIpAddress\",\"drizzle\":\"lastIpAddress\",\"prisma\":\"lastIpAddress\",\"mongodb\":\"lastIpAddress\",\"sql\":\"lastIpAddress\"},\"subject.subjectTimezone\":{\"convex\":\"subjectTimezone\",\"drizzle\":\"subjectTimezone\",\"prisma\":\"subjectTimezone\",\"mongodb\":\"subjectTimezone\",\"sql\":\"subjectTimezone\"},\"subject.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"subject.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"domain\":{\"convex\":\"domain\",\"drizzle\":\"domain\",\"prisma\":\"domain\",\"mongodb\":\"domain\",\"sql\":\"domain\"},\"domain.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"domain.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"domain.description\":{\"convex\":\"description\",\"drizzle\":\"description\",\"prisma\":\"description\",\"mongodb\":\"description\",\"sql\":\"description\"},\"domain.allowedOrigins\":{\"convex\":\"allowedOrigins\",\"drizzle\":\"allowedOrigins\",\"prisma\":\"allowedOrigins\",\"mongodb\":\"allowedOrigins\",\"sql\":\"allowedOrigins\"},\"domain.isVerified\":{\"convex\":\"isVerified\",\"drizzle\":\"isVerified\",\"prisma\":\"isVerified\",\"mongodb\":\"isVerified\",\"sql\":\"isVerified\"},\"domain.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"domain.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"domain.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consentPolicy\":{\"convex\":\"consentPolicy\",\"drizzle\":\"consentPolicy\",\"prisma\":\"consentPolicy\",\"mongodb\":\"consentPolicy\",\"sql\":\"consentPolicy\"},\"consentPolicy.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPolicy.version\":{\"convex\":\"version\",\"drizzle\":\"version\",\"prisma\":\"version\",\"mongodb\":\"version\",\"sql\":\"version\"},\"consentPolicy.type\":{\"convex\":\"type\",\"drizzle\":\"type\",\"prisma\":\"type\",\"mongodb\":\"type\",\"sql\":\"type\"},\"consentPolicy.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"consentPolicy.effectiveDate\":{\"convex\":\"effectiveDate\",\"drizzle\":\"effectiveDate\",\"prisma\":\"effectiveDate\",\"mongodb\":\"effectiveDate\",\"sql\":\"effectiveDate\"},\"consentPolicy.expirationDate\":{\"convex\":\"expirationDate\",\"drizzle\":\"expirationDate\",\"prisma\":\"expirationDate\",\"mongodb\":\"expirationDate\",\"sql\":\"expirationDate\"},\"consentPolicy.content\":{\"convex\":\"content\",\"drizzle\":\"content\",\"prisma\":\"content\",\"mongodb\":\"content\",\"sql\":\"content\"},\"consentPolicy.contentHash\":{\"convex\":\"contentHash\",\"drizzle\":\"contentHash\",\"prisma\":\"contentHash\",\"mongodb\":\"contentHash\",\"sql\":\"contentHash\"},\"consentPolicy.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPolicy.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose\":{\"convex\":\"consentPurpose\",\"drizzle\":\"consentPurpose\",\"prisma\":\"consentPurpose\",\"mongodb\":\"consentPurpose\",\"sql\":\"consentPurpose\"},\"consentPurpose.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPurpose.code\":{\"convex\":\"code\",\"drizzle\":\"code\",\"prisma\":\"code\",\"mongodb\":\"code\",\"sql\":\"code\"},\"consentPurpose.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"consentPurpose.description\":{\"convex\":\"description\",\"drizzle\":\"description\",\"prisma\":\"description\",\"mongodb\":\"description\",\"sql\":\"description\"},\"consentPurpose.isEssential\":{\"convex\":\"isEssential\",\"drizzle\":\"isEssential\",\"prisma\":\"isEssential\",\"mongodb\":\"isEssential\",\"sql\":\"isEssential\"},\"consentPurpose.dataCategory\":{\"convex\":\"dataCategory\",\"drizzle\":\"dataCategory\",\"prisma\":\"dataCategory\",\"mongodb\":\"dataCategory\",\"sql\":\"dataCategory\"},\"consentPurpose.legalBasis\":{\"convex\":\"legalBasis\",\"drizzle\":\"legalBasis\",\"prisma\":\"legalBasis\",\"mongodb\":\"legalBasis\",\"sql\":\"legalBasis\"},\"consentPurpose.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPurpose.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consent\":{\"convex\":\"consent\",\"drizzle\":\"consent\",\"prisma\":\"consent\",\"mongodb\":\"consent\",\"sql\":\"consent\"},\"consent.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consent.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consent.domainId\":{\"convex\":\"domainId\",\"drizzle\":\"domainId\",\"prisma\":\"domainId\",\"mongodb\":\"domainId\",\"sql\":\"domainId\"},\"consent.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"consent.purposeIds\":{\"convex\":\"purposeIds\",\"drizzle\":\"purposeIds\",\"prisma\":\"purposeIds\",\"mongodb\":\"purposeIds\",\"sql\":\"purposeIds\"},\"consent.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"consent.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"consent.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"consent.status\":{\"convex\":\"status\",\"drizzle\":\"status\",\"prisma\":\"status\",\"mongodb\":\"status\",\"sql\":\"status\"},\"consent.withdrawalReason\":{\"convex\":\"withdrawalReason\",\"drizzle\":\"withdrawalReason\",\"prisma\":\"withdrawalReason\",\"mongodb\":\"withdrawalReason\",\"sql\":\"withdrawalReason\"},\"consent.givenAt\":{\"convex\":\"givenAt\",\"drizzle\":\"givenAt\",\"prisma\":\"givenAt\",\"mongodb\":\"givenAt\",\"sql\":\"givenAt\"},\"consent.validUntil\":{\"convex\":\"validUntil\",\"drizzle\":\"validUntil\",\"prisma\":\"validUntil\",\"mongodb\":\"validUntil\",\"sql\":\"validUntil\"},\"consent.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"auditLog\":{\"convex\":\"auditLog\",\"drizzle\":\"auditLog\",\"prisma\":\"auditLog\",\"mongodb\":\"auditLog\",\"sql\":\"auditLog\"},\"auditLog.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"auditLog.entityType\":{\"convex\":\"entityType\",\"drizzle\":\"entityType\",\"prisma\":\"entityType\",\"mongodb\":\"entityType\",\"sql\":\"entityType\"},\"auditLog.entityId\":{\"convex\":\"entityId\",\"drizzle\":\"entityId\",\"prisma\":\"entityId\",\"mongodb\":\"entityId\",\"sql\":\"entityId\"},\"auditLog.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"auditLog.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"auditLog.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"auditLog.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"auditLog.changes\":{\"convex\":\"changes\",\"drizzle\":\"changes\",\"prisma\":\"changes\",\"mongodb\":\"changes\",\"sql\":\"changes\"},\"auditLog.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"auditLog.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"auditLog.eventTimezone\":{\"convex\":\"eventTimezone\",\"drizzle\":\"eventTimezone\",\"prisma\":\"eventTimezone\",\"mongodb\":\"eventTimezone\",\"sql\":\"eventTimezone\"},\"consentRecord\":{\"convex\":\"consentRecord\",\"drizzle\":\"consentRecord\",\"prisma\":\"consentRecord\",\"mongodb\":\"consentRecord\",\"sql\":\"consentRecord\"},\"consentRecord.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentRecord.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consentRecord.consentId\":{\"convex\":\"consentId\",\"drizzle\":\"consentId\",\"prisma\":\"consentId\",\"mongodb\":\"consentId\",\"sql\":\"consentId\"},\"consentRecord.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"consentRecord.details\":{\"convex\":\"details\",\"drizzle\":\"details\",\"prisma\":\"details\",\"mongodb\":\"details\",\"sql\":\"details\"},\"consentRecord.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"}}');"
+		}
+	],
+	"settings": {
+		"table": "private_c15t_settings",
+		"rows": [
+			{
+				"key": "version",
+				"value": "1.0.0"
+			},
+			{
+				"key": "name-variants",
+				"value": {
+					"subject": {
+						"convex": "subject",
+						"drizzle": "subject",
+						"prisma": "subject",
+						"mongodb": "subject",
+						"sql": "subject"
+					},
+					"subject.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"subject.isIdentified": {
+						"convex": "isIdentified",
+						"drizzle": "isIdentified",
+						"prisma": "isIdentified",
+						"mongodb": "isIdentified",
+						"sql": "isIdentified"
+					},
+					"subject.externalId": {
+						"convex": "externalId",
+						"drizzle": "externalId",
+						"prisma": "externalId",
+						"mongodb": "externalId",
+						"sql": "externalId"
+					},
+					"subject.identityProvider": {
+						"convex": "identityProvider",
+						"drizzle": "identityProvider",
+						"prisma": "identityProvider",
+						"mongodb": "identityProvider",
+						"sql": "identityProvider"
+					},
+					"subject.lastIpAddress": {
+						"convex": "lastIpAddress",
+						"drizzle": "lastIpAddress",
+						"prisma": "lastIpAddress",
+						"mongodb": "lastIpAddress",
+						"sql": "lastIpAddress"
+					},
+					"subject.subjectTimezone": {
+						"convex": "subjectTimezone",
+						"drizzle": "subjectTimezone",
+						"prisma": "subjectTimezone",
+						"mongodb": "subjectTimezone",
+						"sql": "subjectTimezone"
+					},
+					"subject.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"subject.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"domain": {
+						"convex": "domain",
+						"drizzle": "domain",
+						"prisma": "domain",
+						"mongodb": "domain",
+						"sql": "domain"
+					},
+					"domain.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"domain.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"domain.description": {
+						"convex": "description",
+						"drizzle": "description",
+						"prisma": "description",
+						"mongodb": "description",
+						"sql": "description"
+					},
+					"domain.allowedOrigins": {
+						"convex": "allowedOrigins",
+						"drizzle": "allowedOrigins",
+						"prisma": "allowedOrigins",
+						"mongodb": "allowedOrigins",
+						"sql": "allowedOrigins"
+					},
+					"domain.isVerified": {
+						"convex": "isVerified",
+						"drizzle": "isVerified",
+						"prisma": "isVerified",
+						"mongodb": "isVerified",
+						"sql": "isVerified"
+					},
+					"domain.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"domain.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"domain.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consentPolicy": {
+						"convex": "consentPolicy",
+						"drizzle": "consentPolicy",
+						"prisma": "consentPolicy",
+						"mongodb": "consentPolicy",
+						"sql": "consentPolicy"
+					},
+					"consentPolicy.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPolicy.version": {
+						"convex": "version",
+						"drizzle": "version",
+						"prisma": "version",
+						"mongodb": "version",
+						"sql": "version"
+					},
+					"consentPolicy.type": {
+						"convex": "type",
+						"drizzle": "type",
+						"prisma": "type",
+						"mongodb": "type",
+						"sql": "type"
+					},
+					"consentPolicy.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"consentPolicy.effectiveDate": {
+						"convex": "effectiveDate",
+						"drizzle": "effectiveDate",
+						"prisma": "effectiveDate",
+						"mongodb": "effectiveDate",
+						"sql": "effectiveDate"
+					},
+					"consentPolicy.expirationDate": {
+						"convex": "expirationDate",
+						"drizzle": "expirationDate",
+						"prisma": "expirationDate",
+						"mongodb": "expirationDate",
+						"sql": "expirationDate"
+					},
+					"consentPolicy.content": {
+						"convex": "content",
+						"drizzle": "content",
+						"prisma": "content",
+						"mongodb": "content",
+						"sql": "content"
+					},
+					"consentPolicy.contentHash": {
+						"convex": "contentHash",
+						"drizzle": "contentHash",
+						"prisma": "contentHash",
+						"mongodb": "contentHash",
+						"sql": "contentHash"
+					},
+					"consentPolicy.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPolicy.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose": {
+						"convex": "consentPurpose",
+						"drizzle": "consentPurpose",
+						"prisma": "consentPurpose",
+						"mongodb": "consentPurpose",
+						"sql": "consentPurpose"
+					},
+					"consentPurpose.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPurpose.code": {
+						"convex": "code",
+						"drizzle": "code",
+						"prisma": "code",
+						"mongodb": "code",
+						"sql": "code"
+					},
+					"consentPurpose.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"consentPurpose.description": {
+						"convex": "description",
+						"drizzle": "description",
+						"prisma": "description",
+						"mongodb": "description",
+						"sql": "description"
+					},
+					"consentPurpose.isEssential": {
+						"convex": "isEssential",
+						"drizzle": "isEssential",
+						"prisma": "isEssential",
+						"mongodb": "isEssential",
+						"sql": "isEssential"
+					},
+					"consentPurpose.dataCategory": {
+						"convex": "dataCategory",
+						"drizzle": "dataCategory",
+						"prisma": "dataCategory",
+						"mongodb": "dataCategory",
+						"sql": "dataCategory"
+					},
+					"consentPurpose.legalBasis": {
+						"convex": "legalBasis",
+						"drizzle": "legalBasis",
+						"prisma": "legalBasis",
+						"mongodb": "legalBasis",
+						"sql": "legalBasis"
+					},
+					"consentPurpose.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPurpose.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consent": {
+						"convex": "consent",
+						"drizzle": "consent",
+						"prisma": "consent",
+						"mongodb": "consent",
+						"sql": "consent"
+					},
+					"consent.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consent.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consent.domainId": {
+						"convex": "domainId",
+						"drizzle": "domainId",
+						"prisma": "domainId",
+						"mongodb": "domainId",
+						"sql": "domainId"
+					},
+					"consent.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"consent.purposeIds": {
+						"convex": "purposeIds",
+						"drizzle": "purposeIds",
+						"prisma": "purposeIds",
+						"mongodb": "purposeIds",
+						"sql": "purposeIds"
+					},
+					"consent.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"consent.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"consent.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"consent.status": {
+						"convex": "status",
+						"drizzle": "status",
+						"prisma": "status",
+						"mongodb": "status",
+						"sql": "status"
+					},
+					"consent.withdrawalReason": {
+						"convex": "withdrawalReason",
+						"drizzle": "withdrawalReason",
+						"prisma": "withdrawalReason",
+						"mongodb": "withdrawalReason",
+						"sql": "withdrawalReason"
+					},
+					"consent.givenAt": {
+						"convex": "givenAt",
+						"drizzle": "givenAt",
+						"prisma": "givenAt",
+						"mongodb": "givenAt",
+						"sql": "givenAt"
+					},
+					"consent.validUntil": {
+						"convex": "validUntil",
+						"drizzle": "validUntil",
+						"prisma": "validUntil",
+						"mongodb": "validUntil",
+						"sql": "validUntil"
+					},
+					"consent.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"auditLog": {
+						"convex": "auditLog",
+						"drizzle": "auditLog",
+						"prisma": "auditLog",
+						"mongodb": "auditLog",
+						"sql": "auditLog"
+					},
+					"auditLog.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"auditLog.entityType": {
+						"convex": "entityType",
+						"drizzle": "entityType",
+						"prisma": "entityType",
+						"mongodb": "entityType",
+						"sql": "entityType"
+					},
+					"auditLog.entityId": {
+						"convex": "entityId",
+						"drizzle": "entityId",
+						"prisma": "entityId",
+						"mongodb": "entityId",
+						"sql": "entityId"
+					},
+					"auditLog.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"auditLog.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"auditLog.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"auditLog.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"auditLog.changes": {
+						"convex": "changes",
+						"drizzle": "changes",
+						"prisma": "changes",
+						"mongodb": "changes",
+						"sql": "changes"
+					},
+					"auditLog.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"auditLog.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"auditLog.eventTimezone": {
+						"convex": "eventTimezone",
+						"drizzle": "eventTimezone",
+						"prisma": "eventTimezone",
+						"mongodb": "eventTimezone",
+						"sql": "eventTimezone"
+					},
+					"consentRecord": {
+						"convex": "consentRecord",
+						"drizzle": "consentRecord",
+						"prisma": "consentRecord",
+						"mongodb": "consentRecord",
+						"sql": "consentRecord"
+					},
+					"consentRecord.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentRecord.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consentRecord.consentId": {
+						"convex": "consentId",
+						"drizzle": "consentId",
+						"prisma": "consentId",
+						"mongodb": "consentId",
+						"sql": "consentId"
+					},
+					"consentRecord.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"consentRecord.details": {
+						"convex": "details",
+						"drizzle": "details",
+						"prisma": "details",
+						"mongodb": "details",
+						"sql": "details"
+					},
+					"consentRecord.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					}
+				}
+			}
+		]
+	},
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "json",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "details",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "private_c15t_settings",
+			"columns": [
+				{
+					"name": "key",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "value",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		}
+	],
+	"ddl": {}
+}

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/postgres.json
@@ -1054,5 +1054,108 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "auditLog_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "consent_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "consentPolicy_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "consentPurpose_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "consentRecord_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "unique_c_domain_name",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "private_c15t_settings",
+			"name": "private_c15t_settings_pkey",
+			"columns": ["key"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "subject",
+			"name": "subject_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {}
 }

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/sqlite.json
@@ -1054,6 +1054,109 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "unique_c_domain_name",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "private_c15t_settings",
+			"name": "sqlite_primary_key",
+			"columns": ["key"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "subject",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {
 		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"eventTimezone\" text not null, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict)",
 		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"isActive\" integer not null, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict)",

--- a/internals/migration-fixtures/fixtures/fumadb-1.0.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/fumadb-1.0.0/sqlite.json
@@ -1,0 +1,1068 @@
+{
+	"shape": "fumadb-1.0.0",
+	"engine": "sqlite",
+	"versions": ["1.8.6"],
+	"era": "fumadb-v2-subpath",
+	"rationale": "The opt-in /v2 path shipped inside 1.8.x. Writes c15t_settings = 1.0.0.",
+	"applied": [
+		{
+			"version": "1.8.6",
+			"era": "fumadb-v2-subpath",
+			"sql": "PRAGMA defer_foreign_keys = ON;\n\ncreate table \"subject\" (\"id\" text not null primary key, \"isIdentified\" integer not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"subjectTimezone\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null);\n\ncreate table \"domain\" (\"id\" text not null primary key, \"name\" text not null, \"description\" text, \"allowedOrigins\" text, \"isVerified\" integer not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null);\n\ncreate unique index \"unique_c_domain_name\" on \"domain\" (\"name\");\n\ncreate table \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" integer not null, \"expirationDate\" integer, \"content\" text not null, \"contentHash\" text not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null);\n\ncreate table \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" integer not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null);\n\ncreate table \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"isActive\" integer not null, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"eventTimezone\" text not null, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"consentRecord\" (\"id\" text not null primary key, \"subjectId\" text not null, \"consentId\" text, \"actionType\" text not null, \"details\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, constraint \"consentRecord_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consentRecord_consent_consent_fk\" foreign key (\"consentId\") references \"consent\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"private_c15t_settings\" (\"key\" text primary key, \"value\" text not null);\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('version', '1.0.0');\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('name-variants', '{\"subject\":{\"convex\":\"subject\",\"drizzle\":\"subject\",\"prisma\":\"subject\",\"mongodb\":\"subject\",\"sql\":\"subject\"},\"subject.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"subject.isIdentified\":{\"convex\":\"isIdentified\",\"drizzle\":\"isIdentified\",\"prisma\":\"isIdentified\",\"mongodb\":\"isIdentified\",\"sql\":\"isIdentified\"},\"subject.externalId\":{\"convex\":\"externalId\",\"drizzle\":\"externalId\",\"prisma\":\"externalId\",\"mongodb\":\"externalId\",\"sql\":\"externalId\"},\"subject.identityProvider\":{\"convex\":\"identityProvider\",\"drizzle\":\"identityProvider\",\"prisma\":\"identityProvider\",\"mongodb\":\"identityProvider\",\"sql\":\"identityProvider\"},\"subject.lastIpAddress\":{\"convex\":\"lastIpAddress\",\"drizzle\":\"lastIpAddress\",\"prisma\":\"lastIpAddress\",\"mongodb\":\"lastIpAddress\",\"sql\":\"lastIpAddress\"},\"subject.subjectTimezone\":{\"convex\":\"subjectTimezone\",\"drizzle\":\"subjectTimezone\",\"prisma\":\"subjectTimezone\",\"mongodb\":\"subjectTimezone\",\"sql\":\"subjectTimezone\"},\"subject.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"subject.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"domain\":{\"convex\":\"domain\",\"drizzle\":\"domain\",\"prisma\":\"domain\",\"mongodb\":\"domain\",\"sql\":\"domain\"},\"domain.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"domain.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"domain.description\":{\"convex\":\"description\",\"drizzle\":\"description\",\"prisma\":\"description\",\"mongodb\":\"description\",\"sql\":\"description\"},\"domain.allowedOrigins\":{\"convex\":\"allowedOrigins\",\"drizzle\":\"allowedOrigins\",\"prisma\":\"allowedOrigins\",\"mongodb\":\"allowedOrigins\",\"sql\":\"allowedOrigins\"},\"domain.isVerified\":{\"convex\":\"isVerified\",\"drizzle\":\"isVerified\",\"prisma\":\"isVerified\",\"mongodb\":\"isVerified\",\"sql\":\"isVerified\"},\"domain.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"domain.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"domain.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consentPolicy\":{\"convex\":\"consentPolicy\",\"drizzle\":\"consentPolicy\",\"prisma\":\"consentPolicy\",\"mongodb\":\"consentPolicy\",\"sql\":\"consentPolicy\"},\"consentPolicy.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPolicy.version\":{\"convex\":\"version\",\"drizzle\":\"version\",\"prisma\":\"version\",\"mongodb\":\"version\",\"sql\":\"version\"},\"consentPolicy.type\":{\"convex\":\"type\",\"drizzle\":\"type\",\"prisma\":\"type\",\"mongodb\":\"type\",\"sql\":\"type\"},\"consentPolicy.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"consentPolicy.effectiveDate\":{\"convex\":\"effectiveDate\",\"drizzle\":\"effectiveDate\",\"prisma\":\"effectiveDate\",\"mongodb\":\"effectiveDate\",\"sql\":\"effectiveDate\"},\"consentPolicy.expirationDate\":{\"convex\":\"expirationDate\",\"drizzle\":\"expirationDate\",\"prisma\":\"expirationDate\",\"mongodb\":\"expirationDate\",\"sql\":\"expirationDate\"},\"consentPolicy.content\":{\"convex\":\"content\",\"drizzle\":\"content\",\"prisma\":\"content\",\"mongodb\":\"content\",\"sql\":\"content\"},\"consentPolicy.contentHash\":{\"convex\":\"contentHash\",\"drizzle\":\"contentHash\",\"prisma\":\"contentHash\",\"mongodb\":\"contentHash\",\"sql\":\"contentHash\"},\"consentPolicy.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPolicy.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose\":{\"convex\":\"consentPurpose\",\"drizzle\":\"consentPurpose\",\"prisma\":\"consentPurpose\",\"mongodb\":\"consentPurpose\",\"sql\":\"consentPurpose\"},\"consentPurpose.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPurpose.code\":{\"convex\":\"code\",\"drizzle\":\"code\",\"prisma\":\"code\",\"mongodb\":\"code\",\"sql\":\"code\"},\"consentPurpose.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"consentPurpose.description\":{\"convex\":\"description\",\"drizzle\":\"description\",\"prisma\":\"description\",\"mongodb\":\"description\",\"sql\":\"description\"},\"consentPurpose.isEssential\":{\"convex\":\"isEssential\",\"drizzle\":\"isEssential\",\"prisma\":\"isEssential\",\"mongodb\":\"isEssential\",\"sql\":\"isEssential\"},\"consentPurpose.dataCategory\":{\"convex\":\"dataCategory\",\"drizzle\":\"dataCategory\",\"prisma\":\"dataCategory\",\"mongodb\":\"dataCategory\",\"sql\":\"dataCategory\"},\"consentPurpose.legalBasis\":{\"convex\":\"legalBasis\",\"drizzle\":\"legalBasis\",\"prisma\":\"legalBasis\",\"mongodb\":\"legalBasis\",\"sql\":\"legalBasis\"},\"consentPurpose.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPurpose.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consent\":{\"convex\":\"consent\",\"drizzle\":\"consent\",\"prisma\":\"consent\",\"mongodb\":\"consent\",\"sql\":\"consent\"},\"consent.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consent.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consent.domainId\":{\"convex\":\"domainId\",\"drizzle\":\"domainId\",\"prisma\":\"domainId\",\"mongodb\":\"domainId\",\"sql\":\"domainId\"},\"consent.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"consent.purposeIds\":{\"convex\":\"purposeIds\",\"drizzle\":\"purposeIds\",\"prisma\":\"purposeIds\",\"mongodb\":\"purposeIds\",\"sql\":\"purposeIds\"},\"consent.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"consent.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"consent.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"consent.status\":{\"convex\":\"status\",\"drizzle\":\"status\",\"prisma\":\"status\",\"mongodb\":\"status\",\"sql\":\"status\"},\"consent.withdrawalReason\":{\"convex\":\"withdrawalReason\",\"drizzle\":\"withdrawalReason\",\"prisma\":\"withdrawalReason\",\"mongodb\":\"withdrawalReason\",\"sql\":\"withdrawalReason\"},\"consent.givenAt\":{\"convex\":\"givenAt\",\"drizzle\":\"givenAt\",\"prisma\":\"givenAt\",\"mongodb\":\"givenAt\",\"sql\":\"givenAt\"},\"consent.validUntil\":{\"convex\":\"validUntil\",\"drizzle\":\"validUntil\",\"prisma\":\"validUntil\",\"mongodb\":\"validUntil\",\"sql\":\"validUntil\"},\"consent.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"auditLog\":{\"convex\":\"auditLog\",\"drizzle\":\"auditLog\",\"prisma\":\"auditLog\",\"mongodb\":\"auditLog\",\"sql\":\"auditLog\"},\"auditLog.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"auditLog.entityType\":{\"convex\":\"entityType\",\"drizzle\":\"entityType\",\"prisma\":\"entityType\",\"mongodb\":\"entityType\",\"sql\":\"entityType\"},\"auditLog.entityId\":{\"convex\":\"entityId\",\"drizzle\":\"entityId\",\"prisma\":\"entityId\",\"mongodb\":\"entityId\",\"sql\":\"entityId\"},\"auditLog.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"auditLog.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"auditLog.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"auditLog.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"auditLog.changes\":{\"convex\":\"changes\",\"drizzle\":\"changes\",\"prisma\":\"changes\",\"mongodb\":\"changes\",\"sql\":\"changes\"},\"auditLog.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"auditLog.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"auditLog.eventTimezone\":{\"convex\":\"eventTimezone\",\"drizzle\":\"eventTimezone\",\"prisma\":\"eventTimezone\",\"mongodb\":\"eventTimezone\",\"sql\":\"eventTimezone\"},\"consentRecord\":{\"convex\":\"consentRecord\",\"drizzle\":\"consentRecord\",\"prisma\":\"consentRecord\",\"mongodb\":\"consentRecord\",\"sql\":\"consentRecord\"},\"consentRecord.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentRecord.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consentRecord.consentId\":{\"convex\":\"consentId\",\"drizzle\":\"consentId\",\"prisma\":\"consentId\",\"mongodb\":\"consentId\",\"sql\":\"consentId\"},\"consentRecord.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"consentRecord.details\":{\"convex\":\"details\",\"drizzle\":\"details\",\"prisma\":\"details\",\"mongodb\":\"details\",\"sql\":\"details\"},\"consentRecord.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"}}');"
+		}
+	],
+	"settings": {
+		"table": "private_c15t_settings",
+		"rows": [
+			{
+				"key": "version",
+				"value": "1.0.0"
+			},
+			{
+				"key": "name-variants",
+				"value": {
+					"subject": {
+						"convex": "subject",
+						"drizzle": "subject",
+						"prisma": "subject",
+						"mongodb": "subject",
+						"sql": "subject"
+					},
+					"subject.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"subject.isIdentified": {
+						"convex": "isIdentified",
+						"drizzle": "isIdentified",
+						"prisma": "isIdentified",
+						"mongodb": "isIdentified",
+						"sql": "isIdentified"
+					},
+					"subject.externalId": {
+						"convex": "externalId",
+						"drizzle": "externalId",
+						"prisma": "externalId",
+						"mongodb": "externalId",
+						"sql": "externalId"
+					},
+					"subject.identityProvider": {
+						"convex": "identityProvider",
+						"drizzle": "identityProvider",
+						"prisma": "identityProvider",
+						"mongodb": "identityProvider",
+						"sql": "identityProvider"
+					},
+					"subject.lastIpAddress": {
+						"convex": "lastIpAddress",
+						"drizzle": "lastIpAddress",
+						"prisma": "lastIpAddress",
+						"mongodb": "lastIpAddress",
+						"sql": "lastIpAddress"
+					},
+					"subject.subjectTimezone": {
+						"convex": "subjectTimezone",
+						"drizzle": "subjectTimezone",
+						"prisma": "subjectTimezone",
+						"mongodb": "subjectTimezone",
+						"sql": "subjectTimezone"
+					},
+					"subject.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"subject.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"domain": {
+						"convex": "domain",
+						"drizzle": "domain",
+						"prisma": "domain",
+						"mongodb": "domain",
+						"sql": "domain"
+					},
+					"domain.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"domain.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"domain.description": {
+						"convex": "description",
+						"drizzle": "description",
+						"prisma": "description",
+						"mongodb": "description",
+						"sql": "description"
+					},
+					"domain.allowedOrigins": {
+						"convex": "allowedOrigins",
+						"drizzle": "allowedOrigins",
+						"prisma": "allowedOrigins",
+						"mongodb": "allowedOrigins",
+						"sql": "allowedOrigins"
+					},
+					"domain.isVerified": {
+						"convex": "isVerified",
+						"drizzle": "isVerified",
+						"prisma": "isVerified",
+						"mongodb": "isVerified",
+						"sql": "isVerified"
+					},
+					"domain.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"domain.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"domain.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consentPolicy": {
+						"convex": "consentPolicy",
+						"drizzle": "consentPolicy",
+						"prisma": "consentPolicy",
+						"mongodb": "consentPolicy",
+						"sql": "consentPolicy"
+					},
+					"consentPolicy.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPolicy.version": {
+						"convex": "version",
+						"drizzle": "version",
+						"prisma": "version",
+						"mongodb": "version",
+						"sql": "version"
+					},
+					"consentPolicy.type": {
+						"convex": "type",
+						"drizzle": "type",
+						"prisma": "type",
+						"mongodb": "type",
+						"sql": "type"
+					},
+					"consentPolicy.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"consentPolicy.effectiveDate": {
+						"convex": "effectiveDate",
+						"drizzle": "effectiveDate",
+						"prisma": "effectiveDate",
+						"mongodb": "effectiveDate",
+						"sql": "effectiveDate"
+					},
+					"consentPolicy.expirationDate": {
+						"convex": "expirationDate",
+						"drizzle": "expirationDate",
+						"prisma": "expirationDate",
+						"mongodb": "expirationDate",
+						"sql": "expirationDate"
+					},
+					"consentPolicy.content": {
+						"convex": "content",
+						"drizzle": "content",
+						"prisma": "content",
+						"mongodb": "content",
+						"sql": "content"
+					},
+					"consentPolicy.contentHash": {
+						"convex": "contentHash",
+						"drizzle": "contentHash",
+						"prisma": "contentHash",
+						"mongodb": "contentHash",
+						"sql": "contentHash"
+					},
+					"consentPolicy.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPolicy.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose": {
+						"convex": "consentPurpose",
+						"drizzle": "consentPurpose",
+						"prisma": "consentPurpose",
+						"mongodb": "consentPurpose",
+						"sql": "consentPurpose"
+					},
+					"consentPurpose.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPurpose.code": {
+						"convex": "code",
+						"drizzle": "code",
+						"prisma": "code",
+						"mongodb": "code",
+						"sql": "code"
+					},
+					"consentPurpose.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"consentPurpose.description": {
+						"convex": "description",
+						"drizzle": "description",
+						"prisma": "description",
+						"mongodb": "description",
+						"sql": "description"
+					},
+					"consentPurpose.isEssential": {
+						"convex": "isEssential",
+						"drizzle": "isEssential",
+						"prisma": "isEssential",
+						"mongodb": "isEssential",
+						"sql": "isEssential"
+					},
+					"consentPurpose.dataCategory": {
+						"convex": "dataCategory",
+						"drizzle": "dataCategory",
+						"prisma": "dataCategory",
+						"mongodb": "dataCategory",
+						"sql": "dataCategory"
+					},
+					"consentPurpose.legalBasis": {
+						"convex": "legalBasis",
+						"drizzle": "legalBasis",
+						"prisma": "legalBasis",
+						"mongodb": "legalBasis",
+						"sql": "legalBasis"
+					},
+					"consentPurpose.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPurpose.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consent": {
+						"convex": "consent",
+						"drizzle": "consent",
+						"prisma": "consent",
+						"mongodb": "consent",
+						"sql": "consent"
+					},
+					"consent.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consent.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consent.domainId": {
+						"convex": "domainId",
+						"drizzle": "domainId",
+						"prisma": "domainId",
+						"mongodb": "domainId",
+						"sql": "domainId"
+					},
+					"consent.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"consent.purposeIds": {
+						"convex": "purposeIds",
+						"drizzle": "purposeIds",
+						"prisma": "purposeIds",
+						"mongodb": "purposeIds",
+						"sql": "purposeIds"
+					},
+					"consent.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"consent.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"consent.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"consent.status": {
+						"convex": "status",
+						"drizzle": "status",
+						"prisma": "status",
+						"mongodb": "status",
+						"sql": "status"
+					},
+					"consent.withdrawalReason": {
+						"convex": "withdrawalReason",
+						"drizzle": "withdrawalReason",
+						"prisma": "withdrawalReason",
+						"mongodb": "withdrawalReason",
+						"sql": "withdrawalReason"
+					},
+					"consent.givenAt": {
+						"convex": "givenAt",
+						"drizzle": "givenAt",
+						"prisma": "givenAt",
+						"mongodb": "givenAt",
+						"sql": "givenAt"
+					},
+					"consent.validUntil": {
+						"convex": "validUntil",
+						"drizzle": "validUntil",
+						"prisma": "validUntil",
+						"mongodb": "validUntil",
+						"sql": "validUntil"
+					},
+					"consent.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"auditLog": {
+						"convex": "auditLog",
+						"drizzle": "auditLog",
+						"prisma": "auditLog",
+						"mongodb": "auditLog",
+						"sql": "auditLog"
+					},
+					"auditLog.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"auditLog.entityType": {
+						"convex": "entityType",
+						"drizzle": "entityType",
+						"prisma": "entityType",
+						"mongodb": "entityType",
+						"sql": "entityType"
+					},
+					"auditLog.entityId": {
+						"convex": "entityId",
+						"drizzle": "entityId",
+						"prisma": "entityId",
+						"mongodb": "entityId",
+						"sql": "entityId"
+					},
+					"auditLog.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"auditLog.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"auditLog.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"auditLog.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"auditLog.changes": {
+						"convex": "changes",
+						"drizzle": "changes",
+						"prisma": "changes",
+						"mongodb": "changes",
+						"sql": "changes"
+					},
+					"auditLog.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"auditLog.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"auditLog.eventTimezone": {
+						"convex": "eventTimezone",
+						"drizzle": "eventTimezone",
+						"prisma": "eventTimezone",
+						"mongodb": "eventTimezone",
+						"sql": "eventTimezone"
+					},
+					"consentRecord": {
+						"convex": "consentRecord",
+						"drizzle": "consentRecord",
+						"prisma": "consentRecord",
+						"mongodb": "consentRecord",
+						"sql": "consentRecord"
+					},
+					"consentRecord.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentRecord.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consentRecord.consentId": {
+						"convex": "consentId",
+						"drizzle": "consentId",
+						"prisma": "consentId",
+						"mongodb": "consentId",
+						"sql": "consentId"
+					},
+					"consentRecord.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"consentRecord.details": {
+						"convex": "details",
+						"drizzle": "details",
+						"prisma": "details",
+						"mongodb": "details",
+						"sql": "details"
+					},
+					"consentRecord.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					}
+				}
+			}
+		]
+	},
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "entityId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "INTEGER",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "INTEGER",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "details",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "private_c15t_settings",
+			"columns": [
+				{
+					"name": "key",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "value",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "externalId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"eventTimezone\" text not null, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict)",
+		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"isActive\" integer not null, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict)",
+		"consentPolicy": "CREATE TABLE \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" integer not null, \"expirationDate\" integer, \"content\" text not null, \"contentHash\" text not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null)",
+		"consentPurpose": "CREATE TABLE \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" integer not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null)",
+		"consentRecord": "CREATE TABLE \"consentRecord\" (\"id\" text not null primary key, \"subjectId\" text not null, \"consentId\" text, \"actionType\" text not null, \"details\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, constraint \"consentRecord_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consentRecord_consent_consent_fk\" foreign key (\"consentId\") references \"consent\" (\"id\") on delete restrict on update restrict)",
+		"domain": "CREATE TABLE \"domain\" (\"id\" text not null primary key, \"name\" text not null, \"description\" text, \"allowedOrigins\" text, \"isVerified\" integer not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null)",
+		"private_c15t_settings": "CREATE TABLE \"private_c15t_settings\" (\"key\" text primary key, \"value\" text not null)",
+		"subject": "CREATE TABLE \"subject\" (\"id\" text not null primary key, \"isIdentified\" integer not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"subjectTimezone\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null)",
+		"unique_c_domain_name": "CREATE UNIQUE INDEX \"unique_c_domain_name\" on \"domain\" (\"name\")"
+	}
+}

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/mysql.unsupported.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/mysql.unsupported.json
@@ -3,5 +3,5 @@
 	"engine": "mysql",
 	"versions": ["2.1.0"],
 	"era": "fumadb-root",
-	"unsupported": "fumadb migration fails on MySQL: \"ID columns must not be updated, not every database supports updating primary keys and often requires workarounds.\" Fails inside execute(), not just SQL rendering."
+	"unsupported": "fumadb migration fails on MySQL: \"BLOB/TEXT column used in key specification without a key length\". fumadb maps string columns to TEXT and indexes them; MySQL needs a prefix length. Trips on domain.name at schema 1.0.0 and runtimePolicyDecision.dedupeKey at 2.0.0. Reproduced on fumadb 0.2.2 and 0.3.0."
 }

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/mysql.unsupported.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/mysql.unsupported.json
@@ -1,0 +1,7 @@
+{
+	"shape": "fumadb-2.0.0",
+	"engine": "mysql",
+	"versions": ["2.1.0"],
+	"era": "fumadb-root",
+	"unsupported": "fumadb migration fails on MySQL: \"ID columns must not be updated, not every database supports updating primary keys and often requires workarounds.\" Fails inside execute(), not just SQL rendering."
+}

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/postgres.json
@@ -1,0 +1,1142 @@
+{
+	"shape": "fumadb-2.0.0",
+	"engine": "postgres",
+	"versions": ["2.1.0"],
+	"era": "fumadb-root",
+	"rationale": "Current shipping shape. Writes c15t_settings = 2.0.0.",
+	"applied": [
+		{
+			"version": "2.1.0",
+			"era": "fumadb-root",
+			"sql": "create table \"subject\" (\"id\" varchar(255) not null primary key, \"externalId\" text, \"identityProvider\" text, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"domain\" (\"id\" varchar(255) not null primary key, \"name\" text not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"consentPolicy\" (\"id\" varchar(255) not null primary key, \"version\" text not null, \"type\" text not null, \"hash\" text, \"effectiveDate\" timestamp not null, \"isActive\" boolean not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"runtimePolicyDecision\" (\"id\" varchar(255) not null primary key, \"tenantId\" text, \"policyId\" text not null, \"fingerprint\" text not null, \"matchedBy\" text not null, \"countryCode\" text, \"regionCode\" text, \"jurisdiction\" text not null, \"language\" text, \"model\" text not null, \"policyI18n\" json, \"uiMode\" text, \"bannerUi\" json, \"dialogUi\" json, \"categories\" json, \"preselectedCategories\" json, \"proofConfig\" json, \"dedupeKey\" text not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null);\n\nalter table \"runtimePolicyDecision\" add constraint \"unique_c_runtimePolicyDecision_dedupeKey\" unique (\"dedupeKey\");\n\ncreate table \"consentPurpose\" (\"id\" varchar(255) not null primary key, \"code\" text not null, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"updatedAt\" timestamp default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"consent\" (\"id\" varchar(255) not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" json not null, \"metadata\" json, \"ipAddress\" text, \"userAgent\" text, \"givenAt\" timestamp default CURRENT_TIMESTAMP not null, \"validUntil\" timestamp, \"jurisdiction\" text, \"jurisdictionModel\" text, \"tcString\" text, \"uiSource\" text, \"consentAction\" text, \"runtimePolicyDecisionId\" text, \"runtimePolicySource\" text, \"tenantId\" text, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict, constraint \"consent_runtimePolicyDecision_runtimePolicyDecision_fk\" foreign key (\"runtimePolicyDecisionId\") references \"runtimePolicyDecision\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"auditLog\" (\"id\" varchar(255) not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" json, \"metadata\" json, \"createdAt\" timestamp default CURRENT_TIMESTAMP not null, \"tenantId\" text, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"private_c15t_settings\" (\"key\" varchar(255) primary key, \"value\" text not null);\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('version', '2.0.0');\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('name-variants', '{\"subject\":{\"convex\":\"subject\",\"drizzle\":\"subject\",\"prisma\":\"subject\",\"mongodb\":\"subject\",\"sql\":\"subject\"},\"subject.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"subject.externalId\":{\"convex\":\"externalId\",\"drizzle\":\"externalId\",\"prisma\":\"externalId\",\"mongodb\":\"externalId\",\"sql\":\"externalId\"},\"subject.identityProvider\":{\"convex\":\"identityProvider\",\"drizzle\":\"identityProvider\",\"prisma\":\"identityProvider\",\"mongodb\":\"identityProvider\",\"sql\":\"identityProvider\"},\"subject.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"subject.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"subject.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"domain\":{\"convex\":\"domain\",\"drizzle\":\"domain\",\"prisma\":\"domain\",\"mongodb\":\"domain\",\"sql\":\"domain\"},\"domain.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"domain.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"domain.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"domain.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"domain.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"consentPolicy\":{\"convex\":\"consentPolicy\",\"drizzle\":\"consentPolicy\",\"prisma\":\"consentPolicy\",\"mongodb\":\"consentPolicy\",\"sql\":\"consentPolicy\"},\"consentPolicy.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPolicy.version\":{\"convex\":\"version\",\"drizzle\":\"version\",\"prisma\":\"version\",\"mongodb\":\"version\",\"sql\":\"version\"},\"consentPolicy.type\":{\"convex\":\"type\",\"drizzle\":\"type\",\"prisma\":\"type\",\"mongodb\":\"type\",\"sql\":\"type\"},\"consentPolicy.hash\":{\"convex\":\"hash\",\"drizzle\":\"hash\",\"prisma\":\"hash\",\"mongodb\":\"hash\",\"sql\":\"hash\"},\"consentPolicy.effectiveDate\":{\"convex\":\"effectiveDate\",\"drizzle\":\"effectiveDate\",\"prisma\":\"effectiveDate\",\"mongodb\":\"effectiveDate\",\"sql\":\"effectiveDate\"},\"consentPolicy.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPolicy.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPolicy.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"runtimePolicyDecision\":{\"convex\":\"runtimePolicyDecision\",\"drizzle\":\"runtimePolicyDecision\",\"prisma\":\"runtimePolicyDecision\",\"mongodb\":\"runtimePolicyDecision\",\"sql\":\"runtimePolicyDecision\"},\"runtimePolicyDecision.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"runtimePolicyDecision.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"runtimePolicyDecision.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"runtimePolicyDecision.fingerprint\":{\"convex\":\"fingerprint\",\"drizzle\":\"fingerprint\",\"prisma\":\"fingerprint\",\"mongodb\":\"fingerprint\",\"sql\":\"fingerprint\"},\"runtimePolicyDecision.matchedBy\":{\"convex\":\"matchedBy\",\"drizzle\":\"matchedBy\",\"prisma\":\"matchedBy\",\"mongodb\":\"matchedBy\",\"sql\":\"matchedBy\"},\"runtimePolicyDecision.countryCode\":{\"convex\":\"countryCode\",\"drizzle\":\"countryCode\",\"prisma\":\"countryCode\",\"mongodb\":\"countryCode\",\"sql\":\"countryCode\"},\"runtimePolicyDecision.regionCode\":{\"convex\":\"regionCode\",\"drizzle\":\"regionCode\",\"prisma\":\"regionCode\",\"mongodb\":\"regionCode\",\"sql\":\"regionCode\"},\"runtimePolicyDecision.jurisdiction\":{\"convex\":\"jurisdiction\",\"drizzle\":\"jurisdiction\",\"prisma\":\"jurisdiction\",\"mongodb\":\"jurisdiction\",\"sql\":\"jurisdiction\"},\"runtimePolicyDecision.language\":{\"convex\":\"language\",\"drizzle\":\"language\",\"prisma\":\"language\",\"mongodb\":\"language\",\"sql\":\"language\"},\"runtimePolicyDecision.model\":{\"convex\":\"model\",\"drizzle\":\"model\",\"prisma\":\"model\",\"mongodb\":\"model\",\"sql\":\"model\"},\"runtimePolicyDecision.policyI18n\":{\"convex\":\"policyI18n\",\"drizzle\":\"policyI18n\",\"prisma\":\"policyI18n\",\"mongodb\":\"policyI18n\",\"sql\":\"policyI18n\"},\"runtimePolicyDecision.uiMode\":{\"convex\":\"uiMode\",\"drizzle\":\"uiMode\",\"prisma\":\"uiMode\",\"mongodb\":\"uiMode\",\"sql\":\"uiMode\"},\"runtimePolicyDecision.bannerUi\":{\"convex\":\"bannerUi\",\"drizzle\":\"bannerUi\",\"prisma\":\"bannerUi\",\"mongodb\":\"bannerUi\",\"sql\":\"bannerUi\"},\"runtimePolicyDecision.dialogUi\":{\"convex\":\"dialogUi\",\"drizzle\":\"dialogUi\",\"prisma\":\"dialogUi\",\"mongodb\":\"dialogUi\",\"sql\":\"dialogUi\"},\"runtimePolicyDecision.categories\":{\"convex\":\"categories\",\"drizzle\":\"categories\",\"prisma\":\"categories\",\"mongodb\":\"categories\",\"sql\":\"categories\"},\"runtimePolicyDecision.preselectedCategories\":{\"convex\":\"preselectedCategories\",\"drizzle\":\"preselectedCategories\",\"prisma\":\"preselectedCategories\",\"mongodb\":\"preselectedCategories\",\"sql\":\"preselectedCategories\"},\"runtimePolicyDecision.proofConfig\":{\"convex\":\"proofConfig\",\"drizzle\":\"proofConfig\",\"prisma\":\"proofConfig\",\"mongodb\":\"proofConfig\",\"sql\":\"proofConfig\"},\"runtimePolicyDecision.dedupeKey\":{\"convex\":\"dedupeKey\",\"drizzle\":\"dedupeKey\",\"prisma\":\"dedupeKey\",\"mongodb\":\"dedupeKey\",\"sql\":\"dedupeKey\"},\"runtimePolicyDecision.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose\":{\"convex\":\"consentPurpose\",\"drizzle\":\"consentPurpose\",\"prisma\":\"consentPurpose\",\"mongodb\":\"consentPurpose\",\"sql\":\"consentPurpose\"},\"consentPurpose.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPurpose.code\":{\"convex\":\"code\",\"drizzle\":\"code\",\"prisma\":\"code\",\"mongodb\":\"code\",\"sql\":\"code\"},\"consentPurpose.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consentPurpose.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"consent\":{\"convex\":\"consent\",\"drizzle\":\"consent\",\"prisma\":\"consent\",\"mongodb\":\"consent\",\"sql\":\"consent\"},\"consent.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consent.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consent.domainId\":{\"convex\":\"domainId\",\"drizzle\":\"domainId\",\"prisma\":\"domainId\",\"mongodb\":\"domainId\",\"sql\":\"domainId\"},\"consent.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"consent.purposeIds\":{\"convex\":\"purposeIds\",\"drizzle\":\"purposeIds\",\"prisma\":\"purposeIds\",\"mongodb\":\"purposeIds\",\"sql\":\"purposeIds\"},\"consent.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"consent.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"consent.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"consent.givenAt\":{\"convex\":\"givenAt\",\"drizzle\":\"givenAt\",\"prisma\":\"givenAt\",\"mongodb\":\"givenAt\",\"sql\":\"givenAt\"},\"consent.validUntil\":{\"convex\":\"validUntil\",\"drizzle\":\"validUntil\",\"prisma\":\"validUntil\",\"mongodb\":\"validUntil\",\"sql\":\"validUntil\"},\"consent.jurisdiction\":{\"convex\":\"jurisdiction\",\"drizzle\":\"jurisdiction\",\"prisma\":\"jurisdiction\",\"mongodb\":\"jurisdiction\",\"sql\":\"jurisdiction\"},\"consent.jurisdictionModel\":{\"convex\":\"jurisdictionModel\",\"drizzle\":\"jurisdictionModel\",\"prisma\":\"jurisdictionModel\",\"mongodb\":\"jurisdictionModel\",\"sql\":\"jurisdictionModel\"},\"consent.tcString\":{\"convex\":\"tcString\",\"drizzle\":\"tcString\",\"prisma\":\"tcString\",\"mongodb\":\"tcString\",\"sql\":\"tcString\"},\"consent.uiSource\":{\"convex\":\"uiSource\",\"drizzle\":\"uiSource\",\"prisma\":\"uiSource\",\"mongodb\":\"uiSource\",\"sql\":\"uiSource\"},\"consent.consentAction\":{\"convex\":\"consentAction\",\"drizzle\":\"consentAction\",\"prisma\":\"consentAction\",\"mongodb\":\"consentAction\",\"sql\":\"consentAction\"},\"consent.runtimePolicyDecisionId\":{\"convex\":\"runtimePolicyDecisionId\",\"drizzle\":\"runtimePolicyDecisionId\",\"prisma\":\"runtimePolicyDecisionId\",\"mongodb\":\"runtimePolicyDecisionId\",\"sql\":\"runtimePolicyDecisionId\"},\"consent.runtimePolicySource\":{\"convex\":\"runtimePolicySource\",\"drizzle\":\"runtimePolicySource\",\"prisma\":\"runtimePolicySource\",\"mongodb\":\"runtimePolicySource\",\"sql\":\"runtimePolicySource\"},\"consent.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"auditLog\":{\"convex\":\"auditLog\",\"drizzle\":\"auditLog\",\"prisma\":\"auditLog\",\"mongodb\":\"auditLog\",\"sql\":\"auditLog\"},\"auditLog.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"auditLog.entityType\":{\"convex\":\"entityType\",\"drizzle\":\"entityType\",\"prisma\":\"entityType\",\"mongodb\":\"entityType\",\"sql\":\"entityType\"},\"auditLog.entityId\":{\"convex\":\"entityId\",\"drizzle\":\"entityId\",\"prisma\":\"entityId\",\"mongodb\":\"entityId\",\"sql\":\"entityId\"},\"auditLog.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"auditLog.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"auditLog.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"auditLog.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"auditLog.changes\":{\"convex\":\"changes\",\"drizzle\":\"changes\",\"prisma\":\"changes\",\"mongodb\":\"changes\",\"sql\":\"changes\"},\"auditLog.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"auditLog.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"auditLog.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"}}');"
+		}
+	],
+	"settings": {
+		"table": "private_c15t_settings",
+		"rows": [
+			{
+				"key": "version",
+				"value": "2.0.0"
+			},
+			{
+				"key": "name-variants",
+				"value": {
+					"subject": {
+						"convex": "subject",
+						"drizzle": "subject",
+						"prisma": "subject",
+						"mongodb": "subject",
+						"sql": "subject"
+					},
+					"subject.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"subject.externalId": {
+						"convex": "externalId",
+						"drizzle": "externalId",
+						"prisma": "externalId",
+						"mongodb": "externalId",
+						"sql": "externalId"
+					},
+					"subject.identityProvider": {
+						"convex": "identityProvider",
+						"drizzle": "identityProvider",
+						"prisma": "identityProvider",
+						"mongodb": "identityProvider",
+						"sql": "identityProvider"
+					},
+					"subject.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"subject.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"subject.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"domain": {
+						"convex": "domain",
+						"drizzle": "domain",
+						"prisma": "domain",
+						"mongodb": "domain",
+						"sql": "domain"
+					},
+					"domain.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"domain.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"domain.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"domain.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"domain.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"consentPolicy": {
+						"convex": "consentPolicy",
+						"drizzle": "consentPolicy",
+						"prisma": "consentPolicy",
+						"mongodb": "consentPolicy",
+						"sql": "consentPolicy"
+					},
+					"consentPolicy.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPolicy.version": {
+						"convex": "version",
+						"drizzle": "version",
+						"prisma": "version",
+						"mongodb": "version",
+						"sql": "version"
+					},
+					"consentPolicy.type": {
+						"convex": "type",
+						"drizzle": "type",
+						"prisma": "type",
+						"mongodb": "type",
+						"sql": "type"
+					},
+					"consentPolicy.hash": {
+						"convex": "hash",
+						"drizzle": "hash",
+						"prisma": "hash",
+						"mongodb": "hash",
+						"sql": "hash"
+					},
+					"consentPolicy.effectiveDate": {
+						"convex": "effectiveDate",
+						"drizzle": "effectiveDate",
+						"prisma": "effectiveDate",
+						"mongodb": "effectiveDate",
+						"sql": "effectiveDate"
+					},
+					"consentPolicy.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPolicy.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPolicy.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"runtimePolicyDecision": {
+						"convex": "runtimePolicyDecision",
+						"drizzle": "runtimePolicyDecision",
+						"prisma": "runtimePolicyDecision",
+						"mongodb": "runtimePolicyDecision",
+						"sql": "runtimePolicyDecision"
+					},
+					"runtimePolicyDecision.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"runtimePolicyDecision.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"runtimePolicyDecision.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"runtimePolicyDecision.fingerprint": {
+						"convex": "fingerprint",
+						"drizzle": "fingerprint",
+						"prisma": "fingerprint",
+						"mongodb": "fingerprint",
+						"sql": "fingerprint"
+					},
+					"runtimePolicyDecision.matchedBy": {
+						"convex": "matchedBy",
+						"drizzle": "matchedBy",
+						"prisma": "matchedBy",
+						"mongodb": "matchedBy",
+						"sql": "matchedBy"
+					},
+					"runtimePolicyDecision.countryCode": {
+						"convex": "countryCode",
+						"drizzle": "countryCode",
+						"prisma": "countryCode",
+						"mongodb": "countryCode",
+						"sql": "countryCode"
+					},
+					"runtimePolicyDecision.regionCode": {
+						"convex": "regionCode",
+						"drizzle": "regionCode",
+						"prisma": "regionCode",
+						"mongodb": "regionCode",
+						"sql": "regionCode"
+					},
+					"runtimePolicyDecision.jurisdiction": {
+						"convex": "jurisdiction",
+						"drizzle": "jurisdiction",
+						"prisma": "jurisdiction",
+						"mongodb": "jurisdiction",
+						"sql": "jurisdiction"
+					},
+					"runtimePolicyDecision.language": {
+						"convex": "language",
+						"drizzle": "language",
+						"prisma": "language",
+						"mongodb": "language",
+						"sql": "language"
+					},
+					"runtimePolicyDecision.model": {
+						"convex": "model",
+						"drizzle": "model",
+						"prisma": "model",
+						"mongodb": "model",
+						"sql": "model"
+					},
+					"runtimePolicyDecision.policyI18n": {
+						"convex": "policyI18n",
+						"drizzle": "policyI18n",
+						"prisma": "policyI18n",
+						"mongodb": "policyI18n",
+						"sql": "policyI18n"
+					},
+					"runtimePolicyDecision.uiMode": {
+						"convex": "uiMode",
+						"drizzle": "uiMode",
+						"prisma": "uiMode",
+						"mongodb": "uiMode",
+						"sql": "uiMode"
+					},
+					"runtimePolicyDecision.bannerUi": {
+						"convex": "bannerUi",
+						"drizzle": "bannerUi",
+						"prisma": "bannerUi",
+						"mongodb": "bannerUi",
+						"sql": "bannerUi"
+					},
+					"runtimePolicyDecision.dialogUi": {
+						"convex": "dialogUi",
+						"drizzle": "dialogUi",
+						"prisma": "dialogUi",
+						"mongodb": "dialogUi",
+						"sql": "dialogUi"
+					},
+					"runtimePolicyDecision.categories": {
+						"convex": "categories",
+						"drizzle": "categories",
+						"prisma": "categories",
+						"mongodb": "categories",
+						"sql": "categories"
+					},
+					"runtimePolicyDecision.preselectedCategories": {
+						"convex": "preselectedCategories",
+						"drizzle": "preselectedCategories",
+						"prisma": "preselectedCategories",
+						"mongodb": "preselectedCategories",
+						"sql": "preselectedCategories"
+					},
+					"runtimePolicyDecision.proofConfig": {
+						"convex": "proofConfig",
+						"drizzle": "proofConfig",
+						"prisma": "proofConfig",
+						"mongodb": "proofConfig",
+						"sql": "proofConfig"
+					},
+					"runtimePolicyDecision.dedupeKey": {
+						"convex": "dedupeKey",
+						"drizzle": "dedupeKey",
+						"prisma": "dedupeKey",
+						"mongodb": "dedupeKey",
+						"sql": "dedupeKey"
+					},
+					"runtimePolicyDecision.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose": {
+						"convex": "consentPurpose",
+						"drizzle": "consentPurpose",
+						"prisma": "consentPurpose",
+						"mongodb": "consentPurpose",
+						"sql": "consentPurpose"
+					},
+					"consentPurpose.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPurpose.code": {
+						"convex": "code",
+						"drizzle": "code",
+						"prisma": "code",
+						"mongodb": "code",
+						"sql": "code"
+					},
+					"consentPurpose.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consentPurpose.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"consent": {
+						"convex": "consent",
+						"drizzle": "consent",
+						"prisma": "consent",
+						"mongodb": "consent",
+						"sql": "consent"
+					},
+					"consent.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consent.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consent.domainId": {
+						"convex": "domainId",
+						"drizzle": "domainId",
+						"prisma": "domainId",
+						"mongodb": "domainId",
+						"sql": "domainId"
+					},
+					"consent.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"consent.purposeIds": {
+						"convex": "purposeIds",
+						"drizzle": "purposeIds",
+						"prisma": "purposeIds",
+						"mongodb": "purposeIds",
+						"sql": "purposeIds"
+					},
+					"consent.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"consent.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"consent.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"consent.givenAt": {
+						"convex": "givenAt",
+						"drizzle": "givenAt",
+						"prisma": "givenAt",
+						"mongodb": "givenAt",
+						"sql": "givenAt"
+					},
+					"consent.validUntil": {
+						"convex": "validUntil",
+						"drizzle": "validUntil",
+						"prisma": "validUntil",
+						"mongodb": "validUntil",
+						"sql": "validUntil"
+					},
+					"consent.jurisdiction": {
+						"convex": "jurisdiction",
+						"drizzle": "jurisdiction",
+						"prisma": "jurisdiction",
+						"mongodb": "jurisdiction",
+						"sql": "jurisdiction"
+					},
+					"consent.jurisdictionModel": {
+						"convex": "jurisdictionModel",
+						"drizzle": "jurisdictionModel",
+						"prisma": "jurisdictionModel",
+						"mongodb": "jurisdictionModel",
+						"sql": "jurisdictionModel"
+					},
+					"consent.tcString": {
+						"convex": "tcString",
+						"drizzle": "tcString",
+						"prisma": "tcString",
+						"mongodb": "tcString",
+						"sql": "tcString"
+					},
+					"consent.uiSource": {
+						"convex": "uiSource",
+						"drizzle": "uiSource",
+						"prisma": "uiSource",
+						"mongodb": "uiSource",
+						"sql": "uiSource"
+					},
+					"consent.consentAction": {
+						"convex": "consentAction",
+						"drizzle": "consentAction",
+						"prisma": "consentAction",
+						"mongodb": "consentAction",
+						"sql": "consentAction"
+					},
+					"consent.runtimePolicyDecisionId": {
+						"convex": "runtimePolicyDecisionId",
+						"drizzle": "runtimePolicyDecisionId",
+						"prisma": "runtimePolicyDecisionId",
+						"mongodb": "runtimePolicyDecisionId",
+						"sql": "runtimePolicyDecisionId"
+					},
+					"consent.runtimePolicySource": {
+						"convex": "runtimePolicySource",
+						"drizzle": "runtimePolicySource",
+						"prisma": "runtimePolicySource",
+						"mongodb": "runtimePolicySource",
+						"sql": "runtimePolicySource"
+					},
+					"consent.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"auditLog": {
+						"convex": "auditLog",
+						"drizzle": "auditLog",
+						"prisma": "auditLog",
+						"mongodb": "auditLog",
+						"sql": "auditLog"
+					},
+					"auditLog.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"auditLog.entityType": {
+						"convex": "entityType",
+						"drizzle": "entityType",
+						"prisma": "entityType",
+						"mongodb": "entityType",
+						"sql": "entityType"
+					},
+					"auditLog.entityId": {
+						"convex": "entityId",
+						"drizzle": "entityId",
+						"prisma": "entityId",
+						"mongodb": "entityId",
+						"sql": "entityId"
+					},
+					"auditLog.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"auditLog.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"auditLog.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"auditLog.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"auditLog.changes": {
+						"convex": "changes",
+						"drizzle": "changes",
+						"prisma": "changes",
+						"mongodb": "changes",
+						"sql": "changes"
+					},
+					"auditLog.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"auditLog.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"auditLog.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					}
+				}
+			}
+		]
+	},
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "consentAction",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "domainId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdiction",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdictionModel",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "json",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "runtimePolicyDecisionId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "runtimePolicySource",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tcString",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "uiSource",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "hash",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "private_c15t_settings",
+			"columns": [
+				{
+					"name": "key",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "value",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "runtimePolicyDecision",
+			"columns": [
+				{
+					"name": "bannerUi",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "categories",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "countryCode",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "dedupeKey",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dialogUi",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "fingerprint",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdiction",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "language",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "matchedBy",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "model",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyI18n",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "preselectedCategories",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "proofConfig",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "regionCode",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "uiMode",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		}
+	],
+	"ddl": {}
+}

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/postgres.json
@@ -1138,5 +1138,102 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "auditLog_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "consent_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "consentPolicy_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "consentPurpose_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "private_c15t_settings",
+			"name": "private_c15t_settings_pkey",
+			"columns": ["key"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "runtimePolicyDecision",
+			"name": "unique_c_runtimePolicyDecision_dedupeKey",
+			"columns": ["dedupeKey"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "runtimePolicyDecision",
+			"name": "runtimePolicyDecision_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "subject",
+			"name": "subject_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["runtimePolicyDecisionId"],
+			"referencedTable": "runtimePolicyDecision",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {}
 }

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/sqlite.json
@@ -1138,6 +1138,103 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "private_c15t_settings",
+			"name": "sqlite_primary_key",
+			"columns": ["key"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "runtimePolicyDecision",
+			"name": "unique_c_runtimePolicyDecision_dedupeKey",
+			"columns": ["dedupeKey"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "runtimePolicyDecision",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "subject",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["runtimePolicyDecisionId"],
+			"referencedTable": "runtimePolicyDecision",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {
 		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict)",
 		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"jurisdiction\" text, \"jurisdictionModel\" text, \"tcString\" text, \"uiSource\" text, \"consentAction\" text, \"runtimePolicyDecisionId\" text, \"runtimePolicySource\" text, \"tenantId\" text, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict, constraint \"consent_runtimePolicyDecision_runtimePolicyDecision_fk\" foreign key (\"runtimePolicyDecisionId\") references \"runtimePolicyDecision\" (\"id\") on delete restrict on update restrict)",

--- a/internals/migration-fixtures/fixtures/fumadb-2.0.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/fumadb-2.0.0/sqlite.json
@@ -1,0 +1,1152 @@
+{
+	"shape": "fumadb-2.0.0",
+	"engine": "sqlite",
+	"versions": ["2.1.0"],
+	"era": "fumadb-root",
+	"rationale": "Current shipping shape. Writes c15t_settings = 2.0.0.",
+	"applied": [
+		{
+			"version": "2.1.0",
+			"era": "fumadb-root",
+			"sql": "PRAGMA defer_foreign_keys = ON;\n\ncreate table \"subject\" (\"id\" text not null primary key, \"externalId\" text, \"identityProvider\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"domain\" (\"id\" text not null primary key, \"name\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"hash\" text, \"effectiveDate\" integer not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"runtimePolicyDecision\" (\"id\" text not null primary key, \"tenantId\" text, \"policyId\" text not null, \"fingerprint\" text not null, \"matchedBy\" text not null, \"countryCode\" text, \"regionCode\" text, \"jurisdiction\" text not null, \"language\" text, \"model\" text not null, \"policyI18n\" text, \"uiMode\" text, \"bannerUi\" text, \"dialogUi\" text, \"categories\" text, \"preselectedCategories\" text, \"proofConfig\" text, \"dedupeKey\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null);\n\ncreate unique index \"unique_c_runtimePolicyDecision_dedupeKey\" on \"runtimePolicyDecision\" (\"dedupeKey\");\n\ncreate table \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text);\n\ncreate table \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"jurisdiction\" text, \"jurisdictionModel\" text, \"tcString\" text, \"uiSource\" text, \"consentAction\" text, \"runtimePolicyDecisionId\" text, \"runtimePolicySource\" text, \"tenantId\" text, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict, constraint \"consent_runtimePolicyDecision_runtimePolicyDecision_fk\" foreign key (\"runtimePolicyDecisionId\") references \"runtimePolicyDecision\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict);\n\ncreate table \"private_c15t_settings\" (\"key\" text primary key, \"value\" text not null);\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('version', '2.0.0');\n\ninsert into \"private_c15t_settings\" (\"key\", \"value\") values ('name-variants', '{\"subject\":{\"convex\":\"subject\",\"drizzle\":\"subject\",\"prisma\":\"subject\",\"mongodb\":\"subject\",\"sql\":\"subject\"},\"subject.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"subject.externalId\":{\"convex\":\"externalId\",\"drizzle\":\"externalId\",\"prisma\":\"externalId\",\"mongodb\":\"externalId\",\"sql\":\"externalId\"},\"subject.identityProvider\":{\"convex\":\"identityProvider\",\"drizzle\":\"identityProvider\",\"prisma\":\"identityProvider\",\"mongodb\":\"identityProvider\",\"sql\":\"identityProvider\"},\"subject.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"subject.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"subject.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"domain\":{\"convex\":\"domain\",\"drizzle\":\"domain\",\"prisma\":\"domain\",\"mongodb\":\"domain\",\"sql\":\"domain\"},\"domain.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"domain.name\":{\"convex\":\"name\",\"drizzle\":\"name\",\"prisma\":\"name\",\"mongodb\":\"name\",\"sql\":\"name\"},\"domain.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"domain.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"domain.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"consentPolicy\":{\"convex\":\"consentPolicy\",\"drizzle\":\"consentPolicy\",\"prisma\":\"consentPolicy\",\"mongodb\":\"consentPolicy\",\"sql\":\"consentPolicy\"},\"consentPolicy.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPolicy.version\":{\"convex\":\"version\",\"drizzle\":\"version\",\"prisma\":\"version\",\"mongodb\":\"version\",\"sql\":\"version\"},\"consentPolicy.type\":{\"convex\":\"type\",\"drizzle\":\"type\",\"prisma\":\"type\",\"mongodb\":\"type\",\"sql\":\"type\"},\"consentPolicy.hash\":{\"convex\":\"hash\",\"drizzle\":\"hash\",\"prisma\":\"hash\",\"mongodb\":\"hash\",\"sql\":\"hash\"},\"consentPolicy.effectiveDate\":{\"convex\":\"effectiveDate\",\"drizzle\":\"effectiveDate\",\"prisma\":\"effectiveDate\",\"mongodb\":\"effectiveDate\",\"sql\":\"effectiveDate\"},\"consentPolicy.isActive\":{\"convex\":\"isActive\",\"drizzle\":\"isActive\",\"prisma\":\"isActive\",\"mongodb\":\"isActive\",\"sql\":\"isActive\"},\"consentPolicy.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPolicy.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"runtimePolicyDecision\":{\"convex\":\"runtimePolicyDecision\",\"drizzle\":\"runtimePolicyDecision\",\"prisma\":\"runtimePolicyDecision\",\"mongodb\":\"runtimePolicyDecision\",\"sql\":\"runtimePolicyDecision\"},\"runtimePolicyDecision.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"runtimePolicyDecision.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"runtimePolicyDecision.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"runtimePolicyDecision.fingerprint\":{\"convex\":\"fingerprint\",\"drizzle\":\"fingerprint\",\"prisma\":\"fingerprint\",\"mongodb\":\"fingerprint\",\"sql\":\"fingerprint\"},\"runtimePolicyDecision.matchedBy\":{\"convex\":\"matchedBy\",\"drizzle\":\"matchedBy\",\"prisma\":\"matchedBy\",\"mongodb\":\"matchedBy\",\"sql\":\"matchedBy\"},\"runtimePolicyDecision.countryCode\":{\"convex\":\"countryCode\",\"drizzle\":\"countryCode\",\"prisma\":\"countryCode\",\"mongodb\":\"countryCode\",\"sql\":\"countryCode\"},\"runtimePolicyDecision.regionCode\":{\"convex\":\"regionCode\",\"drizzle\":\"regionCode\",\"prisma\":\"regionCode\",\"mongodb\":\"regionCode\",\"sql\":\"regionCode\"},\"runtimePolicyDecision.jurisdiction\":{\"convex\":\"jurisdiction\",\"drizzle\":\"jurisdiction\",\"prisma\":\"jurisdiction\",\"mongodb\":\"jurisdiction\",\"sql\":\"jurisdiction\"},\"runtimePolicyDecision.language\":{\"convex\":\"language\",\"drizzle\":\"language\",\"prisma\":\"language\",\"mongodb\":\"language\",\"sql\":\"language\"},\"runtimePolicyDecision.model\":{\"convex\":\"model\",\"drizzle\":\"model\",\"prisma\":\"model\",\"mongodb\":\"model\",\"sql\":\"model\"},\"runtimePolicyDecision.policyI18n\":{\"convex\":\"policyI18n\",\"drizzle\":\"policyI18n\",\"prisma\":\"policyI18n\",\"mongodb\":\"policyI18n\",\"sql\":\"policyI18n\"},\"runtimePolicyDecision.uiMode\":{\"convex\":\"uiMode\",\"drizzle\":\"uiMode\",\"prisma\":\"uiMode\",\"mongodb\":\"uiMode\",\"sql\":\"uiMode\"},\"runtimePolicyDecision.bannerUi\":{\"convex\":\"bannerUi\",\"drizzle\":\"bannerUi\",\"prisma\":\"bannerUi\",\"mongodb\":\"bannerUi\",\"sql\":\"bannerUi\"},\"runtimePolicyDecision.dialogUi\":{\"convex\":\"dialogUi\",\"drizzle\":\"dialogUi\",\"prisma\":\"dialogUi\",\"mongodb\":\"dialogUi\",\"sql\":\"dialogUi\"},\"runtimePolicyDecision.categories\":{\"convex\":\"categories\",\"drizzle\":\"categories\",\"prisma\":\"categories\",\"mongodb\":\"categories\",\"sql\":\"categories\"},\"runtimePolicyDecision.preselectedCategories\":{\"convex\":\"preselectedCategories\",\"drizzle\":\"preselectedCategories\",\"prisma\":\"preselectedCategories\",\"mongodb\":\"preselectedCategories\",\"sql\":\"preselectedCategories\"},\"runtimePolicyDecision.proofConfig\":{\"convex\":\"proofConfig\",\"drizzle\":\"proofConfig\",\"prisma\":\"proofConfig\",\"mongodb\":\"proofConfig\",\"sql\":\"proofConfig\"},\"runtimePolicyDecision.dedupeKey\":{\"convex\":\"dedupeKey\",\"drizzle\":\"dedupeKey\",\"prisma\":\"dedupeKey\",\"mongodb\":\"dedupeKey\",\"sql\":\"dedupeKey\"},\"runtimePolicyDecision.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose\":{\"convex\":\"consentPurpose\",\"drizzle\":\"consentPurpose\",\"prisma\":\"consentPurpose\",\"mongodb\":\"consentPurpose\",\"sql\":\"consentPurpose\"},\"consentPurpose.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consentPurpose.code\":{\"convex\":\"code\",\"drizzle\":\"code\",\"prisma\":\"code\",\"mongodb\":\"code\",\"sql\":\"code\"},\"consentPurpose.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"consentPurpose.updatedAt\":{\"convex\":\"updatedAt\",\"drizzle\":\"updatedAt\",\"prisma\":\"updatedAt\",\"mongodb\":\"updatedAt\",\"sql\":\"updatedAt\"},\"consentPurpose.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"consent\":{\"convex\":\"consent\",\"drizzle\":\"consent\",\"prisma\":\"consent\",\"mongodb\":\"consent\",\"sql\":\"consent\"},\"consent.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"consent.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"consent.domainId\":{\"convex\":\"domainId\",\"drizzle\":\"domainId\",\"prisma\":\"domainId\",\"mongodb\":\"domainId\",\"sql\":\"domainId\"},\"consent.policyId\":{\"convex\":\"policyId\",\"drizzle\":\"policyId\",\"prisma\":\"policyId\",\"mongodb\":\"policyId\",\"sql\":\"policyId\"},\"consent.purposeIds\":{\"convex\":\"purposeIds\",\"drizzle\":\"purposeIds\",\"prisma\":\"purposeIds\",\"mongodb\":\"purposeIds\",\"sql\":\"purposeIds\"},\"consent.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"consent.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"consent.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"consent.givenAt\":{\"convex\":\"givenAt\",\"drizzle\":\"givenAt\",\"prisma\":\"givenAt\",\"mongodb\":\"givenAt\",\"sql\":\"givenAt\"},\"consent.validUntil\":{\"convex\":\"validUntil\",\"drizzle\":\"validUntil\",\"prisma\":\"validUntil\",\"mongodb\":\"validUntil\",\"sql\":\"validUntil\"},\"consent.jurisdiction\":{\"convex\":\"jurisdiction\",\"drizzle\":\"jurisdiction\",\"prisma\":\"jurisdiction\",\"mongodb\":\"jurisdiction\",\"sql\":\"jurisdiction\"},\"consent.jurisdictionModel\":{\"convex\":\"jurisdictionModel\",\"drizzle\":\"jurisdictionModel\",\"prisma\":\"jurisdictionModel\",\"mongodb\":\"jurisdictionModel\",\"sql\":\"jurisdictionModel\"},\"consent.tcString\":{\"convex\":\"tcString\",\"drizzle\":\"tcString\",\"prisma\":\"tcString\",\"mongodb\":\"tcString\",\"sql\":\"tcString\"},\"consent.uiSource\":{\"convex\":\"uiSource\",\"drizzle\":\"uiSource\",\"prisma\":\"uiSource\",\"mongodb\":\"uiSource\",\"sql\":\"uiSource\"},\"consent.consentAction\":{\"convex\":\"consentAction\",\"drizzle\":\"consentAction\",\"prisma\":\"consentAction\",\"mongodb\":\"consentAction\",\"sql\":\"consentAction\"},\"consent.runtimePolicyDecisionId\":{\"convex\":\"runtimePolicyDecisionId\",\"drizzle\":\"runtimePolicyDecisionId\",\"prisma\":\"runtimePolicyDecisionId\",\"mongodb\":\"runtimePolicyDecisionId\",\"sql\":\"runtimePolicyDecisionId\"},\"consent.runtimePolicySource\":{\"convex\":\"runtimePolicySource\",\"drizzle\":\"runtimePolicySource\",\"prisma\":\"runtimePolicySource\",\"mongodb\":\"runtimePolicySource\",\"sql\":\"runtimePolicySource\"},\"consent.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"},\"auditLog\":{\"convex\":\"auditLog\",\"drizzle\":\"auditLog\",\"prisma\":\"auditLog\",\"mongodb\":\"auditLog\",\"sql\":\"auditLog\"},\"auditLog.id\":{\"convex\":\"id\",\"drizzle\":\"id\",\"prisma\":\"id\",\"mongodb\":\"_id\",\"sql\":\"id\"},\"auditLog.entityType\":{\"convex\":\"entityType\",\"drizzle\":\"entityType\",\"prisma\":\"entityType\",\"mongodb\":\"entityType\",\"sql\":\"entityType\"},\"auditLog.entityId\":{\"convex\":\"entityId\",\"drizzle\":\"entityId\",\"prisma\":\"entityId\",\"mongodb\":\"entityId\",\"sql\":\"entityId\"},\"auditLog.actionType\":{\"convex\":\"actionType\",\"drizzle\":\"actionType\",\"prisma\":\"actionType\",\"mongodb\":\"actionType\",\"sql\":\"actionType\"},\"auditLog.subjectId\":{\"convex\":\"subjectId\",\"drizzle\":\"subjectId\",\"prisma\":\"subjectId\",\"mongodb\":\"subjectId\",\"sql\":\"subjectId\"},\"auditLog.ipAddress\":{\"convex\":\"ipAddress\",\"drizzle\":\"ipAddress\",\"prisma\":\"ipAddress\",\"mongodb\":\"ipAddress\",\"sql\":\"ipAddress\"},\"auditLog.userAgent\":{\"convex\":\"userAgent\",\"drizzle\":\"userAgent\",\"prisma\":\"userAgent\",\"mongodb\":\"userAgent\",\"sql\":\"userAgent\"},\"auditLog.changes\":{\"convex\":\"changes\",\"drizzle\":\"changes\",\"prisma\":\"changes\",\"mongodb\":\"changes\",\"sql\":\"changes\"},\"auditLog.metadata\":{\"convex\":\"metadata\",\"drizzle\":\"metadata\",\"prisma\":\"metadata\",\"mongodb\":\"metadata\",\"sql\":\"metadata\"},\"auditLog.createdAt\":{\"convex\":\"createdAt\",\"drizzle\":\"createdAt\",\"prisma\":\"createdAt\",\"mongodb\":\"createdAt\",\"sql\":\"createdAt\"},\"auditLog.tenantId\":{\"convex\":\"tenantId\",\"drizzle\":\"tenantId\",\"prisma\":\"tenantId\",\"mongodb\":\"tenantId\",\"sql\":\"tenantId\"}}');"
+		}
+	],
+	"settings": {
+		"table": "private_c15t_settings",
+		"rows": [
+			{
+				"key": "version",
+				"value": "2.0.0"
+			},
+			{
+				"key": "name-variants",
+				"value": {
+					"subject": {
+						"convex": "subject",
+						"drizzle": "subject",
+						"prisma": "subject",
+						"mongodb": "subject",
+						"sql": "subject"
+					},
+					"subject.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"subject.externalId": {
+						"convex": "externalId",
+						"drizzle": "externalId",
+						"prisma": "externalId",
+						"mongodb": "externalId",
+						"sql": "externalId"
+					},
+					"subject.identityProvider": {
+						"convex": "identityProvider",
+						"drizzle": "identityProvider",
+						"prisma": "identityProvider",
+						"mongodb": "identityProvider",
+						"sql": "identityProvider"
+					},
+					"subject.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"subject.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"subject.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"domain": {
+						"convex": "domain",
+						"drizzle": "domain",
+						"prisma": "domain",
+						"mongodb": "domain",
+						"sql": "domain"
+					},
+					"domain.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"domain.name": {
+						"convex": "name",
+						"drizzle": "name",
+						"prisma": "name",
+						"mongodb": "name",
+						"sql": "name"
+					},
+					"domain.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"domain.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"domain.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"consentPolicy": {
+						"convex": "consentPolicy",
+						"drizzle": "consentPolicy",
+						"prisma": "consentPolicy",
+						"mongodb": "consentPolicy",
+						"sql": "consentPolicy"
+					},
+					"consentPolicy.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPolicy.version": {
+						"convex": "version",
+						"drizzle": "version",
+						"prisma": "version",
+						"mongodb": "version",
+						"sql": "version"
+					},
+					"consentPolicy.type": {
+						"convex": "type",
+						"drizzle": "type",
+						"prisma": "type",
+						"mongodb": "type",
+						"sql": "type"
+					},
+					"consentPolicy.hash": {
+						"convex": "hash",
+						"drizzle": "hash",
+						"prisma": "hash",
+						"mongodb": "hash",
+						"sql": "hash"
+					},
+					"consentPolicy.effectiveDate": {
+						"convex": "effectiveDate",
+						"drizzle": "effectiveDate",
+						"prisma": "effectiveDate",
+						"mongodb": "effectiveDate",
+						"sql": "effectiveDate"
+					},
+					"consentPolicy.isActive": {
+						"convex": "isActive",
+						"drizzle": "isActive",
+						"prisma": "isActive",
+						"mongodb": "isActive",
+						"sql": "isActive"
+					},
+					"consentPolicy.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPolicy.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"runtimePolicyDecision": {
+						"convex": "runtimePolicyDecision",
+						"drizzle": "runtimePolicyDecision",
+						"prisma": "runtimePolicyDecision",
+						"mongodb": "runtimePolicyDecision",
+						"sql": "runtimePolicyDecision"
+					},
+					"runtimePolicyDecision.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"runtimePolicyDecision.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"runtimePolicyDecision.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"runtimePolicyDecision.fingerprint": {
+						"convex": "fingerprint",
+						"drizzle": "fingerprint",
+						"prisma": "fingerprint",
+						"mongodb": "fingerprint",
+						"sql": "fingerprint"
+					},
+					"runtimePolicyDecision.matchedBy": {
+						"convex": "matchedBy",
+						"drizzle": "matchedBy",
+						"prisma": "matchedBy",
+						"mongodb": "matchedBy",
+						"sql": "matchedBy"
+					},
+					"runtimePolicyDecision.countryCode": {
+						"convex": "countryCode",
+						"drizzle": "countryCode",
+						"prisma": "countryCode",
+						"mongodb": "countryCode",
+						"sql": "countryCode"
+					},
+					"runtimePolicyDecision.regionCode": {
+						"convex": "regionCode",
+						"drizzle": "regionCode",
+						"prisma": "regionCode",
+						"mongodb": "regionCode",
+						"sql": "regionCode"
+					},
+					"runtimePolicyDecision.jurisdiction": {
+						"convex": "jurisdiction",
+						"drizzle": "jurisdiction",
+						"prisma": "jurisdiction",
+						"mongodb": "jurisdiction",
+						"sql": "jurisdiction"
+					},
+					"runtimePolicyDecision.language": {
+						"convex": "language",
+						"drizzle": "language",
+						"prisma": "language",
+						"mongodb": "language",
+						"sql": "language"
+					},
+					"runtimePolicyDecision.model": {
+						"convex": "model",
+						"drizzle": "model",
+						"prisma": "model",
+						"mongodb": "model",
+						"sql": "model"
+					},
+					"runtimePolicyDecision.policyI18n": {
+						"convex": "policyI18n",
+						"drizzle": "policyI18n",
+						"prisma": "policyI18n",
+						"mongodb": "policyI18n",
+						"sql": "policyI18n"
+					},
+					"runtimePolicyDecision.uiMode": {
+						"convex": "uiMode",
+						"drizzle": "uiMode",
+						"prisma": "uiMode",
+						"mongodb": "uiMode",
+						"sql": "uiMode"
+					},
+					"runtimePolicyDecision.bannerUi": {
+						"convex": "bannerUi",
+						"drizzle": "bannerUi",
+						"prisma": "bannerUi",
+						"mongodb": "bannerUi",
+						"sql": "bannerUi"
+					},
+					"runtimePolicyDecision.dialogUi": {
+						"convex": "dialogUi",
+						"drizzle": "dialogUi",
+						"prisma": "dialogUi",
+						"mongodb": "dialogUi",
+						"sql": "dialogUi"
+					},
+					"runtimePolicyDecision.categories": {
+						"convex": "categories",
+						"drizzle": "categories",
+						"prisma": "categories",
+						"mongodb": "categories",
+						"sql": "categories"
+					},
+					"runtimePolicyDecision.preselectedCategories": {
+						"convex": "preselectedCategories",
+						"drizzle": "preselectedCategories",
+						"prisma": "preselectedCategories",
+						"mongodb": "preselectedCategories",
+						"sql": "preselectedCategories"
+					},
+					"runtimePolicyDecision.proofConfig": {
+						"convex": "proofConfig",
+						"drizzle": "proofConfig",
+						"prisma": "proofConfig",
+						"mongodb": "proofConfig",
+						"sql": "proofConfig"
+					},
+					"runtimePolicyDecision.dedupeKey": {
+						"convex": "dedupeKey",
+						"drizzle": "dedupeKey",
+						"prisma": "dedupeKey",
+						"mongodb": "dedupeKey",
+						"sql": "dedupeKey"
+					},
+					"runtimePolicyDecision.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose": {
+						"convex": "consentPurpose",
+						"drizzle": "consentPurpose",
+						"prisma": "consentPurpose",
+						"mongodb": "consentPurpose",
+						"sql": "consentPurpose"
+					},
+					"consentPurpose.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consentPurpose.code": {
+						"convex": "code",
+						"drizzle": "code",
+						"prisma": "code",
+						"mongodb": "code",
+						"sql": "code"
+					},
+					"consentPurpose.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"consentPurpose.updatedAt": {
+						"convex": "updatedAt",
+						"drizzle": "updatedAt",
+						"prisma": "updatedAt",
+						"mongodb": "updatedAt",
+						"sql": "updatedAt"
+					},
+					"consentPurpose.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"consent": {
+						"convex": "consent",
+						"drizzle": "consent",
+						"prisma": "consent",
+						"mongodb": "consent",
+						"sql": "consent"
+					},
+					"consent.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"consent.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"consent.domainId": {
+						"convex": "domainId",
+						"drizzle": "domainId",
+						"prisma": "domainId",
+						"mongodb": "domainId",
+						"sql": "domainId"
+					},
+					"consent.policyId": {
+						"convex": "policyId",
+						"drizzle": "policyId",
+						"prisma": "policyId",
+						"mongodb": "policyId",
+						"sql": "policyId"
+					},
+					"consent.purposeIds": {
+						"convex": "purposeIds",
+						"drizzle": "purposeIds",
+						"prisma": "purposeIds",
+						"mongodb": "purposeIds",
+						"sql": "purposeIds"
+					},
+					"consent.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"consent.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"consent.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"consent.givenAt": {
+						"convex": "givenAt",
+						"drizzle": "givenAt",
+						"prisma": "givenAt",
+						"mongodb": "givenAt",
+						"sql": "givenAt"
+					},
+					"consent.validUntil": {
+						"convex": "validUntil",
+						"drizzle": "validUntil",
+						"prisma": "validUntil",
+						"mongodb": "validUntil",
+						"sql": "validUntil"
+					},
+					"consent.jurisdiction": {
+						"convex": "jurisdiction",
+						"drizzle": "jurisdiction",
+						"prisma": "jurisdiction",
+						"mongodb": "jurisdiction",
+						"sql": "jurisdiction"
+					},
+					"consent.jurisdictionModel": {
+						"convex": "jurisdictionModel",
+						"drizzle": "jurisdictionModel",
+						"prisma": "jurisdictionModel",
+						"mongodb": "jurisdictionModel",
+						"sql": "jurisdictionModel"
+					},
+					"consent.tcString": {
+						"convex": "tcString",
+						"drizzle": "tcString",
+						"prisma": "tcString",
+						"mongodb": "tcString",
+						"sql": "tcString"
+					},
+					"consent.uiSource": {
+						"convex": "uiSource",
+						"drizzle": "uiSource",
+						"prisma": "uiSource",
+						"mongodb": "uiSource",
+						"sql": "uiSource"
+					},
+					"consent.consentAction": {
+						"convex": "consentAction",
+						"drizzle": "consentAction",
+						"prisma": "consentAction",
+						"mongodb": "consentAction",
+						"sql": "consentAction"
+					},
+					"consent.runtimePolicyDecisionId": {
+						"convex": "runtimePolicyDecisionId",
+						"drizzle": "runtimePolicyDecisionId",
+						"prisma": "runtimePolicyDecisionId",
+						"mongodb": "runtimePolicyDecisionId",
+						"sql": "runtimePolicyDecisionId"
+					},
+					"consent.runtimePolicySource": {
+						"convex": "runtimePolicySource",
+						"drizzle": "runtimePolicySource",
+						"prisma": "runtimePolicySource",
+						"mongodb": "runtimePolicySource",
+						"sql": "runtimePolicySource"
+					},
+					"consent.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					},
+					"auditLog": {
+						"convex": "auditLog",
+						"drizzle": "auditLog",
+						"prisma": "auditLog",
+						"mongodb": "auditLog",
+						"sql": "auditLog"
+					},
+					"auditLog.id": {
+						"convex": "id",
+						"drizzle": "id",
+						"prisma": "id",
+						"mongodb": "_id",
+						"sql": "id"
+					},
+					"auditLog.entityType": {
+						"convex": "entityType",
+						"drizzle": "entityType",
+						"prisma": "entityType",
+						"mongodb": "entityType",
+						"sql": "entityType"
+					},
+					"auditLog.entityId": {
+						"convex": "entityId",
+						"drizzle": "entityId",
+						"prisma": "entityId",
+						"mongodb": "entityId",
+						"sql": "entityId"
+					},
+					"auditLog.actionType": {
+						"convex": "actionType",
+						"drizzle": "actionType",
+						"prisma": "actionType",
+						"mongodb": "actionType",
+						"sql": "actionType"
+					},
+					"auditLog.subjectId": {
+						"convex": "subjectId",
+						"drizzle": "subjectId",
+						"prisma": "subjectId",
+						"mongodb": "subjectId",
+						"sql": "subjectId"
+					},
+					"auditLog.ipAddress": {
+						"convex": "ipAddress",
+						"drizzle": "ipAddress",
+						"prisma": "ipAddress",
+						"mongodb": "ipAddress",
+						"sql": "ipAddress"
+					},
+					"auditLog.userAgent": {
+						"convex": "userAgent",
+						"drizzle": "userAgent",
+						"prisma": "userAgent",
+						"mongodb": "userAgent",
+						"sql": "userAgent"
+					},
+					"auditLog.changes": {
+						"convex": "changes",
+						"drizzle": "changes",
+						"prisma": "changes",
+						"mongodb": "changes",
+						"sql": "changes"
+					},
+					"auditLog.metadata": {
+						"convex": "metadata",
+						"drizzle": "metadata",
+						"prisma": "metadata",
+						"mongodb": "metadata",
+						"sql": "metadata"
+					},
+					"auditLog.createdAt": {
+						"convex": "createdAt",
+						"drizzle": "createdAt",
+						"prisma": "createdAt",
+						"mongodb": "createdAt",
+						"sql": "createdAt"
+					},
+					"auditLog.tenantId": {
+						"convex": "tenantId",
+						"drizzle": "tenantId",
+						"prisma": "tenantId",
+						"mongodb": "tenantId",
+						"sql": "tenantId"
+					}
+				}
+			}
+		]
+	},
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "entityId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "consentAction",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "domainId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdiction",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdictionModel",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "runtimePolicyDecisionId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "runtimePolicySource",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tcString",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "uiSource",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "INTEGER",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "hash",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		},
+		{
+			"name": "private_c15t_settings",
+			"columns": [
+				{
+					"name": "key",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "value",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "runtimePolicyDecision",
+			"columns": [
+				{
+					"name": "bannerUi",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "categories",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "countryCode",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "dedupeKey",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dialogUi",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "fingerprint",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "jurisdiction",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "language",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "matchedBy",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "model",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyI18n",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "preselectedCategories",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "proofConfig",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "regionCode",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "uiMode",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				},
+				{
+					"name": "externalId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "tenantId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": true
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text, \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text, constraint \"auditLog_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict)",
+		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null, \"domainId\" text not null, \"policyId\" text, \"purposeIds\" text not null, \"metadata\" text, \"ipAddress\" text, \"userAgent\" text, \"givenAt\" integer default CURRENT_TIMESTAMP not null, \"validUntil\" integer, \"jurisdiction\" text, \"jurisdictionModel\" text, \"tcString\" text, \"uiSource\" text, \"consentAction\" text, \"runtimePolicyDecisionId\" text, \"runtimePolicySource\" text, \"tenantId\" text, constraint \"consent_subject_subject_fk\" foreign key (\"subjectId\") references \"subject\" (\"id\") on delete restrict on update restrict, constraint \"consent_domain_domain_fk\" foreign key (\"domainId\") references \"domain\" (\"id\") on delete restrict on update restrict, constraint \"consent_consentPolicy_policy_fk\" foreign key (\"policyId\") references \"consentPolicy\" (\"id\") on delete restrict on update restrict, constraint \"consent_runtimePolicyDecision_runtimePolicyDecision_fk\" foreign key (\"runtimePolicyDecisionId\") references \"runtimePolicyDecision\" (\"id\") on delete restrict on update restrict)",
+		"consentPolicy": "CREATE TABLE \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"hash\" text, \"effectiveDate\" integer not null, \"isActive\" integer not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text)",
+		"consentPurpose": "CREATE TABLE \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text)",
+		"domain": "CREATE TABLE \"domain\" (\"id\" text not null primary key, \"name\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text)",
+		"private_c15t_settings": "CREATE TABLE \"private_c15t_settings\" (\"key\" text primary key, \"value\" text not null)",
+		"runtimePolicyDecision": "CREATE TABLE \"runtimePolicyDecision\" (\"id\" text not null primary key, \"tenantId\" text, \"policyId\" text not null, \"fingerprint\" text not null, \"matchedBy\" text not null, \"countryCode\" text, \"regionCode\" text, \"jurisdiction\" text not null, \"language\" text, \"model\" text not null, \"policyI18n\" text, \"uiMode\" text, \"bannerUi\" text, \"dialogUi\" text, \"categories\" text, \"preselectedCategories\" text, \"proofConfig\" text, \"dedupeKey\" text not null, \"createdAt\" integer default CURRENT_TIMESTAMP not null)",
+		"subject": "CREATE TABLE \"subject\" (\"id\" text not null primary key, \"externalId\" text, \"identityProvider\" text, \"createdAt\" integer default CURRENT_TIMESTAMP not null, \"updatedAt\" integer default CURRENT_TIMESTAMP not null, \"tenantId\" text)",
+		"unique_c_runtimePolicyDecision_dedupeKey": "CREATE UNIQUE INDEX \"unique_c_runtimePolicyDecision_dedupeKey\" on \"runtimePolicyDecision\" (\"dedupeKey\")"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/mysql.json
@@ -1,0 +1,522 @@
+{
+	"shape": "legacy-fresh-1.0",
+	"engine": "mysql",
+	"versions": ["1.0.0"],
+	"era": "legacy",
+	"rationale": "Earliest published release. The floor of what a legacy database can look like.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPolicy": "CREATE TABLE `consentPolicy` (\n  `id` varchar(36) NOT NULL,\n  `version` text NOT NULL,\n  `type` text NOT NULL,\n  `name` text NOT NULL,\n  `effectiveDate` datetime NOT NULL,\n  `expirationDate` datetime DEFAULT NULL,\n  `content` text NOT NULL,\n  `contentHash` text NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPurpose": "CREATE TABLE `consentPurpose` (\n  `id` varchar(36) NOT NULL,\n  `code` text NOT NULL,\n  `name` text NOT NULL,\n  `description` text NOT NULL,\n  `isEssential` tinyint(1) NOT NULL,\n  `dataCategory` text,\n  `legalBasis` text,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentRecord": "CREATE TABLE `consentRecord` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `consentId` varchar(36) DEFAULT NULL,\n  `actionType` text NOT NULL,\n  `details` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"domain": "CREATE TABLE `domain` (\n  `id` varchar(36) NOT NULL,\n  `name` varchar(255) NOT NULL,\n  `description` text,\n  `allowedOrigins` json DEFAULT NULL,\n  `isVerified` tinyint(1) NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"subject": "CREATE TABLE `subject` (\n  `id` varchar(36) NOT NULL,\n  `isIdentified` tinyint(1) NOT NULL,\n  `externalId` text,\n  `identityProvider` text,\n  `lastIpAddress` text,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  `subjectTimezone` varchar(50) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/mysql.json
@@ -510,6 +510,65 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "name",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [],
 	"ddl": {
 		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
 		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/postgres.json
@@ -1,0 +1,514 @@
+{
+	"shape": "legacy-fresh-1.0",
+	"engine": "postgres",
+	"versions": ["1.0.0"],
+	"era": "legacy",
+	"rationale": "Earliest published release. The floor of what a legacy database can look like.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/postgres.json
@@ -510,5 +510,101 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "auditLog_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "consent_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "consentPolicy_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "consentPurpose_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "consentRecord_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_name_key",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "subject_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {}
 }

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/sqlite.json
@@ -1,0 +1,522 @@
+{
+	"shape": "legacy-fresh-1.0",
+	"engine": "sqlite",
+	"versions": ["1.0.0"],
+	"era": "legacy",
+	"rationale": "Earliest published release. The floor of what a legacy database can look like.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
+		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",
+		"consentPolicy": "CREATE TABLE \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" date not null, \"expirationDate\" date, \"content\" text not null, \"contentHash\" text not null, \"isActive\" integer not null, \"createdAt\" date not null)",
+		"consentPurpose": "CREATE TABLE \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" integer not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date not null)",
+		"consentRecord": "CREATE TABLE \"consentRecord\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"consentId\" text references \"consent\" (\"id\"), \"actionType\" text not null, \"details\" text, \"createdAt\" date not null)",
+		"domain": "CREATE TABLE \"domain\" (\"id\" text not null primary key, \"name\" text not null unique, \"description\" text, \"allowedOrigins\" text, \"isVerified\" integer not null, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date)",
+		"subject": "CREATE TABLE \"subject\" (\"id\" text not null primary key, \"isIdentified\" integer not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"createdAt\" date not null, \"updatedAt\" date not null, \"subjectTimezone\" text)"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.0/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.0/sqlite.json
@@ -510,6 +510,102 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_autoindex_domain_2",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {
 		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
 		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/mysql.json
@@ -1,0 +1,522 @@
+{
+	"shape": "legacy-fresh-1.8",
+	"engine": "mysql",
+	"versions": ["1.8.6"],
+	"era": "legacy",
+	"rationale": "Last legacy release, installed fresh. Contrast with legacy-upgraded to expose drift.",
+	"applied": [
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPolicy": "CREATE TABLE `consentPolicy` (\n  `id` varchar(36) NOT NULL,\n  `version` text NOT NULL,\n  `type` text NOT NULL,\n  `name` text NOT NULL,\n  `effectiveDate` datetime NOT NULL,\n  `expirationDate` datetime DEFAULT NULL,\n  `content` text NOT NULL,\n  `contentHash` text NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPurpose": "CREATE TABLE `consentPurpose` (\n  `id` varchar(36) NOT NULL,\n  `code` text NOT NULL,\n  `name` text NOT NULL,\n  `description` text NOT NULL,\n  `isEssential` tinyint(1) NOT NULL,\n  `dataCategory` text,\n  `legalBasis` text,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentRecord": "CREATE TABLE `consentRecord` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `consentId` varchar(36) DEFAULT NULL,\n  `actionType` text NOT NULL,\n  `details` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"domain": "CREATE TABLE `domain` (\n  `id` varchar(36) NOT NULL,\n  `name` varchar(255) NOT NULL,\n  `description` text,\n  `allowedOrigins` json DEFAULT NULL,\n  `isVerified` tinyint(1) NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"subject": "CREATE TABLE `subject` (\n  `id` varchar(36) NOT NULL,\n  `isIdentified` tinyint(1) NOT NULL,\n  `externalId` text,\n  `identityProvider` text,\n  `lastIpAddress` text,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  `subjectTimezone` varchar(50) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/mysql.json
@@ -510,6 +510,65 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "name",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [],
 	"ddl": {
 		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
 		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/postgres.json
@@ -1,0 +1,514 @@
+{
+	"shape": "legacy-fresh-1.8",
+	"engine": "postgres",
+	"versions": ["1.8.6"],
+	"era": "legacy",
+	"rationale": "Last legacy release, installed fresh. Contrast with legacy-upgraded to expose drift.",
+	"applied": [
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {}
+}

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/postgres.json
@@ -510,5 +510,101 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "auditLog_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "consent_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "consentPolicy_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "consentPurpose_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "consentRecord_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_name_key",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "subject_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {}
 }

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/sqlite.json
@@ -510,6 +510,102 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_autoindex_domain_2",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {
 		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
 		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",

--- a/internals/migration-fixtures/fixtures/legacy-fresh-1.8/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-fresh-1.8/sqlite.json
@@ -1,0 +1,522 @@
+{
+	"shape": "legacy-fresh-1.8",
+	"engine": "sqlite",
+	"versions": ["1.8.6"],
+	"era": "legacy",
+	"rationale": "Last legacy release, installed fresh. Contrast with legacy-upgraded to expose drift.",
+	"applied": [
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
+		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",
+		"consentPolicy": "CREATE TABLE \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" date not null, \"expirationDate\" date, \"content\" text not null, \"contentHash\" text not null, \"isActive\" integer not null, \"createdAt\" date not null)",
+		"consentPurpose": "CREATE TABLE \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" integer not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date not null)",
+		"consentRecord": "CREATE TABLE \"consentRecord\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"consentId\" text references \"consent\" (\"id\"), \"actionType\" text not null, \"details\" text, \"createdAt\" date not null)",
+		"domain": "CREATE TABLE \"domain\" (\"id\" text not null primary key, \"name\" text not null unique, \"description\" text, \"allowedOrigins\" text, \"isVerified\" integer not null, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date)",
+		"subject": "CREATE TABLE \"subject\" (\"id\" text not null primary key, \"isIdentified\" integer not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"createdAt\" date not null, \"updatedAt\" date not null, \"subjectTimezone\" text)"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/mysql.json
@@ -1,0 +1,530 @@
+{
+	"shape": "legacy-upgraded",
+	"engine": "mysql",
+	"versions": ["1.0.0", "1.4.2", "1.8.6"],
+	"era": "legacy",
+	"rationale": "A database created at 1.0 and walked forward. The legacy migrator only ever added tables and columns (RFC §3.2), so this can retain columns a fresh 1.8 install never had. Cannot be reproduced from any schema definition in the repo.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		},
+		{
+			"version": "1.4.2",
+			"era": "legacy"
+		},
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "json",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "varchar",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "tinyint",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "varchar",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "datetime",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPolicy": "CREATE TABLE `consentPolicy` (\n  `id` varchar(36) NOT NULL,\n  `version` text NOT NULL,\n  `type` text NOT NULL,\n  `name` text NOT NULL,\n  `effectiveDate` datetime NOT NULL,\n  `expirationDate` datetime DEFAULT NULL,\n  `content` text NOT NULL,\n  `contentHash` text NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentPurpose": "CREATE TABLE `consentPurpose` (\n  `id` varchar(36) NOT NULL,\n  `code` text NOT NULL,\n  `name` text NOT NULL,\n  `description` text NOT NULL,\n  `isEssential` tinyint(1) NOT NULL,\n  `dataCategory` text,\n  `legalBasis` text,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"consentRecord": "CREATE TABLE `consentRecord` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `consentId` varchar(36) DEFAULT NULL,\n  `actionType` text NOT NULL,\n  `details` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"domain": "CREATE TABLE `domain` (\n  `id` varchar(36) NOT NULL,\n  `name` varchar(255) NOT NULL,\n  `description` text,\n  `allowedOrigins` json DEFAULT NULL,\n  `isVerified` tinyint(1) NOT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `name` (`name`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+		"subject": "CREATE TABLE `subject` (\n  `id` varchar(36) NOT NULL,\n  `isIdentified` tinyint(1) NOT NULL,\n  `externalId` text,\n  `identityProvider` text,\n  `lastIpAddress` text,\n  `createdAt` datetime NOT NULL,\n  `updatedAt` datetime NOT NULL,\n  `subjectTimezone` varchar(50) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+	}
+}

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/mysql.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/mysql.json
@@ -518,6 +518,65 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "name",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "PRIMARY",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [],
 	"ddl": {
 		"auditLog": "CREATE TABLE `auditLog` (\n  `id` varchar(36) NOT NULL,\n  `entityType` text NOT NULL,\n  `entityId` text NOT NULL,\n  `actionType` text NOT NULL,\n  `subjectId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `changes` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `createdAt` datetime NOT NULL,\n  `eventTimezone` varchar(50) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
 		"consent": "CREATE TABLE `consent` (\n  `id` varchar(36) NOT NULL,\n  `subjectId` varchar(36) NOT NULL,\n  `domainId` varchar(36) NOT NULL,\n  `purposeIds` json DEFAULT NULL,\n  `metadata` json DEFAULT NULL,\n  `policyId` varchar(36) DEFAULT NULL,\n  `ipAddress` text,\n  `userAgent` text,\n  `status` text NOT NULL,\n  `withdrawalReason` text,\n  `givenAt` datetime NOT NULL,\n  `validUntil` datetime DEFAULT NULL,\n  `isActive` tinyint(1) NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/postgres.json
@@ -518,5 +518,101 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "auditLog_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "consent_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "consentPolicy_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "consentPurpose_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "consentRecord_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "domain_name_key",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "subject_pkey",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {}
 }

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/postgres.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/postgres.json
@@ -1,0 +1,522 @@
+{
+	"shape": "legacy-upgraded",
+	"engine": "postgres",
+	"versions": ["1.0.0", "1.4.2", "1.8.6"],
+	"era": "legacy",
+	"rationale": "A database created at 1.0 and walked forward. The legacy migrator only ever added tables and columns (RFC §3.2), so this can retain columns a fresh 1.8 install never had. Cannot be reproduced from any schema definition in the repo.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		},
+		{
+			"version": "1.4.2",
+			"era": "legacy"
+		},
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "jsonb",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "text",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "bool",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "text",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "timestamp",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {}
+}

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/sqlite.json
@@ -518,6 +518,102 @@
 			]
 		}
 	],
+	"indexes": [
+		{
+			"table": "auditLog",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consent",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPolicy",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentPurpose",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "consentRecord",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		},
+		{
+			"table": "domain",
+			"name": "sqlite_autoindex_domain_2",
+			"columns": ["name"],
+			"isUnique": true,
+			"isPrimary": false
+		},
+		{
+			"table": "subject",
+			"name": "sqlite_primary_key",
+			"columns": ["id"],
+			"isUnique": true,
+			"isPrimary": true
+		}
+	],
+	"foreignKeys": [
+		{
+			"table": "auditLog",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["domainId"],
+			"referencedTable": "domain",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["policyId"],
+			"referencedTable": "consentPolicy",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consent",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["consentId"],
+			"referencedTable": "consent",
+			"referencedColumns": ["id"]
+		},
+		{
+			"table": "consentRecord",
+			"columns": ["subjectId"],
+			"referencedTable": "subject",
+			"referencedColumns": ["id"]
+		}
+	],
 	"ddl": {
 		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
 		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",

--- a/internals/migration-fixtures/fixtures/legacy-upgraded/sqlite.json
+++ b/internals/migration-fixtures/fixtures/legacy-upgraded/sqlite.json
@@ -1,0 +1,530 @@
+{
+	"shape": "legacy-upgraded",
+	"engine": "sqlite",
+	"versions": ["1.0.0", "1.4.2", "1.8.6"],
+	"era": "legacy",
+	"rationale": "A database created at 1.0 and walked forward. The legacy migrator only ever added tables and columns (RFC §3.2), so this can retain columns a fresh 1.8 install never had. Cannot be reproduced from any schema definition in the repo.",
+	"applied": [
+		{
+			"version": "1.0.0",
+			"era": "legacy"
+		},
+		{
+			"version": "1.4.2",
+			"era": "legacy"
+		},
+		{
+			"version": "1.8.6",
+			"era": "legacy"
+		}
+	],
+	"settings": null,
+	"tables": [
+		{
+			"name": "auditLog",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "changes",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "entityType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "eventTimezone",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consent",
+			"columns": [
+				{
+					"name": "domainId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "givenAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "ipAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "metadata",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "policyId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "purposeIds",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "status",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "userAgent",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "validUntil",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "withdrawalReason",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPolicy",
+			"columns": [
+				{
+					"name": "content",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "contentHash",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "effectiveDate",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "expirationDate",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "type",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "version",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentPurpose",
+			"columns": [
+				{
+					"name": "code",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "dataCategory",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isEssential",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "legalBasis",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "consentRecord",
+			"columns": [
+				{
+					"name": "actionType",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "consentId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "details",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectId",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "domain",
+			"columns": [
+				{
+					"name": "allowedOrigins",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "description",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isActive",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isVerified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "name",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		},
+		{
+			"name": "subject",
+			"columns": [
+				{
+					"name": "createdAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "externalId",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "id",
+					"dataType": "TEXT",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "identityProvider",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "isIdentified",
+					"dataType": "INTEGER",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "lastIpAddress",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "subjectTimezone",
+					"dataType": "TEXT",
+					"isNullable": true,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				},
+				{
+					"name": "updatedAt",
+					"dataType": "date",
+					"isNullable": false,
+					"isAutoIncrementing": false,
+					"hasDefaultValue": false
+				}
+			]
+		}
+	],
+	"ddl": {
+		"auditLog": "CREATE TABLE \"auditLog\" (\"id\" text not null primary key, \"entityType\" text not null, \"entityId\" text not null, \"actionType\" text not null, \"subjectId\" text references \"subject\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"changes\" text, \"metadata\" text, \"createdAt\" date not null, \"eventTimezone\" text not null)",
+		"consent": "CREATE TABLE \"consent\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"domainId\" text not null references \"domain\" (\"id\"), \"purposeIds\" text, \"metadata\" text, \"policyId\" text references \"consentPolicy\" (\"id\"), \"ipAddress\" text, \"userAgent\" text, \"status\" text not null, \"withdrawalReason\" text, \"givenAt\" date not null, \"validUntil\" date, \"isActive\" integer not null)",
+		"consentPolicy": "CREATE TABLE \"consentPolicy\" (\"id\" text not null primary key, \"version\" text not null, \"type\" text not null, \"name\" text not null, \"effectiveDate\" date not null, \"expirationDate\" date, \"content\" text not null, \"contentHash\" text not null, \"isActive\" integer not null, \"createdAt\" date not null)",
+		"consentPurpose": "CREATE TABLE \"consentPurpose\" (\"id\" text not null primary key, \"code\" text not null, \"name\" text not null, \"description\" text not null, \"isEssential\" integer not null, \"dataCategory\" text, \"legalBasis\" text, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date not null)",
+		"consentRecord": "CREATE TABLE \"consentRecord\" (\"id\" text not null primary key, \"subjectId\" text not null references \"subject\" (\"id\"), \"consentId\" text references \"consent\" (\"id\"), \"actionType\" text not null, \"details\" text, \"createdAt\" date not null)",
+		"domain": "CREATE TABLE \"domain\" (\"id\" text not null primary key, \"name\" text not null unique, \"description\" text, \"allowedOrigins\" text, \"isVerified\" integer not null, \"isActive\" integer not null, \"createdAt\" date not null, \"updatedAt\" date)",
+		"subject": "CREATE TABLE \"subject\" (\"id\" text not null primary key, \"isIdentified\" integer not null, \"externalId\" text, \"identityProvider\" text, \"lastIpAddress\" text, \"createdAt\" date not null, \"updatedAt\" date not null, \"subjectTimezone\" text)"
+	}
+}

--- a/internals/migration-fixtures/package.json
+++ b/internals/migration-fixtures/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@c15t/migration-fixtures",
+	"version": "1.0.0",
+	"type": "module",
+	"private": true,
+	"description": "Ground-truth database shapes captured from published @c15t/backend releases, used to test the migrator.",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
+		}
+	},
+	"scripts": {
+		"generate": "bun src/generate.ts",
+		"check-types": "tsc --noEmit",
+		"lint": "bun biome lint ./src",
+		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write"
+	},
+	"devDependencies": {
+		"@c15t/typescript-config": "workspace:*",
+		"typescript": "6.0.3",
+		"@types/node": "^24.10.1"
+	}
+}

--- a/internals/migration-fixtures/src/engines.ts
+++ b/internals/migration-fixtures/src/engines.ts
@@ -97,12 +97,26 @@ export const teardown = async () => { await db.destroy(); };
 						'  bun run generate --engine mysql --mysql-url mysql://root:c15t@127.0.0.1:3399/c15t'
 				);
 			}
+			// Unlike sqlite and postgres, which get a fresh in-process database per
+			// run, MySQL is a shared server. Every shape must start from a blank
+			// schema or it captures whatever the previous shape left behind — and
+			// a dirty database changes the migration path, not just the result.
 			return `
-import { Kysely, MysqlDialect } from 'kysely';
+import { Kysely, MysqlDialect, sql } from 'kysely';
 import { createPool } from 'mysql2';
 
 const pool = createPool(${JSON.stringify(mysqlUrl)});
 export const db = new Kysely({ dialect: new MysqlDialect({ pool }) });
+
+const existing = await db.introspection.getTables();
+if (existing.length > 0) {
+  await sql\`set foreign_key_checks = 0\`.execute(db);
+  for (const table of existing) {
+    await sql.raw(\`drop table if exists \\\`\${table.name}\\\`\`).execute(db);
+  }
+  await sql\`set foreign_key_checks = 1\`.execute(db);
+}
+
 export const teardown = async () => { await db.destroy(); };
 `;
 		}

--- a/internals/migration-fixtures/src/engines.ts
+++ b/internals/migration-fixtures/src/engines.ts
@@ -1,0 +1,110 @@
+/**
+ * The three SQL engines c15t supports, and what each needs in order to be
+ * driven by a published package inside a throwaway workspace.
+ *
+ * sqlite and postgres run in-process. MySQL needs a real server, so fixtures
+ * for it are generated locally against Docker and the dumps are committed —
+ * CI verifies against the committed dumps rather than standing up a database
+ * (RFC §7 keeps Docker off CI's critical path).
+ */
+
+export type EngineName = 'sqlite' | 'postgres' | 'mysql';
+
+export interface Engine {
+	readonly name: EngineName;
+	/** Packages the throwaway workspace needs on top of the c15t release. */
+	readonly deps: readonly string[];
+	/**
+	 * `type` for the legacy kysely adapter's `DatabaseConfiguration`, and
+	 * `provider` for the fumadb kysely adapter. They disagree on spelling, so
+	 * both are recorded.
+	 */
+	readonly legacyType: string;
+	readonly fumadbProvider: string;
+	/** Whether generating this engine's fixtures needs Docker. */
+	readonly needsDocker: boolean;
+}
+
+export const ENGINES: readonly Engine[] = [
+	{
+		name: 'sqlite',
+		deps: ['kysely', 'better-sqlite3'],
+		legacyType: 'sqlite',
+		fumadbProvider: 'sqlite',
+		needsDocker: false,
+	},
+	{
+		name: 'postgres',
+		deps: ['kysely', '@electric-sql/pglite', 'kysely-pglite'],
+		legacyType: 'postgres',
+		fumadbProvider: 'postgresql',
+		needsDocker: false,
+	},
+	{
+		name: 'mysql',
+		deps: ['kysely', 'mysql2'],
+		legacyType: 'mysql',
+		fumadbProvider: 'mysql',
+		needsDocker: true,
+	},
+] as const;
+
+export function engineByName(name: string): Engine {
+	const engine = ENGINES.find((candidate) => candidate.name === name);
+	if (!engine) {
+		const known = ENGINES.map((candidate) => candidate.name).join(', ');
+		throw new Error(`Unknown engine "${name}". Known engines: ${known}`);
+	}
+	return engine;
+}
+
+/**
+ * Source for the Kysely instance the driver script runs against, evaluated
+ * inside the throwaway workspace where the engine's drivers are installed.
+ *
+ * Emitted as source rather than imported because each throwaway workspace has
+ * its own copy of kysely — sharing an instance across installs would risk
+ * dual-package hazards between the generator and the release under test.
+ */
+export function connectionSource(
+	engine: Engine,
+	mysqlUrl: string | undefined
+): string {
+	switch (engine.name) {
+		case 'sqlite':
+			return `
+import Database from 'better-sqlite3';
+import { Kysely, SqliteDialect } from 'kysely';
+
+const database = new Database(':memory:');
+export const db = new Kysely({ dialect: new SqliteDialect({ database }) });
+export const teardown = async () => { await db.destroy(); };
+`;
+		case 'postgres':
+			return `
+import { Kysely } from 'kysely';
+import { KyselyPGlite } from 'kysely-pglite';
+
+const pglite = await KyselyPGlite.create();
+export const db = new Kysely({ dialect: pglite.dialect });
+export const teardown = async () => { await db.destroy(); };
+`;
+		case 'mysql': {
+			if (!mysqlUrl) {
+				throw new Error(
+					'MySQL fixtures need a server. Pass --mysql-url, or start one with:\n' +
+						'  docker run --rm -d -p 3399:3306 -e MYSQL_ROOT_PASSWORD=c15t -e MYSQL_DATABASE=c15t --name c15t-fixtures mysql:8\n' +
+						'  bun run generate --engine mysql --mysql-url mysql://root:c15t@127.0.0.1:3399/c15t'
+				);
+			}
+			return `
+import { Kysely, MysqlDialect } from 'kysely';
+import { createPool } from 'mysql2';
+
+const pool = createPool(${JSON.stringify(mysqlUrl)});
+export const db = new Kysely({ dialect: new MysqlDialect({ pool }) });
+export const teardown = async () => { await db.destroy(); };
+`;
+		}
+	}
+}

--- a/internals/migration-fixtures/src/generate.ts
+++ b/internals/migration-fixtures/src/generate.ts
@@ -1,0 +1,313 @@
+/**
+ * Regenerates the committed database fixtures by installing published
+ * `@c15t/backend` releases into throwaway workspaces and running each one's
+ * own migrator against a blank database.
+ *
+ * The releases are installed on demand rather than declared as dependencies:
+ * generation is rare, the old releases drag native drivers and a MongoDB
+ * client behind them, and nobody running `bun install` in this repo should
+ * pay for a tool they will not run.
+ *
+ *   bun run generate                                    # every in-process shape
+ *   bun run generate --engine sqlite
+ *   bun run generate --shape legacy-upgraded
+ *   bun run generate --engine mysql --mysql-url mysql://root:c15t@127.0.0.1:3399/c15t
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	connectionSource,
+	ENGINES,
+	type Engine,
+	engineByName,
+} from './engines';
+import { introspectSource } from './introspect';
+import { SHAPES, type Shape, shapeByName } from './shapes';
+
+const FIXTURES_DIR = join(
+	dirname(dirname(fileURLToPath(import.meta.url))),
+	'fixtures'
+);
+
+interface Args {
+	shapes: readonly Shape[];
+	engines: readonly Engine[];
+	mysqlUrl: string | undefined;
+	keepWorkspace: boolean;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+	const flag = (name: string): string | undefined => {
+		const index = argv.indexOf(`--${name}`);
+		return index === -1 ? undefined : argv[index + 1];
+	};
+
+	const shapeName = flag('shape');
+	const engineName = flag('engine');
+	const mysqlUrl = flag('mysql-url');
+
+	const engines = engineName
+		? [engineByName(engineName)]
+		: // MySQL needs Docker, so it is opt-in via --engine mysql rather than
+			// something a bare `bun run generate` silently fails on.
+			ENGINES.filter((engine) => !engine.needsDocker);
+
+	return {
+		shapes: shapeName ? [shapeByName(shapeName)] : SHAPES,
+		engines,
+		mysqlUrl,
+		keepWorkspace: argv.includes('--keep-workspace'),
+	};
+}
+
+/**
+ * The kysely range a published release declares. 2.x declares none (it reaches
+ * kysely through fumadb), so fall back to the last range that was declared
+ * explicitly.
+ */
+const KYSELY_FALLBACK = '^0.28.15';
+
+async function kyselyRangeFor(version: string): Promise<string> {
+	const response = await fetch(
+		`https://registry.npmjs.org/@c15t%2Fbackend/${version}`
+	);
+	if (!response.ok) return KYSELY_FALLBACK;
+	const manifest = (await response.json()) as {
+		dependencies?: Record<string, string>;
+		peerDependencies?: Record<string, string>;
+	};
+	return (
+		manifest.dependencies?.kysely ??
+		manifest.peerDependencies?.kysely ??
+		KYSELY_FALLBACK
+	);
+}
+
+/** npm alias for a release, safe to use as a JS identifier prefix. */
+function aliasFor(version: string): string {
+	return `c15t_${version.replaceAll('.', '_')}`;
+}
+
+/** Subpaths each era exposes, relative to the aliased package. */
+function eraSubpaths(era: Shape['era']): {
+	migrator: string;
+	schema?: string;
+	adapter?: string;
+} {
+	switch (era) {
+		case 'legacy':
+			return { migrator: 'pkgs/migrations' };
+		case 'fumadb-v2-subpath':
+			return {
+				migrator: 'v2/db/migrator',
+				schema: 'v2/db/schema',
+				adapter: 'v2/db/adapters/kysely',
+			};
+		case 'fumadb-root':
+			return {
+				migrator: 'db/migrator',
+				schema: 'db/schema',
+				adapter: 'db/adapters/kysely',
+			};
+	}
+}
+
+function driverSource(shape: Shape, engine: Engine): string {
+	const imports: string[] = [];
+	const steps: string[] = [];
+
+	for (const version of shape.versions) {
+		const alias = aliasFor(version);
+		const paths = eraSubpaths(shape.era);
+
+		if (shape.era === 'legacy') {
+			imports.push(
+				`import { getMigrations as getMigrations_${alias} } from '${alias}/${paths.migrator}';`
+			);
+			// The legacy migrator diffs its schema against the live database and
+			// applies what is missing, so running it against an already-migrated
+			// database is exactly how a real upgrade behaved.
+			steps.push(`
+  {
+    const result = await getMigrations_${alias}({
+      appName: 'migration-fixtures',
+      secret: '${'0'.repeat(32)}',
+      database: { db, type: '${engine.legacyType}' },
+    });
+    await result.runMigrations();
+    applied.push({ version: '${version}', era: '${shape.era}' });
+  }`);
+		} else {
+			imports.push(
+				`import { migrator as migrator_${alias} } from '${alias}/${paths.migrator}';`,
+				`import { DB as DB_${alias} } from '${alias}/${paths.schema}';`,
+				`import { kyselyAdapter as kyselyAdapter_${alias} } from '${alias}/${paths.adapter}';`
+			);
+			// migrator() returns a *plan*; nothing touches the database until
+			// execute() is called. The CLI does the same (migrator-result.ts:51).
+			steps.push(`
+  {
+    const client = DB_${alias}.client(
+      kyselyAdapter_${alias}({ db, provider: '${engine.fumadbProvider}' })
+    );
+    const plan = await migrator_${alias}({ db: client, schema: 'latest' });
+    const planSql = typeof plan?.getSQL === 'function' ? plan.getSQL() : '';
+    if (typeof plan?.execute !== 'function') {
+      throw new Error(
+        'migrator() returned no execute(); adapter likely unsupported for migrations'
+      );
+    }
+    await plan.execute();
+    applied.push({ version: '${version}', era: '${shape.era}', sql: planSql });
+  }`);
+		}
+	}
+
+	// Result goes to a file, not stdout: some releases log to stdout during
+	// migration (1.8.6's legacy path does), which corrupts a stdout handoff.
+	return `${imports.join('\n')}
+import { writeFileSync } from 'node:fs';
+import { db, teardown } from './connection.mjs';
+import { capture } from './introspect.mjs';
+
+const applied = [];
+
+try {
+${steps.join('\n')}
+
+  const captured = await capture(db);
+  writeFileSync('result.json', JSON.stringify({ applied, ...captured }));
+} finally {
+  await teardown();
+}
+`;
+}
+
+async function generateOne(
+	shape: Shape,
+	engine: Engine,
+	args: Args
+): Promise<void> {
+	const workspace = await mkdtemp(
+		join(tmpdir(), `c15t-fixture-${shape.name}-`)
+	);
+	process.stderr.write(`  ${shape.name} / ${engine.name} … `);
+
+	try {
+		const dependencies: Record<string, string> = {};
+		for (const version of shape.versions) {
+			dependencies[aliasFor(version)] = `npm:@c15t/backend@${version}`;
+		}
+		for (const dep of engine.deps) {
+			dependencies[dep] = 'latest';
+		}
+		// Use the kysely the release itself was built against rather than
+		// `latest`. 0.29 dropped the `Migrator` export that kysely-pglite still
+		// imports, and a release should be exercised with its own dependency
+		// anyway. For a multi-version chain, the newest release wins — that is
+		// what a real deployment that upgraded would have resolved to.
+		dependencies.kysely = await kyselyRangeFor(
+			shape.versions[shape.versions.length - 1] as string
+		);
+
+		await writeFile(
+			join(workspace, 'package.json'),
+			`${JSON.stringify(
+				{
+					name: 'fixture-workspace',
+					private: true,
+					type: 'module',
+					dependencies,
+				},
+				null,
+				2
+			)}\n`
+		);
+		await writeFile(
+			join(workspace, 'connection.mjs'),
+			connectionSource(engine, args.mysqlUrl)
+		);
+		await writeFile(
+			join(workspace, 'introspect.mjs'),
+			introspectSource(engine.name)
+		);
+		await writeFile(join(workspace, 'driver.mjs'), driverSource(shape, engine));
+
+		const install = spawnSync('bun', ['install', '--no-save'], {
+			cwd: workspace,
+			encoding: 'utf8',
+		});
+		if (install.status !== 0) {
+			throw new Error(`bun install failed:\n${install.stderr.trim()}`);
+		}
+
+		// Node, not Bun: better-sqlite3's NAPI module hard-crashes the Bun
+		// runtime (`NAPI FATAL ERROR: Error::New`). Bun still does the install,
+		// which is where the speed matters.
+		const run = spawnSync('node', ['driver.mjs'], {
+			cwd: workspace,
+			encoding: 'utf8',
+		});
+		if (run.status !== 0) {
+			throw new Error(`driver failed:\n${run.stderr.trim()}`);
+		}
+
+		const captured = JSON.parse(
+			await readFile(join(workspace, 'result.json'), 'utf8')
+		);
+		const fixture = {
+			shape: shape.name,
+			engine: engine.name,
+			versions: shape.versions,
+			era: shape.era,
+			rationale: shape.rationale,
+			...captured,
+		};
+
+		const outDir = join(FIXTURES_DIR, shape.name);
+		mkdirSync(outDir, { recursive: true });
+		await writeFile(
+			join(outDir, `${engine.name}.json`),
+			`${JSON.stringify(fixture, null, '\t')}\n`
+		);
+
+		process.stderr.write(
+			`${fixture.tables.length} tables${fixture.settings ? ', c15t_settings present' : ''}\n`
+		);
+	} finally {
+		if (args.keepWorkspace) {
+			process.stderr.write(`    workspace kept at ${workspace}\n`);
+		} else {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	}
+}
+
+const args = parseArgs(process.argv.slice(2));
+process.stderr.write(
+	`Generating ${args.shapes.length} shape(s) × ${args.engines.length} engine(s)\n`
+);
+
+let failures = 0;
+for (const shape of args.shapes) {
+	for (const engine of args.engines) {
+		try {
+			await generateOne(shape, engine, args);
+		} catch (error) {
+			failures += 1;
+			process.stderr.write(
+				`FAILED\n${error instanceof Error ? error.message : String(error)}\n`
+			);
+		}
+	}
+}
+
+if (failures > 0) {
+	process.stderr.write(`\n${failures} combination(s) failed\n`);
+	process.exit(1);
+}

--- a/internals/migration-fixtures/src/generate.ts
+++ b/internals/migration-fixtures/src/generate.ts
@@ -156,14 +156,28 @@ function driverSource(shape: Shape, engine: Engine): string {
       kyselyAdapter_${alias}({ db, provider: '${engine.fumadbProvider}' })
     );
     const plan = await migrator_${alias}({ db: client, schema: 'latest' });
-    const planSql = typeof plan?.getSQL === 'function' ? plan.getSQL() : '';
+    // getSQL() is best-effort: on MySQL, fumadb's SQL preprocessing throws
+    // ("ID columns must not be updated") even where execute() succeeds, so a
+    // failure to render SQL must not fail the capture.
+    let planSql = '';
+    let planSqlError = null;
+    try {
+      if (typeof plan?.getSQL === 'function') planSql = plan.getSQL();
+    } catch (error) {
+      planSqlError = error instanceof Error ? error.message : String(error);
+    }
     if (typeof plan?.execute !== 'function') {
       throw new Error(
         'migrator() returned no execute(); adapter likely unsupported for migrations'
       );
     }
     await plan.execute();
-    applied.push({ version: '${version}', era: '${shape.era}', sql: planSql });
+    applied.push({
+      version: '${version}',
+      era: '${shape.era}',
+      sql: planSql,
+      ...(planSqlError ? { sqlRenderError: planSqlError } : {}),
+    });
   }`);
 		}
 	}
@@ -193,10 +207,35 @@ async function generateOne(
 	engine: Engine,
 	args: Args
 ): Promise<void> {
+	process.stderr.write(`  ${shape.name} / ${engine.name} … `);
+
+	// A combination the release provably cannot produce is recorded as such,
+	// so the absent fixture reads as a finding rather than missing coverage.
+	const blocker = shape.unsupported?.[engine.name];
+	if (blocker) {
+		const outDir = join(FIXTURES_DIR, shape.name);
+		mkdirSync(outDir, { recursive: true });
+		await writeFile(
+			join(outDir, `${engine.name}.unsupported.json`),
+			`${JSON.stringify(
+				{
+					shape: shape.name,
+					engine: engine.name,
+					versions: shape.versions,
+					era: shape.era,
+					unsupported: blocker,
+				},
+				null,
+				'\t'
+			)}\n`
+		);
+		process.stderr.write('unsupported by the release (recorded)\n');
+		return;
+	}
+
 	const workspace = await mkdtemp(
 		join(tmpdir(), `c15t-fixture-${shape.name}-`)
 	);
-	process.stderr.write(`  ${shape.name} / ${engine.name} … `);
 
 	try {
 		const dependencies: Record<string, string> = {};

--- a/internals/migration-fixtures/src/index.ts
+++ b/internals/migration-fixtures/src/index.ts
@@ -14,4 +14,10 @@ export type {
 	CapturedShape,
 	CapturedTable,
 } from './introspect';
+export {
+	columnNames,
+	domainTableNames,
+	loadFixture,
+	type UnsupportedShape,
+} from './load';
 export { type MigratorEra, SHAPES, type Shape, shapeByName } from './shapes';

--- a/internals/migration-fixtures/src/index.ts
+++ b/internals/migration-fixtures/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Ground-truth database shapes captured from published `@c15t/backend`
+ * releases. Consumed by the migrator's tests to prove that a real database
+ * from any shipped version upgrades correctly.
+ *
+ * Fixtures are committed JSON under `fixtures/<shape>/<engine>.json` and are
+ * regenerated with `bun run generate`. See the README for why they are
+ * generated from npm rather than from the schema definitions in this repo.
+ */
+
+export { ENGINES, type Engine, type EngineName, engineByName } from './engines';
+export type {
+	CapturedColumn,
+	CapturedShape,
+	CapturedTable,
+} from './introspect';
+export { type MigratorEra, SHAPES, type Shape, shapeByName } from './shapes';

--- a/internals/migration-fixtures/src/introspect.ts
+++ b/internals/migration-fixtures/src/introspect.ts
@@ -21,6 +21,30 @@ export interface CapturedTable {
 	readonly columns: readonly CapturedColumn[];
 }
 
+/**
+ * An index or unique constraint.
+ *
+ * Names are captured but should not be compared across engines — each engine
+ * generates its own for implicit primary key and unique indexes. Compare on
+ * `(table, columns, isUnique)` instead; that is the part that describes
+ * behaviour.
+ */
+export interface CapturedIndex {
+	readonly table: string;
+	readonly name: string;
+	/** In index order, not alphabetical — column order is significant. */
+	readonly columns: readonly string[];
+	readonly isUnique: boolean;
+	readonly isPrimary: boolean;
+}
+
+export interface CapturedForeignKey {
+	readonly table: string;
+	readonly columns: readonly string[];
+	readonly referencedTable: string;
+	readonly referencedColumns: readonly string[];
+}
+
 export interface CapturedShape {
 	readonly shape: string;
 	readonly engine: string;
@@ -29,6 +53,13 @@ export interface CapturedShape {
 	/** Contents of `c15t_settings` if the release wrote one, else null. */
 	readonly settings: Record<string, unknown> | null;
 	readonly tables: readonly CapturedTable[];
+	/**
+	 * Indexes and unique constraints. Without these, "the shapes are identical"
+	 * only ever meant "the columns are identical" — the migrator has to
+	 * converge constraints too, so they are part of the contract.
+	 */
+	readonly indexes: readonly CapturedIndex[];
+	readonly foreignKeys: readonly CapturedForeignKey[];
 	/** Engine-native DDL, keyed by object name. Empty where unavailable. */
 	readonly ddl: Record<string, string>;
 }
@@ -106,10 +137,241 @@ export async function capture(db) {
     }
   }
 
-  return { settings, tables, ddl };
+  const { indexes, foreignKeys } = await constraints(db, tables);
+
+  return { settings, tables, indexes, foreignKeys, ddl };
 }
+
+${constraintsSource(engine)}
 `;
 }
+
+/**
+ * Index and foreign-key capture, per engine.
+ *
+ * There is no portable way to do this — `information_schema` does not describe
+ * indexes on SQLite at all, and its foreign-key views disagree between
+ * Postgres and MySQL on how composite keys are ordered. Each engine gets the
+ * query that is actually correct for it, normalised into the same shape.
+ */
+function constraintsSource(engine: string): string {
+	switch (engine) {
+		case 'sqlite':
+			return SQLITE_CONSTRAINTS;
+		case 'postgres':
+			return POSTGRES_CONSTRAINTS;
+		case 'mysql':
+			return MYSQL_CONSTRAINTS;
+		default:
+			return `async function constraints() { return { indexes: [], foreignKeys: [] }; }`;
+	}
+}
+
+const SORT = `
+function sortIndexes(rows) {
+  return rows.sort((a, b) =>
+    a.table.localeCompare(b.table) ||
+    a.columns.join(',').localeCompare(b.columns.join(',')) ||
+    a.name.localeCompare(b.name)
+  );
+}
+function sortForeignKeys(rows) {
+  return rows.sort((a, b) =>
+    a.table.localeCompare(b.table) ||
+    a.columns.join(',').localeCompare(b.columns.join(','))
+  );
+}
+`;
+
+const SQLITE_CONSTRAINTS = `${SORT}
+async function constraints(db, tables) {
+  const { sql } = await import('kysely');
+  const indexes = [];
+  const foreignKeys = [];
+
+  for (const table of tables) {
+    // SQLite reports the implicit rowid primary key through index_list only
+    // when it is a real index, so PK detection also consults table_info.
+    const pk = await sql.raw(\`select name from pragma_table_info('\${table.name}') where pk > 0 order by pk\`).execute(db);
+    if (pk.rows.length > 0) {
+      indexes.push({
+        table: table.name,
+        name: 'sqlite_primary_key',
+        columns: pk.rows.map((row) => row.name),
+        isUnique: true,
+        isPrimary: true,
+      });
+    }
+
+    const list = await sql.raw(\`select name, "unique", origin from pragma_index_list('\${table.name}')\`).execute(db);
+    for (const index of list.rows) {
+      // origin 'pk' duplicates what table_info already reported.
+      if (index.origin === 'pk') continue;
+      const info = await sql.raw(\`select name from pragma_index_info('\${index.name}') order by seqno\`).execute(db);
+      indexes.push({
+        table: table.name,
+        name: index.name,
+        columns: info.rows.map((row) => row.name),
+        isUnique: index.unique === 1 || index.unique === true,
+        isPrimary: false,
+      });
+    }
+
+    const fks = await sql.raw(\`select "table", "from", "to", id, seq from pragma_foreign_key_list('\${table.name}') order by id, seq\`).execute(db);
+    const grouped = new Map();
+    for (const row of fks.rows) {
+      const existing = grouped.get(row.id) ?? {
+        table: table.name,
+        columns: [],
+        referencedTable: row.table,
+        referencedColumns: [],
+      };
+      existing.columns.push(row.from);
+      existing.referencedColumns.push(row.to);
+      grouped.set(row.id, existing);
+    }
+    foreignKeys.push(...grouped.values());
+  }
+
+  return { indexes: sortIndexes(indexes), foreignKeys: sortForeignKeys(foreignKeys) };
+}
+`;
+
+const POSTGRES_CONSTRAINTS = `${SORT}
+async function constraints(db) {
+  const { sql } = await import('kysely');
+
+  const idx = await sql\`
+    select
+      t.relname as table_name,
+      i.relname as index_name,
+      ix.indisunique as is_unique,
+      ix.indisprimary as is_primary,
+      a.attname as column_name,
+      k.ord as ordinal
+    from pg_class t
+    join pg_namespace n on n.oid = t.relnamespace
+    join pg_index ix on t.oid = ix.indrelid
+    join pg_class i on i.oid = ix.indexrelid
+    join unnest(ix.indkey) with ordinality as k(attnum, ord) on true
+    join pg_attribute a on a.attrelid = t.oid and a.attnum = k.attnum
+    where n.nspname = 'public' and t.relkind = 'r'
+    order by t.relname, i.relname, k.ord
+  \`.execute(db);
+
+  const byIndex = new Map();
+  for (const row of idx.rows) {
+    const key = row.table_name + '.' + row.index_name;
+    const existing = byIndex.get(key) ?? {
+      table: row.table_name,
+      name: row.index_name,
+      columns: [],
+      isUnique: row.is_unique === true,
+      isPrimary: row.is_primary === true,
+    };
+    existing.columns.push(row.column_name);
+    byIndex.set(key, existing);
+  }
+
+  const fk = await sql\`
+    select
+      con.conname as name,
+      cl.relname as table_name,
+      att.attname as column_name,
+      fcl.relname as referenced_table,
+      fatt.attname as referenced_column,
+      k.ord as ordinal
+    from pg_constraint con
+    join pg_class cl on cl.oid = con.conrelid
+    join pg_class fcl on fcl.oid = con.confrelid
+    join unnest(con.conkey) with ordinality as k(attnum, ord) on true
+    join unnest(con.confkey) with ordinality as f(attnum, ord) on f.ord = k.ord
+    join pg_attribute att on att.attrelid = con.conrelid and att.attnum = k.attnum
+    join pg_attribute fatt on fatt.attrelid = con.confrelid and fatt.attnum = f.attnum
+    where con.contype = 'f'
+    order by cl.relname, con.conname, k.ord
+  \`.execute(db);
+
+  const byFk = new Map();
+  for (const row of fk.rows) {
+    const key = row.table_name + '.' + row.name;
+    const existing = byFk.get(key) ?? {
+      table: row.table_name,
+      columns: [],
+      referencedTable: row.referenced_table,
+      referencedColumns: [],
+    };
+    existing.columns.push(row.column_name);
+    existing.referencedColumns.push(row.referenced_column);
+    byFk.set(key, existing);
+  }
+
+  return {
+    indexes: sortIndexes([...byIndex.values()]),
+    foreignKeys: sortForeignKeys([...byFk.values()]),
+  };
+}
+`;
+
+const MYSQL_CONSTRAINTS = `${SORT}
+async function constraints(db) {
+  const { sql } = await import('kysely');
+
+  const idx = await sql\`
+    select table_name, index_name, non_unique, column_name, seq_in_index
+    from information_schema.statistics
+    where table_schema = database()
+    order by table_name, index_name, seq_in_index
+  \`.execute(db);
+
+  const byIndex = new Map();
+  for (const row of idx.rows) {
+    const table = row.table_name ?? row.TABLE_NAME;
+    const name = row.index_name ?? row.INDEX_NAME;
+    const column = row.column_name ?? row.COLUMN_NAME;
+    const nonUnique = row.non_unique ?? row.NON_UNIQUE;
+    const key = table + '.' + name;
+    const existing = byIndex.get(key) ?? {
+      table,
+      name,
+      columns: [],
+      isUnique: Number(nonUnique) === 0,
+      isPrimary: name === 'PRIMARY',
+    };
+    existing.columns.push(column);
+    byIndex.set(key, existing);
+  }
+
+  const fk = await sql\`
+    select table_name, constraint_name, column_name,
+           referenced_table_name, referenced_column_name, ordinal_position
+    from information_schema.key_column_usage
+    where table_schema = database() and referenced_table_name is not null
+    order by table_name, constraint_name, ordinal_position
+  \`.execute(db);
+
+  const byFk = new Map();
+  for (const row of fk.rows) {
+    const table = row.table_name ?? row.TABLE_NAME;
+    const name = row.constraint_name ?? row.CONSTRAINT_NAME;
+    const key = table + '.' + name;
+    const existing = byFk.get(key) ?? {
+      table,
+      columns: [],
+      referencedTable: row.referenced_table_name ?? row.REFERENCED_TABLE_NAME,
+      referencedColumns: [],
+    };
+    existing.columns.push(row.column_name ?? row.COLUMN_NAME);
+    existing.referencedColumns.push(row.referenced_column_name ?? row.REFERENCED_COLUMN_NAME);
+    byFk.set(key, existing);
+  }
+
+  return {
+    indexes: sortIndexes([...byIndex.values()]),
+    foreignKeys: sortForeignKeys([...byFk.values()]),
+  };
+}
+`;
 
 function rawDdlQuery(engine: string): string | null {
 	switch (engine) {

--- a/internals/migration-fixtures/src/introspect.ts
+++ b/internals/migration-fixtures/src/introspect.ts
@@ -1,0 +1,127 @@
+/**
+ * Captured shape of a database after a published c15t release migrated it.
+ *
+ * The JSON is the contract that migration tests assert against: it is
+ * engine-normalised and deterministically ordered, so a diff means the shape
+ * really changed rather than that a driver reordered its output. Raw DDL is
+ * captured alongside it where the engine offers it cheaply, purely so a human
+ * reviewing a fixture change can read what actually happened.
+ */
+
+export interface CapturedColumn {
+	readonly name: string;
+	readonly dataType: string;
+	readonly isNullable: boolean;
+	readonly isAutoIncrementing: boolean;
+	readonly hasDefaultValue: boolean;
+}
+
+export interface CapturedTable {
+	readonly name: string;
+	readonly columns: readonly CapturedColumn[];
+}
+
+export interface CapturedShape {
+	readonly shape: string;
+	readonly engine: string;
+	readonly versions: readonly string[];
+	readonly era: string;
+	/** Contents of `c15t_settings` if the release wrote one, else null. */
+	readonly settings: Record<string, unknown> | null;
+	readonly tables: readonly CapturedTable[];
+	/** Engine-native DDL, keyed by object name. Empty where unavailable. */
+	readonly ddl: Record<string, string>;
+}
+
+/**
+ * Source for the capture step, evaluated inside the throwaway workspace.
+ *
+ * Emitted as source for the same reason as the connection: the workspace has
+ * its own kysely, and the introspection API must come from the same copy that
+ * built the connection.
+ */
+export function introspectSource(engine: string): string {
+	return `
+const RAW_DDL_QUERY = ${JSON.stringify(rawDdlQuery(engine))};
+
+export async function capture(db) {
+  const tables = (await db.introspection.getTables())
+    .filter((table) => !table.isView)
+    .map((table) => ({
+      name: table.name,
+      columns: [...table.columns]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((column) => ({
+          name: column.name,
+          dataType: column.dataType,
+          isNullable: column.isNullable,
+          isAutoIncrementing: column.isAutoIncrementing,
+          hasDefaultValue: column.hasDefaultValue,
+        })),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // fumadb's version marker. Observed as 'private_c15t_settings' on 2.1.0, but
+  // matched by suffix so a prefix change in any release still resolves.
+  // Legacy releases never create it, so its absence is part of the fixture.
+  let settings = null;
+  const settingsTable = tables.find((table) =>
+    /(^|_)c15t_settings$/.test(table.name)
+  );
+  if (settingsTable) {
+    const { sql } = await import('kysely');
+    const result = await sql
+      .raw(\`select * from "\${settingsTable.name}"\`)
+      .execute(db);
+    // fumadb stores JSON documents (notably 'name-variants', the physical
+    // per-dialect names) as escaped strings. Parse them so a fixture diff is
+    // reviewable instead of one enormous quoted line.
+    settings = {
+      table: settingsTable.name,
+      rows: result.rows.map((row) => {
+        if (typeof row.value !== 'string') return row;
+        try {
+          return { ...row, value: JSON.parse(row.value) };
+        } catch {
+          return row;
+        }
+      }),
+    };
+  }
+
+  const ddl = {};
+  if (RAW_DDL_QUERY) {
+    const { sql } = await import('kysely');
+    if (${JSON.stringify(engine)} === 'mysql') {
+      for (const table of tables) {
+        const result = await sql.raw(\`show create table \\\`\${table.name}\\\`\`).execute(db);
+        const row = result.rows[0] ?? {};
+        ddl[table.name] = row['Create Table'] ?? row['Create View'] ?? '';
+      }
+    } else {
+      const result = await sql.raw(RAW_DDL_QUERY).execute(db);
+      for (const row of result.rows) {
+        if (row.sql) ddl[row.name] = row.sql;
+      }
+    }
+  }
+
+  return { settings, tables, ddl };
+}
+`;
+}
+
+function rawDdlQuery(engine: string): string | null {
+	switch (engine) {
+		case 'sqlite':
+			return 'select name, sql from sqlite_master where sql is not null order by name';
+		case 'mysql':
+			// Handled per-table by the emitted source; a non-null value just
+			// switches raw DDL capture on.
+			return 'show tables';
+		default:
+			// Postgres has no cheap single-statement DDL dump without pg_dump.
+			// The normalised JSON carries the contract for that engine.
+			return null;
+	}
+}

--- a/internals/migration-fixtures/src/introspect.ts
+++ b/internals/migration-fixtures/src/introspect.ts
@@ -163,7 +163,7 @@ function constraintsSource(engine: string): string {
 		case 'mysql':
 			return MYSQL_CONSTRAINTS;
 		default:
-			return `async function constraints() { return { indexes: [], foreignKeys: [] }; }`;
+			return 'async function constraints() { return { indexes: [], foreignKeys: [] }; }';
 	}
 }
 

--- a/internals/migration-fixtures/src/load.ts
+++ b/internals/migration-fixtures/src/load.ts
@@ -1,0 +1,98 @@
+/**
+ * Reads committed fixtures so tests can assert against them.
+ *
+ * Fixtures are JSON on disk rather than generated at test time on purpose: a
+ * test that regenerated them would be asserting a release against itself. The
+ * committed file is the record of what a published release actually produced,
+ * and a diff to it in review is the signal that something changed.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { EngineName } from './engines';
+import type { CapturedShape } from './introspect';
+
+const FIXTURES_DIR = join(
+	dirname(dirname(fileURLToPath(import.meta.url))),
+	'fixtures'
+);
+
+/** Recorded reason a release cannot produce a shape on a given engine. */
+export interface UnsupportedShape {
+	readonly shape: string;
+	readonly engine: string;
+	readonly versions: readonly string[];
+	readonly era: string;
+	readonly unsupported: string;
+}
+
+/**
+ * Loads one fixture.
+ *
+ * Returns `{ kind: 'unsupported' }` where the release provably cannot produce
+ * that shape on that engine — currently the two fumadb shapes on MySQL, which
+ * fumadb cannot migrate at all. Callers must handle that case rather than
+ * treating a missing fixture as a failure; the absence is a finding.
+ */
+export async function loadFixture(
+	shape: string,
+	engine: EngineName
+): Promise<
+	| { readonly kind: 'captured'; readonly fixture: CapturedShape }
+	| { readonly kind: 'unsupported'; readonly reason: UnsupportedShape }
+> {
+	const base = join(FIXTURES_DIR, shape);
+
+	const unsupported = await readJson<UnsupportedShape>(
+		join(base, `${engine}.unsupported.json`)
+	);
+	if (unsupported) {
+		return { kind: 'unsupported', reason: unsupported };
+	}
+
+	const captured = await readJson<CapturedShape>(join(base, `${engine}.json`));
+	if (!captured) {
+		throw new Error(
+			`No fixture for shape "${shape}" on engine "${engine}". ` +
+				'Regenerate with: bun run --cwd internals/migration-fixtures generate'
+		);
+	}
+	return { kind: 'captured', fixture: captured };
+}
+
+/** Table names in a captured shape, excluding fumadb's own marker table. */
+export function domainTableNames(
+	fixture: CapturedShape
+): ReadonlyArray<string> {
+	return fixture.tables
+		.map((table) => table.name)
+		.filter((name) => !/(^|_)c15t_settings$/.test(name))
+		.sort();
+}
+
+/** Column names for one table in a captured shape, sorted. */
+export function columnNames(
+	fixture: CapturedShape,
+	table: string
+): ReadonlyArray<string> {
+	const found = fixture.tables.find((candidate) => candidate.name === table);
+	if (!found) {
+		const known = fixture.tables.map((candidate) => candidate.name).join(', ');
+		throw new Error(
+			`Fixture "${fixture.shape}/${fixture.engine}" has no table "${table}". Has: ${known}`
+		);
+	}
+	return found.columns.map((column) => column.name).sort();
+}
+
+async function readJson<T>(path: string): Promise<T | undefined> {
+	try {
+		return JSON.parse(await readFile(path, 'utf8')) as T;
+	} catch (error) {
+		if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+			return undefined;
+		}
+		throw error;
+	}
+}

--- a/internals/migration-fixtures/src/shapes.ts
+++ b/internals/migration-fixtures/src/shapes.ts
@@ -30,7 +30,25 @@ export interface Shape {
 	readonly era: MigratorEra;
 	/** Why this shape exists — copied into the fixture manifest. */
 	readonly rationale: string;
+	/**
+	 * Engines this shape provably cannot be produced on, with the observed
+	 * reason. Recorded rather than silently skipped: "this release could never
+	 * migrate this engine" is a fact the v3 migrator needs, not a gap in
+	 * coverage.
+	 */
+	readonly unsupported?: Readonly<Record<string, string>>;
 }
+
+/**
+ * Both fumadb eras fail to migrate a blank MySQL database, in `execute()` as
+ * well as `getSQL()`. Verified against the exact dependency each release pins
+ * (2.1.0 pins fumadb 0.2.2), so this is the released behaviour rather than a
+ * resolution artifact. The implication is that fumadb-managed MySQL databases
+ * most likely do not exist in the wild — the documented migrator could never
+ * have created one.
+ */
+const FUMADB_MYSQL_FAILURE =
+	'fumadb migration fails on MySQL: "ID columns must not be updated, not every database supports updating primary keys and often requires workarounds." Fails inside execute(), not just SQL rendering.';
 
 export const SHAPES: readonly Shape[] = [
 	{
@@ -60,12 +78,14 @@ export const SHAPES: readonly Shape[] = [
 		era: 'fumadb-v2-subpath',
 		rationale:
 			'The opt-in /v2 path shipped inside 1.8.x. Writes c15t_settings = 1.0.0.',
+		unsupported: { mysql: FUMADB_MYSQL_FAILURE },
 	},
 	{
 		name: 'fumadb-2.0.0',
 		versions: ['2.1.0'],
 		era: 'fumadb-root',
 		rationale: 'Current shipping shape. Writes c15t_settings = 2.0.0.',
+		unsupported: { mysql: FUMADB_MYSQL_FAILURE },
 	},
 ] as const;
 

--- a/internals/migration-fixtures/src/shapes.ts
+++ b/internals/migration-fixtures/src/shapes.ts
@@ -1,0 +1,79 @@
+/**
+ * The database shapes that exist in the wild, and the published package that
+ * produces each one.
+ *
+ * See `internals/rfcs/0004-backend-effect-rewrite.md` §3.1 for why there are
+ * three eras rather than two. In short: 1.0.x–1.8.x shipped a legacy
+ * introspection-diff migrator at the root export, 1.8.x *additionally* shipped
+ * an opt-in `/v2` subpath backed by fumadb at schema 1.0.0, and 2.x promoted
+ * that surface to the root at schema 2.0.0.
+ */
+
+/** How a given package era exposes its migrator. */
+export type MigratorEra =
+	/** `getMigrations(options)` from `@c15t/backend/pkgs/migrations`. */
+	| 'legacy'
+	/** `migrator({ db, schema })` from `@c15t/backend/v2/db/migrator`. */
+	| 'fumadb-v2-subpath'
+	/** `migrator({ db, schema })` from `@c15t/backend/db/migrator`. */
+	| 'fumadb-root';
+
+export interface Shape {
+	/** Directory name under `fixtures/`. */
+	readonly name: string;
+	/**
+	 * Published versions applied in order against the same database. Most
+	 * shapes are a single fresh install; `legacy-upgraded` walks a database
+	 * through several releases the way a long-lived deployment did.
+	 */
+	readonly versions: readonly string[];
+	readonly era: MigratorEra;
+	/** Why this shape exists — copied into the fixture manifest. */
+	readonly rationale: string;
+}
+
+export const SHAPES: readonly Shape[] = [
+	{
+		name: 'legacy-fresh-1.0',
+		versions: ['1.0.0'],
+		era: 'legacy',
+		rationale:
+			'Earliest published release. The floor of what a legacy database can look like.',
+	},
+	{
+		name: 'legacy-fresh-1.8',
+		versions: ['1.8.6'],
+		era: 'legacy',
+		rationale:
+			'Last legacy release, installed fresh. Contrast with legacy-upgraded to expose drift.',
+	},
+	{
+		name: 'legacy-upgraded',
+		versions: ['1.0.0', '1.4.2', '1.8.6'],
+		era: 'legacy',
+		rationale:
+			'A database created at 1.0 and walked forward. The legacy migrator only ever added tables and columns (RFC §3.2), so this can retain columns a fresh 1.8 install never had. Cannot be reproduced from any schema definition in the repo.',
+	},
+	{
+		name: 'fumadb-1.0.0',
+		versions: ['1.8.6'],
+		era: 'fumadb-v2-subpath',
+		rationale:
+			'The opt-in /v2 path shipped inside 1.8.x. Writes c15t_settings = 1.0.0.',
+	},
+	{
+		name: 'fumadb-2.0.0',
+		versions: ['2.1.0'],
+		era: 'fumadb-root',
+		rationale: 'Current shipping shape. Writes c15t_settings = 2.0.0.',
+	},
+] as const;
+
+export function shapeByName(name: string): Shape {
+	const shape = SHAPES.find((candidate) => candidate.name === name);
+	if (!shape) {
+		const known = SHAPES.map((candidate) => candidate.name).join(', ');
+		throw new Error(`Unknown shape "${name}". Known shapes: ${known}`);
+	}
+	return shape;
+}

--- a/internals/migration-fixtures/src/shapes.ts
+++ b/internals/migration-fixtures/src/shapes.ts
@@ -40,15 +40,19 @@ export interface Shape {
 }
 
 /**
- * Both fumadb eras fail to migrate a blank MySQL database, in `execute()` as
- * well as `getSQL()`. Verified against the exact dependency each release pins
- * (2.1.0 pins fumadb 0.2.2), so this is the released behaviour rather than a
- * resolution artifact. The implication is that fumadb-managed MySQL databases
- * most likely do not exist in the wild — the documented migrator could never
- * have created one.
+ * Both fumadb eras fail to migrate a blank MySQL database. fumadb maps a
+ * `string` column to MySQL `TEXT` and then puts an index on it, and MySQL
+ * requires a prefix length to index TEXT/BLOB. Different eras trip over
+ * different columns — `domain.name` at schema 1.0.0, and
+ * `runtimePolicyDecision.dedupeKey` at 2.0.0 — but the cause is the same.
+ *
+ * Reproduced on fumadb 0.2.2 (pinned by 2.1.0) *and* 0.3.0 (pinned by this
+ * repo on the v3 line), so it is not fixed upstream. The implication is that
+ * fumadb-managed MySQL databases most likely do not exist in the wild: the
+ * documented migrator could never have created one.
  */
 const FUMADB_MYSQL_FAILURE =
-	'fumadb migration fails on MySQL: "ID columns must not be updated, not every database supports updating primary keys and often requires workarounds." Fails inside execute(), not just SQL rendering.';
+	'fumadb migration fails on MySQL: "BLOB/TEXT column used in key specification without a key length". fumadb maps string columns to TEXT and indexes them; MySQL needs a prefix length. Trips on domain.name at schema 1.0.0 and runtimePolicyDecision.dedupeKey at 2.0.0. Reproduced on fumadb 0.2.2 and 0.3.0.';
 
 export const SHAPES: readonly Shape[] = [
 	{

--- a/internals/migration-fixtures/tsconfig.json
+++ b/internals/migration-fixtures/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": ["@c15t/typescript-config/node.json"],
+	"compilerOptions": {
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "fixtures"]
+}


### PR DESCRIPTION
Adds `internals/migration-fixtures` — ground-truth database shapes captured from **published** `@c15t/backend` releases, so the v3 migrator can be tested against what users actually have. Implements RFC 0004 §3.4. Private, not published, not part of any build.

## How

Each fixture is produced by installing a real release into a throwaway workspace, running **that release's own migrator** against a blank database, and capturing the result. Releases are installed on demand rather than declared as dependencies — generation is rare and the old releases drag native drivers and a MongoDB client behind them.

13 artifacts: 5 shapes × 3 engines. sqlite and postgres run in-process; MySQL is opt-in behind `--engine mysql` so Docker stays off CI's critical path, with CI verifying against the committed dumps.

| Shape | Released by | Migrator entry |
| --- | --- | --- |
| `legacy-fresh-1.0` | `1.0.0` | `pkgs/migrations` (root) |
| `legacy-fresh-1.8` | `1.8.6` | `pkgs/migrations` (root) |
| `legacy-upgraded` | `1.0.0` → `1.4.2` → `1.8.6` | `pkgs/migrations` (root) |
| `fumadb-1.0.0` | `1.8.6` | `v2/db/migrator` (opt-in subpath) |
| `fumadb-2.0.0` | `2.1.0` | `db/migrator` (root) |

## Findings

**There is one legacy shape, not a family.** The RFC reasoned that a strictly-additive migrator with no ledger would let a 1.0→1.8 database keep columns a fresh 1.8 install never had. Measured, it doesn't: all three legacy fixtures are identical in tables and columns on all three engines. The legacy schema never changed across the 1.x line. This makes the migrator's adoption step materially simpler — one known source shape.

**fumadb cannot migrate MySQL, and it isn't fixed on the v3 line.** Both fumadb shapes fail on a blank MySQL database with `BLOB/TEXT column used in key specification without a key length` — fumadb maps `string` to `TEXT` and then indexes it. Reproduced against both `fumadb@0.2.2` (released 2.1.0) and `fumadb@0.3.0` (pinned here on v3), using the real c15t schema; a minimal `idColumn` schema migrates fine on both, so it's specific to c15t's schema.

MySQL is advertised in `docs/self-host/guides/database-setup.mdx`, so **this is a live bug on the current line**, independent of the rewrite. Worth its own fix or a documented caveat. Those cells are committed as `mysql.unsupported.json` so the absence reads as a finding rather than missing coverage.

## Known gap

Captured metadata is tables and columns only. Indexes, foreign keys and check constraints are **not** captured yet, so both findings are established for columns and unproven for constraints. Worth closing before the migrator's tests depend on them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added migration fixture generation and loading for SQLite, PostgreSQL, and MySQL.
  * Added coverage for legacy and modern schemas, including fresh and upgraded installations.
  * Added normalized schema metadata, settings, indexes, relationships, and database-specific SQL capture.
  * Added clear handling and reporting for unsupported MySQL migration scenarios.

* **Documentation**
  * Added guidance for generating, reviewing, maintaining, and regenerating migration fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->