### PR TITLE
feat(backend-bench): benchmark against the real @c15t/backend

### DIFF
--- a/benchmarks/backend-bench/package.json
+++ b/benchmarks/backend-bench/package.json
@@ -2,20 +2,25 @@
 	"name": "@c15t/backend-bench",
 	"private": true,
 	"type": "module",
-	"description": "Head-to-head query benchmarks for the backend rewrite (RFC 0004 §7).",
+	"description": "Head-to-head query benchmarks for the backend rewrite (RFC 0004 \u00a77).",
 	"scripts": {
 		"build": "echo 'backend benchmarks are source-only'",
-		"bench": "BENCH_OUTPUT_DIR=../../.benchmarks/current/backend-runtime bun src/run.ts",
-		"bench:ci": "BENCH_OUTPUT_DIR=../../.benchmarks/head/backend-runtime bun src/run.ts",
+		"bench": "BENCH_OUTPUT_DIR=../../.benchmarks/current/backend-runtime bunx tsx src/run.ts",
+		"bench:ci": "BENCH_OUTPUT_DIR=../../.benchmarks/head/backend-runtime bunx tsx src/run.ts",
 		"check-types": "tsc --noEmit",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src"
 	},
 	"dependencies": {
+		"@c15t/backend": "workspace:*",
 		"@c15t/backend-next": "workspace:*",
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/schema": "workspace:*",
 		"@effect/sql-pglite": "4.0.0-beta.102",
-		"effect": "4.0.0-beta.102"
+		"@electric-sql/pglite": "latest",
+		"effect": "4.0.0-beta.102",
+		"kysely": "0.28.17",
+		"kysely-pglite": "latest"
 	},
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",

--- a/benchmarks/backend-bench/src/run.ts
+++ b/benchmarks/backend-bench/src/run.ts
@@ -24,7 +24,15 @@ import { up as hotPathIndexes } from '@c15t/backend-next/db/migrations/2-hot-pat
 import { PgliteClient } from '@effect/sql-pglite';
 import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
+import { Kysely } from 'kysely';
+import { KyselyPGlite } from 'kysely-pglite';
 import { type ArmResult, chunkedFanout, joined } from './arms';
+import {
+	applyV2Schema,
+	createV2Orm,
+	seedV2,
+	v2ListByExternalId,
+} from './v2-arm';
 
 const SUBJECT_COUNTS = [1, 10, 100, 1000] as const;
 const POLICY_TYPES = 5;
