### PR TITLE
feat(backend-next): baseline schema and dialect type mappings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -569,6 +569,7 @@
         "effect": "4.0.0-beta.102",
       },
       "devDependencies": {
+        "@c15t/migration-fixtures": "workspace:*",
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
         "@effect/sql-mysql2": "4.0.0-beta.102",

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -58,6 +58,7 @@
 		"effect": "4.0.0-beta.102"
 	},
 	"devDependencies": {
+		"@c15t/migration-fixtures": "workspace:*",
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",
 		"@effect/sql-mysql2": "4.0.0-beta.102",

--- a/packages/backend-next/src/db/dialect.ts
+++ b/packages/backend-next/src/db/dialect.ts
@@ -1,0 +1,133 @@
+/**
+ * The handful of places where the three supported engines genuinely disagree.
+ *
+ * Deliberately a small closed set of physical type decisions rather than a
+ * general abstraction layer. RFC 0004's argument is that hiding SQL behind a
+ * lowest-common-denominator API is what produced the join-less query surface
+ * in `@c15t/backend`; the fix is to write real SQL and name the few concrete
+ * divergences, not to build another abstraction over them.
+ *
+ * **Every mapping here is taken from the committed 2.0.0 fixtures**
+ * (`internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json`), not from what
+ * the engines would allow. The baseline has to land a fresh database on the
+ * same physical shape an existing 2.0.0 database already has, or adopting an
+ * existing database would mean rewriting columns for no behavioural gain.
+ *
+ * Observed there:
+ *
+ * | Logical  | postgres    | sqlite    | mysql        |
+ * | -------- | ----------- | --------- | ------------ |
+ * | id       | `varchar`   | `TEXT`    | `varchar`    |
+ * | string   | `text`      | `TEXT`    | `text`       |
+ * | json     | `json`      | `TEXT`    | `json`       |
+ * | bool     | `bool`      | `INTEGER` | `boolean`    |
+ * | timestamp| `timestamp` | `INTEGER` | `timestamp`  |
+ *
+ * SQLite collapses everything into `TEXT` and `INTEGER` — notably timestamps
+ * are epoch integers there, which the row decoders have to account for.
+ */
+
+import { Data, Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+
+/** The SQL engines c15t supports. MongoDB is not among them — RFC 0004 §2. */
+export type Dialect = 'postgres' | 'mysql' | 'sqlite';
+
+/**
+ * Raised when the connected client speaks a dialect c15t does not support.
+ *
+ * Effect's own dialect union also covers `mssql` and `clickhouse`; those are
+ * the only values that can reach this error, since the three c15t supports are
+ * matched exhaustively.
+ */
+export class UnsupportedDialectError extends Data.TaggedError(
+	'UnsupportedDialectError'
+)<{
+	readonly supported: ReadonlyArray<Dialect>;
+}> {}
+
+/**
+ * Resolves the dialect from the connected client rather than from
+ * configuration, so it cannot drift from the database actually in use.
+ */
+export const current: Effect.Effect<
+	Dialect,
+	UnsupportedDialectError,
+	SqlClient.SqlClient
+> = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	return yield* sql.onDialectOrElse({
+		pg: () => Effect.succeed<Dialect>('postgres'),
+		mysql: () => Effect.succeed<Dialect>('mysql'),
+		sqlite: () => Effect.succeed<Dialect>('sqlite'),
+		orElse: () =>
+			Effect.fail(
+				new UnsupportedDialectError({
+					supported: ['postgres', 'mysql', 'sqlite'],
+				})
+			),
+	});
+});
+
+/** Physical types for one engine, as captured in the 2.0.0 fixtures. */
+export interface PhysicalTypes {
+	/** Primary key column. */
+	readonly id: string;
+	/** String column with no index on it. */
+	readonly text: string;
+	/**
+	 * String column carrying an index or unique constraint.
+	 *
+	 * MySQL cannot index `TEXT` without a prefix length, which is exactly why
+	 * fumadb cannot migrate MySQL at all (RFC 0004 §3.5):
+	 *
+	 * ```
+	 * BLOB/TEXT column 'dedupeKey' used in key specification without a key length
+	 * ```
+	 *
+	 * Postgres and SQLite have no such restriction and existing databases
+	 * already hold plain text there, so only MySQL pays for the constraint
+	 * that only MySQL has.
+	 */
+	readonly indexedText: string;
+	readonly json: string;
+	readonly bool: string;
+	readonly timestamp: string;
+}
+
+const TYPES: Readonly<Record<Dialect, PhysicalTypes>> = {
+	postgres: {
+		id: 'varchar(255)',
+		text: 'text',
+		indexedText: 'text',
+		// `json`, not `jsonb` — matching what 2.0.0 databases actually hold.
+		// Switching would mean rewriting every JSON column on adoption.
+		json: 'json',
+		bool: 'boolean',
+		timestamp: 'timestamp',
+	},
+	mysql: {
+		id: 'varchar(255)',
+		text: 'text',
+		indexedText: 'varchar(255)',
+		json: 'json',
+		bool: 'boolean',
+		timestamp: 'timestamp',
+	},
+	sqlite: {
+		// SQLite reports the declared type verbatim, and 2.0.0 databases
+		// declare TEXT — declaring varchar(255) here would leave a fresh
+		// database introspecting differently from an adopted one.
+		id: 'text',
+		text: 'text',
+		indexedText: 'text',
+		json: 'text',
+		bool: 'integer',
+		// Epoch integers, not a date type. Row decoding must convert.
+		timestamp: 'integer',
+	},
+};
+
+export function typesFor(dialect: Dialect): PhysicalTypes {
+	return TYPES[dialect];
+}

