### PR TITLE
feat(backend-next): adopt existing databases, and a two-query read path

### DIFF
--- a/packages/backend-next/src/db/adopt.test.ts
+++ b/packages/backend-next/src/db/adopt.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Adoption is the riskiest code in the package: it is the only part that
+ * touches a database someone else's production data lives in. These tests
+ * exist mostly to pin the properties that make it safe.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { apply, LEDGER_TABLE, plan } from './adopt';
+import { classify } from './classify';
+import { up as baseline } from './migrations/1-baseline';
+
+const Pglite = PgliteClient.layer({});
+
+/** A 1.0.0-era database: seven tables, no runtimePolicyDecision, with data. */
+const legacyish = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	yield* sql.unsafe(`create table "subject" (
+		"id" varchar(255) primary key, "externalId" text, "createdAt" timestamp
+	)`);
+	yield* sql.unsafe(`create table "domain" (
+		"id" varchar(255) primary key, "name" text
+	)`);
+	yield* sql.unsafe(
+		`create table "consentPolicy" ("id" varchar(255) primary key)`
+	);
+	yield* sql.unsafe(
+		`create table "consentPurpose" ("id" varchar(255) primary key)`
+	);
+	yield* sql.unsafe(`create table "auditLog" ("id" varchar(255) primary key)`);
+	yield* sql.unsafe(`create table "consent" (
+		"id" varchar(255) primary key,
+		"subjectId" text,
+		"domainId" text,
+		"metadata" jsonb,
+		"status" text,
+		"withdrawalReason" text
+	)`);
+	yield* sql.unsafe(`create table "consentRecord" (
+		"id" varchar(255) primary key, "consentId" text
+	)`);
+
+	yield* sql.unsafe(
+		`insert into "subject" ("id", "externalId") values ('sub_1', 'ext_1')`
+	);
+	yield* sql.unsafe(
+		`insert into "domain" ("id", "name") values ('dom_1', 'a.com')`
+	);
+	yield* sql.unsafe(
+		`insert into "consent" ("id", "subjectId", "domainId", "status", "withdrawalReason") values ('cns_1', 'sub_1', 'dom_1', 'active', 'changed mind')`
+	);
+	yield* sql.unsafe(
+		`insert into "consentRecord" ("id", "consentId") values ('rec_1', 'cns_1')`
+	);
+});
+
+const columnsOf = Effect.fn('columnsOf')(function* (table: string) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ column_name: string }>`
+		select column_name from information_schema.columns where table_name = ${table}
+	`;
+	return rows.map((row) => row.column_name).sort();
+});
+
+describe('adopt', () => {
+	it.effect(
+		'plans a full create for an empty database',
+		() =>
+			Effect.gen(function* () {
+				const adoption = yield* plan;
+				assert.strictEqual(adoption.shape._tag, 'Empty');
+				assert.isUndefined(adoption.blocked);
+				assert.strictEqual(
+					adoption.steps.filter((step) => step.kind === 'create-table').length,
+					7
+				);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'never drops data that schema 2.0.0 removed',
+		() =>
+			Effect.gen(function* () {
+				yield* legacyish;
+				const adoption = yield* plan;
+
+				assert.isUndefined(adoption.blocked);
+				assert.deepStrictEqual(
+					adoption.steps.filter(
+						(step) =>
+							step.sql.includes('drop table') ||
+							step.sql.includes('drop column')
+					),
+					[],
+					'adoption must never drop anything'
+				);
+
+				yield* apply(adoption);
+
+				// consentRecord was dropped in 2.0.0. Discarding it would discard
+				// consent history, so it stays and is reported instead.
+				const sql = yield* SqlClient.SqlClient;
+				const kept = yield* sql<{
+					count: string;
+				}>`select count(*) as count from "consentRecord"`;
+				assert.strictEqual(Number(kept[0]?.count), 1);
+
+				const consent = yield* columnsOf('consent');
+				assert.include(consent, 'withdrawalReason');
+				assert.include(consent, 'status');
+				assert.include(
+					adoption.retained.join(' '),
+					'withdrawalReason',
+					'retained columns should be reported to the operator'
+				);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'brings a 1.0.0-era database up to the baseline contract',
+		() =>
+			Effect.gen(function* () {
+				yield* legacyish;
+				yield* apply(yield* plan);
+
+				// Every column the backend reads must now exist, whatever else does.
+				const consent = yield* columnsOf('consent');
+				for (const column of [
+					'runtimePolicyDecisionId',
+					'runtimePolicySource',
+					'tcString',
+					'uiSource',
+					'consentAction',
+					'jurisdiction',
+					'tenantId',
+				]) {
+					assert.include(consent, column);
+				}
+
+				const tables = yield* (function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const rows = yield* sql<{ table_name: string }>`
+						select table_name from information_schema.tables
+						where table_schema = 'public' and table_type = 'BASE TABLE'
+					`;
+					return rows.map((row) => row.table_name);
+				})();
+				assert.include(tables, 'runtimePolicyDecision');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'reports the database as ours once adopted',
+		() =>
+			Effect.gen(function* () {
+				yield* legacyish;
+				yield* apply(yield* plan);
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Baseline');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'is safe to re-run after a partial application',
+		() =>
+			Effect.gen(function* () {
+				yield* legacyish;
+				yield* apply(yield* plan);
+				const first = yield* columnsOf('consent');
+
+				// Re-planning against the now-adopted database should be a no-op.
+				const second = yield* plan;
+				assert.strictEqual(second.shape._tag, 'Baseline');
+				yield* apply(second);
+				assert.deepStrictEqual(yield* columnsOf('consent'), first);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'refuses to add a foreign key that existing rows would violate',
+		() =>
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				yield* baseline;
+				// Drop the constraint so we can create the orphan, mimicking a
+				// MySQL database that never had foreign keys at all.
+				yield* sql.unsafe(
+					`alter table "consent" drop constraint "consent_subjectId_fkey"`
+				);
+				yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+					values ('dom_1', 'a.com', now(), now())`);
+				yield* sql.unsafe(`insert into "consent"
+					("id", "subjectId", "domainId", "purposeIds", "givenAt")
+					values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
+
+				const adoption = yield* plan;
+
+				assert.isDefined(adoption.blocked);
+				assert.include(adoption.blocked ?? '', '1 row(s)');
+				assert.include(adoption.blocked ?? '', 'skipForeignKeys');
+				assert.strictEqual(adoption.orphans.length, 1);
+				assert.strictEqual(adoption.orphans[0]?.table, 'consent');
+				assert.strictEqual(adoption.orphans[0]?.count, 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'proceeds without foreign keys when explicitly told to',
+		() =>
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				yield* baseline;
+				yield* sql.unsafe(
+					`alter table "consent" drop constraint "consent_subjectId_fkey"`
+				);
+				yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+					values ('dom_1', 'a.com', now(), now())`);
+				yield* sql.unsafe(`insert into "consent"
+					("id", "subjectId", "domainId", "purposeIds", "givenAt")
+					values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
+
+				const adoption = yield* plan;
+				yield* apply(adoption, { skipForeignKeys: true });
+
+				// The orphan row survives — the operator chose integrity later
+				// over losing data now.
+				const rows = yield* sql<{
+					count: string;
+				}>`select count(*) as count from "consent"`;
+				assert.strictEqual(Number(rows[0]?.count), 1);
+
+				const ledger = yield* sql<{ name: string }>`${sql.unsafe(
+					`select "name" from "${LEDGER_TABLE}"`
+				)}`;
+				assert.strictEqual(ledger[0]?.name, '1-baseline');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+});

--- a/packages/backend-next/src/db/adopt.test.ts
+++ b/packages/backend-next/src/db/adopt.test.ts
@@ -155,6 +155,69 @@ describe('adopt', () => {
 	);
 
 	it.effect(
+		'emits no destructive statement for any shape it can encounter',
+		() =>
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				const destructive = /\b(drop|truncate)\b|\bdelete\s+from\b/i;
+
+				// Empty database.
+				for (const step of (yield* plan).steps) {
+					assert.notMatch(step.sql, destructive, step.description);
+				}
+
+				// A 1.0.0-era database with data.
+				yield* legacyish;
+				for (const step of (yield* plan).steps) {
+					assert.notMatch(step.sql, destructive, step.description);
+				}
+
+				// A 2.0.0-shaped database missing only the newer columns.
+				yield* sql.unsafe('drop schema public cascade');
+				yield* sql.unsafe('create schema public');
+				yield* baseline;
+				yield* sql.unsafe(`alter table "consent" drop column "tenantId"`);
+				for (const step of (yield* plan).steps) {
+					assert.notMatch(step.sql, destructive, step.description);
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'refuses to apply a plan carrying a destructive statement',
+		() =>
+			Effect.gen(function* () {
+				yield* legacyish;
+				const adoption = yield* plan;
+
+				// Simulates a future edit smuggling a drop into an additive step.
+				const tampered = {
+					...adoption,
+					steps: [
+						...adoption.steps,
+						{
+							kind: 'add-column' as const,
+							description: 'sneaky',
+							sql: 'drop table "consentRecord"',
+						},
+					],
+				};
+
+				const outcome = yield* Effect.exit(apply(tampered));
+				assert.isTrue(outcome._tag === 'Failure');
+
+				// And the table it targeted is untouched.
+				const sql = yield* SqlClient.SqlClient;
+				const rows = yield* sql<{
+					count: string;
+				}>`select count(*) as count from "consentRecord"`;
+				assert.strictEqual(Number(rows[0]?.count), 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
 		'reports the database as ours once adopted',
 		() =>
 			Effect.gen(function* () {

--- a/packages/backend-next/src/db/adopt.ts
+++ b/packages/backend-next/src/db/adopt.ts
@@ -1,0 +1,348 @@
+/**
+ * Brings an existing c15t database up to the baseline, so Effect's `Migrator`
+ * can take over from a known state.
+ *
+ * This is the one-time on-ramp described in RFC 0004 §3.3. Everything after it
+ * is an ordinary numbered migration; this step exists only because a database
+ * from a shipped release has no ledger and an unknown shape.
+ *
+ * ## Adoption is purely additive
+ *
+ * It creates tables and adds columns. It **never drops a table, drops a
+ * column, or changes a column's type.**
+ *
+ * That is a deliberate constraint, not a limitation. Going from schema 1.0.0
+ * to 2.0.0 removed columns that hold real user data — `consent.status`,
+ * `consent.withdrawalReason`, `consentPolicy.content`,
+ * `consentPurpose.legalBasis` — and dropped the `consentRecord` table
+ * outright. On a consent management platform those are audit records and
+ * withdrawal history. Silently discarding them during a package upgrade is not
+ * a trade-off worth making, and there is no way to ask the operator mid-
+ * migration.
+ *
+ * So an adopted database ends up as **baseline plus whatever it already had**.
+ * The backend only ever reads columns in the spec, so the extras are inert.
+ * The plan reports them under `retained` and the operator can drop them
+ * deliberately, later, once they are satisfied nothing needs them.
+ *
+ * The practical consequence, which is worth stating plainly: a fresh install
+ * and an adopted database are identical *in the columns the contract covers*,
+ * not byte-identical. The parity that matters is the former.
+ *
+ * ## Foreign keys are validated before they are added
+ *
+ * The legacy migrator emitted foreign keys on Postgres and SQLite but **none
+ * on MySQL**, so referential integrity in shipped c15t depends on which engine
+ * the operator chose. Adding them to a MySQL database is therefore a migration
+ * that can fail on pre-existing rows.
+ *
+ * Rather than discover that half-way through, every foreign key we would add
+ * is counted first. Orphans mean the plan is blocked and reports exactly what
+ * is wrong, before any DDL runs.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { classify, type Shape } from './classify';
+import * as Dialect from './dialect';
+import {
+	addColumnSql,
+	createTableSql,
+	type ForeignKeySpec,
+	TABLES,
+	type TableSpec,
+} from './schema';
+
+/** Name of the ledger this package owns, distinct from fumadb's marker. */
+export const LEDGER_TABLE = 'c15t_migrations';
+
+export interface AdoptionStep {
+	readonly kind: 'create-table' | 'add-column' | 'add-foreign-key' | 'stamp';
+	readonly description: string;
+	readonly sql: string;
+}
+
+/** Rows that would violate a foreign key we are about to add. */
+export interface OrphanReport {
+	readonly table: string;
+	readonly column: string;
+	readonly referencesTable: string;
+	readonly count: number;
+}
+
+export interface Plan {
+	readonly shape: Shape;
+	readonly steps: readonly AdoptionStep[];
+	/** Tables and columns present in the database but not in the spec. */
+	readonly retained: readonly string[];
+	readonly orphans: readonly OrphanReport[];
+	/** Set when the plan must not be applied. */
+	readonly blocked: string | undefined;
+}
+
+interface Existing {
+	readonly tables: ReadonlySet<string>;
+	readonly columns: ReadonlyMap<string, ReadonlySet<string>>;
+	readonly foreignKeys: ReadonlySet<string>;
+}
+
+const fkKey = (table: string, column: string) => `${table}.${column}`;
+
+const observeExisting = Effect.fn('adopt.observe')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+
+	const columnRows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select m.name as table_name, c.name as column_name
+				from sqlite_master m
+				join pragma_table_info(m.name) c
+				where m.type = 'table'
+			`,
+		mysql: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select table_name, column_name from information_schema.columns
+				where table_schema = database()
+			`,
+		orElse: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select table_name, column_name from information_schema.columns
+				where table_schema = 'public'
+			`,
+	});
+
+	const columns = new Map<string, Set<string>>();
+	for (const row of columnRows) {
+		const set = columns.get(row.table_name) ?? new Set<string>();
+		set.add(row.column_name);
+		columns.set(row.table_name, set);
+	}
+
+	// SQLite cannot add a foreign key to an existing table at all, so knowing
+	// which already exist matters for more than tidiness there.
+	const fkRows = yield* sql
+		.onDialectOrElse({
+			sqlite: () =>
+				sql<{ table_name: string; column_name: string }>`
+					select m.name as table_name, f."from" as column_name
+					from sqlite_master m join pragma_foreign_key_list(m.name) f
+					where m.type = 'table'
+				`,
+			mysql: () =>
+				sql<{ table_name: string; column_name: string }>`
+					select table_name, column_name from information_schema.key_column_usage
+					where table_schema = database() and referenced_table_name is not null
+				`,
+			orElse: () =>
+				sql<{ table_name: string; column_name: string }>`
+					select cl.relname as table_name, att.attname as column_name
+					from pg_constraint con
+					join pg_class cl on cl.oid = con.conrelid
+					join unnest(con.conkey) as k(attnum) on true
+					join pg_attribute att on att.attrelid = con.conrelid and att.attnum = k.attnum
+					where con.contype = 'f'
+				`,
+		})
+		.pipe(Effect.orElseSucceed(() => []));
+
+	return {
+		tables: new Set(columns.keys()),
+		columns,
+		foreignKeys: new Set(
+			fkRows.map((row) => fkKey(row.table_name, row.column_name))
+		),
+	} satisfies Existing;
+});
+
+/** Counts rows that would violate a foreign key before it is added. */
+const countOrphans = Effect.fn('adopt.countOrphans')(function* (
+	table: TableSpec,
+	fk: ForeignKeySpec
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ orphans: number | string }>`${sql.unsafe(`
+		select count(*) as orphans
+		from "${table.name}" child
+		left join "${fk.referencesTable}" parent
+			on parent."${fk.referencesColumn}" = child."${fk.column}"
+		where child."${fk.column}" is not null
+			and parent."${fk.referencesColumn}" is null
+	`)}`;
+	return Number(rows[0]?.orphans ?? 0);
+});
+
+/**
+ * Works out what adoption would do, without doing any of it.
+ *
+ * Safe against production, and intended to be exactly what `--dry-run` prints.
+ */
+export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
+	Effect.gen(function* () {
+		const shape = yield* classify;
+		const dialect = yield* Dialect.current.pipe(
+			Effect.orElseSucceed(() => 'postgres' as const)
+		);
+		const types = Dialect.typesFor(dialect);
+		const existing = yield* observeExisting();
+
+		if (shape._tag === 'Unknown') {
+			return {
+				shape,
+				steps: [],
+				retained: [],
+				orphans: [],
+				blocked: `Refusing to migrate an unrecognised database. ${shape.why}`,
+			};
+		}
+
+		if (shape._tag === 'Baseline') {
+			return {
+				shape,
+				steps: [],
+				retained: [],
+				orphans: [],
+				blocked: undefined,
+			};
+		}
+
+		const steps: AdoptionStep[] = [];
+		const orphans: OrphanReport[] = [];
+
+		for (const table of TABLES) {
+			if (!existing.tables.has(table.name)) {
+				steps.push({
+					kind: 'create-table',
+					description: `Create "${table.name}"`,
+					sql: createTableSql(table, types),
+				});
+				continue;
+			}
+
+			const present = existing.columns.get(table.name) ?? new Set<string>();
+			for (const column of table.columns) {
+				if (present.has(column.name)) continue;
+				steps.push({
+					kind: 'add-column',
+					description: `Add "${table.name}"."${column.name}"`,
+					sql: addColumnSql(table.name, column, types),
+				});
+			}
+
+			// Only an already-existing table needs an ALTER for its foreign keys;
+			// a freshly created one carries them inline.
+			for (const fk of table.foreignKeys) {
+				if (existing.foreignKeys.has(fkKey(table.name, fk.column))) continue;
+				// The referenced table must exist before it can be pointed at. If
+				// we are creating it in this same plan, there is nothing to orphan.
+				if (!existing.tables.has(fk.referencesTable)) continue;
+				if (!present.has(fk.column)) continue;
+
+				const count = yield* countOrphans(table, fk).pipe(
+					Effect.orElseSucceed(() => 0)
+				);
+				if (count > 0) {
+					orphans.push({
+						table: table.name,
+						column: fk.column,
+						referencesTable: fk.referencesTable,
+						count,
+					});
+					continue;
+				}
+
+				steps.push({
+					kind: 'add-foreign-key',
+					description: `Add foreign key "${table.name}"."${fk.column}" -> "${fk.referencesTable}"`,
+					sql: `alter table "${table.name}" add foreign key ("${fk.column}") references "${fk.referencesTable}"("${fk.referencesColumn}")`,
+				});
+			}
+		}
+
+		steps.push({
+			kind: 'stamp',
+			description: 'Record the baseline in the migration ledger',
+			sql: `create table if not exists "${LEDGER_TABLE}" ("id" integer primary key, "name" ${types.text} not null, "appliedAt" ${types.timestamp} not null)`,
+		});
+
+		const specTables = new Set(TABLES.map((table) => table.name));
+		const specColumns = new Map(
+			TABLES.map((table) => [
+				table.name,
+				new Set(table.columns.map((column) => column.name)),
+			])
+		);
+		const retained: string[] = [];
+		for (const [table, columns] of existing.columns) {
+			if (!specTables.has(table)) {
+				if (table === 'consentRecord') {
+					retained.push(
+						`table "consentRecord" (dropped in schema 2.0.0; left in place rather than discarding consent history)`
+					);
+				}
+				continue;
+			}
+			const known = specColumns.get(table);
+			for (const column of columns) {
+				if (!known?.has(column)) {
+					retained.push(`"${table}"."${column}"`);
+				}
+			}
+		}
+
+		return {
+			shape,
+			steps,
+			retained: retained.sort(),
+			orphans,
+			blocked:
+				orphans.length > 0
+					? `Refusing to add foreign keys: ${orphans
+							.map(
+								(orphan) =>
+									`${orphan.count} row(s) in "${orphan.table}" reference a missing "${orphan.referencesTable}" via "${orphan.column}"`
+							)
+							.join('; ')}. Clean the data, or re-run with skipForeignKeys.`
+					: undefined,
+		};
+	});
+
+export interface ApplyOptions {
+	/**
+	 * Proceed without adding foreign keys when orphan rows block them.
+	 *
+	 * The deliberate escape hatch for a database — in practice a MySQL one,
+	 * which never had foreign keys — whose existing rows cannot satisfy them.
+	 */
+	readonly skipForeignKeys?: boolean;
+}
+
+/** Applies a plan. Refuses a blocked one unless the blocker is opted out of. */
+export const apply = Effect.fn('adopt.apply')(function* (
+	adoption: Plan,
+	options: ApplyOptions = {}
+) {
+	const sql = yield* SqlClient.SqlClient;
+
+	const skippable =
+		adoption.orphans.length > 0 && options.skipForeignKeys === true;
+	if (adoption.blocked !== undefined && !skippable) {
+		return yield* Effect.die(new Error(adoption.blocked));
+	}
+
+	const steps = options.skipForeignKeys
+		? adoption.steps.filter((step) => step.kind !== 'add-foreign-key')
+		: adoption.steps;
+
+	for (const step of steps) {
+		yield* sql.unsafe(step.sql);
+	}
+
+	yield* sql`insert into ${sql.unsafe(`"${LEDGER_TABLE}"`)} ("id", "name", "appliedAt") values (1, '1-baseline', ${new Date()})`.pipe(
+		// Re-running adoption should not fail on the ledger row it already
+		// wrote. Idempotency matters here: RFC §3.3 requires the step be safe
+		// to re-run after a mid-flight failure.
+		Effect.orElseSucceed(() => [])
+	);
+
+	return steps.length;
+});

--- a/packages/backend-next/src/db/adopt.ts
+++ b/packages/backend-next/src/db/adopt.ts
@@ -316,12 +316,38 @@ export interface ApplyOptions {
 	readonly skipForeignKeys?: boolean;
 }
 
+/**
+ * Statement-level verbs that would destroy data.
+ *
+ * `AdoptionStep['kind']` already has no destructive member, but `sql` is a
+ * free-form string — nothing in the type system stops a future edit putting a
+ * `drop` into a step tagged `add-column`. This is the backstop that makes
+ * "adoption never deletes anything" an enforced invariant rather than a
+ * convention, on the one code path that runs against other people's data.
+ *
+ * Word boundaries matter: a column legitimately named `dropdown` must not trip
+ * it, and does not.
+ */
+const DESTRUCTIVE = /\b(drop|truncate)\b|\bdelete\s+from\b/i;
+
 /** Applies a plan. Refuses a blocked one unless the blocker is opted out of. */
 export const apply = Effect.fn('adopt.apply')(function* (
 	adoption: Plan,
 	options: ApplyOptions = {}
 ) {
 	const sql = yield* SqlClient.SqlClient;
+
+	const destructive = adoption.steps.filter((step) =>
+		DESTRUCTIVE.test(step.sql)
+	);
+	if (destructive.length > 0) {
+		return yield* Effect.die(
+			new Error(
+				'Adoption is add-only and must never delete. Refusing to run: ' +
+					destructive.map((step) => step.description).join('; ')
+			)
+		);
+	}
 
 	const skippable =
 		adoption.orphans.length > 0 && options.skipForeignKeys === true;

--- a/packages/backend-next/src/db/classify.test.ts
+++ b/packages/backend-next/src/db/classify.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Classification decides whether an upgrade is correct or destructive, so the
+ * cases that matter most are the ambiguous ones — particularly a
+ * fumadb-shaped database with no version marker, which an earlier draft of
+ * RFC 0004 would have misfiled as legacy and converged destructively.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { classify } from './classify';
+import { up as baseline } from './migrations/1-baseline';
+
+const Pglite = PgliteClient.layer({});
+
+/**
+ * The seven tables legacy and fumadb 1.0.0 share, differing only in whether
+ * `consent.metadata` is `jsonb` (legacy) or `json` (fumadb). Everything not
+ * load-bearing for classification is omitted.
+ */
+const sevenTables = (metadataType: 'json' | 'jsonb') =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient;
+		for (const table of [
+			'subject',
+			'domain',
+			'consentPolicy',
+			'consentPurpose',
+			'auditLog',
+		]) {
+			yield* sql.unsafe(
+				`create table "${table}" ("id" varchar(255) primary key)`
+			);
+		}
+		yield* sql.unsafe(
+			`create table "consent" ("id" varchar(255) primary key, "metadata" ${metadataType})`
+		);
+		yield* sql.unsafe(
+			`create table "consentRecord" ("id" varchar(255) primary key)`
+		);
+	});
+
+const withMarker = (version: string) =>
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient;
+		yield* sql.unsafe(
+			`create table "private_c15t_settings" ("key" text primary key, "value" text)`
+		);
+		yield* sql.unsafe(
+			`insert into "private_c15t_settings" ("key", "value") values ('version', '${version}')`
+		);
+	});
+
+describe('classify', () => {
+	it.effect(
+		'reports Empty for a database with no c15t tables',
+		() =>
+			Effect.gen(function* () {
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Empty');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'recognises our own baseline output as the 2.0.0 shape',
+		() =>
+			Effect.gen(function* () {
+				// Expected, and worth stating: the baseline reproduces 2.0.0
+				// exactly, so before the ledger is stamped it is indistinguishable
+				// from an adopted 2.0.0 database. That is the whole point.
+				yield* baseline;
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Fumadb200');
+				if (shape._tag === 'Fumadb200') {
+					assert.isFalse(shape.hasMarker);
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'reports Baseline once the ledger exists',
+		() =>
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				yield* baseline;
+				yield* sql.unsafe(
+					`create table "c15t_migrations" ("id" integer primary key, "name" text)`
+				);
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Baseline');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'distinguishes legacy from fumadb 1.0.0 by column type when neither has a marker',
+		() =>
+			Effect.gen(function* () {
+				yield* sevenTables('jsonb');
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Legacy');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'does not mistake an unmarked fumadb 1.0.0 database for legacy',
+		() =>
+			Effect.gen(function* () {
+				// The ORM codegen path: c15t printed schema for the user to apply
+				// with Drizzle/Prisma/TypeORM, so fumadb's migrator never ran and
+				// never wrote a marker — but the schema is fumadb-shaped. Treating
+				// this as legacy would converge it destructively.
+				yield* sevenTables('json');
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Fumadb100');
+				if (shape._tag === 'Fumadb100') {
+					assert.isFalse(shape.hasMarker);
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'trusts the marker over shape inference when one is present',
+		() =>
+			Effect.gen(function* () {
+				yield* sevenTables('jsonb');
+				yield* withMarker('1.0.0');
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Fumadb100');
+				if (shape._tag === 'Fumadb100') {
+					assert.isTrue(shape.hasMarker);
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'refuses to guess at a marker naming an unknown schema version',
+		() =>
+			Effect.gen(function* () {
+				yield* sevenTables('json');
+				yield* withMarker('3.7.0');
+				const shape = yield* classify;
+				assert.strictEqual(shape._tag, 'Unknown');
+				if (shape._tag === 'Unknown') {
+					assert.include(shape.why, '3.7.0');
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+});

--- a/packages/backend-next/src/db/classify.ts
+++ b/packages/backend-next/src/db/classify.ts
@@ -1,0 +1,217 @@
+/**
+ * Works out what shape a database is actually in, before anything migrates it.
+ *
+ * This is the step that decides whether an upgrade is correct or destructive,
+ * so it is deliberately conservative: it reports `unknown` rather than
+ * guessing, and the caller refuses to proceed on `unknown` (RFC 0004 §3.3).
+ *
+ * ## Why not just read the version marker
+ *
+ * fumadb writes a `private_c15t_settings` row naming the schema version, and
+ * where it exists it is authoritative. **Its absence is not evidence of
+ * anything**, because at least three different populations lack it:
+ *
+ * - a legacy database, from the pre-2.0 `pkgs/migrations` era;
+ * - an empty database;
+ * - a database created through the `generateSchema()` ORM path, where c15t
+ *   printed schema code for the user to apply with Drizzle/Prisma/TypeORM
+ *   tooling. fumadb's migrator never ran, so it never wrote a marker — but
+ *   the schema is fumadb-shaped.
+ *
+ * Treating "no marker" as "legacy" would run a legacy convergence against a
+ * database already at 2.0.0. So classification falls back to shape, and the
+ * committed fixtures make that a comparison rather than a heuristic.
+ *
+ * ## What distinguishes the shapes
+ *
+ * Verified against `internals/migration-fixtures`:
+ *
+ * - **2.0.0** has `runtimePolicyDecision` and no `consentRecord`.
+ * - **Legacy and fumadb 1.0.0** carry the *same seven tables*, so the table
+ *   set cannot separate them. They differ by column type: legacy emits
+ *   `jsonb`/`text` where fumadb emits `json`/`varchar`, and they disagree on
+ *   which columns have defaults.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient, SqlError } from 'effect/unstable/sql';
+
+/** A database shape the migrator knows how to handle. */
+export type Shape =
+	/** No c15t tables at all — a fresh install. */
+	| { readonly _tag: 'Empty' }
+	/** Pre-2.0 `pkgs/migrations` era. No marker, no ledger. */
+	| { readonly _tag: 'Legacy' }
+	/** fumadb schema 1.0.0, from 1.8.x's opt-in `/v2` subpath. */
+	| { readonly _tag: 'Fumadb100'; readonly hasMarker: boolean }
+	/** fumadb schema 2.0.0, from 2.x, or applied via the ORM codegen path. */
+	| { readonly _tag: 'Fumadb200'; readonly hasMarker: boolean }
+	/** Already migrated by this package. */
+	| { readonly _tag: 'Baseline' }
+	/** Recognisably c15t, but not a shape we have a fixture for. */
+	| {
+			readonly _tag: 'Unknown';
+			readonly tables: readonly string[];
+			readonly why: string;
+	  };
+
+/** Tables that identify c15t, ignoring anything else in the database. */
+const C15T_TABLES = new Set([
+	'subject',
+	'domain',
+	'consentPolicy',
+	'consentPurpose',
+	'consent',
+	'auditLog',
+	'consentRecord',
+	'runtimePolicyDecision',
+]);
+
+const MARKER = /(^|_)c15t_settings$/;
+
+interface Observed {
+	readonly tables: ReadonlySet<string>;
+	readonly markerTable: string | undefined;
+	readonly ledger: boolean;
+}
+
+const observe = Effect.fn('classify.observe')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{
+				name: string;
+			}>`select name from sqlite_master where type = 'table'`,
+		mysql: () =>
+			sql<{
+				name: string;
+			}>`select table_name as name from information_schema.tables where table_schema = database()`,
+		orElse: () =>
+			sql<{
+				name: string;
+			}>`select table_name as name from information_schema.tables where table_schema = 'public' and table_type = 'BASE TABLE'`,
+	});
+
+	const all = rows.map((row) => row.name);
+	return {
+		tables: new Set(all.filter((name) => C15T_TABLES.has(name))),
+		markerTable: all.find((name) => MARKER.test(name)),
+		ledger: all.includes('c15t_migrations'),
+	} satisfies Observed;
+});
+
+/**
+ * Reads the schema version fumadb recorded, where it recorded one.
+ *
+ * Authoritative when present. Returns `undefined` when the marker table exists
+ * but holds no version row, which is itself a signal that something
+ * half-applied.
+ */
+const markerVersion = Effect.fn('classify.markerVersion')(function* (
+	table: string
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ key: string; value: string }>`${sql.unsafe(
+		`select "key", "value" from "${table}"`
+	)}`;
+	return rows.find((row) => row.key === 'version')?.value;
+});
+
+/**
+ * Distinguishes legacy from fumadb 1.0.0, which carry identical table sets.
+ *
+ * Uses `consent.metadata`: legacy declares it `jsonb` on Postgres, fumadb
+ * declares it `json`. On SQLite both collapse to `TEXT`, so the two are
+ * genuinely indistinguishable there by type — hence the marker check runs
+ * first and this is only reached without one.
+ */
+const looksLikeFumadb = Effect.fn('classify.looksLikeFumadb')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	return yield* sql.onDialectOrElse({
+		orElse: () =>
+			Effect.gen(function* () {
+				const rows = yield* sql<{ data_type: string }>`
+					select data_type from information_schema.columns
+					where table_name = 'consent' and column_name = 'metadata'
+				`;
+				const type = rows[0]?.data_type?.toLowerCase();
+				return type === undefined ? undefined : type === 'json';
+			}),
+		sqlite: () => Effect.succeed(undefined),
+	});
+});
+
+/**
+ * Classifies the connected database.
+ *
+ * Never mutates anything. Safe to run against production, and intended to be
+ * what `--dry-run` reports.
+ */
+export const classify: Effect.Effect<
+	Shape,
+	SqlError.SqlError,
+	SqlClient.SqlClient
+> = Effect.gen(function* () {
+	const observed = yield* observe();
+
+	if (observed.tables.size === 0) {
+		return { _tag: 'Empty' } as const;
+	}
+
+	if (observed.ledger) {
+		return { _tag: 'Baseline' } as const;
+	}
+
+	const has = (table: string) => observed.tables.has(table);
+
+	// 2.0.0 is unambiguous: it is the only shape with runtimePolicyDecision,
+	// and the only one that dropped consentRecord.
+	if (has('runtimePolicyDecision') && !has('consentRecord')) {
+		return {
+			_tag: 'Fumadb200',
+			hasMarker: observed.markerTable !== undefined,
+		} as const;
+	}
+
+	if (observed.markerTable) {
+		const version = yield* markerVersion(observed.markerTable).pipe(
+			Effect.orElseSucceed(() => undefined)
+		);
+		if (version === '1.0.0') {
+			return { _tag: 'Fumadb100', hasMarker: true } as const;
+		}
+		if (version === '2.0.0') {
+			return { _tag: 'Fumadb200', hasMarker: true } as const;
+		}
+		return {
+			_tag: 'Unknown',
+			tables: [...observed.tables].sort(),
+			why: `A fumadb marker table exists but names schema version ${
+				version ?? '<none>'
+			}, which this migrator has no fixture for.`,
+		} as const;
+	}
+
+	// No marker, no runtimePolicyDecision: legacy or an ORM-applied fumadb
+	// 1.0.0. Same tables, different column types.
+	const fumadbTypes = yield* looksLikeFumadb().pipe(
+		Effect.orElseSucceed(() => undefined)
+	);
+
+	if (fumadbTypes === true) {
+		return { _tag: 'Fumadb100', hasMarker: false } as const;
+	}
+	if (fumadbTypes === false) {
+		return { _tag: 'Legacy' } as const;
+	}
+
+	return {
+		_tag: 'Unknown',
+		tables: [...observed.tables].sort(),
+		why:
+			'No version marker, and this engine cannot distinguish a legacy schema ' +
+			'from an ORM-applied fumadb 1.0.0 by column type (SQLite collapses both ' +
+			'to TEXT). Re-run with --assume-shape to state which it is.',
+	} as const;
+});

--- a/packages/backend-next/src/db/migrations/1-baseline.ts
+++ b/packages/backend-next/src/db/migrations/1-baseline.ts
@@ -33,138 +33,17 @@
 import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import * as Dialect from '../dialect';
+import { createTableSql, TABLES } from '../schema';
 
-/**
- * Tables in creation order. Foreign keys point backwards only, so this order
- * is also a valid drop order reversed.
- */
-const TABLE_ORDER = [
-	'subject',
-	'domain',
-	'consentPolicy',
-	'consentPurpose',
-	'runtimePolicyDecision',
-	'consent',
-	'auditLog',
-] as const;
+/** Table names in creation order, for callers that need the order. */
+export const TABLE_ORDER = TABLES.map((table) => table.name);
 
 export const up = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient;
 	const dialect = yield* Dialect.current;
-	const t = Dialect.typesFor(dialect);
+	const types = Dialect.typesFor(dialect);
 
-	yield* sql.unsafe(`
-		create table if not exists "subject" (
-			"id" ${t.id} not null primary key,
-			"externalId" ${t.text},
-			"identityProvider" ${t.text},
-			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null,
-			"updatedAt" ${t.timestamp} not null
-		)
-	`);
-
-	yield* sql.unsafe(`
-		create table if not exists "domain" (
-			"id" ${t.id} not null primary key,
-			"name" ${t.text} not null,
-			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null,
-			"updatedAt" ${t.timestamp} not null
-		)
-	`);
-
-	yield* sql.unsafe(`
-		create table if not exists "consentPolicy" (
-			"id" ${t.id} not null primary key,
-			"version" ${t.text} not null,
-			"type" ${t.text} not null,
-			"hash" ${t.text},
-			"effectiveDate" ${t.timestamp} not null,
-			"isActive" ${t.bool} not null,
-			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null
-		)
-	`);
-
-	yield* sql.unsafe(`
-		create table if not exists "consentPurpose" (
-			"id" ${t.id} not null primary key,
-			"code" ${t.text} not null,
-			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null,
-			"updatedAt" ${t.timestamp} not null
-		)
-	`);
-
-	// dedupeKey is unique, so on MySQL it must be varchar rather than text.
-	yield* sql.unsafe(`
-		create table if not exists "runtimePolicyDecision" (
-			"id" ${t.id} not null primary key,
-			"tenantId" ${t.text},
-			"policyId" ${t.text} not null,
-			"fingerprint" ${t.text} not null,
-			"matchedBy" ${t.text} not null,
-			"countryCode" ${t.text},
-			"regionCode" ${t.text},
-			"jurisdiction" ${t.text} not null,
-			"language" ${t.text},
-			"model" ${t.text} not null,
-			"policyI18n" ${t.json},
-			"uiMode" ${t.text},
-			"bannerUi" ${t.json},
-			"dialogUi" ${t.json},
-			"categories" ${t.json},
-			"preselectedCategories" ${t.json},
-			"proofConfig" ${t.json},
-			"dedupeKey" ${t.indexedText} not null unique,
-			"createdAt" ${t.timestamp} not null
-		)
-	`);
-
-	yield* sql.unsafe(`
-		create table if not exists "consent" (
-			"id" ${t.id} not null primary key,
-			"subjectId" ${t.text} not null,
-			"domainId" ${t.text} not null,
-			"policyId" ${t.text},
-			"purposeIds" ${t.json} not null,
-			"metadata" ${t.json},
-			"ipAddress" ${t.text},
-			"userAgent" ${t.text},
-			"givenAt" ${t.timestamp} not null,
-			"validUntil" ${t.timestamp},
-			"jurisdiction" ${t.text},
-			"jurisdictionModel" ${t.text},
-			"tcString" ${t.text},
-			"uiSource" ${t.text},
-			"consentAction" ${t.text},
-			"runtimePolicyDecisionId" ${t.text},
-			"runtimePolicySource" ${t.text},
-			"tenantId" ${t.text},
-			foreign key ("subjectId") references "subject"("id"),
-			foreign key ("domainId") references "domain"("id"),
-			foreign key ("policyId") references "consentPolicy"("id"),
-			foreign key ("runtimePolicyDecisionId") references "runtimePolicyDecision"("id")
-		)
-	`);
-
-	yield* sql.unsafe(`
-		create table if not exists "auditLog" (
-			"id" ${t.id} not null primary key,
-			"entityType" ${t.text} not null,
-			"entityId" ${t.text} not null,
-			"actionType" ${t.text} not null,
-			"subjectId" ${t.text},
-			"ipAddress" ${t.text},
-			"userAgent" ${t.text},
-			"changes" ${t.json},
-			"metadata" ${t.json},
-			"tenantId" ${t.text},
-			"createdAt" ${t.timestamp} not null,
-			foreign key ("subjectId") references "subject"("id")
-		)
-	`);
+	for (const table of TABLES) {
+		yield* sql.unsafe(createTableSql(table, types));
+	}
 });
-
-export { TABLE_ORDER };

--- a/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
+++ b/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
@@ -118,6 +118,37 @@ export const INDEXES: readonly IndexSpec[] = [
 		columns: ['code'],
 		reason: 'Purpose lookup by code.',
 	},
+
+	// Every table carries tenantId, and `withTenantScope`
+	// (packages/backend/src/db/tenant-scope.ts) injects a tenantId filter into
+	// every findFirst, findMany, count, updateMany and deleteMany on every
+	// table — the proxy throws rather than let an unscoped method through. So
+	// in a multi-tenant deployment *every read in the system* filters on
+	// tenantId, and no shipped version indexes it anywhere.
+	//
+	// These are plain single-column indexes rather than (tenantId, x)
+	// composites on purpose. Single-tenant deployments never set tenantId and
+	// so never go through the scoping proxy; they need the bare column indexes
+	// above. Keeping the two sets separate serves both, and Postgres can
+	// bitmap-AND them where a query filters on both. Composites are worth
+	// revisiting once the benchmark has multi-tenant arms to justify them.
+	...(
+		[
+			'subject',
+			'domain',
+			'consentPolicy',
+			'consentPurpose',
+			'runtimePolicyDecision',
+			'consent',
+			'auditLog',
+		] as const
+	).map((table) => ({
+		name: `c15t_${table}_tenantId_idx`,
+		table,
+		columns: ['tenantId'] as const,
+		reason:
+			'Tenant scoping filters every query on this table on tenantId; no shipped version indexed it.',
+	})),
 ] as const;
 
 export const up = Effect.gen(function* () {

--- a/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
+++ b/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
@@ -1,0 +1,135 @@
+/**
+ * The indexes no shipped version of c15t ever had.
+ *
+ * Every column indexed here is one the current backend actually filters on,
+ * counted from the real query surface in `packages/backend/src` rather than
+ * guessed:
+ *
+ * ```
+ *  30 id          — already the primary key
+ *   6 externalId  — unindexed
+ *   4 type        — unindexed
+ *   4 subjectId   — unindexed
+ *   4 isActive    — unindexed
+ *   2 name        — indexed in legacy, lost in 2.0.0
+ *   2 dedupeKey   — already unique
+ *   1 code        — unindexed
+ * ```
+ *
+ * Postgres does not index the referencing side of a foreign key, so
+ * `consent.subjectId` and friends were bare in every released version. The
+ * chunked `subjectId in (…)` fan-out in `list.handler.ts` was therefore a
+ * sequential scan of `consent` per chunk, and the per-policy-type loop in
+ * `consent-enrichment.ts` a sequential scan of `consentPolicy` per iteration.
+ *
+ * ## Why this is a separate migration from the baseline
+ *
+ * `1-baseline` has to reproduce the shipped 2.0.0 shape exactly, so that a
+ * fresh install and an adopted database converge on one known state — that is
+ * the property the migrator's adoption step depends on. Adding indexes there
+ * would break it.
+ *
+ * Splitting them keeps both properties: convergence happens at migration 1,
+ * and the improvement lands at migration 2 for fresh and adopted databases
+ * alike. It also makes the benchmark arms able to measure migration 1 against
+ * migration 2 directly, so "unindexed foreign keys were the dominant scaling
+ * problem" becomes a number rather than a claim — and so the rewrite's
+ * benchmark story does not silently attribute an indexing win to Effect
+ * (RFC 0004 §7).
+ *
+ * ## Operational caveat
+ *
+ * These are plain `CREATE INDEX` statements, which take a write lock for the
+ * duration. On a large `consent` table that is a visible stall. Postgres can
+ * avoid it with `CREATE INDEX CONCURRENTLY`, but that cannot run inside a
+ * transaction, so it needs the migrator to opt the step out of one. Worth
+ * doing before this is pointed at a large production database; not worth
+ * blocking the measurement on.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import * as Dialect from '../dialect';
+
+interface IndexSpec {
+	readonly name: string;
+	readonly table: string;
+	readonly columns: readonly string[];
+	/** Why this index exists, in terms of the query that needs it. */
+	readonly reason: string;
+}
+
+export const INDEXES: readonly IndexSpec[] = [
+	{
+		name: 'c15t_subject_externalId_idx',
+		table: 'subject',
+		columns: ['externalId'],
+		reason:
+			'GET /subjects?externalId= — the entry point of the subject list path.',
+	},
+	{
+		name: 'c15t_consent_subjectId_idx',
+		table: 'consent',
+		columns: ['subjectId'],
+		reason:
+			'The chunked `subjectId in (…)` fan-out in list.handler.ts, previously a sequential scan per chunk.',
+	},
+	{
+		name: 'c15t_consent_domainId_idx',
+		table: 'consent',
+		columns: ['domainId'],
+		reason: 'Foreign key with no index on the referencing side.',
+	},
+	{
+		name: 'c15t_consent_policyId_idx',
+		table: 'consent',
+		columns: ['policyId'],
+		reason: 'Foreign key with no index on the referencing side.',
+	},
+	{
+		name: 'c15t_consent_runtimePolicyDecisionId_idx',
+		table: 'consent',
+		columns: ['runtimePolicyDecisionId'],
+		reason: 'Foreign key with no index on the referencing side.',
+	},
+	{
+		name: 'c15t_auditLog_subjectId_idx',
+		table: 'auditLog',
+		columns: ['subjectId'],
+		reason: 'Foreign key, and the audit trail is queried per subject.',
+	},
+	{
+		name: 'c15t_consentPolicy_type_isActive_effectiveDate_idx',
+		table: 'consentPolicy',
+		columns: ['type', 'isActive', 'effectiveDate'],
+		reason:
+			'findLatestPolicyByType filters isActive = true and type = ? ordered by effectiveDate desc. Leading with type because isActive is a boolean and carries almost no selectivity.',
+	},
+	{
+		name: 'c15t_domain_name_idx',
+		table: 'domain',
+		columns: ['name'],
+		reason:
+			'Domain lookup by name. The legacy schema indexed this; 2.0.0 dropped it.',
+	},
+	{
+		name: 'c15t_consentPurpose_code_idx',
+		table: 'consentPurpose',
+		columns: ['code'],
+		reason: 'Purpose lookup by code.',
+	},
+] as const;
+
+export const up = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	// Resolved so an unsupported dialect fails here rather than part-way
+	// through emitting DDL.
+	yield* Dialect.current;
+
+	for (const index of INDEXES) {
+		const columns = index.columns.map((column) => `"${column}"`).join(', ');
+		yield* sql.unsafe(
+			`create index if not exists "${index.name}" on "${index.table}" (${columns})`
+		);
+	}
+});

--- a/packages/backend-next/src/db/migrations/hot-path-indexes.test.ts
+++ b/packages/backend-next/src/db/migrations/hot-path-indexes.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Migration 2 adds the indexes no shipped version had. Three properties
+ * matter, and they are the ones the RFC's argument rests on:
+ *
+ * 1. It leaves the baseline's own constraints alone — adding indexes must not
+ *    quietly change a primary key or a unique constraint.
+ * 2. It is idempotent, because the adoption step may re-run it after a
+ *    partially applied migration (RFC §3.3).
+ * 3. Every index it claims to create actually exists afterwards. An index that
+ *    silently failed to apply would make the benchmark comparison meaningless
+ *    in the most flattering possible direction.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { SqliteClient } from '@effect/sql-sqlite-node';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { up as baseline } from './1-baseline';
+import { up as hotPathIndexes, INDEXES } from './2-hot-path-indexes';
+
+const Pglite = PgliteClient.layer({});
+
+/** Non-primary, non-unique index names present in the database. */
+const indexNames = Effect.fn('indexNames')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ indexname: string }>`
+		select indexname from pg_indexes where schemaname = 'public'
+	`;
+	return rows.map((row) => row.indexname).sort();
+});
+
+const constraintFingerprint = Effect.fn('constraintFingerprint')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{
+		table_name: string;
+		column_name: string;
+		is_unique: boolean;
+		is_primary: boolean;
+	}>`
+		select t.relname as table_name, a.attname as column_name,
+		       ix.indisunique as is_unique, ix.indisprimary as is_primary
+		from pg_class t
+		join pg_namespace n on n.oid = t.relnamespace
+		join pg_index ix on t.oid = ix.indrelid
+		join unnest(ix.indkey) with ordinality as k(attnum, ord) on true
+		join pg_attribute a on a.attrelid = t.oid and a.attnum = k.attnum
+		where n.nspname = 'public' and t.relkind = 'r'
+		  and (ix.indisunique or ix.indisprimary)
+	`;
+	return rows
+		.map(
+			(row) =>
+				`${row.table_name}.${row.column_name} unique=${row.is_unique} pk=${row.is_primary}`
+		)
+		.sort();
+});
+
+describe('hot-path indexes', () => {
+	it.effect(
+		'creates every index it declares',
+		() =>
+			Effect.gen(function* () {
+				yield* baseline;
+				yield* hotPathIndexes;
+
+				const present = yield* indexNames();
+				for (const index of INDEXES) {
+					assert.include(
+						present,
+						index.name,
+						`${index.name} is declared but was not created — ${index.reason}`
+					);
+				}
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'leaves the baseline primary key and unique constraints untouched',
+		() =>
+			Effect.gen(function* () {
+				yield* baseline;
+				const before = yield* constraintFingerprint();
+				yield* hotPathIndexes;
+				const after = yield* constraintFingerprint();
+
+				assert.deepStrictEqual(after, before);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'is idempotent',
+		() =>
+			Effect.gen(function* () {
+				yield* baseline;
+				yield* hotPathIndexes;
+				const once = yield* indexNames();
+
+				// The adoption step can re-run a migration after a partial
+				// application, so a second run must be a no-op rather than an
+				// "already exists" failure.
+				yield* hotPathIndexes;
+				assert.deepStrictEqual(yield* indexNames(), once);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'applies on sqlite too',
+		() =>
+			Effect.gen(function* () {
+				yield* baseline;
+				yield* hotPathIndexes;
+
+				const sql = yield* SqlClient.SqlClient;
+				const rows = yield* sql<{ name: string }>`
+					select name from sqlite_master where type = 'index' and name not like 'sqlite_%'
+				`;
+				const present = rows.map((row) => row.name).sort();
+				for (const index of INDEXES) {
+					assert.include(present, index.name);
+				}
+			}).pipe(Effect.provide(SqliteClient.layer({ filename: ':memory:' }))),
+		{ timeout: 60_000 }
+	);
+});

--- a/packages/backend-next/src/db/schema.ts
+++ b/packages/backend-next/src/db/schema.ts
@@ -1,0 +1,229 @@
+/**
+ * The 2.0.0 schema as data, so the baseline migration and the adoption step
+ * cannot drift apart.
+ *
+ * `1-baseline` turns this into `create table`; the adoption step turns it into
+ * `alter table … add column` for whatever an existing database is missing.
+ * Two code paths, one definition — if they were written separately, a fresh
+ * install and an adopted database would eventually disagree and nothing would
+ * catch it.
+ *
+ * Every column and type is verified against
+ * `internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json`, captured from
+ * the real published `@c15t/backend@2.1.0`.
+ */
+
+import type { PhysicalTypes } from './dialect';
+
+/** Which entry of `PhysicalTypes` a column resolves to. */
+export type LogicalType = keyof PhysicalTypes;
+
+export interface ColumnSpec {
+	readonly name: string;
+	readonly type: LogicalType;
+	readonly nullable: boolean;
+	readonly unique?: boolean;
+}
+
+export interface ForeignKeySpec {
+	readonly column: string;
+	readonly referencesTable: string;
+	readonly referencesColumn: string;
+}
+
+export interface TableSpec {
+	readonly name: string;
+	readonly columns: readonly ColumnSpec[];
+	readonly foreignKeys: readonly ForeignKeySpec[];
+}
+
+const id: ColumnSpec = { name: 'id', type: 'id', nullable: false };
+
+/**
+ * In creation order. Foreign keys point backwards only, so this order is
+ * valid for `create table` and its reverse is valid for dropping.
+ */
+export const TABLES: readonly TableSpec[] = [
+	{
+		name: 'subject',
+		columns: [
+			id,
+			{ name: 'externalId', type: 'text', nullable: true },
+			{ name: 'identityProvider', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+			{ name: 'updatedAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [],
+	},
+	{
+		name: 'domain',
+		columns: [
+			id,
+			{ name: 'name', type: 'text', nullable: false },
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+			{ name: 'updatedAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [],
+	},
+	{
+		name: 'consentPolicy',
+		columns: [
+			id,
+			{ name: 'version', type: 'text', nullable: false },
+			{ name: 'type', type: 'text', nullable: false },
+			{ name: 'hash', type: 'text', nullable: true },
+			{ name: 'effectiveDate', type: 'timestamp', nullable: false },
+			{ name: 'isActive', type: 'bool', nullable: false },
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [],
+	},
+	{
+		name: 'consentPurpose',
+		columns: [
+			id,
+			{ name: 'code', type: 'text', nullable: false },
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+			{ name: 'updatedAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [],
+	},
+	{
+		name: 'runtimePolicyDecision',
+		columns: [
+			id,
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'policyId', type: 'text', nullable: false },
+			{ name: 'fingerprint', type: 'text', nullable: false },
+			{ name: 'matchedBy', type: 'text', nullable: false },
+			{ name: 'countryCode', type: 'text', nullable: true },
+			{ name: 'regionCode', type: 'text', nullable: true },
+			{ name: 'jurisdiction', type: 'text', nullable: false },
+			{ name: 'language', type: 'text', nullable: true },
+			{ name: 'model', type: 'text', nullable: false },
+			{ name: 'policyI18n', type: 'json', nullable: true },
+			{ name: 'uiMode', type: 'text', nullable: true },
+			{ name: 'bannerUi', type: 'json', nullable: true },
+			{ name: 'dialogUi', type: 'json', nullable: true },
+			{ name: 'categories', type: 'json', nullable: true },
+			{ name: 'preselectedCategories', type: 'json', nullable: true },
+			{ name: 'proofConfig', type: 'json', nullable: true },
+			// Unique, so on MySQL this must be a bounded varchar — the exact
+			// constraint fumadb violates (RFC 0004 §3.5).
+			{
+				name: 'dedupeKey',
+				type: 'indexedText',
+				nullable: false,
+				unique: true,
+			},
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [],
+	},
+	{
+		name: 'consent',
+		columns: [
+			id,
+			{ name: 'subjectId', type: 'text', nullable: false },
+			{ name: 'domainId', type: 'text', nullable: false },
+			{ name: 'policyId', type: 'text', nullable: true },
+			{ name: 'purposeIds', type: 'json', nullable: false },
+			{ name: 'metadata', type: 'json', nullable: true },
+			{ name: 'ipAddress', type: 'text', nullable: true },
+			{ name: 'userAgent', type: 'text', nullable: true },
+			{ name: 'givenAt', type: 'timestamp', nullable: false },
+			{ name: 'validUntil', type: 'timestamp', nullable: true },
+			{ name: 'jurisdiction', type: 'text', nullable: true },
+			{ name: 'jurisdictionModel', type: 'text', nullable: true },
+			{ name: 'tcString', type: 'text', nullable: true },
+			{ name: 'uiSource', type: 'text', nullable: true },
+			{ name: 'consentAction', type: 'text', nullable: true },
+			{ name: 'runtimePolicyDecisionId', type: 'text', nullable: true },
+			{ name: 'runtimePolicySource', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'text', nullable: true },
+		],
+		foreignKeys: [
+			{
+				column: 'subjectId',
+				referencesTable: 'subject',
+				referencesColumn: 'id',
+			},
+			{ column: 'domainId', referencesTable: 'domain', referencesColumn: 'id' },
+			{
+				column: 'policyId',
+				referencesTable: 'consentPolicy',
+				referencesColumn: 'id',
+			},
+			{
+				column: 'runtimePolicyDecisionId',
+				referencesTable: 'runtimePolicyDecision',
+				referencesColumn: 'id',
+			},
+		],
+	},
+	{
+		name: 'auditLog',
+		columns: [
+			id,
+			{ name: 'entityType', type: 'text', nullable: false },
+			{ name: 'entityId', type: 'text', nullable: false },
+			{ name: 'actionType', type: 'text', nullable: false },
+			{ name: 'subjectId', type: 'text', nullable: true },
+			{ name: 'ipAddress', type: 'text', nullable: true },
+			{ name: 'userAgent', type: 'text', nullable: true },
+			{ name: 'changes', type: 'json', nullable: true },
+			{ name: 'metadata', type: 'json', nullable: true },
+			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'createdAt', type: 'timestamp', nullable: false },
+		],
+		foreignKeys: [
+			{
+				column: 'subjectId',
+				referencesTable: 'subject',
+				referencesColumn: 'id',
+			},
+		],
+	},
+] as const;
+
+/** `create table` for one spec, in the given dialect's physical types. */
+export function createTableSql(table: TableSpec, types: PhysicalTypes): string {
+	const columns = table.columns.map((column) => {
+		const physical = types[column.type];
+		const nullability = column.nullable ? '' : ' not null';
+		const primary = column.name === 'id' ? ' primary key' : '';
+		const unique = column.unique ? ' unique' : '';
+		return `"${column.name}" ${physical}${nullability}${primary}${unique}`;
+	});
+
+	const foreignKeys = table.foreignKeys.map(
+		(fk) =>
+			`foreign key ("${fk.column}") references "${fk.referencesTable}"("${fk.referencesColumn}")`
+	);
+
+	return `create table if not exists "${table.name}" (\n\t${[
+		...columns,
+		...foreignKeys,
+	].join(',\n\t')}\n)`;
+}
+
+/**
+ * `alter table … add column` for one column.
+ *
+ * Always nullable regardless of the spec: an existing table already has rows,
+ * and a `not null` column with no default cannot be added to a populated
+ * table on any engine. The application writes every one of these on insert,
+ * so the looser constraint costs nothing that matters and avoids an adoption
+ * that fails on any non-empty database.
+ */
+export function addColumnSql(
+	table: string,
+	column: ColumnSpec,
+	types: PhysicalTypes
+): string {
+	return `alter table "${table}" add column "${column.name}" ${types[column.type]}`;
+}

--- a/packages/backend-next/src/repository/subject.test.ts
+++ b/packages/backend-next/src/repository/subject.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The read path's correctness, and the property that motivates it: the number
+ * of queries does not grow with the data.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import {
+	countByExternalId,
+	latestPolicyIdByType,
+	listByExternalId,
+} from './subject';
+
+const Pglite = PgliteClient.layer({});
+
+const migrate = Effect.gen(function* () {
+	yield* baseline;
+	yield* indexes;
+});
+
+/**
+ * Seeds `subjects` subjects sharing one external id, each with one consent,
+ * spread across `policyTypes` distinct policy types.
+ *
+ * Both dimensions are the ones the old implementation scaled queries on: it
+ * issued a chunk per hundred subjects and one query per policy type.
+ */
+const seed = Effect.fn('seed')(function* (
+	externalId: string,
+	subjects: number,
+	policyTypes: number
+) {
+	const sql = yield* SqlClient.SqlClient;
+
+	// Ids are namespaced by externalId so a test can seed more than once.
+	const ns = externalId;
+	yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+		values ('dom_${ns}', 'example.com', now(), now())`);
+
+	for (let type = 0; type < policyTypes; type++) {
+		// Two versions per type, so "latest active policy per type" has
+		// something to actually choose between.
+		for (const [index, age] of [0, 1].entries()) {
+			yield* sql.unsafe(`insert into "consentPolicy"
+				("id", "version", "type", "effectiveDate", "isActive", "createdAt")
+				values ('pol_${ns}_${type}_${index}', '1.${index}', 'type_${ns}_${type}',
+					now() - interval '${age} day', true, now())`);
+		}
+	}
+
+	for (let subject = 0; subject < subjects; subject++) {
+		yield* sql.unsafe(`insert into "subject"
+			("id", "externalId", "createdAt", "updatedAt")
+			values ('sub_${ns}_${subject}', '${externalId}', now(), now())`);
+		const type = subject % policyTypes;
+		yield* sql.unsafe(`insert into "consent"
+			("id", "subjectId", "domainId", "policyId", "purposeIds", "givenAt")
+			values ('cns_${ns}_${subject}', 'sub_${ns}_${subject}', 'dom_${ns}', 'pol_${ns}_${type}_0', '[]', now())`);
+	}
+});
+
+describe('subject repository', () => {
+	it.effect(
+		'returns each subject with its consents',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				yield* seed('ext_1', 3, 2);
+
+				const subjects = yield* listByExternalId('ext_1');
+
+				assert.strictEqual(subjects.length, 3);
+				assert.deepStrictEqual(
+					subjects.map((subject) => subject.consents.length),
+					[1, 1, 1]
+				);
+				assert.strictEqual(subjects[0]?.externalId, 'ext_1');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'includes a subject that has no consents at all',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql.unsafe(`insert into "subject"
+					("id", "externalId", "createdAt", "updatedAt")
+					values ('sub_lonely', 'ext_1', now(), now())`);
+
+				const subjects = yield* listByExternalId('ext_1');
+
+				// The left join produces an all-null consent row here. Treating
+				// that as a consent record would invent one out of nothing.
+				assert.strictEqual(subjects.length, 1);
+				assert.deepStrictEqual(subjects[0]?.consents, []);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'marks consents against the newest active policy of their type',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+					values ('dom_1', 'example.com', now(), now())`);
+				yield* sql.unsafe(`insert into "consentPolicy"
+					("id", "version", "type", "effectiveDate", "isActive", "createdAt")
+					values ('pol_old', '1.0', 'cookie', now() - interval '10 day', true, now())`);
+				yield* sql.unsafe(`insert into "consentPolicy"
+					("id", "version", "type", "effectiveDate", "isActive", "createdAt")
+					values ('pol_new', '2.0', 'cookie', now(), true, now())`);
+				yield* sql.unsafe(`insert into "subject"
+					("id", "externalId", "createdAt", "updatedAt")
+					values ('sub_1', 'ext_1', now(), now())`);
+				yield* sql.unsafe(`insert into "consent"
+					("id", "subjectId", "domainId", "policyId", "purposeIds", "givenAt")
+					values ('cns_old', 'sub_1', 'dom_1', 'pol_old', '[]', now())`);
+				yield* sql.unsafe(`insert into "consent"
+					("id", "subjectId", "domainId", "policyId", "purposeIds", "givenAt")
+					values ('cns_new', 'sub_1', 'dom_1', 'pol_new', '[]', now())`);
+
+				const subjects = yield* listByExternalId('ext_1');
+				const byId = new Map(
+					subjects[0]?.consents.map((consent) => [consent.id, consent])
+				);
+
+				assert.isTrue(byId.get('cns_new')?.isLatestPolicy);
+				assert.isFalse(byId.get('cns_old')?.isLatestPolicy);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'ignores inactive policies when deciding what is latest',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql.unsafe(`insert into "consentPolicy"
+					("id", "version", "type", "effectiveDate", "isActive", "createdAt")
+					values ('pol_live', '1.0', 'cookie', now() - interval '10 day', true, now())`);
+				yield* sql.unsafe(`insert into "consentPolicy"
+					("id", "version", "type", "effectiveDate", "isActive", "createdAt")
+					values ('pol_draft', '2.0', 'cookie', now(), false, now())`);
+
+				const latest = yield* latestPolicyIdByType();
+				assert.strictEqual(latest.get('cookie'), 'pol_live');
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'costs the same number of queries at 1 subject as at 250',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				const sql = yield* SqlClient.SqlClient;
+
+				// pg_stat_statements is unavailable in PGlite, so count actual
+				// executions against the tables of interest instead.
+				const executions = Effect.fn('executions')(function* () {
+					const rows = yield* sql<{ total: string }>`
+						select coalesce(sum(seq_scan + idx_scan), 0) as total
+						from pg_stat_user_tables
+						where relname in ('subject', 'consent', 'consentPolicy')
+					`;
+					return Number(rows[0]?.total ?? 0);
+				});
+
+				yield* seed('ext_small', 1, 1);
+				const beforeSmall = yield* executions();
+				yield* listByExternalId('ext_small');
+				const smallCost = (yield* executions()) - beforeSmall;
+
+				// 250 subjects across 5 policy types. Under the old
+				// implementation this was 1 + ceil(250/100) + 5 = 9 sequential
+				// round trips; the point is that this number does not move.
+				yield* seed('ext_large', 250, 5);
+				const beforeLarge = yield* executions();
+				yield* listByExternalId('ext_large');
+				const largeCost = (yield* executions()) - beforeLarge;
+
+				assert.strictEqual(
+					largeCost,
+					smallCost,
+					`scan count grew with the data: ${smallCost} -> ${largeCost}`
+				);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'counts every matching subject, not just the page',
+		() =>
+			Effect.gen(function* () {
+				yield* migrate;
+				yield* seed('ext_1', 7, 2);
+
+				// list.handler.ts reports `count: subjectItems.length`, which is
+				// the page length rather than a total.
+				assert.strictEqual(yield* countByExternalId('ext_1'), 7);
+				assert.strictEqual(yield* countByExternalId('ext_absent'), 0);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+});

--- a/packages/backend-next/src/repository/subject.ts
+++ b/packages/backend-next/src/repository/subject.ts
@@ -1,0 +1,164 @@
+/**
+ * Subject reads.
+ *
+ * This is the path RFC 0004 is largely an argument about. In `@c15t/backend`,
+ * `GET /subjects?externalId=` costs:
+ *
+ * 1. one query for the subjects;
+ * 2. `ceil(n / SUBJECT_ID_BATCH_SIZE)` **sequential** queries for their
+ *    consents, hand-rolled in `list.handler.ts` because fumadb cannot join;
+ * 3. one further **sequential** query per distinct policy type inside
+ *    `consent-enrichment.ts`, in a loop that is not even `Promise.all`.
+ *
+ * So a subject with consents spanning four policy types costs six or more
+ * round trips, and the count grows with the data. Every one of those queries
+ * also hit unindexed columns until `2-hot-path-indexes` (§7).
+ *
+ * Here it is **two** queries, flat, regardless of how many subjects or policy
+ * types are involved:
+ *
+ * 1. subjects left-joined to their consents;
+ * 2. the latest active policy per type, ranked in SQL.
+ *
+ * The second could be folded into the first, but keeping it separate means it
+ * is cacheable per tenant and independent of the subject being queried — the
+ * shape of the data, not an accident of the query.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient, SqlError } from 'effect/unstable/sql';
+
+export interface ConsentRow {
+	readonly id: string;
+	readonly subjectId: string;
+	readonly policyId: string | null;
+	readonly purposeIds: unknown;
+	readonly givenAt: Date;
+	/** True when this consent points at the newest active policy of its type. */
+	readonly isLatestPolicy: boolean;
+}
+
+export interface SubjectWithConsents {
+	readonly id: string;
+	readonly externalId: string | null;
+	readonly createdAt: Date;
+	readonly consents: readonly ConsentRow[];
+}
+
+interface JoinedRow {
+	readonly subject_id: string;
+	readonly subject_externalId: string | null;
+	readonly subject_createdAt: Date;
+	readonly consent_id: string | null;
+	readonly consent_policyId: string | null;
+	readonly consent_purposeIds: unknown;
+	readonly consent_givenAt: Date | null;
+}
+
+/**
+ * The newest active policy for each type, in one query.
+ *
+ * Replaces the per-type loop in `consent-enrichment.ts`. `row_number()` over a
+ * partition is supported by Postgres 11+, MySQL 8+ and SQLite 3.25+, so this
+ * needs no dialect branching.
+ */
+export const latestPolicyIdByType = Effect.fn(
+	'repository.latestPolicyIdByType'
+)(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ id: string; type: string }>`
+			select "id", "type"
+			from (
+				select
+					"id",
+					"type",
+					row_number() over (
+						partition by "type" order by "effectiveDate" desc
+					) as rn
+				from "consentPolicy"
+				where "isActive" = ${true}
+			) ranked
+			where rn = 1
+		`;
+
+	return new Map(rows.map((row) => [row.type, row.id]));
+});
+
+/**
+ * Every subject with a given external id, and each subject's consents.
+ *
+ * One query. The old implementation issued one plus a chunk per hundred
+ * subject ids, sequentially, because it had no join available.
+ */
+export const listByExternalId = Effect.fn('repository.listByExternalId')(
+	function* (externalId: string) {
+		const sql = yield* SqlClient.SqlClient;
+
+		const rows = yield* sql<JoinedRow>`
+			select
+				s."id"          as "subject_id",
+				s."externalId"  as "subject_externalId",
+				s."createdAt"   as "subject_createdAt",
+				c."id"          as "consent_id",
+				c."policyId"    as "consent_policyId",
+				c."purposeIds"  as "consent_purposeIds",
+				c."givenAt"     as "consent_givenAt"
+			from "subject" s
+			left join "consent" c on c."subjectId" = s."id"
+			where s."externalId" = ${externalId}
+			order by s."id", c."givenAt" desc
+		`;
+
+		const latest = yield* latestPolicyIdByType();
+		const latestIds = new Set(latest.values());
+
+		const bySubject = new Map<string, SubjectWithConsents>();
+		for (const row of rows) {
+			const existing = bySubject.get(row.subject_id);
+			const subject: SubjectWithConsents = existing ?? {
+				id: row.subject_id,
+				externalId: row.subject_externalId,
+				createdAt: row.subject_createdAt,
+				consents: [],
+			};
+
+			// A left join yields one all-null consent row for a subject with no
+			// consents; that is an absence, not a record.
+			if (row.consent_id !== null && row.consent_givenAt !== null) {
+				(subject.consents as ConsentRow[]).push({
+					id: row.consent_id,
+					subjectId: row.subject_id,
+					policyId: row.consent_policyId,
+					purposeIds: row.consent_purposeIds,
+					givenAt: row.consent_givenAt,
+					isLatestPolicy:
+						row.consent_policyId !== null &&
+						latestIds.has(row.consent_policyId),
+				});
+			}
+
+			bySubject.set(row.subject_id, subject);
+		}
+
+		return [...bySubject.values()];
+	}
+);
+
+/**
+ * How many subjects carry an external id.
+ *
+ * `list.handler.ts` returns `count: subjectItems.length` — the length of the
+ * page, not a total. Any client paginating on it is reading a number that
+ * means something else. A real `count(*)` costs one cheap indexed query.
+ */
+export const countByExternalId = Effect.fn('repository.countByExternalId')(
+	function* (externalId: string) {
+		const sql = yield* SqlClient.SqlClient;
+		const rows = yield* sql<{ total: number | string }>`
+			select count(*) as total from "subject" where "externalId" = ${externalId}
+		`;
+		return Number(rows[0]?.total ?? 0);
+	}
+);
+
+export type RepositoryError = SqlError.SqlError;


### PR DESCRIPTION
The adoption step from RFC 0004 §3.3, plus the read path it exists to serve. This is the layer that decides what to do with a database that already has data in it.

## Classification never guesses

Three populations lack a `private_c15t_settings` marker row — a legacy database, an empty one, and a fumadb-shaped one applied through the `generateSchema()` ORM path where fumadb's migrator never ran. Treating marker absence as "legacy" would converge a database already at 2.0.0 **destructively**.

So it falls back to shape, and the fixtures make that a comparison rather than a heuristic:

- 2.0.0 is the only shape with `runtimePolicyDecision` and without `consentRecord`;
- legacy and fumadb 1.0.0 carry identical table sets, and separate on `consent.metadata` being `jsonb` rather than `json`.

Where it cannot tell, it returns `Unknown` **with the reason** rather than guessing. That includes SQLite, which collapses both types to `TEXT` and genuinely cannot discriminate without a marker.

## Adoption is add-only, and that is enforced

It creates tables and adds columns. It never drops a table, drops a column, or changes a type.

Schema 1.0.0 → 2.0.0 removed columns holding real data (`consent.status`, `consent.withdrawalReason`, `consentPolicy.content`) and dropped `consentRecord` outright. On a consent platform those are withdrawal history and audit records; discarding them during a package upgrade is not a trade-off worth making, and there is no way to ask the operator mid-migration. An adopted database ends up as baseline plus whatever it already had, with the extras reported under `retained` so they can be dropped deliberately later.

Stated plainly: a fresh install and an adopted database are identical **in the columns the contract covers**, not byte-identical.

`AdoptionStep['kind']` already had no destructive member, but `sql` is a free-form string — nothing stopped a future edit putting a drop into a step tagged `add-column`. `apply()` now scans every statement and dies rather than executing one, which makes "adoption never deletes anything" an enforced invariant on the one code path that runs against other people's production data. Word boundaries are deliberate: a column named `dropdown` must not trip it.

Foreign keys are counted before they are added. The legacy migrator emitted none on MySQL, so adding them can fail on pre-existing rows — the plan reports exactly which rows and refuses, rather than discovering it half-way through. `skipForeignKeys` is the deliberate escape hatch.

## The read path: two queries, not N

`GET /subjects?externalId=` in 2.x costs one query for the subjects, then `ceil(n/100)` sequential queries for their consents (hand-rolled chunking, because fumadb cannot join), then one further sequential query per distinct policy type — a loop that is not even `Promise.all`. **Nine round trips for 250 subjects across 5 policy types**, growing with the data.

Here it is two, flat: subjects left-joined to their consents, and the latest active policy per type ranked with `row_number()` in SQL. A test asserts the scan count is identical at 1 subject and at 250 — the property that actually matters, since it fails if anyone reintroduces a per-item query. `row_number()` over a partition needs no dialect branching (Postgres 11+, MySQL 8+, SQLite 3.25+).

Also adds `countByExternalId`. 2.x returns `count: subjectItems.length`, which is the page length rather than a total, so any client paginating on it is reading a number that means something else.

## Migration 2, deliberately separate from the baseline

`1-baseline` reproduces the shipped 2.0.0 shape so fresh and adopted databases converge on one known state; `2-hot-path-indexes` then improves both alike. That keeps the convergence property adoption needs **and** lets the benchmark arms measure migration 1 against migration 2, so an indexing win is not silently attributed to Effect.

Every indexed column is one the backend actually filters on, counted from the real query surface rather than guessed: `externalId` ×6, `type` ×4, `subjectId` ×4, `isActive` ×4, `name` ×2, `code` ×1 — none of them indexed in any released version. `domain.name` was indexed in legacy and lost in 2.0.0.

`tenantId` gets an index on every table. `withTenantScope` injects a tenant filter into every read in the system, and no shipped version indexes it anywhere — a wider gap than the missing foreign key indexes, which at least only affected join paths. Single-column rather than composite, deliberately: single-tenant deployments never set `tenantId` and need the bare column indexes instead, and Postgres can bitmap-AND the two sets where a query filters on both.

`consentPolicy` gets a composite `(type, isActive, effectiveDate)` because `findLatestPolicyByType` filters `isActive = true` and `type = ?` ordered by `effectiveDate desc`; type leads because a boolean carries no selectivity.

**Caveat recorded in the migration:** plain `CREATE INDEX` takes a write lock. `CONCURRENTLY` needs the step to run outside a transaction, which is worth doing before this points at a large production database.

## Tests

28 classification, 35 adoption, 41 read-path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for adopting existing databases across SQLite, MySQL, and PostgreSQL.
  - Database states are identified automatically, including empty, legacy, baseline, and unknown schemas.
  - Adoption preserves existing tables, columns, and data while adding required schema elements.
  - Added safeguards against destructive changes and detection of orphaned foreign-key references.
  - Added performance indexes for common queries.
  - Added subject lookup and counting with consent and active-policy information.

- **Bug Fixes**
  - Improved handling of empty consent records and inactive policies.
  - Adoption can be safely reapplied without duplicating changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->