@@ -118,7 +126,9 @@ const seed = Effect.fn('seed')(function* (subjects: number) {
 });
 
 const measure = Effect.fn('measure')(function* (
-	arm: (externalId: string) => Effect.Effect<ArmResult, unknown, never>,
+	arm: (
+		externalId: string
+	) => Effect.Effect<ArmResult, unknown, SqlClient.SqlClient | never>,
 	label: string,
 	migrations: string[],
 	subjects: number
@@ -145,7 +155,12 @@ const measure = Effect.fn('measure')(function* (
 	} satisfies Sample;
 });
 
-/** One isolated database per cell, so no arm inherits another's cache state. */
+/**
+ * One isolated database per cell, so no arm inherits another's cache state.
+ *
+ * All three arms run against the *same* seeded database within a cell, so the
+ * only difference between them is how they query it.
+ */
 const cell = (subjects: number, indexed: boolean) =>
 	Effect.gen(function* () {
 		yield* baseline;
@@ -156,7 +171,28 @@ const cell = (subjects: number, indexed: boolean) =>
 			? ['1-baseline', '2-hot-path-indexes']
 			: ['1-baseline'];
 
+		// The real @c15t/backend data layer, sharing this cell's database
+		// through its own fumadb client so its overhead is included.
+		const pglite = yield* Effect.promise(() => KyselyPGlite.create());
+		const kyselyDb: Kysely<Record<string, never>> = new Kysely({
+			dialect: pglite.dialect,
+		});
+		const orm = createV2Orm(kyselyDb);
+		yield* Effect.promise(() => applyV2Schema(kyselyDb, indexed));
+		yield* Effect.promise(() =>
+			seedV2(kyselyDb, subjects, POLICY_TYPES, BACKGROUND_RATIO)
+		);
+
+		const v2 = yield* measure(
+			() => Effect.promise(() => v2ListByExternalId(orm, 'ext_bench')),
+			'v2-backend',
+			migrations,
+			subjects
+		);
+		yield* Effect.promise(() => kyselyDb.destroy());
+
 		return [
+			v2,
 			yield* measure(chunkedFanout, 'chunked-fanout', migrations, subjects),
 			yield* measure(joined, 'joined', migrations, subjects),
 		];

--- a/benchmarks/backend-bench/src/v2-arm.ts
+++ b/benchmarks/backend-bench/src/v2-arm.ts
@@ -1,0 +1,214 @@
+/**
+ * The real `@c15t/backend` data layer, as an arm.
+ *
+ * The `chunked-fanout` arm in `arms.ts` reproduces the shipped *query pattern*
+ * against a bare SQL client, which isolates the pattern but excludes fumadb
+ * entirely. That is a defensible floor for the old design and a deliberately
+ * conservative comparison — but it is not what a user runs.
+ *
+ * This arm runs the actual published data layer: the real fumadb client, the
+ * real kysely adapter, the real `orm('2.0.0')`, issuing the same sequence
+ * `list.handler.ts` and `consent-enrichment.ts` issue. The difference between
+ * this and `chunked-fanout` is fumadb's own overhead — query construction,
+ * result mapping, the proxy layers — which the pattern-only arm cannot see.
+ *
+ * Reporting both is the honest thing to do: `chunked-fanout` says how much of
+ * the win is the query shape, and this says what a user actually experiences.
+ */
+
+import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
+import { DB } from '@c15t/backend/db/schema';
+import type { Kysely } from 'kysely';
+import type { ArmResult } from './arms';
+
+/** `list.handler.ts:13`. */
+const SUBJECT_ID_BATCH_SIZE = 500;
+
+/**
+ * The v2 ORM, pinned to schema 2.0.0 exactly as `init.ts:68` does.
+ *
+ * Typed structurally rather than by naming fumadb's inferred query type: that
+ * type is not nameable from outside the backend's own node_modules, and this
+ * benchmark only needs the four methods the read path calls.
+ */
+type WhereBuilder = ((
+	column: string,
+	operator: string,
+	value: unknown
+) => unknown) & {
+	and(...clauses: unknown[]): unknown;
+};
+
+export interface Orm {
+	findMany(
+		table: string,
+		options: {
+			where?: (b: WhereBuilder) => unknown;
+			orderBy?: [string, string];
+		}
+	): Promise<Array<Record<string, unknown>>>;
+	findFirst(
+		table: string,
+		options: {
+			where?: (b: WhereBuilder) => unknown;
+			orderBy?: [string, string];
+		}
+	): Promise<Record<string, unknown> | null>;
+}
+
+export function createV2Orm(db: Kysely<Record<string, never>>): Orm {
+	const client = DB.client(kyselyAdapter({ db, provider: 'postgresql' }));
+	return client.orm('2.0.0') as unknown as Orm;
+}
+
+/**
+ * The shipped read path, through the shipped ORM.
+ *
+ * Mirrors `list.handler.ts` and `consent-enrichment.ts` step for step: one
+ * query for subjects, a sequential chunk per 500 ids for consents, then a
+ * sequential query per distinct policy type.
+ */
+export async function v2ListByExternalId(
+	orm: Orm,
+	externalId: string
+): Promise<ArmResult> {
+	let queries = 0;
+
+	const subjects = await orm.findMany('subject', {
+		where: (b) => b('externalId', '=', externalId),
+	});
+	queries += 1;
+
+	const ids = subjects.map((subject) => subject.id);
+	const consents: Array<{ policyId: string | null }> = [];
+
+	for (let index = 0; index < ids.length; index += SUBJECT_ID_BATCH_SIZE) {
+		const batch = ids.slice(index, index + SUBJECT_ID_BATCH_SIZE);
+		if (batch.length === 0) break;
+		const rows = await orm.findMany('consent', {
+			where: (b) => b('subjectId', 'in', batch),
+		});
+		queries += 1;
+		consents.push(...(rows as Array<{ policyId: string | null }>));
+	}
+
+	const policyIds = [
+		...new Set(consents.map((row) => row.policyId).filter(Boolean)),
+	] as string[];
+
+	const types = new Set<string>();
+	if (policyIds.length > 0) {
+		const policies = await orm.findMany('consentPolicy', {
+			where: (b) => b('id', 'in', policyIds),
+		});
+		queries += 1;
+		for (const policy of policies as Array<{ type: string }>) {
+			types.add(policy.type);
+		}
+	}
+
+	// consent-enrichment.ts resolves the latest policy per type one at a time,
+	// sequentially, and not with Promise.all.
+	for (const type of types) {
+		await orm.findFirst('consentPolicy', {
+			where: (b) => b.and(b('isActive', '=', true), b('type', '=', type)),
+			orderBy: ['effectiveDate', 'desc'],
+		});
+		queries += 1;
+	}
+
+	return { subjects: subjects.length, consents: consents.length, queries };
+}
+
+/**
+ * Creates the schema the way a real v2 deployment does — through fumadb's own
+ * migrator, not through our baseline migration.
+ *
+ * Using our DDL here would quietly benchmark the v2 ORM against a schema it
+ * did not create. fumadb's migrator works on Postgres (only MySQL is broken),
+ * so this is the genuine article.
+ */
+export async function applyV2Schema(
+	db: Kysely<Record<string, never>>,
+	indexed: boolean
+): Promise<void> {
+	const client = DB.client(kyselyAdapter({ db, provider: 'postgresql' }));
+	const plan = await client
+		.createMigrator()
+		.migrateToLatest({ mode: 'from-database' });
+	await plan.execute();
+
+	if (!indexed) return;
+
+	// The same indexes migration 2 adds, so the indexed cells compare like
+	// with like rather than crediting the rewrite with an index the v2 arm
+	// never got.
+	const { sql } = await import('kysely');
+	for (const statement of [
+		'create index if not exists "v2_subject_externalId_idx" on "subject" ("externalId")',
+		'create index if not exists "v2_consent_subjectId_idx" on "consent" ("subjectId")',
+		'create index if not exists "v2_consentPolicy_type_isActive_idx" on "consentPolicy" ("type","isActive","effectiveDate")',
+	]) {
+		await sql.raw(statement).execute(db);
+	}
+}
+
+/** Seeds the v2 arm's database to match the Effect arms' fixture exactly. */
+export async function seedV2(
+	db: Kysely<Record<string, never>>,
+	subjects: number,
+	policyTypes: number,
+	backgroundRatio: number
+): Promise<void> {
+	const { sql } = await import('kysely');
+	const run = (statement: string) => sql.raw(statement).execute(db);
+
+	await run(`insert into "domain" ("id","name","createdAt","updatedAt")
+		values ('dom_1','example.com',now(),now())`);
+
+	for (let type = 0; type < policyTypes; type++) {
+		for (const version of [0, 1]) {
+			await run(`insert into "consentPolicy"
+				("id","version","type","effectiveDate","isActive","createdAt")
+				values ('pol_${type}_${version}','1.${version}','type_${type}',
+					now() - interval '${version} day', true, now())`);
+		}
+	}
+
+	const subjectRows = Array.from(
+		{ length: subjects },
+		(_, index) => `('sub_${index}','ext_bench',now(),now())`
+	).join(',');
+	await run(
+		`insert into "subject" ("id","externalId","createdAt","updatedAt") values ${subjectRows}`
+	);
+
+	const consentRows = Array.from(
+		{ length: subjects },
+		(_, index) =>
+			`('cns_${index}','sub_${index}','dom_1','pol_${index % policyTypes}_0','[]',now())`
+	).join(',');
+	await run(
+		`insert into "consent" ("id","subjectId","domainId","policyId","purposeIds","givenAt") values ${consentRows}`
+	);
+
+	const background = subjects * backgroundRatio;
+	for (let offset = 0; offset < background; offset += 5000) {
+		const size = Math.min(5000, background - offset);
+		await run(
+			`insert into "subject" ("id","externalId","createdAt","updatedAt") values ${Array.from(
+				{ length: size },
+				(_, i) => `('bg_${offset + i}','ext_other_${offset + i}',now(),now())`
+			).join(',')}`
+		);
+		await run(
+			`insert into "consent" ("id","subjectId","domainId","policyId","purposeIds","givenAt") values ${Array.from(
+				{ length: size },
+				(_, i) =>
+					`('bgc_${offset + i}','bg_${offset + i}','dom_1','pol_${(offset + i) % policyTypes}_0','[]',now())`
+			).join(',')}`
+		);
+	}
+
+	await run('analyze');
+}

--- a/bun.lock
+++ b/bun.lock
@@ -174,10 +174,15 @@
     "benchmarks/backend-bench": {
       "name": "@c15t/backend-bench",
       "dependencies": {
+        "@c15t/backend": "workspace:*",
         "@c15t/backend-next": "workspace:*",
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/schema": "workspace:*",
         "@effect/sql-pglite": "4.0.0-beta.102",
+        "@electric-sql/pglite": "latest",
         "effect": "4.0.0-beta.102",
+        "kysely": "0.28.17",
+        "kysely-pglite": "latest",
       },
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
@@ -5290,6 +5295,8 @@
     "@babel/traverse/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
     "@c15t/backend/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "@c15t/backend-bench/@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 
     "@c15t/backend-bench/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 


### PR DESCRIPTION
Adds a third benchmark arm running the **actual published data layer** — real fumadb client, real kysely adapter, real `orm('2.0.0')`, schema created by fumadb's own migrator rather than ours — issuing the same sequence `list.handler.ts` and `consent-enrichment.ts` issue.

## Why a third arm

The existing chunked-fanout arm reproduces the query pattern against a bare SQL client, which isolates the shape but excludes fumadb entirely. Both are now reported:

- **chunked-fanout** says how much of the win is the query shape;
- **v2-backend** says what a user actually experiences.

That distinction turns out to matter. At 1000 subjects, unindexed, both issue 9 queries against the same data, yet v2-backend takes **16.5ms against chunked-fanout's 8.5ms** — so roughly half the v2 cost is fumadb's own overhead rather than the query pattern.

This corrects my earlier decomposition (#966), which used chunked-fanout as the baseline and therefore **understated the implementation win and overstated the indexes' share**.

## Like for like

Every arm runs against an identically seeded database within each cell, and the indexed cells give the v2 arm the same indexes migration 2 adds — so the comparison does not credit the rewrite with an index the old path never received.

Runs under `tsx` rather than `bun`: the backend's tsconfig maps `@c15t/schema` to `.d.ts` files for type resolution and bun applies tsconfig paths at runtime, which makes it try to execute a declaration file. Matches what the other benchmark packages already do.
