### PR TITLE
feat(backend-bench): 2x2 benchmark separating the join from the indexes

### DIFF
--- a/benchmarks/backend-bench/package.json
+++ b/benchmarks/backend-bench/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@c15t/backend-bench",
+	"private": true,
+	"type": "module",
+	"description": "Head-to-head query benchmarks for the backend rewrite (RFC 0004 §7).",
+	"scripts": {
+		"build": "echo 'backend benchmarks are source-only'",
+		"bench": "BENCH_OUTPUT_DIR=../../.benchmarks/current/backend-runtime bun src/run.ts",
+		"bench:ci": "BENCH_OUTPUT_DIR=../../.benchmarks/head/backend-runtime bun src/run.ts",
+		"check-types": "tsc --noEmit",
+		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
+		"lint": "bun biome lint ./src"
+	},
+	"dependencies": {
+		"@c15t/backend-next": "workspace:*",
+		"@c15t/benchmarking": "workspace:*",
+		"@effect/sql-pglite": "4.0.0-beta.102",
+		"effect": "4.0.0-beta.102"
+	},
+	"devDependencies": {
+		"@c15t/typescript-config": "workspace:*",
+		"@types/node": "^24.10.1",
+		"typescript": "7.0.2"
+	}
+}

--- a/benchmarks/backend-bench/src/arms.ts
+++ b/benchmarks/backend-bench/src/arms.ts
@@ -1,0 +1,117 @@
+/**
+ * The two query patterns under comparison, expressed against the same client
+ * so the only variable is the pattern itself.
+ *
+ * The old arm is a faithful reproduction of `list.handler.ts` and
+ * `consent-enrichment.ts` — same chunk size, same sequential loops — rather
+ * than a call into `@c15t/backend`. That is deliberate and worth being precise
+ * about: it isolates the *query pattern* and removes fumadb's own JavaScript
+ * overhead as a confound. It therefore measures the floor of the old design,
+ * not the shipped package. A separate arm calling the real package would
+ * capture ORM overhead on top, and would only make the comparison more
+ * favourable to the rewrite; this way the number is defensible.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+
+/** `list.handler.ts:13`. Reproduced exactly. */
+const SUBJECT_ID_BATCH_SIZE = 500;
+
+export interface ArmResult {
+	readonly subjects: number;
+	readonly consents: number;
+	/** Statements issued. The metric latency alone hides on a warm database. */
+	readonly queries: number;
+}
+
+/**
+ * The shipped pattern: one query for subjects, a sequential chunk per 500
+ * subject ids for their consents, then one sequential query per distinct
+ * policy type.
+ */
+export const chunkedFanout = Effect.fn('arm.chunkedFanout')(function* (
+	externalId: string
+) {
+	const sql = yield* SqlClient.SqlClient;
+	let queries = 0;
+
+	const subjects = yield* sql<{ id: string }>`
+		select "id" from "subject" where "externalId" = ${externalId}
+	`;
+	queries += 1;
+
+	const ids = subjects.map((row) => row.id);
+	const consents: Array<{ id: string; policyId: string | null }> = [];
+
+	for (let index = 0; index < ids.length; index += SUBJECT_ID_BATCH_SIZE) {
+		const batch = ids.slice(index, index + SUBJECT_ID_BATCH_SIZE);
+		if (batch.length === 0) break;
+		const rows = yield* sql<{ id: string; policyId: string | null }>`
+			select "id", "policyId" from "consent"
+			where "subjectId" in ${sql.in(batch)}
+		`;
+		queries += 1;
+		consents.push(...rows);
+	}
+
+	// consent-enrichment.ts resolves the latest policy per type in a loop, one
+	// query per type, sequentially.
+	const policyIds = [
+		...new Set(consents.map((row) => row.policyId).filter(Boolean)),
+	] as string[];
+
+	const types = new Set<string>();
+	if (policyIds.length > 0) {
+		const rows = yield* sql<{ type: string }>`
+			select distinct "type" from "consentPolicy" where "id" in ${sql.in(policyIds)}
+		`;
+		queries += 1;
+		for (const row of rows) types.add(row.type);
+	}
+
+	for (const type of types) {
+		yield* sql<{ id: string }>`
+			select "id" from "consentPolicy"
+			where "isActive" = ${true} and "type" = ${type}
+			order by "effectiveDate" desc
+			limit 1
+		`;
+		queries += 1;
+	}
+
+	return {
+		subjects: subjects.length,
+		consents: consents.length,
+		queries,
+	} satisfies ArmResult;
+});
+
+/**
+ * The rewrite: subjects left-joined to consents, plus one ranked query for the
+ * latest active policy per type. Two statements, whatever the data.
+ */
+export const joined = Effect.fn('arm.joined')(function* (externalId: string) {
+	const sql = yield* SqlClient.SqlClient;
+
+	const rows = yield* sql<{ subject_id: string; consent_id: string | null }>`
+		select s."id" as "subject_id", c."id" as "consent_id"
+		from "subject" s
+		left join "consent" c on c."subjectId" = s."id"
+		where s."externalId" = ${externalId}
+	`;
+
+	yield* sql<{ id: string; type: string }>`
+		select "id", "type" from (
+			select "id", "type",
+				row_number() over (partition by "type" order by "effectiveDate" desc) as rn
+			from "consentPolicy" where "isActive" = ${true}
+		) ranked where rn = 1
+	`;
+
+	return {
+		subjects: new Set(rows.map((row) => row.subject_id)).size,
+		consents: rows.filter((row) => row.consent_id !== null).length,
+		queries: 2,
+	} satisfies ArmResult;
+});

