### PR TITLE
feat(backend-next): HTTP surface with the wire contract enforced

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -795,6 +795,7 @@
       "version": "2.1.1-canary-20260727202135",
       "dependencies": {
         "@c15t/translations": "workspace:*",
+        "base-x": "5.0.1",
         "valibot": "1.4.2",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -580,7 +580,10 @@
       "name": "@c15t/backend-next",
       "version": "0.0.0",
       "dependencies": {
+        "@c15t/schema": "workspace:*",
         "effect": "4.0.0-beta.102",
+        "hono": "4.12.27",
+        "valibot": "1.4.2",
       },
       "devDependencies": {
         "@c15t/migration-fixtures": "workspace:*",

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -55,7 +55,10 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"effect": "4.0.0-beta.102"
+		"@c15t/schema": "workspace:*",
+		"effect": "4.0.0-beta.102",
+		"hono": "4.12.27",
+		"valibot": "1.4.2"
 	},
 	"devDependencies": {
 		"@c15t/migration-fixtures": "workspace:*",

--- a/packages/backend-next/src/http/app.test.ts
+++ b/packages/backend-next/src/http/app.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The HTTP surface, exercised through real requests.
+ *
+ * These assert the wire contract rather than the implementation, because wire
+ * compatibility with `@c15t/backend` 2.x is the hard requirement that makes
+ * running both packages side by side possible (RFC 0004 §Non-goals). Response
+ * bodies are checked against the same `@c15t/schema` schemas the 2.x routes
+ * validate against, so a drift fails here instead of reaching a client.
+ */
+
+import { listSubjectsOutputSchema } from '@c15t/schema';
+import { PgliteClient } from '@effect/sql-pglite';
+import { Effect, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import * as v from 'valibot';
+import { afterEach, assert, beforeEach, describe, it } from 'vitest';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import { createApp } from './app';
+
+let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
+let app: ReturnType<typeof createApp>;
+
+beforeEach(async () => {
+	runtime = ManagedRuntime.make(PgliteClient.layer({}));
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			yield* baseline;
+			yield* indexes;
+		})
+	);
+	app = createApp(runtime);
+});
+
+afterEach(async () => {
+	await runtime.dispose();
+});
+
+const seed = () =>
+	runtime.runPromise(
+		Effect.gen(function* () {
+			const sql = yield* SqlClient.SqlClient;
+			yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
+				values ('dom_1','example.com',now(),now())`);
+			yield* sql.unsafe(`insert into "consentPolicy"
+				("id","version","type","effectiveDate","isActive","createdAt")
+				values ('pol_1','1.0','cookie',now(),true,now())`);
+			yield* sql.unsafe(`insert into "subject"
+				("id","externalId","createdAt","updatedAt")
+				values ('sub_1','ext_1',now(),now())`);
+			yield* sql.unsafe(`insert into "consent"
+				("id","subjectId","domainId","policyId","purposeIds","givenAt")
+				values ('cns_1','sub_1','dom_1','pol_1','[]',now())`);
+		})
+	);
+
+describe('GET /subjects', () => {
+	it('returns a body satisfying the shared output schema', async () => {
+		await seed();
+
+		const response = await app.request('/subjects?externalId=ext_1');
+		assert.strictEqual(response.status, 200);
+
+		const body = await response.json();
+
+		// Dates arrive as ISO strings over the wire; the schema expects Date,
+		// so revive before validating — as a 2.x client would. Done generically
+		// rather than field by field, because naming each one means a new date
+		// field silently fails the assertion for the wrong reason.
+		const ISO = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/;
+		const revive = (value: unknown): unknown => {
+			if (typeof value === 'string')
+				return ISO.test(value) ? new Date(value) : value;
+			if (Array.isArray(value)) return value.map(revive);
+			if (value !== null && typeof value === 'object') {
+				return Object.fromEntries(
+					Object.entries(value).map(([key, nested]) => [key, revive(nested)])
+				);
+			}
+			return value;
+		};
+		const revived = revive(body);
+
+		const parsed = v.safeParse(listSubjectsOutputSchema, revived);
+		assert.isTrue(
+			parsed.success,
+			parsed.success ? '' : JSON.stringify(v.flatten(parsed.issues))
+		);
+	});
+
+	it('reports a missing externalId the way 2.x does', async () => {
+		const response = await app.request('/subjects');
+
+		assert.strictEqual(response.status, 400);
+		assert.deepStrictEqual(await response.json(), {
+			message: 'externalId query parameter is required',
+			cause: { code: 'EXTERNAL_ID_REQUIRED' },
+		});
+	});
+
+	it('treats an empty externalId as missing rather than matching nothing', async () => {
+		// A bare `?externalId=` is a client bug, and answering it with an empty
+		// list would hide that. 2.x rejects it, so this does too.
+		const response = await app.request('/subjects?externalId=');
+		assert.strictEqual(response.status, 400);
+	});
+
+	it('returns an empty list for an externalId nobody has', async () => {
+		await seed();
+		const response = await app.request('/subjects?externalId=ext_absent');
+
+		assert.strictEqual(response.status, 200);
+		assert.deepStrictEqual(await response.json(), { subjects: [] });
+	});
+
+	it('does not leak database detail when a query fails', async () => {
+		// Drop the table out from under the handler to force a SqlError.
+		await runtime.runPromise(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql.unsafe('drop table "consent" cascade');
+			})
+		);
+
+		const response = await app.request('/subjects?externalId=ext_1');
+		const body = await response.json();
+
+		assert.strictEqual(response.status, 500);
+		// Table and column names in an error body are information disclosure,
+		// and more so on a consent platform. Detail belongs in the wide event.
+		assert.deepStrictEqual(body, {
+			message: 'Internal server error',
+			cause: { code: 'DATABASE_ERROR' },
+		});
+		assert.notInclude(JSON.stringify(body), 'consent');
+	});
+});

--- a/packages/backend-next/src/http/app.ts
+++ b/packages/backend-next/src/http/app.ts
@@ -1,0 +1,121 @@
+/**
+ * The HTTP surface.
+ *
+ * Hono stays, because RFC 0004 changes the data layer and the runtime, not the
+ * wire. Routes hand off to Effect immediately and the app owns exactly two
+ * things: turning a request into handler inputs, and turning a typed failure
+ * into a response.
+ *
+ * ## Wire compatibility is enforced, not asserted
+ *
+ * §Non-goals makes wire compatibility with `@c15t/backend` 2.x a hard
+ * requirement. Rather than restate the response shapes here and hope they stay
+ * aligned, every handler validates its output against the **same
+ * `@c15t/schema` schema the 2.x routes validate against**. If the two drift,
+ * this package fails its own tests rather than shipping a silently different
+ * response.
+ *
+ * That also means the schemas remain the single source of truth across the
+ * cutover, which is what makes running both packages against one contract
+ * possible at all.
+ */
+
+import { listSubjectsOutputSchema } from '@c15t/schema';
+import { Effect, ManagedRuntime } from 'effect';
+import type { SqlClient } from 'effect/unstable/sql';
+import { Hono } from 'hono';
+import * as v from 'valibot';
+import { listByExternalId } from '../repository/subject';
+import { BadRequestError, type RouteError, toHttp } from './errors';
+
+export interface AppLayers {
+	readonly sql: SqlClient.SqlClient;
+}
+
+/**
+ * Builds the app over a runtime that already has its layers provided.
+ *
+ * The runtime is constructed once by the caller and reused for every request —
+ * building a layer per request would open a connection pool per request.
+ */
+export function createApp(
+	runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>
+) {
+	const app = new Hono();
+
+	/**
+	 * Runs a handler and maps its typed failure onto a response.
+	 *
+	 * `Effect.result` moves the typed error into the success channel, so what
+	 * comes back is a value to branch on. A defect is left alone and still
+	 * rejects the promise — laundering one into a tidy 500 would erase the
+	 * distinction the typed channel exists to make.
+	 */
+	const run = async <A>(
+		effect: Effect.Effect<A, RouteError, SqlClient.SqlClient>
+	): Promise<
+		{ ok: true; value: A } | { ok: false; failure: ReturnType<typeof toHttp> }
+	> => {
+		const result = await runtime.runPromise(Effect.result(effect));
+		return result._tag === 'Success'
+			? { ok: true, value: result.success }
+			: { ok: false, failure: toHttp(result.failure) };
+	};
+
+	app.get('/subjects', async (c) => {
+		const externalId = c.req.query('externalId');
+
+		const result = await run(
+			Effect.gen(function* () {
+				if (externalId === undefined || externalId === '') {
+					// Matches 2.x's error shape exactly, code included.
+					return yield* new BadRequestError({
+						message: 'externalId query parameter is required',
+						code: 'EXTERNAL_ID_REQUIRED',
+					});
+				}
+
+				const subjects = yield* listByExternalId(externalId);
+
+				return {
+					subjects: subjects.map((subject) => ({
+						id: subject.id,
+						// 2.x falls back to the queried value when the stored
+						// column is null, and the schema requires a string.
+						externalId: subject.externalId ?? externalId,
+						createdAt: subject.createdAt,
+						consents: subject.consents.map((consent) => ({
+							id: consent.id,
+							type: consent.type,
+							policyId: consent.policyId,
+							policyVersion: consent.policyVersion,
+							policyHash: consent.policyHash,
+							policyEffectiveDate: consent.policyEffectiveDate,
+							givenAt: consent.givenAt,
+							isLatestPolicy: consent.isLatestPolicy,
+						})),
+					})),
+				};
+			})
+		);
+
+		if (!result.ok) {
+			return c.json(result.failure.body, result.failure.status);
+		}
+
+		// The contract check. Parsing against the shared schema means a drift
+		// from 2.x is a test failure here, not a surprise for a client.
+		const parsed = v.safeParse(listSubjectsOutputSchema, result.value);
+		if (!parsed.success) {
+			throw new Error(
+				`Response does not satisfy listSubjectsOutputSchema: ${v
+					.flatten(parsed.issues)
+					.root?.join(', ')}`
+			);
+		}
+
+		return c.json(result.value);
+	});
+
+	return app;
+}

--- a/packages/backend-next/src/http/errors.ts
+++ b/packages/backend-next/src/http/errors.ts
@@ -1,0 +1,67 @@
+/**
+ * Mapping from the package's typed failures to HTTP responses.
+ *
+ * The point of Effect's typed error channel is that every way a handler can
+ * fail is in its signature. That only pays off if the translation to HTTP is
+ * exhaustive — a `default: 500` swallows the guarantee and turns a known
+ * failure into an opaque one. So this switch is total over the tagged errors,
+ * and anything genuinely unexpected is a defect rather than a 500 with a
+ * shrug.
+ */
+
+import { Data } from 'effect';
+import { SqlError } from 'effect/unstable/sql';
+
+/** A request referenced something that does not exist. */
+export class NotFoundError extends Data.TaggedError('NotFoundError')<{
+	readonly resource: string;
+	readonly id: string;
+}> {}
+
+/** A request was structurally valid but semantically wrong. */
+export class BadRequestError extends Data.TaggedError('BadRequestError')<{
+	readonly message: string;
+	/** Machine-readable code, matching what 2.x puts in `cause.code`. */
+	readonly code: string;
+}> {}
+
+/** Every failure a route is allowed to surface. */
+export type RouteError = NotFoundError | BadRequestError | SqlError.SqlError;
+
+export interface HttpFailure {
+	readonly status: 400 | 404 | 500;
+	readonly body: {
+		readonly message: string;
+		readonly cause?: { readonly code: string };
+	};
+}
+
+export function toHttp(error: RouteError): HttpFailure {
+	switch (error._tag) {
+		case 'NotFoundError':
+			return {
+				status: 404,
+				body: {
+					message: `${error.resource} not found`,
+					cause: { code: 'NOT_FOUND' },
+				},
+			};
+		case 'BadRequestError':
+			return {
+				status: 400,
+				body: { message: error.message, cause: { code: error.code } },
+			};
+		case 'SqlError':
+			// Deliberately opaque to the client: a database error message can
+			// carry table and column names, and on a consent platform that is
+			// information disclosure. The detail belongs in the wide event, not
+			// the response body.
+			return {
+				status: 500,
+				body: {
+					message: 'Internal server error',
+					cause: { code: 'DATABASE_ERROR' },
+				},
+			};
+	}
+}

--- a/packages/backend-next/src/http/init.test.ts
+++ b/packages/backend-next/src/http/init.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `/init` and `/manifest`.
+ *
+ * The load-bearing assertion is the parity one: what this backend returns for
+ * `/init` must equal what a host computes locally from the same `/manifest`.
+ * RFC 0001 splits those two paths precisely so a host can skip the round trip,
+ * and they are only interchangeable if they agree. A disagreement would show
+ * different visitors different banners depending on which path their host
+ * happened to take.
+ */
+
+import {
+	buildConsentManifestFromConfig,
+	type ConsentManifestConfig,
+	resolveInitFromManifest,
+} from '@c15t/schema/types';
+import { assert, describe, it } from 'vitest';
+import { buildInitResponse, readInitSignals } from './init';
+import {
+	buildManifestResponse,
+	createManifestCacheControl,
+	DEFAULT_MANIFEST_S_MAXAGE,
+} from './manifest';
+
+const config: ConsentManifestConfig = {
+	tenantId: 'tenant_1',
+	appName: 'Example',
+};
+
+describe('init signals', () => {
+	it('treats sec-gpc as affirmative only when it is exactly "1"', () => {
+		// The spec defines '1' as the only affirmative value. Reading 'true' or
+		// '0' as consent-relevant would act on a signal the visitor did not
+		// send.
+		for (const [value, expected] of [
+			['1', true],
+			['0', false],
+			['true', false],
+			['', false],
+		] as const) {
+			const headers = new Headers(value === '' ? {} : { 'sec-gpc': value });
+			assert.strictEqual(readInitSignals(headers).gpc, expected, value);
+		}
+	});
+
+	it('defaults language to en when the header is absent', () => {
+		assert.strictEqual(readInitSignals(new Headers()).language, 'en');
+	});
+
+	it('reports absent geo as null rather than guessing', () => {
+		const signals = readInitSignals(new Headers());
+		assert.isNull(signals.country);
+		assert.isNull(signals.region);
+	});
+});
+
+describe('init and manifest parity', () => {
+	it('matches what a host resolves locally from the manifest', async () => {
+		const headers = new Headers({
+			'accept-language': 'de-DE',
+			'sec-gpc': '1',
+		});
+
+		const fromBackend = await buildInitResponse(config, headers);
+
+		// What a host would do: fetch /manifest once, then resolve locally for
+		// each visitor without touching the backend again.
+		const manifest = await buildConsentManifestFromConfig(config);
+		const fromHost = resolveInitFromManifest(manifest, {
+			country: null,
+			region: null,
+			language: 'de-DE',
+			gpc: true,
+		});
+
+		assert.deepStrictEqual(fromBackend.body, fromHost);
+	});
+
+	it('serves a manifest whose etag is its own revision', async () => {
+		const result = await buildManifestResponse(config, undefined, null);
+		const manifest = await buildConsentManifestFromConfig(config);
+
+		// Deriving a second hash would risk the etag and the revision
+		// disagreeing about whether a manifest changed.
+		assert.strictEqual(result.etag, `"${manifest.revision}"`);
+	});
+
+	it('produces a stable revision for unchanged config', async () => {
+		const first = await buildConsentManifestFromConfig(config);
+		const second = await buildConsentManifestFromConfig(config);
+
+		// A revision that moved on every build would bust every CDN cache and
+		// every client etag on every deploy.
+		assert.strictEqual(first.revision, second.revision);
+	});
+});
+
+describe('manifest cache control', () => {
+	it('uses the shipped defaults', () => {
+		assert.strictEqual(
+			createManifestCacheControl(undefined),
+			`public, s-maxage=${DEFAULT_MANIFEST_S_MAXAGE}, stale-while-revalidate=86400`
+		);
+	});
+
+	it('falls back rather than emitting a nonsense directive', () => {
+		// A negative or non-finite value is a config mistake. Passing it
+		// through would put something a CDN acts on into the header.
+		for (const bad of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+			assert.include(
+				createManifestCacheControl({ sMaxAge: bad }),
+				`s-maxage=${DEFAULT_MANIFEST_S_MAXAGE}`
+			);
+		}
+	});
+
+	it('honours a configured value', () => {
+		assert.include(
+			createManifestCacheControl({ sMaxAge: 60, staleWhileRevalidate: 120 }),
+			's-maxage=60, stale-while-revalidate=120'
+		);
+	});
+});

--- a/packages/backend-next/src/http/init.ts
+++ b/packages/backend-next/src/http/init.ts
@@ -1,0 +1,81 @@
+/**
+ * `GET /init` — the per-request consent decision.
+ *
+ * Every piece of this is shared with `@c15t/backend` rather than
+ * reimplemented: the manifest comes from `buildConsentManifestFromConfig`, geo
+ * from `getRegionFromHeaders`, and the decision itself from
+ * `resolveInitFromManifest`. This module contributes header parsing and
+ * nothing else.
+ *
+ * That is the whole point of RFC 0001's design. `/init` is the one endpoint on
+ * the critical rendering path, and it is also the one whose output a host can
+ * compute locally from the manifest. If a backend resolved it differently from
+ * the shared resolver, hosts doing local resolution would disagree with the
+ * server for the same visitor — which on a consent platform means showing the
+ * wrong banner, or none. Keeping exactly one resolver makes that class of bug
+ * unreachable rather than merely tested for.
+ *
+ * Like `/manifest`, this touches no database.
+ */
+
+import { getRegionFromHeaders, headersToRecord } from '@c15t/schema/geo';
+import {
+	buildConsentManifestFromConfig,
+	type ConsentManifestConfig,
+	type InitOutput,
+	resolveInitFromManifest,
+} from '@c15t/schema/types';
+
+export interface InitRequestSignals {
+	readonly country: string | null;
+	readonly region: string | null;
+	readonly language: string;
+	readonly gpc: boolean;
+}
+
+/**
+ * Extracts the four per-request inputs from headers.
+ *
+ * These are the only request-dependent values in an `/init` response —
+ * everything else comes from the manifest, which is why the manifest can be
+ * cached per tenant and this cannot.
+ */
+export function readInitSignals(headers: Headers): InitRequestSignals {
+	const { country, region } = getRegionFromHeaders(headersToRecord(headers));
+
+	return {
+		country: country ?? null,
+		region: region ?? null,
+		// Matches 2.x: the raw header, defaulted to 'en'. Narrowing to a
+		// primary subtag happens downstream in the resolver, not here.
+		language: headers.get('accept-language') || 'en',
+		// Global Privacy Control is a signal, not a preference: the spec
+		// defines '1' as the only affirmative value, so anything else is
+		// absence rather than a false.
+		gpc: headers.get('sec-gpc') === '1',
+	};
+}
+
+/**
+ * Resolves an `/init` response for one request.
+ *
+ * Geo-dependent by definition, so unlike `/manifest` it must not be cached
+ * across visitors.
+ */
+export async function buildInitResponse(
+	config: ConsentManifestConfig,
+	headers: Headers
+): Promise<{ body: InitOutput; signals: InitRequestSignals }> {
+	const signals = readInitSignals(headers);
+	const manifest = await buildConsentManifestFromConfig(config);
+
+	return {
+		body: resolveInitFromManifest(manifest, {
+			country: signals.country,
+			region: signals.region,
+			language: signals.language,
+			gpc: signals.gpc,
+		}),
+		signals,
+	};
+}

--- a/packages/backend-next/src/http/manifest.ts
+++ b/packages/backend-next/src/http/manifest.ts
@@ -1,0 +1,88 @@
+/**
+ * `GET /manifest` — the geo-independent, CDN-cacheable consent manifest.
+ *
+ * The manifest is per-tenant static configuration, and resolving an `/init`
+ * response from it is a pure function. Both of those live in `@c15t/schema`,
+ * so this route is transport and caching only — it builds nothing itself.
+ *
+ * That is deliberate and load-bearing during the parallel phase. Two backends
+ * serve the same tenants; if they built manifests independently, a divergence
+ * would break clients that cached one and resolved against the other, and it
+ * would silently invalidate both the contract tests and the benchmark. RFC
+ * 0001 states the principle — exactly one implementation — and RFC 0004 relies
+ * on it.
+ *
+ * Nothing here touches the database. `/manifest` is config, not data.
+ */
+
+import {
+	buildConsentManifestFromConfig,
+	type ConsentManifestConfig,
+	sliceConsentManifestLanguage,
+} from '@c15t/schema/types';
+
+/** Matches the shipped defaults in `routes/manifest.ts`. */
+export const DEFAULT_MANIFEST_S_MAXAGE = 300;
+export const DEFAULT_MANIFEST_STALE_WHILE_REVALIDATE = 86_400;
+
+export interface ManifestCacheOptions {
+	readonly sMaxAge?: number;
+	readonly staleWhileRevalidate?: number;
+}
+
+function normalizeCacheSeconds(
+	value: number | undefined,
+	fallback: number
+): number {
+	// A negative or non-finite value is a configuration mistake, not an
+	// instruction to disable caching — fall back rather than emit nonsense
+	// into a header a CDN will act on.
+	return Number.isFinite(value) && value !== undefined && value >= 0
+		? Math.floor(value)
+		: fallback;
+}
+
+export function createManifestCacheControl(
+	cache: ManifestCacheOptions | undefined
+): string {
+	const sMaxAge = normalizeCacheSeconds(
+		cache?.sMaxAge,
+		DEFAULT_MANIFEST_S_MAXAGE
+	);
+	const staleWhileRevalidate = normalizeCacheSeconds(
+		cache?.staleWhileRevalidate,
+		DEFAULT_MANIFEST_STALE_WHILE_REVALIDATE
+	);
+	return `public, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`;
+}
+
+export interface ManifestResult {
+	readonly body: unknown;
+	readonly etag: string;
+	readonly cacheControl: string;
+}
+
+/**
+ * Builds the manifest response.
+ *
+ * `?language=` serves a single-language slice with identical cache semantics —
+ * the slice is derived from the same manifest, so it cannot drift from the
+ * full document.
+ */
+export async function buildManifestResponse(
+	config: ConsentManifestConfig,
+	cache: ManifestCacheOptions | undefined,
+	language: string | null
+): Promise<ManifestResult> {
+	const manifest = await buildConsentManifestFromConfig(config);
+
+	return {
+		body: language
+			? sliceConsentManifestLanguage(manifest, language)
+			: manifest,
+		// The revision already fingerprints the manifest, so it is the etag.
+		// Deriving a second hash would risk the two disagreeing.
+		etag: `"${manifest.revision}"`,
+		cacheControl: createManifestCacheControl(cache),
+	};
+}

--- a/packages/backend-next/src/repository/subject.ts
+++ b/packages/backend-next/src/repository/subject.ts
@@ -31,7 +31,17 @@ import { SqlClient, SqlError } from 'effect/unstable/sql';
 export interface ConsentRow {
 	readonly id: string;
 	readonly subjectId: string;
-	readonly policyId: string | null;
+	/**
+	 * The policy's type, which the wire contract requires on every consent.
+	 *
+	 * 2.x fetched this in a second pass inside `consent-enrichment.ts`; joining
+	 * it here costs nothing extra and keeps the whole read at one query.
+	 */
+	readonly type: string;
+	readonly policyId: string | undefined;
+	readonly policyVersion: string | undefined;
+	readonly policyHash: string | undefined;
+	readonly policyEffectiveDate: Date | undefined;
 	readonly purposeIds: unknown;
 	readonly givenAt: Date;
 	/** True when this consent points at the newest active policy of its type. */
@@ -53,7 +63,14 @@ interface JoinedRow {
 	readonly consent_policyId: string | null;
 	readonly consent_purposeIds: unknown;
 	readonly consent_givenAt: Date | null;
+	readonly policy_type: string | null;
+	readonly policy_version: string | null;
+	readonly policy_hash: string | null;
+	readonly policy_effectiveDate: Date | null;
 }
+
+/** Valibot `optional` means absent, not null; the database means null. */
+const orUndefined = <T>(value: T | null): T | undefined => value ?? undefined;
 
 /**
  * The newest active policy for each type, in one query.
@@ -102,9 +119,14 @@ export const listByExternalId = Effect.fn('repository.listByExternalId')(
 				c."id"          as "consent_id",
 				c."policyId"    as "consent_policyId",
 				c."purposeIds"  as "consent_purposeIds",
-				c."givenAt"     as "consent_givenAt"
+				c."givenAt"     as "consent_givenAt",
+				p."type"          as "policy_type",
+				p."version"       as "policy_version",
+				p."hash"          as "policy_hash",
+				p."effectiveDate" as "policy_effectiveDate"
 			from "subject" s
 			left join "consent" c on c."subjectId" = s."id"
+			left join "consentPolicy" p on p."id" = c."policyId"
 			where s."externalId" = ${externalId}
 			order by s."id", c."givenAt" desc
 		`;
@@ -128,7 +150,14 @@ export const listByExternalId = Effect.fn('repository.listByExternalId')(
 				(subject.consents as ConsentRow[]).push({
 					id: row.consent_id,
 					subjectId: row.subject_id,
-					policyId: row.consent_policyId,
+					// A consent whose policy row is gone still has to satisfy the
+					// contract's required `type`; '' is the honest answer rather
+					// than inventing one.
+					type: row.policy_type ?? '',
+					policyId: orUndefined(row.consent_policyId),
+					policyVersion: orUndefined(row.policy_version),
+					policyHash: orUndefined(row.policy_hash),
+					policyEffectiveDate: orUndefined(row.policy_effectiveDate),
 					purposeIds: row.consent_purposeIds,
 					givenAt: row.consent_givenAt,
 					isLatestPolicy:

--- a/packages/backend/src/handlers/init/manifest.ts
+++ b/packages/backend/src/handlers/init/manifest.ts
@@ -1,65 +1,21 @@
 import {
+	buildConsentManifestFromConfig,
 	type ConsentManifest,
-	createConsentManifestPolicyPack,
-	createDeterministicFingerprintSync,
-	createPolicyFingerprint,
-	createResolvedPolicyFromConfig,
 } from '@c15t/schema/types';
 import type { C15TEdgeOptions } from '~/edge/types';
 
-const DEFAULT_GVL_ENDPOINT = 'https://gvl.inth.app';
-
 export type InitManifestOptions = Omit<C15TEdgeOptions, 'logger'>;
 
-function buildGvlReference(
-	options: InitManifestOptions
-): ConsentManifest['iab'] {
-	if (options.iab?.enabled !== true) {
-		return undefined;
-	}
-
-	return {
-		enabled: true,
-		customVendors: options.iab.customVendors,
-		gvl: {
-			url: options.iab.endpoint ?? DEFAULT_GVL_ENDPOINT,
-		},
-	};
-}
-
+/**
+ * Builds the consent manifest for these options.
+ *
+ * Delegates to `@c15t/schema` so there is exactly one implementation. RFC 0001
+ * makes that a design principle, and RFC 0004's parallel phase depends on it:
+ * two backends serve the same tenants, and a manifest that differed between
+ * them would invalidate the contract tests and the benchmark comparison alike.
+ */
 export async function buildConsentManifestFromOptions(
 	options: InitManifestOptions
 ): Promise<ConsentManifest> {
-	const policyPacks = options.policyPacks
-		? await Promise.all(
-				options.policyPacks.map(async (policy) => {
-					const resolvedPolicy = createResolvedPolicyFromConfig(policy);
-					const fingerprint = await createPolicyFingerprint(resolvedPolicy);
-					return createConsentManifestPolicyPack({ policy, fingerprint });
-				})
-			)
-		: undefined;
-
-	const manifest: ConsentManifest = {
-		schemaVersion: 1,
-		revision: '',
-		tenantId: options.tenantId,
-		appName: options.appName,
-		branding: options.branding || 'c15t',
-		defaults: {
-			disableGeoLocation: options.disableGeoLocation,
-		},
-		policyPacks,
-		translations: {
-			customTranslations: options.customTranslations,
-			i18n: options.i18n,
-		},
-		cmpId: options.iab?.cmpId,
-		iab: buildGvlReference(options),
-	};
-
-	return {
-		...manifest,
-		revision: createDeterministicFingerprintSync(manifest),
-	};
+	return buildConsentManifestFromConfig(options);
 }

--- a/packages/backend/src/handlers/subject/id-parity.test.ts
+++ b/packages/backend/src/handlers/subject/id-parity.test.ts
@@ -1,0 +1,33 @@
+import { buildConsentId as shared } from '@c15t/schema/types';
+import { assert, it } from 'vitest';
+import { buildConsentId as shipped } from '~/handlers/subject/consent-idempotency';
+
+it('shared derivation matches the shipping one byte for byte', async () => {
+	const cases = [
+		{
+			subjectId: 'sub_1',
+			domainId: 'dom_1',
+			givenAt: new Date(1_700_000_000_000),
+		},
+		{
+			tenantId: 't1',
+			subjectId: 'sub_2',
+			domainId: 'dom_2',
+			policyId: 'pol_1',
+			givenAt: new Date(1_800_000_123_456),
+		},
+		{
+			subjectId: 'sub_3',
+			domainId: 'dom_3',
+			policyId: null,
+			givenAt: new Date(1_650_000_000_000),
+		},
+	];
+	for (const input of cases) {
+		assert.strictEqual(
+			await shared(input),
+			await shipped(input),
+			JSON.stringify(input)
+		);
+	}
+});

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -68,6 +68,7 @@
 	],
 	"dependencies": {
 		"@c15t/translations": "workspace:*",
+		"base-x": "5.0.1",
 		"valibot": "1.4.2"
 	},
 	"devDependencies": {

--- a/packages/schema/src/shared/consent-manifest.ts
+++ b/packages/schema/src/shared/consent-manifest.ts
@@ -6,6 +6,10 @@ import {
 	getJurisdictionFromLocation,
 } from './jurisdiction-runtime';
 import {
+	createDeterministicFingerprintSync,
+	createPolicyFingerprint,
+} from './policy-fingerprint';
+import {
 	createResolvedPolicyFromConfig,
 	type JurisdictionCode,
 	type PolicyConfig,
@@ -381,3 +385,103 @@ export function resolveInitFromManifest(
 }
 
 export { checkJurisdiction };
+
+/**
+ * The configuration a consent manifest is built from.
+ *
+ * Declared structurally rather than as the backend's options type, so this can
+ * live here without the schema package depending on the backend. Any config
+ * object carrying these fields will do.
+ */
+export interface ConsentManifestConfig {
+	readonly tenantId?: string;
+	readonly appName?: string;
+	readonly branding?: ConsentManifest['branding'];
+	readonly disableGeoLocation?: boolean;
+	readonly policyPacks?: Parameters<
+		typeof createConsentManifestPolicyPack
+	>[0]['policy'][];
+	readonly customTranslations?: ConsentManifest['translations'] extends
+		| { customTranslations?: infer T }
+		| undefined
+		? T
+		: never;
+	readonly i18n?: ConsentManifest['translations'] extends
+		| { i18n?: infer T }
+		| undefined
+		? T
+		: never;
+	readonly iab?: {
+		readonly enabled?: boolean;
+		readonly cmpId?: number;
+		readonly customVendors?: NonNullable<
+			ConsentManifest['iab']
+		>['customVendors'];
+		readonly endpoint?: string;
+	};
+}
+
+const DEFAULT_GVL_ENDPOINT = 'https://gvl.inth.app';
+
+function buildGvlReference(
+	config: ConsentManifestConfig
+): ConsentManifest['iab'] {
+	if (config.iab?.enabled !== true) {
+		return undefined;
+	}
+
+	return {
+		enabled: true,
+		customVendors: config.iab.customVendors,
+		gvl: { url: config.iab.endpoint ?? DEFAULT_GVL_ENDPOINT },
+	};
+}
+
+/**
+ * Builds a consent manifest from per-tenant configuration.
+ *
+ * Lives here rather than in a backend so that every implementation serving
+ * `/manifest` produces a byte-identical document from the same config. RFC
+ * 0001 makes that a design principle — "there is exactly one resolver
+ * implementation" — and it matters more during RFC 0004's parallel phase,
+ * where two backends serve the same tenants and any divergence would
+ * invalidate both the contract tests and the benchmark comparison.
+ *
+ * Pure and geo-independent by construction: nothing here reads a request.
+ */
+export async function buildConsentManifestFromConfig(
+	config: ConsentManifestConfig
+): Promise<ConsentManifest> {
+	const policyPacks = config.policyPacks
+		? await Promise.all(
+				config.policyPacks.map(async (policy) => {
+					const resolvedPolicy = createResolvedPolicyFromConfig(policy);
+					const fingerprint = await createPolicyFingerprint(resolvedPolicy);
+					return createConsentManifestPolicyPack({ policy, fingerprint });
+				})
+			)
+		: undefined;
+
+	const manifest: ConsentManifest = {
+		schemaVersion: 1,
+		revision: '',
+		tenantId: config.tenantId,
+		appName: config.appName,
+		branding: config.branding || 'c15t',
+		defaults: { disableGeoLocation: config.disableGeoLocation },
+		policyPacks,
+		translations: {
+			customTranslations: config.customTranslations,
+			i18n: config.i18n,
+		},
+		cmpId: config.iab?.cmpId,
+		iab: buildGvlReference(config),
+	};
+
+	// The revision is a fingerprint of the manifest itself, so a client can
+	// tell two manifests apart without diffing them.
+	return {
+		...manifest,
+		revision: createDeterministicFingerprintSync(manifest),
+	};
+}

--- a/packages/schema/src/shared/entity-id.ts
+++ b/packages/schema/src/shared/entity-id.ts
@@ -1,0 +1,118 @@
+/**
+ * Entity id derivation.
+ *
+ * Lives here because **two backends must derive byte-identical ids**. During
+ * RFC 0004's parallel phase both serve the same tenants, and consent
+ * idempotency is keyed on a deterministic id: if the two implementations
+ * disagreed by so much as an alphabet character or an epoch offset, the same
+ * submission would land twice and a visitor would have duplicate consent
+ * records. That is not a bug a test in one package would catch.
+ *
+ * Every constant below is therefore load-bearing and must not be "tidied".
+ */
+
+import baseX from 'base-x';
+import { hashSha256Hex } from './policy-fingerprint';
+
+/** Table name to id prefix. Prefixes are part of the id format. */
+const PREFIXES = {
+	auditLog: 'log',
+	consent: 'cns',
+	consentPolicy: 'pol',
+	consentPurpose: 'pur',
+	domain: 'dom',
+	runtimePolicyDecision: 'rpd',
+	subject: 'sub',
+} as const;
+
+export type EntityKind = keyof typeof PREFIXES;
+
+// Base58 without the ambiguous glyphs (0, O, I, l), so an id can be read
+// aloud or transcribed without loss.
+const b58 = baseX('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz');
+
+const EPOCH_TIMESTAMP = 1_700_000_000_000;
+const ID_BYTE_LENGTH = 20;
+const TIMESTAMP_BYTE_LENGTH = 8;
+
+/**
+ * Writes the timestamp as an offset from the epoch, big-endian.
+ *
+ * Leading with time makes ids sort chronologically, which keeps inserts at the
+ * right-hand edge of a B-tree index rather than scattered through it.
+ *
+ * Pre-epoch and non-finite timestamps clamp to zero. They therefore share a
+ * zero prefix and are not chronologically ordered relative to each other — the
+ * hash bytes still keep them distinct. This clamp is **not** optional
+ * defensiveness: `givenAt` can be backdated, consent records predating the
+ * epoch exist, and dropping it would derive a different id for every one of
+ * them. Two backends disagreeing there means duplicated consent.
+ */
+function writeTimestamp(buf: Uint8Array, timestamp: number): void {
+	const rawOffset = timestamp - EPOCH_TIMESTAMP;
+	const offset = Number.isFinite(rawOffset) ? Math.max(0, rawOffset) : 0;
+
+	const high = Math.floor(offset / 0x1_00_00_00_00);
+	const low = offset >>> 0;
+
+	buf[0] = (high >>> 24) & 255;
+	buf[1] = (high >>> 16) & 255;
+	buf[2] = (high >>> 8) & 255;
+	buf[3] = high & 255;
+	buf[4] = (low >>> 24) & 255;
+	buf[5] = (low >>> 16) & 255;
+	buf[6] = (low >>> 8) & 255;
+	buf[7] = low & 255;
+}
+
+/**
+ * Derives an id that is a pure function of the identity that produced it.
+ *
+ * The same identity always yields the same id, which is what lets a write be
+ * idempotent without a read-then-write race: the database's primary key does
+ * the deduplication.
+ */
+export async function generateDeterministicId(
+	kind: EntityKind,
+	timestamp: number,
+	identity: readonly (string | null)[]
+): Promise<string> {
+	const digest = await hashSha256Hex(JSON.stringify(identity));
+	const buf = new Uint8Array(ID_BYTE_LENGTH);
+
+	writeTimestamp(buf, timestamp);
+
+	for (let i = TIMESTAMP_BYTE_LENGTH; i < ID_BYTE_LENGTH; i++) {
+		const offset = (i - TIMESTAMP_BYTE_LENGTH) * 2;
+		buf[i] = Number.parseInt(digest.slice(offset, offset + 2), 16);
+	}
+
+	return `${PREFIXES[kind]}_${b58.encode(buf)}`;
+}
+
+/** The fields that identify a single consent submission. */
+export interface ConsentSubmissionIdentity {
+	readonly tenantId?: string;
+	readonly subjectId: string;
+	readonly domainId: string;
+	readonly policyId?: string | null;
+	readonly givenAt: Date;
+}
+
+/**
+ * Derives a consent's primary key from the submission that produced it.
+ *
+ * Field order is part of the format — the identity is JSON-serialised before
+ * hashing, so reordering these changes every id that would ever be derived.
+ */
+export function buildConsentId(
+	input: ConsentSubmissionIdentity
+): Promise<string> {
+	return generateDeterministicId('consent', input.givenAt.getTime(), [
+		input.tenantId ?? null,
+		input.subjectId,
+		input.domainId,
+		input.policyId ?? null,
+		input.givenAt.toISOString(),
+	]);
+}

--- a/packages/schema/src/shared/index.ts
+++ b/packages/schema/src/shared/index.ts
@@ -4,9 +4,11 @@ export {
 	brandingValues,
 } from './branding';
 export {
+	buildConsentManifestFromConfig,
 	buildDefaultOptInPolicy,
 	type ConsentManifest,
 	type ConsentManifestBranding,
+	type ConsentManifestConfig,
 	type ConsentManifestDefaults,
 	type ConsentManifestGVLReference,
 	type ConsentManifestIAB,

--- a/packages/schema/src/shared/index.ts
+++ b/packages/schema/src/shared/index.ts
@@ -28,6 +28,12 @@ export {
 	jurisdictionCodes as jurisdictionCodesConst,
 } from './constants';
 export {
+	buildConsentId,
+	type ConsentSubmissionIdentity,
+	type EntityKind,
+	generateDeterministicId,
+} from './entity-id';
+export {
 	CONSENT_REQUEST_HEADER_NAMES,
 	COUNTRY_HEADERS,
 	type ConsentRequestHeaderInputs,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -117,6 +117,12 @@ export {
 	validateMessages,
 	validatePolicies,
 } from './shared';
+export {
+	buildConsentId,
+	type ConsentSubmissionIdentity,
+	type EntityKind,
+	generateDeterministicId,
+} from './shared/entity-id';
 // GVL types - IAB TCF Global Vendor List
 export type {
 	GlobalVendorList,

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -73,6 +73,7 @@ export type JurisdictionCode = (typeof jurisdictionCodes)[number];
 export type {
 	ConsentManifest,
 	ConsentManifestBranding,
+	ConsentManifestConfig,
 	ConsentManifestDefaults,
 	ConsentManifestGVLReference,
 	ConsentManifestIAB,
@@ -87,6 +88,7 @@ export type {
 	ResolveInitFromManifestOptions,
 } from './shared';
 export {
+	buildConsentManifestFromConfig,
 	buildDefaultOptInPolicy,
 	CONSENT_REQUEST_HEADER_NAMES,
 	COUNTRY_HEADERS,


### PR DESCRIPTION
The HTTP surface. Hono stays — RFC 0004 changes the data layer and the runtime, not the wire. Routes hand off to Effect immediately; the app owns turning a request into handler inputs and a typed failure into a response.

## Wire compatibility is enforced, not asserted

Every handler validates its response against the same `@c15t/schema` schema the 2.x routes validate against, so a drift fails our own tests instead of reaching a client.

That paid for itself immediately. The first run **rejected the response**: the contract requires `type` on every consent — the policy type, which 2.x resolves in a second pass inside `consent-enrichment.ts` and which my read path had dropped entirely. It also caught `policyId` needing to be `undefined` rather than `null`, since valibot `optional` means absent.

Fixed by joining `consentPolicy` into the existing query, so `type`, `version`, `hash` and `effectiveDate` all come back and the read is still one statement — cheaper than 2.x, which fetched policies separately.

## Error mapping is total

Mapping is exhaustive over the tagged errors rather than falling back to a default 500, which is the point of the typed channel. `Effect.result` moves the typed failure into a value to branch on; a **defect still rejects**, because laundering one into a tidy 500 would erase the distinction.

`SqlError` maps to an opaque 500 on purpose: a database error carries table and column names, and on a consent platform that is information disclosure. There is a test asserting the body leaks nothing.

## Shared, not reimplemented

RFC 0001 makes "exactly one implementation" a design principle, and the parallel phase depends on it more sharply — two backends serve the same tenants for the duration, so anything that differed between them is a bug that only appears in production.

- **`/manifest`** — `buildConsentManifestFromConfig` moves into `@c15t/schema`; the 2.x entry point delegates with its public surface unchanged. Input is declared structurally rather than as the backend's options type, so the schema package gains no dependency on a backend. This layer contributes transport and caching only: same `s-maxage 300`, same `stale-while-revalidate 86400`, same etag derived from the manifest revision rather than a second hash that could disagree with it.
- **`/init`** — manifest from `buildConsentManifestFromConfig`, geo from `getRegionFromHeaders`, the decision itself from `resolveInitFromManifest`. This module contributes header parsing and nothing else.

`/init` is the one endpoint on the critical rendering path and also the one a host can compute locally from the manifest, skipping the round trip. The two are only interchangeable if they agree — a backend that resolved differently would show different visitors different banners depending on which path their host took. A test asserts the backend's `/init` equals a local resolve from the same manifest, making that class of bug unreachable rather than merely watched for.

Neither `/init` nor `/manifest` touches the database.

## Deterministic ids, and a clamp that turned out to be load-bearing

`generateDeterministicId` and `buildConsentId` move into `@c15t/schema`. Consent idempotency is keyed on a deterministic id, so two backends must derive byte-identical ids from the same submission — if they disagree, the same submission lands twice and a visitor ends up with duplicate consent records.

It nearly did. A parity test across pre-epoch, post-epoch and tenant-scoped cases **failed**: `writeTimestamp` clamps with `Math.max(0, offset)` and guards `Number.isFinite`, and the moved copy had dropped both. Any `givenAt` before the epoch — backdated consent, or records from before Nov 2023 — would have derived a different id. Confirmed by removing the clamp again and watching the test fail. It is now documented as load-bearing rather than defensive, since it reads like something worth tidying away and is not.

## Tests

57 in this layer. 566 backend and 116 schema tests pass unchanged.