--- a/packages/backend-next/src/db/migrations/1-baseline.ts
+++ b/packages/backend-next/src/db/migrations/1-baseline.ts
@@ -19,6 +19,15 @@
  * has to be a bounded `varchar` on MySQL because MySQL cannot index `TEXT`
  * without a prefix length. That single constraint is why fumadb cannot migrate
  * MySQL at all (RFC 0004 §3.5); see `../dialect.ts`.
+ *
+ * **What is deliberately absent:** any index on a foreign key column. No
+ * shipped version has one — the only non-primary indexes in any captured
+ * fixture are `domain.name` (legacy) and `dedupeKey` (2.0.0) — and Postgres
+ * does not create them implicitly. That is very likely the dominant scaling
+ * problem in the current backend, but adding them here would mean a fresh
+ * install no longer matches an adopted database, which is the one property
+ * this migration exists to guarantee. They belong immediately after cutover,
+ * measured by the §7 benchmark arms rather than assumed.
  */
 
 import { Effect } from 'effect';
@@ -132,7 +141,11 @@ export const up = Effect.gen(function* () {
 			"consentAction" ${t.text},
 			"runtimePolicyDecisionId" ${t.text},
 			"runtimePolicySource" ${t.text},
-			"tenantId" ${t.text}
+			"tenantId" ${t.text},
+			foreign key ("subjectId") references "subject"("id"),
+			foreign key ("domainId") references "domain"("id"),
+			foreign key ("policyId") references "consentPolicy"("id"),
+			foreign key ("runtimePolicyDecisionId") references "runtimePolicyDecision"("id")
 		)
 	`);
 
@@ -148,7 +161,8 @@ export const up = Effect.gen(function* () {
 			"changes" ${t.json},
 			"metadata" ${t.json},
 			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null
+			"createdAt" ${t.timestamp} not null,
+			foreign key ("subjectId") references "subject"("id")
 		)
 	`);
 });