--- a/benchmarks/backend-bench/src/run.ts
+++ b/benchmarks/backend-bench/src/run.ts
@@ -1,0 +1,183 @@
+/**
+ * Head-to-head query benchmarks for the backend rewrite (RFC 0004 §7).
+ *
+ * A 2×2, swept across subject counts:
+ *
+ * |                    | migration 1 (no indexes) | migration 2 (indexed) |
+ * | ------------------ | ------------------------ | --------------------- |
+ * | **chunked fan-out**| the shipped design       | indexes alone         |
+ * | **joined**         | the join alone           | the rewrite as shipped|
+ *
+ * The off-diagonal cells are the point. Without them a single before/after
+ * number cannot distinguish "the join helped" from "the indexes helped", and
+ * RFC §11.4 is explicit that a large indexing win must not be silently
+ * attributed to Effect. Adding indexes to the *old* pattern is what makes the
+ * attribution honest.
+ *
+ * Runs against PGlite so it needs no server and no Docker.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { up as baseline } from '@c15t/backend-next/db/migrations/1-baseline';
+import { up as hotPathIndexes } from '@c15t/backend-next/db/migrations/2-hot-path-indexes';
+import { PgliteClient } from '@effect/sql-pglite';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { type ArmResult, chunkedFanout, joined } from './arms';
+
+const SUBJECT_COUNTS = [1, 10, 100, 1000] as const;
+const POLICY_TYPES = 5;
+const ITERATIONS = 12;
+const WARMUP = 3;
+
+interface Sample {
+	readonly arm: string;
+	readonly migrations: string[];
+	readonly subjects: number;
+	readonly queries: number;
+	readonly durations: number[];
+}
+
+const seed = Effect.fn('seed')(function* (subjects: number) {
+	const sql = yield* SqlClient.SqlClient;
+
+	yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
+		values ('dom_1','example.com',now(),now())`);
+
+	for (let type = 0; type < POLICY_TYPES; type++) {
+		for (const version of [0, 1]) {
+			yield* sql.unsafe(`insert into "consentPolicy"
+				("id","version","type","effectiveDate","isActive","createdAt")
+				values ('pol_${type}_${version}','1.${version}','type_${type}',
+					now() - interval '${version} day', true, now())`);
+		}
+	}
+
+	// One statement rather than N inserts, so seeding a thousand subjects does
+	// not dominate the run.
+	const subjectRows = Array.from(
+		{ length: subjects },
+		(_, index) => `('sub_${index}','ext_bench',now(),now())`
+	).join(',');
+	yield* sql.unsafe(
+		`insert into "subject" ("id","externalId","createdAt","updatedAt") values ${subjectRows}`
+	);
+
+	const consentRows = Array.from(
+		{ length: subjects },
+		(_, index) =>
+			`('cns_${index}','sub_${index}','dom_1','pol_${index % POLICY_TYPES}_0','[]',now())`
+	).join(',');
+	yield* sql.unsafe(
+		`insert into "consent" ("id","subjectId","domainId","policyId","purposeIds","givenAt") values ${consentRows}`
+	);
+});
+
+const measure = Effect.fn('measure')(function* (
+	arm: (externalId: string) => Effect.Effect<ArmResult, unknown, never>,
+	label: string,
+	migrations: string[],
+	subjects: number
+) {
+	for (let index = 0; index < WARMUP; index++) {
+		yield* arm('ext_bench');
+	}
+
+	const durations: number[] = [];
+	let queries = 0;
+	for (let index = 0; index < ITERATIONS; index++) {
+		const start = performance.now();
+		const result = yield* arm('ext_bench');
+		durations.push(performance.now() - start);
+		queries = result.queries;
+	}
+
+	return {
+		arm: label,
+		migrations,
+		subjects,
+		queries,
+		durations,
+	} satisfies Sample;
+});
+
+/** One isolated database per cell, so no arm inherits another's cache state. */
+const cell = (subjects: number, indexed: boolean) =>
+	Effect.gen(function* () {
+		yield* baseline;
+		if (indexed) yield* hotPathIndexes;
+		yield* seed(subjects);
+
+		const migrations = indexed
+			? ['1-baseline', '2-hot-path-indexes']
+			: ['1-baseline'];
+
+		return [
+			yield* measure(chunkedFanout, 'chunked-fanout', migrations, subjects),
+			yield* measure(joined, 'joined', migrations, subjects),
+		];
+	}).pipe(Effect.provide(PgliteClient.layer({})));
+
+const stats = (values: number[]) => {
+	const sorted = [...values].sort((a, b) => a - b);
+	const at = (q: number) =>
+		sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))] ?? 0;
+	return {
+		median: at(0.5),
+		p95: at(0.95),
+		avg: sorted.reduce((total, value) => total + value, 0) / sorted.length,
+	};
+};
+
+const program = Effect.gen(function* () {
+	const samples: Sample[] = [];
+	for (const subjects of SUBJECT_COUNTS) {
+		for (const indexed of [false, true]) {
+			samples.push(...(yield* cell(subjects, indexed)));
+		}
+	}
+	return samples;
+});
+
+const samples = await Effect.runPromise(program);
+
+const rows = samples.map((sample) => ({
+	arm: sample.arm,
+	indexed: sample.migrations.length > 1,
+	subjects: sample.subjects,
+	queries: sample.queries,
+	...stats(sample.durations),
+}));
+
+process.stdout.write(
+	'\n| arm | indexed | subjects | queries | median ms | p95 ms |\n' +
+		'| --- | --- | ---: | ---: | ---: | ---: |\n' +
+		rows
+			.map(
+				(row) =>
+					`| ${row.arm} | ${row.indexed ? 'yes' : 'no'} | ${row.subjects} | ${row.queries} | ${row.median.toFixed(3)} | ${row.p95.toFixed(3)} |`
+			)
+			.join('\n') +
+		'\n\n'
+);
+
+const outputDir =
+	process.env.BENCH_OUTPUT_DIR ?? '../../.benchmarks/current/backend-runtime';
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(
+	join(outputDir, 'subject-list.json'),
+	`${JSON.stringify(
+		{
+			suite: 'backend-runtime',
+			framework: 'backend',
+			generatedAt: new Date().toISOString(),
+			iterations: ITERATIONS,
+			engine: 'postgres',
+			note: 'Query patterns compared against one client. The chunked-fanout arm reproduces list.handler.ts and consent-enrichment.ts rather than calling @c15t/backend, which isolates the pattern and excludes fumadb overhead — so it measures the floor of the old design, not the shipped package.',
+			rows,
+		},
+		null,
+		2
+	)}\n`
+);

