### PR TITLE
feat(backend-next): idempotent consent writes via ON CONFLICT

### DIFF
--- a/packages/backend-next/src/repository/consent.test.ts
+++ b/packages/backend-next/src/repository/consent.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Consent writes must record exactly one row per submission.
+ *
+ * A duplicate is not cosmetic here — it is a second legal record of the same
+ * act, and it corrupts the audit trail the platform exists to produce. So
+ * these tests care mostly about the ways a second row could sneak in:
+ * retries, concurrency, and rows written by older code.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { record } from './consent';
+
+const Pglite = PgliteClient.layer({});
+
+const GIVEN_AT = new Date(1_800_000_000_000);
+
+const setup = Effect.gen(function* () {
+	yield* baseline;
+	const sql = yield* SqlClient.SqlClient;
+	yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
+		values ('dom_1','example.com',now(),now())`);
+	yield* sql.unsafe(`insert into "subject" ("id","externalId","createdAt","updatedAt")
+		values ('sub_1','ext_1',now(),now())`);
+});
+
+const submission = {
+	subjectId: 'sub_1',
+	domainId: 'dom_1',
+	policyId: null,
+	givenAt: GIVEN_AT,
+	purposeIds: ['analytics'],
+};
+
+const countConsents = Effect.fn('countConsents')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{
+		total: string;
+	}>`select count(*) as total from "consent"`;
+	return Number(rows[0]?.total ?? 0);
+});
+
+describe('consent.record', () => {
+	it.effect(
+		'records a new submission',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+				const result = yield* record(submission);
+
+				assert.isTrue(result.created);
+				assert.match(result.id, /^cns_/);
+				assert.strictEqual(yield* countConsents(), 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'is idempotent across retries',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+				const first = yield* record(submission);
+				const second = yield* record(submission);
+
+				assert.isTrue(first.created);
+				// The caller can tell a replay from a fresh consent, so the audit
+				// trail records one act rather than two.
+				assert.isFalse(second.created);
+				assert.strictEqual(second.id, first.id);
+				assert.strictEqual(yield* countConsents(), 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'records one row when the same submission arrives concurrently',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+
+				// The case the old read-then-write could lose: both calls read
+				// "absent" before either wrote. `on conflict` closes that window
+				// because the check and the write are one statement.
+				const results = yield* Effect.all(
+					[record(submission), record(submission), record(submission)],
+					{ concurrency: 'unbounded' }
+				);
+
+				assert.strictEqual(yield* countConsents(), 1);
+				assert.strictEqual(
+					results.filter((result) => result.created).length,
+					1,
+					'exactly one caller should be told it created the row'
+				);
+				const ids = new Set(results.map((result) => result.id));
+				assert.strictEqual(ids.size, 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'treats a different givenAt as a different consent',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+				yield* record(submission);
+				const later = yield* record({
+					...submission,
+					givenAt: new Date(GIVEN_AT.getTime() + 1000),
+				});
+
+				// Consent given at a different moment is a distinct act, even
+				// from the same subject for the same policy.
+				assert.isTrue(later.created);
+				assert.strictEqual(yield* countConsents(), 2);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'finds a row written before deterministic ids existed',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+				const sql = yield* SqlClient.SqlClient;
+
+				// Older code wrote a random primary key, so the conflict target
+				// cannot see it — only the identity tuple can. A rolling deploy
+				// can still produce these after the new code is live.
+				yield* sql.unsafe(`insert into "consent"
+					("id","subjectId","domainId","policyId","purposeIds","givenAt")
+					values ('cns_legacyrandom','sub_1','dom_1',null,'[]',
+						to_timestamp(${GIVEN_AT.getTime()} / 1000.0))`);
+
+				const result = yield* record(submission);
+
+				assert.isFalse(result.created);
+				assert.strictEqual(result.id, 'cns_legacyrandom');
+				assert.strictEqual(yield* countConsents(), 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'keeps tenants apart',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+				yield* record({ ...submission, tenantId: 'tenant_a' });
+				const other = yield* record({ ...submission, tenantId: 'tenant_b' });
+
+				// Two tenants recording structurally identical consent are two
+				// separate legal records, not a duplicate.
+				assert.isTrue(other.created);
+				assert.strictEqual(yield* countConsents(), 2);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+});

--- a/packages/backend-next/src/repository/consent.ts
+++ b/packages/backend-next/src/repository/consent.ts
@@ -1,0 +1,130 @@
+/**
+ * Consent writes.
+ *
+ * Recording a consent has to be idempotent: a client that retries a request,
+ * or two requests racing from the same visitor, must produce one record rather
+ * than two. On a consent platform a duplicate is not a cosmetic problem — it
+ * is a second legal record of the same act.
+ *
+ * `@c15t/backend` achieves this by reading first and then writing: look up the
+ * deterministic primary key, fall back to a lookup on the identity tuple for
+ * rows written by older random-id code, attempt the insert, and if it throws,
+ * decide whether the error was a unique violation by string-matching adapter
+ * error codes (`23505`, `ER_DUP_ENTRY`, `P2002`, `SQLITE_CONSTRAINT…`) and
+ * then message substrings as a fallback. That leaves a race window between the
+ * read and the write, and it treats "is this a duplicate?" as a question to be
+ * answered by parsing prose.
+ *
+ * Here the database answers it. `insert … on conflict do nothing returning *`
+ * is atomic: either this call inserted the row or someone already had, and the
+ * return value says which. No window, and no error-string sniffing — the error
+ * never happens.
+ *
+ * The legacy identity lookup is kept, because it is not redundant: rows
+ * written before deterministic ids existed have unrelated primary keys, and
+ * only the identity tuple can find them.
+ */
+
+import { buildConsentId, type ConsentSubmissionIdentity } from '@c15t/schema';
+import { Effect } from 'effect';
+import { SqlClient, SqlError } from 'effect/unstable/sql';
+
+export interface ConsentSubmission extends ConsentSubmissionIdentity {
+	readonly purposeIds: readonly string[];
+	readonly metadata?: unknown;
+	readonly ipAddress?: string | null;
+	readonly userAgent?: string | null;
+}
+
+export interface RecordedConsent {
+	readonly id: string;
+	/**
+	 * False when an identical submission was already recorded.
+	 *
+	 * Surfaced rather than hidden so a caller can tell a fresh consent from a
+	 * replay — the audit trail should record one, not both.
+	 */
+	readonly created: boolean;
+}
+
+/**
+ * Finds a consent written before deterministic ids existed.
+ *
+ * Such a row has an unrelated random primary key, so only the identity tuple
+ * can match it. This must run whenever the primary-key lookup misses: during a
+ * rolling deploy an older process can write a random-id row *after* a newer
+ * one has started, so process start time cannot be used to rule it out.
+ */
+const findLegacySubmission = Effect.fn('consent.findLegacy')(function* (
+	identity: ConsentSubmissionIdentity
+) {
+	const sql = yield* SqlClient.SqlClient;
+
+	const rows = yield* sql<{ id: string }>`
+		select "id" from "consent"
+		where "subjectId" = ${identity.subjectId}
+			and "domainId" = ${identity.domainId}
+			and "givenAt" = ${identity.givenAt}
+			and ${
+				identity.policyId === undefined || identity.policyId === null
+					? sql`"policyId" is null`
+					: sql`"policyId" = ${identity.policyId}`
+			}
+			and ${
+				identity.tenantId === undefined
+					? sql`"tenantId" is null`
+					: sql`"tenantId" = ${identity.tenantId}`
+			}
+		limit 1
+	`;
+
+	return rows[0]?.id;
+});
+
+/**
+ * Records a consent, exactly once.
+ *
+ * Safe to call repeatedly with the same submission: the second and subsequent
+ * calls return the existing id with `created: false`.
+ */
+export const record = Effect.fn('consent.record')(function* (
+	submission: ConsentSubmission
+): Generator<
+	Effect.Effect<unknown, SqlError.SqlError, SqlClient.SqlClient>,
+	RecordedConsent
+> {
+	const sql = yield* SqlClient.SqlClient;
+	const id = yield* Effect.promise(() => buildConsentId(submission));
+
+	// A row written by an older process has a random primary key, so the
+	// conflict target below cannot see it. Check for it first.
+	const legacyId = yield* findLegacySubmission(submission);
+	if (legacyId !== undefined) {
+		return { id: legacyId, created: false };
+	}
+
+	const inserted = yield* sql<{ id: string }>`
+		insert into "consent" (
+			"id", "subjectId", "domainId", "policyId", "purposeIds",
+			"metadata", "ipAddress", "userAgent", "givenAt", "tenantId"
+		) values (
+			${id},
+			${submission.subjectId},
+			${submission.domainId},
+			${submission.policyId ?? null},
+			${JSON.stringify(submission.purposeIds)},
+			${submission.metadata === undefined ? null : JSON.stringify(submission.metadata)},
+			${submission.ipAddress ?? null},
+			${submission.userAgent ?? null},
+			${submission.givenAt},
+			${submission.tenantId ?? null}
+		)
+		on conflict ("id") do nothing
+		returning "id"
+	`;
+
+	// An empty result means the conflict target matched — someone else wrote
+	// this exact submission, possibly concurrently. That is success, not
+	// failure, and it is the whole reason this is one statement.
+	return inserted.length > 0 ? { id, created: true } : { id, created: false };
+});


### PR DESCRIPTION
Recording a consent must be idempotent — a retry or two racing requests from one visitor must produce a single row, because a duplicate is a second legal record of the same act and corrupts the audit trail.

## How 2.x does it, and why that is not enough

Read first, then write: look up the deterministic key, fall back to an identity-tuple lookup for legacy rows, attempt the insert, and if it throws decide whether it was a duplicate by string-matching adapter error codes (`23505`, `ER_DUP_ENTRY`, `P2002`, `SQLITE_CONSTRAINT`…) and then message substrings.

That leaves a **race window between the read and the write**, and answers "is this a duplicate?" by parsing prose.

## Here the database answers it

`insert ... on conflict do nothing returning *` is atomic: either this call wrote the row or someone already had, and the return value says which. The error-string matching disappears entirely, because the error never occurs.

The legacy identity lookup stays, and is not redundant: rows written before deterministic ids have unrelated primary keys, so only the identity tuple finds them, and a rolling deploy can still produce one after the new code is live.

## Tests

6, including the concurrency case the old read-then-write could lose — three simultaneous identical submissions produce one row, and exactly one caller is told it created it. Also covers tenant isolation and treating a different `givenAt` as a distinct act.