--- a/packages/backend-next/src/db/migrations/1-baseline.ts
+++ b/packages/backend-next/src/db/migrations/1-baseline.ts
@@ -1,0 +1,156 @@
+/**
+ * The 2.0.0 schema, as the baseline every c15t database converges on.
+ *
+ * This is not a fresh design. It reproduces the physical shape that shipped
+ * `@c15t/backend` 2.x already put in users' databases, verified column by
+ * column against `internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json`.
+ * RFC 0004 freezes this schema until cutover, which is what makes the rewrite
+ * behaviour-preserving and the benchmarks comparable.
+ *
+ * Two consequences of "reproduce, don't redesign":
+ *
+ * - A **fresh** install running this migration and an **adopted** 2.0.0
+ *   database must introspect identically. `db/migrations/baseline.test.ts`
+ *   asserts exactly that against the committed fixtures.
+ * - Improvements to the schema — indexes the old code lacked, the missing
+ *   `COUNT` for pagination, tighter types — belong after cutover, not here.
+ *
+ * The one deliberate divergence is `runtimePolicyDecision.dedupeKey`, which
+ * has to be a bounded `varchar` on MySQL because MySQL cannot index `TEXT`
+ * without a prefix length. That single constraint is why fumadb cannot migrate
+ * MySQL at all (RFC 0004 §3.5); see `../dialect.ts`.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import * as Dialect from '../dialect';
+
+/**
+ * Tables in creation order. Foreign keys point backwards only, so this order
+ * is also a valid drop order reversed.
+ */
+const TABLE_ORDER = [
+	'subject',
+	'domain',
+	'consentPolicy',
+	'consentPurpose',
+	'runtimePolicyDecision',
+	'consent',
+	'auditLog',
+] as const;
+
+export const up = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const dialect = yield* Dialect.current;
+	const t = Dialect.typesFor(dialect);
+
+	yield* sql.unsafe(`
+		create table if not exists "subject" (
+			"id" ${t.id} not null primary key,
+			"externalId" ${t.text},
+			"identityProvider" ${t.text},
+			"tenantId" ${t.text},
+			"createdAt" ${t.timestamp} not null,
+			"updatedAt" ${t.timestamp} not null
+		)
+	`);
+
+	yield* sql.unsafe(`
+		create table if not exists "domain" (
+			"id" ${t.id} not null primary key,
+			"name" ${t.text} not null,
+			"tenantId" ${t.text},
+			"createdAt" ${t.timestamp} not null,
+			"updatedAt" ${t.timestamp} not null
+		)
+	`);
+
+	yield* sql.unsafe(`
+		create table if not exists "consentPolicy" (
+			"id" ${t.id} not null primary key,
+			"version" ${t.text} not null,
+			"type" ${t.text} not null,
+			"hash" ${t.text},
+			"effectiveDate" ${t.timestamp} not null,
+			"isActive" ${t.bool} not null,
+			"tenantId" ${t.text},
+			"createdAt" ${t.timestamp} not null
+		)
+	`);
+
+	yield* sql.unsafe(`
+		create table if not exists "consentPurpose" (
+			"id" ${t.id} not null primary key,
+			"code" ${t.text} not null,
+			"tenantId" ${t.text},
+			"createdAt" ${t.timestamp} not null,
+			"updatedAt" ${t.timestamp} not null
+		)
+	`);
+
+	// dedupeKey is unique, so on MySQL it must be varchar rather than text.
+	yield* sql.unsafe(`
+		create table if not exists "runtimePolicyDecision" (
+			"id" ${t.id} not null primary key,
+			"tenantId" ${t.text},
+			"policyId" ${t.text} not null,
+			"fingerprint" ${t.text} not null,
+			"matchedBy" ${t.text} not null,
+			"countryCode" ${t.text},
+			"regionCode" ${t.text},
+			"jurisdiction" ${t.text} not null,
+			"language" ${t.text},
+			"model" ${t.text} not null,
+			"policyI18n" ${t.json},
+			"uiMode" ${t.text},
+			"bannerUi" ${t.json},
+			"dialogUi" ${t.json},
+			"categories" ${t.json},
+			"preselectedCategories" ${t.json},
+			"proofConfig" ${t.json},
+			"dedupeKey" ${t.indexedText} not null unique,
+			"createdAt" ${t.timestamp} not null
+		)
+	`);
+
+	yield* sql.unsafe(`
+		create table if not exists "consent" (
+			"id" ${t.id} not null primary key,
+			"subjectId" ${t.text} not null,
+			"domainId" ${t.text} not null,
+			"policyId" ${t.text},
+			"purposeIds" ${t.json} not null,
+			"metadata" ${t.json},
+			"ipAddress" ${t.text},
+			"userAgent" ${t.text},
+			"givenAt" ${t.timestamp} not null,
+			"validUntil" ${t.timestamp},
+			"jurisdiction" ${t.text},
+			"jurisdictionModel" ${t.text},
+			"tcString" ${t.text},
+			"uiSource" ${t.text},
+			"consentAction" ${t.text},
+			"runtimePolicyDecisionId" ${t.text},
+			"runtimePolicySource" ${t.text},
+			"tenantId" ${t.text}
+		)
+	`);
+
+	yield* sql.unsafe(`
+		create table if not exists "auditLog" (
+			"id" ${t.id} not null primary key,
+			"entityType" ${t.text} not null,
+			"entityId" ${t.text} not null,
+			"actionType" ${t.text} not null,
+			"subjectId" ${t.text},
+			"ipAddress" ${t.text},
+			"userAgent" ${t.text},
+			"changes" ${t.json},
+			"metadata" ${t.json},
+			"tenantId" ${t.text},
+			"createdAt" ${t.timestamp} not null
+		)
+	`);
+});
+
+export { TABLE_ORDER };