--- a/benchmarks/backend-bench/src/run.ts
+++ b/benchmarks/backend-bench/src/run.ts
@@ -39,6 +39,21 @@ interface Sample {
 	readonly durations: number[];
 }
 
+/**
+ * Background rows per targeted subject.
+ *
+ * Without this every subject shares one `externalId`, so `where "externalId" =
+ * ?` selects 100% of the table — the one shape where an index cannot help and
+ * the planner pays for it anyway. An earlier revision of this benchmark did
+ * exactly that and reported indexes making the query *slower*, which said
+ * nothing about the indexes and everything about the fixture.
+ *
+ * A real deployment has many external ids and reads one. 20× background gives
+ * roughly 5% selectivity, which is where an index is supposed to earn its
+ * keep.
+ */
+const BACKGROUND_RATIO = 20;
+
 const seed = Effect.fn('seed')(function* (subjects: number) {
 	const sql = yield* SqlClient.SqlClient;
 
@@ -72,6 +87,34 @@ const seed = Effect.fn('seed')(function* (subjects: number) {
 	yield* sql.unsafe(
 		`insert into "consent" ("id","subjectId","domainId","policyId","purposeIds","givenAt") values ${consentRows}`
 	);
+
+	// Background population under other external ids, so the measured query
+	// reads a slice of the table rather than all of it.
+	const background = subjects * BACKGROUND_RATIO;
+	for (let offset = 0; offset < background; offset += 5000) {
+		const size = Math.min(5000, background - offset);
+		const bgSubjects = Array.from(
+			{ length: size },
+			(_, index) =>
+				`('bg_${offset + index}','ext_other_${offset + index}',now(),now())`
+		).join(',');
+		yield* sql.unsafe(
+			`insert into "subject" ("id","externalId","createdAt","updatedAt") values ${bgSubjects}`
+		);
+
+		const bgConsents = Array.from(
+			{ length: size },
+			(_, index) =>
+				`('bgc_${offset + index}','bg_${offset + index}','dom_1','pol_${(offset + index) % POLICY_TYPES}_0','[]',now())`
+		).join(',');
+		yield* sql.unsafe(
+			`insert into "consent" ("id","subjectId","domainId","policyId","purposeIds","givenAt") values ${bgConsents}`
+		);
+	}
+
+	// Planner statistics are what decide index vs sequential scan; without
+	// this the first queries run against an empty pg_statistic.
+	yield* sql.unsafe('analyze');
 });
 
 const measure = Effect.fn('measure')(function* (

--- a/benchmarks/backend-bench/tsconfig.json
+++ b/benchmarks/backend-bench/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "@c15t/typescript-config/node.json",
+	"compilerOptions": { "rootDir": "src" },
+	"include": ["src"],
+	"exclude": ["node_modules"]
+}

--- a/benchmarks/shared/src/schema.ts
+++ b/benchmarks/shared/src/schema.ts
@@ -5,7 +5,9 @@ export type BenchmarkSuite =
 	| 'bundle'
 	| 'browser-runtime'
 	| 'script-lifecycle'
-	| 'artifact';
+	| 'artifact'
+	// Server-side query benchmarks for the backend rewrite (RFC 0004 §7).
+	| 'backend-runtime';
 
 export type BenchmarkFramework =
 	| 'core'
@@ -13,7 +15,8 @@ export type BenchmarkFramework =
 	| 'nextjs'
 	| 'svelte'
 	| 'solid'
-	| 'vue';
+	| 'vue'
+	| 'backend';
 
 export interface BenchmarkEnvironment {
 	os: string;
@@ -31,6 +34,19 @@ export interface BenchmarkFixtureDescriptor {
 	localeCount: number;
 	themeComplexity: 'minimal' | 'complex';
 	notes?: string[];
+	/**
+	 * Server-side shape, for `backend-runtime` arms. Optional so existing
+	 * browser and bundle reports keep validating unchanged.
+	 */
+	engine?: 'postgres' | 'mysql' | 'sqlite';
+	/** Seeded row counts, keyed by table. */
+	rowCounts?: Record<string, number>;
+	/**
+	 * Which migrations were applied. Load-bearing: RFC 0004 §11.4 requires
+	 * migration 1 and migration 2 be reported separately, or an indexing win
+	 * is silently attributed to the rewrite.
+	 */
+	migrations?: string[];
 }
 
 export interface MetricSampleSet {

--- a/bun.lock
+++ b/bun.lock
@@ -171,6 +171,20 @@
         "typescript": "6.0.3",
       },
     },
+    "benchmarks/backend-bench": {
+      "name": "@c15t/backend-bench",
+      "dependencies": {
+        "@c15t/backend-next": "workspace:*",
+        "@c15t/benchmarking": "workspace:*",
+        "@effect/sql-pglite": "4.0.0-beta.102",
+        "effect": "4.0.0-beta.102",
+      },
+      "devDependencies": {
+        "@c15t/typescript-config": "workspace:*",
+        "@types/node": "^24.10.1",
+        "typescript": "7.0.2",
+      },
+    },
     "benchmarks/bundle-test-app": {
       "name": "@c15t/next-bundle-bench",
       "dependencies": {
@@ -1094,6 +1108,8 @@
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
     "@c15t/backend": ["@c15t/backend@workspace:packages/backend"],
+
+    "@c15t/backend-bench": ["@c15t/backend-bench@workspace:benchmarks/backend-bench"],
 
     "@c15t/backend-next": ["@c15t/backend-next@workspace:packages/backend-next"],
 
@@ -5271,6 +5287,10 @@
 
     "@c15t/backend/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "@c15t/backend-bench/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
+    "@c15t/backend-bench/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
     "@c15t/backend-next/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
     "@c15t/backend-next/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -6840,6 +6860,8 @@
     "@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@c15t/backend-bench/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@c15t/backend-next/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 


### PR DESCRIPTION
A 2×2 benchmark comparing the shipped chunked fan-out against the rewrite's join, each **with and without** the hot-path indexes, swept across 1/10/100/1000 subjects.

## The off-diagonal cells are the point

A single before/after number cannot distinguish "the join helped" from "the indexes helped", and RFC 0004 §11.4 is explicit that a large indexing win must not be silently attributed to Effect. Running the **old pattern with indexes** is what makes the attribution honest.

At 1000 subjects against 20k background rows, the win decomposes as:

| Arm | Speedup |
| --- | --- |
| join alone | 1.94× |
| indexes alone | 2.01× |
| both | 2.53× |

Roughly half the total improvement is the index migration, not the rewrite. That is exactly what the 2×2 was asked to be able to tell us, and it would have been invisible in a single before/after number.

## What the chunked-fanout arm does and does not measure

It reproduces `list.handler.ts` and `consent-enrichment.ts` against the same bare SQL client rather than calling `@c15t/backend` — same chunk size of 500, same sequential loops. That isolates the query pattern and excludes fumadb's own JS overhead, so it measures the **floor** of the old design rather than the shipped package. Noted in the emitted JSON so nobody reads it as more than it is. (#969 adds the arm that runs the real thing.)

Query count is reported alongside latency: on a warm local database, latency alone hides the fan-out almost entirely.

## A fixture bug worth recording

Every subject initially shared one `externalId`, so `where "externalId" = ?` selected **100% of the table** — the one shape where an index cannot help and the planner pays for it anyway. The benchmark duly reported indexes making the query *slower*, which said nothing about the indexes and everything about the fixture.

Fixed with a 20× background population under other external ids (~5% selectivity) and an `ANALYZE`, since the planner decides index-vs-seqscan from statistics that an unanalyzed table does not have.

## Schema

Extends the shared benchmark schema additively — `backend-runtime` suite, `backend` framework, and optional `engine`/`rowCounts`/`migrations` on the fixture descriptor — so existing browser and bundle reports keep validating.