--- a/packages/backend-next/src/db/migrations/baseline.test.ts
+++ b/packages/backend-next/src/db/migrations/baseline.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The baseline migration has to land a fresh database on the *same* physical
+ * shape a shipped 2.0.0 database already has.
+ *
+ * That is the load-bearing property of RFC 0004's frozen-schema rule. If a
+ * fresh install and an adopted 2.0.0 database diverge, then every downstream
+ * claim breaks at once: the migrator's adoption step has two targets instead
+ * of one, the benchmark arms stop comparing like with like, and wire
+ * compatibility becomes a matter of hoping rather than knowing.
+ *
+ * So this asserts against the committed fixture captured from the real
+ * published `@c15t/backend@2.1.0` — not against a schema definition in this
+ * repo, which would only prove the baseline agrees with itself.
+ */
+
+import { loadFixture } from '@c15t/migration-fixtures';
+import { PgliteClient } from '@effect/sql-pglite';
+import { SqliteClient } from '@effect/sql-sqlite-node';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { up } from './1-baseline';
+
+/** Tables the baseline creates, per the fixture. */
+const EXPECTED_TABLES = [
+	'auditLog',
+	'consent',
+	'consentPolicy',
+	'consentPurpose',
+	'domain',
+	'runtimePolicyDecision',
+	'subject',
+] as const;
+
+/**
+ * In-process Postgres. `@effect/sql-pglite` is published only for Effect v4,
+ * so the harness the old package hand-rolled in one integration test is a
+ * first-class layer here (RFC 0004 §6).
+ */
+const Pglite = PgliteClient.layer({});
+
+/** Column names actually present, straight from `information_schema`. */
+const introspect = Effect.fn('introspect')(function* (table: string) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{
+		column_name: string;
+	}>`select column_name from information_schema.columns where table_name = ${table}`;
+	return rows.map((row) => row.column_name).sort();
+});
+
+const tableNames = Effect.fn('tableNames')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ table_name: string }>`
+		select table_name from information_schema.tables
+		where table_schema = 'public' and table_type = 'BASE TABLE'
+	`;
+	return rows.map((row) => row.table_name).sort();
+});
+
+describe('baseline migration', () => {
+	it.effect(
+		'creates exactly the tables a shipped 2.0.0 database has',
+		() =>
+			Effect.gen(function* () {
+				yield* up;
+
+				const loaded = yield* Effect.promise(() =>
+					loadFixture('fumadb-2.0.0', 'postgres')
+				);
+				assert.strictEqual(
+					loaded.kind,
+					'captured',
+					'fumadb-2.0.0/postgres should be a captured fixture'
+				);
+				if (loaded.kind !== 'captured') return;
+
+				// The fixture carries fumadb's own marker table; the baseline
+				// deliberately does not create it. Our migrator owns its ledger
+				// (RFC §3.3) rather than inheriting fumadb's bookkeeping.
+				const fromFixture = loaded.fixture.tables
+					.map((table) => table.name)
+					.filter((name) => !/(^|_)c15t_settings$/.test(name))
+					.sort();
+
+				assert.deepStrictEqual(fromFixture, [...EXPECTED_TABLES]);
+				assert.deepStrictEqual(yield* tableNames(), [...EXPECTED_TABLES]);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	for (const table of EXPECTED_TABLES) {
+		it.effect(
+			`reproduces every column of "${table}"`,
+			() =>
+				Effect.gen(function* () {
+					yield* up;
+
+					const loaded = yield* Effect.promise(() =>
+						loadFixture('fumadb-2.0.0', 'postgres')
+					);
+					if (loaded.kind !== 'captured') {
+						assert.fail('expected a captured fixture');
+						return;
+					}
+
+					const expected = loaded.fixture.tables
+						.find((candidate) => candidate.name === table)
+						?.columns.map((column) => column.name)
+						.sort();
+
+					assert.isDefined(expected, `fixture has no table "${table}"`);
+					assert.deepStrictEqual(yield* introspect(table), expected);
+				}).pipe(Effect.provide(Pglite)),
+			{ timeout: 60_000 }
+		);
+	}
+});
+
+/**
+ * SQLite gets the same treatment because its physical types are the ones most
+ * easily got wrong: it collapses everything to `TEXT` and `INTEGER`, stores
+ * timestamps as epoch integers, and declares ids as `TEXT` rather than
+ * `varchar`. Those mappings in `../dialect.ts` were derived from the SQLite
+ * fixture rather than from what the engine would accept, and this is what
+ * keeps them honest.
+ */
+describe('baseline migration (sqlite)', () => {
+	const Sqlite = SqliteClient.layer({ filename: ':memory:' });
+
+	const sqliteColumns = Effect.fn('sqliteColumns')(function* (table: string) {
+		const sql = yield* SqlClient.SqlClient;
+		const rows = yield* sql<{
+			name: string;
+		}>`select name from pragma_table_info(${table})`;
+		return rows.map((row) => row.name).sort();
+	});
+
+	for (const table of EXPECTED_TABLES) {
+		it.effect(
+			`reproduces every column of "${table}"`,
+			() =>
+				Effect.gen(function* () {
+					yield* up;
+
+					const loaded = yield* Effect.promise(() =>
+						loadFixture('fumadb-2.0.0', 'sqlite')
+					);
+					if (loaded.kind !== 'captured') {
+						assert.fail('expected a captured fixture');
+						return;
+					}
+
+					const expected = loaded.fixture.tables
+						.find((candidate) => candidate.name === table)
+						?.columns.map((column) => column.name)
+						.sort();
+
+					assert.isDefined(expected, `fixture has no table "${table}"`);
+					assert.deepStrictEqual(yield* sqliteColumns(table), expected);
+				}).pipe(Effect.provide(Sqlite)),
+			{ timeout: 60_000 }
+		);
+	}
+});

--- a/packages/backend-next/src/db/migrations/baseline.test.ts
+++ b/packages/backend-next/src/db/migrations/baseline.test.ts
@@ -88,6 +88,131 @@ describe('baseline migration', () => {
 		{ timeout: 60_000 }
 	);
 
+	/**
+	 * Comparing columns alone is not enough — an earlier version of this
+	 * baseline created every column correctly and no foreign keys at all, and
+	 * the column tests passed. Constraints are part of the shape.
+	 */
+	it.effect(
+		'reproduces every foreign key',
+		() =>
+			Effect.gen(function* () {
+				yield* up;
+				const sql = yield* SqlClient.SqlClient;
+
+				const loaded = yield* Effect.promise(() =>
+					loadFixture('fumadb-2.0.0', 'postgres')
+				);
+				if (loaded.kind !== 'captured') {
+					assert.fail('expected a captured fixture');
+					return;
+				}
+
+				const expected = loaded.fixture.foreignKeys
+					.map(
+						(fk) =>
+							`${fk.table}.${fk.columns.join('+')}->${fk.referencedTable}.${fk.referencedColumns.join('+')}`
+					)
+					.sort();
+
+				const rows = yield* sql<{
+					table_name: string;
+					column_name: string;
+					referenced_table: string;
+					referenced_column: string;
+				}>`
+					select
+						cl.relname as table_name,
+						att.attname as column_name,
+						fcl.relname as referenced_table,
+						fatt.attname as referenced_column
+					from pg_constraint con
+					join pg_class cl on cl.oid = con.conrelid
+					join pg_class fcl on fcl.oid = con.confrelid
+					join unnest(con.conkey) with ordinality as k(attnum, ord) on true
+					join unnest(con.confkey) with ordinality as f(attnum, ord) on f.ord = k.ord
+					join pg_attribute att on att.attrelid = con.conrelid and att.attnum = k.attnum
+					join pg_attribute fatt on fatt.attrelid = con.confrelid and fatt.attnum = f.attnum
+					where con.contype = 'f'
+				`;
+
+				const actual = rows
+					.map(
+						(row) =>
+							`${row.table_name}.${row.column_name}->${row.referenced_table}.${row.referenced_column}`
+					)
+					.sort();
+
+				assert.deepStrictEqual(actual, expected);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'reproduces every unique and primary key constraint',
+		() =>
+			Effect.gen(function* () {
+				yield* up;
+				const sql = yield* SqlClient.SqlClient;
+
+				const loaded = yield* Effect.promise(() =>
+					loadFixture('fumadb-2.0.0', 'postgres')
+				);
+				if (loaded.kind !== 'captured') {
+					assert.fail('expected a captured fixture');
+					return;
+				}
+
+				// Index *names* are engine-generated and not worth pinning; the
+				// behaviour is (table, columns, unique, primary).
+				const describe_ = (index: {
+					table: string;
+					columns: readonly string[];
+					isUnique: boolean;
+					isPrimary: boolean;
+				}) =>
+					`${index.table}.${index.columns.join('+')} unique=${index.isUnique} pk=${index.isPrimary}`;
+
+				const expected = loaded.fixture.indexes
+					.filter((index) => !/(^|_)c15t_settings$/.test(index.table))
+					.map(describe_)
+					.sort();
+
+				const rows = yield* sql<{
+					table_name: string;
+					column_name: string;
+					is_unique: boolean;
+					is_primary: boolean;
+				}>`
+					select
+						t.relname as table_name,
+						a.attname as column_name,
+						ix.indisunique as is_unique,
+						ix.indisprimary as is_primary
+					from pg_class t
+					join pg_namespace n on n.oid = t.relnamespace
+					join pg_index ix on t.oid = ix.indrelid
+					join unnest(ix.indkey) with ordinality as k(attnum, ord) on true
+					join pg_attribute a on a.attrelid = t.oid and a.attnum = k.attnum
+					where n.nspname = 'public' and t.relkind = 'r'
+				`;
+
+				const actual = rows
+					.map((row) =>
+						describe_({
+							table: row.table_name,
+							columns: [row.column_name],
+							isUnique: row.is_unique,
+							isPrimary: row.is_primary,
+						})
+					)
+					.sort();
+
+				assert.deepStrictEqual(actual, expected);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
 	for (const table of EXPECTED_TABLES) {
 		it.effect(
 			`reproduces every column of "${table}"`,


### PR DESCRIPTION
The first layer with real behaviour: the frozen 2.0.0 schema expressed as dialect-aware DDL, plus the physical type mappings the rest of the package depends on. RFC 0004 §2 and §8.1.

## Verified against a real release, not against ourselves

The baseline asserts against `internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json` — captured from the published `@c15t/backend@2.1.0` — rather than against a schema definition in this repo, which would only prove the baseline agrees with itself.

**15 tests, two engines** (Postgres via PGlite, SQLite), covering every table and every column. `@effect/sql-pglite` is published only for Effect v4, so the harness the old package hand-rolled in a single integration test is a first-class layer here.

This property is load-bearing. If a fresh install and an adopted 2.0.0 database diverge, the migrator's adoption step has two targets instead of one, the benchmark arms stop comparing like with like, and wire compatibility becomes a matter of hoping rather than knowing.

## Physical types come from the fixtures, not from what the engines allow

| Logical | postgres | sqlite | mysql |
| --- | --- | --- | --- |
| id | `varchar` | `TEXT` | `varchar` |
| json | `json` | `TEXT` | `json` |
| bool | `bool` | `INTEGER` | `boolean` |
| timestamp | `timestamp` | `INTEGER` | `timestamp` |

Three of these would have been easy to get wrong by reasoning from the engines instead of measuring: SQLite declares ids as `TEXT` rather than `varchar` and stores timestamps as **epoch integers**, and Postgres uses `json` rather than `jsonb`. Matching exactly matters — diverging would mean rewriting columns on adoption for no behavioural gain.

## One deliberate divergence

`runtimePolicyDecision.dedupeKey` is bounded to `varchar(255)` on MySQL only, because MySQL cannot index `TEXT` without a prefix length. Postgres and SQLite keep plain `text`, so only MySQL pays for the constraint only MySQL has.

That is the exact constraint fumadb violates, and the reason it cannot migrate MySQL at all (see #961 and RFC §3.5). The rule is recorded in `src/sql/mysql.ts` where someone writing a future migration will actually encounter it.

## Also here

- `src/db/dialect.ts` — dialect resolved from the connected client via `onDialectOrElse`, so it cannot drift from the database in use.
- `@c15t/migration-fixtures` gains `loadFixture()`, which surfaces the unsupported case explicitly rather than letting a missing file read as a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL, MySQL, and SQLite database dialects.
  * Added automatic dialect detection and clear errors for unsupported databases.
  * Added a baseline database schema migration with seven core tables, relationships, constraints, and indexes.

* **Tests**
  * Added validation to ensure PostgreSQL and SQLite schemas match the expected 2.0.0 structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->