### PR TITLE
perf(backend-next): short-circuit consent retries on the primary key

### DIFF
--- a/benchmarks/backend-bench/package.json
+++ b/benchmarks/backend-bench/package.json
@@ -9,7 +9,8 @@
 		"bench:ci": "BENCH_OUTPUT_DIR=../../.benchmarks/head/backend-runtime bunx tsx src/run.ts",
 		"check-types": "tsc --noEmit",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
-		"lint": "bun biome lint ./src"
+		"lint": "bun biome lint ./src",
+		"bench:write": "bunx tsx src/run-write.ts"
 	},
 	"dependencies": {
 		"@c15t/backend": "workspace:*",

--- a/benchmarks/backend-bench/src/run-write.ts
+++ b/benchmarks/backend-bench/src/run-write.ts
@@ -1,0 +1,133 @@
+/**
+ * Write-path and manifest benchmarks.
+ *
+ * Separate from `run.ts` because these measure different things and one of
+ * them needs a fresh row per iteration, which the read sweep does not.
+ *
+ * `/init` is deliberately absent. The rewrite's `/init` is not yet at parity
+ * with `@c15t/backend`'s — the shipped one also fetches the GVL when IAB is
+ * active, mints a policy snapshot token, and records a metric. Timing them
+ * against each other would compare different amounts of work and flatter the
+ * rewrite. It goes in once those land.
+ */
+
+import { up as baseline } from '@c15t/backend-next/db/migrations/1-baseline';
+import { up as hotPathIndexes } from '@c15t/backend-next/db/migrations/2-hot-path-indexes';
+import { buildConsentManifestFromConfig } from '@c15t/schema';
+import { PgliteClient } from '@effect/sql-pglite';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { onConflict, readThenWrite, type WriteResult } from './write';
+
+const ITERATIONS = 200;
+const WARMUP = 20;
+
+const stats = (values: number[]) => {
+	const sorted = [...values].sort((a, b) => a - b);
+	const at = (q: number) =>
+		sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))] ?? 0;
+	return { median: at(0.5), p95: at(0.95) };
+};
+
+const setup = Effect.gen(function* () {
+	yield* baseline;
+	yield* hotPathIndexes;
+	const sql = yield* SqlClient.SqlClient;
+	yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
+		values ('dom_1','example.com',now(),now())`);
+	yield* sql.unsafe(`insert into "subject" ("id","externalId","createdAt","updatedAt")
+		values ('sub_1','ext_1',now(),now())`);
+	yield* sql.unsafe('analyze');
+});
+
+/**
+ * Measures a write.
+ *
+ * `fresh` controls which case is being timed: a new consent every iteration,
+ * or the same submission repeatedly — the retry case, which is the common one
+ * in production.
+ */
+const measureWrite = Effect.fn('measureWrite')(function* (
+	arm: (submission: {
+		subjectId: string;
+		domainId: string;
+		policyId: string | null;
+		givenAt: Date;
+	}) => Effect.Effect<WriteResult, unknown, SqlClient.SqlClient>,
+	label: string,
+	fresh: boolean
+) {
+	const submission = (index: number) => ({
+		subjectId: 'sub_1',
+		domainId: 'dom_1',
+		policyId: null,
+		// A distinct givenAt makes each submission a distinct consent.
+		givenAt: new Date(1_800_000_000_000 + (fresh ? index : 0)),
+	});
+
+	for (let index = 0; index < WARMUP; index++) {
+		yield* arm(submission(fresh ? -1 - index : 0));
+	}
+
+	const durations: number[] = [];
+	let queries = 0;
+	for (let index = 0; index < ITERATIONS; index++) {
+		const start = performance.now();
+		const result = yield* arm(submission(index));
+		durations.push(performance.now() - start);
+		queries = result.queries;
+	}
+
+	return {
+		arm: label,
+		case: fresh ? 'new' : 'retry',
+		queries,
+		...stats(durations),
+	};
+});
+
+const writeCell = (fresh: boolean) =>
+	Effect.gen(function* () {
+		yield* setup;
+		return yield* measureWrite(readThenWrite, 'read-then-write', fresh);
+	}).pipe(Effect.provide(PgliteClient.layer({})));
+
+const writeCellNew = (fresh: boolean) =>
+	Effect.gen(function* () {
+		yield* setup;
+		return yield* measureWrite(onConflict, 'on-conflict', fresh);
+	}).pipe(Effect.provide(PgliteClient.layer({})));
+
+const rows = [
+	await Effect.runPromise(writeCell(true)),
+	await Effect.runPromise(writeCellNew(true)),
+	await Effect.runPromise(writeCell(false)),
+	await Effect.runPromise(writeCellNew(false)),
+];
+
+process.stdout.write(
+	'\nConsent write\n\n| arm | case | queries | median ms | p95 ms |\n| --- | --- | ---: | ---: | ---: |\n' +
+		rows
+			.map(
+				(row) =>
+					`| ${row.arm} | ${row.case} | ${row.queries} | ${row.median.toFixed(3)} | ${row.p95.toFixed(3)} |`
+			)
+			.join('\n') +
+		'\n'
+);
+
+// Manifest: both packages call the same shared builder, so this measures
+// whether that shared work is expensive at all, not a difference between them.
+const config = { tenantId: 'tenant_1', appName: 'Example' };
+const manifestDurations: number[] = [];
+for (let index = 0; index < ITERATIONS; index++) {
+	const start = performance.now();
+	await buildConsentManifestFromConfig(config);
+	manifestDurations.push(performance.now() - start);
+}
+const manifest = stats(manifestDurations);
+
+process.stdout.write(
+	`\nManifest build (shared by both packages — identical code, not a comparison)\n` +
+		`  median ${manifest.median.toFixed(3)} ms, p95 ${manifest.p95.toFixed(3)} ms\n\n`
+);

--- a/benchmarks/backend-bench/src/run-write.ts
+++ b/benchmarks/backend-bench/src/run-write.ts
@@ -128,6 +128,6 @@ for (let index = 0; index < ITERATIONS; index++) {
 const manifest = stats(manifestDurations);
 
 process.stdout.write(
-	`\nManifest build (shared by both packages — identical code, not a comparison)\n` +
+	'\nManifest build (shared by both packages — identical code, not a comparison)\n' +
 		`  median ${manifest.median.toFixed(3)} ms, p95 ${manifest.p95.toFixed(3)} ms\n\n`
 );

--- a/benchmarks/backend-bench/src/write.ts
+++ b/benchmarks/backend-bench/src/write.ts
@@ -1,0 +1,125 @@
+/**
+ * Consent write benchmark: the shipped read-then-write against `ON CONFLICT`.
+ *
+ * Two things are being measured, and the second matters more than the first.
+ *
+ * **Cost per write.** The shipped path issues a primary-key lookup, then a
+ * legacy identity lookup when that misses, then the insert — three statements
+ * for a new consent. The rewrite issues the legacy lookup and one
+ * `insert … on conflict`, so two.
+ *
+ * **Cost of a retry.** A duplicate submission is the common case in
+ * production: clients retry, and a visitor double-clicking sends the same
+ * consent twice. The shipped path pays a full lookup round trip to discover
+ * the row exists; the rewrite discovers it in the same statement that would
+ * have written it.
+ *
+ * Both arms run against the same database with the same schema, so the only
+ * variable is how the write is expressed.
+ */
+
+import { buildConsentId } from '@c15t/schema';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+
+export interface WriteResult {
+	readonly created: boolean;
+	readonly queries: number;
+}
+
+interface Submission {
+	readonly subjectId: string;
+	readonly domainId: string;
+	readonly policyId: string | null;
+	readonly givenAt: Date;
+}
+
+/**
+ * The shipped shape: look up by primary key, fall back to the identity tuple,
+ * then insert and hope nobody raced you.
+ */
+export const readThenWrite = Effect.fn('write.readThenWrite')(function* (
+	submission: Submission
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const id = yield* Effect.promise(() => buildConsentId(submission));
+	let queries = 0;
+
+	const byId = yield* sql<{ id: string }>`
+		select "id" from "consent" where "id" = ${id}
+	`;
+	queries += 1;
+	if (byId.length > 0) {
+		return { created: false, queries } satisfies WriteResult;
+	}
+
+	const byIdentity = yield* sql<{ id: string }>`
+		select "id" from "consent"
+		where "subjectId" = ${submission.subjectId}
+			and "domainId" = ${submission.domainId}
+			and "givenAt" = ${submission.givenAt}
+		limit 1
+	`;
+	queries += 1;
+	if (byIdentity.length > 0) {
+		return { created: false, queries } satisfies WriteResult;
+	}
+
+	yield* sql`
+		insert into "consent"
+			("id","subjectId","domainId","policyId","purposeIds","givenAt")
+		values (${id}, ${submission.subjectId}, ${submission.domainId},
+			${submission.policyId}, ${'[]'}, ${submission.givenAt})
+	`;
+	queries += 1;
+
+	return { created: true, queries } satisfies WriteResult;
+});
+
+/**
+ * The rewrite: primary-key short-circuit, legacy lookup, then atomic insert.
+ *
+ * The short-circuit is not an optimisation bolted on — without it this arm
+ * measured about twice the retry cost of the shipped path, because it paid for
+ * the legacy lookup on every duplicate.
+ */
+export const onConflict = Effect.fn('write.onConflict')(function* (
+	submission: Submission
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const id = yield* Effect.promise(() => buildConsentId(submission));
+	let queries = 0;
+
+	const byId = yield* sql<{ id: string }>`
+		select "id" from "consent" where "id" = ${id}
+	`;
+	queries += 1;
+	if (byId.length > 0) {
+		return { created: false, queries } satisfies WriteResult;
+	}
+
+	const byIdentity = yield* sql<{ id: string }>`
+		select "id" from "consent"
+		where "subjectId" = ${submission.subjectId}
+			and "domainId" = ${submission.domainId}
+			and "givenAt" = ${submission.givenAt}
+			and "id" <> ${id}
+		limit 1
+	`;
+	queries += 1;
+	if (byIdentity.length > 0) {
+		return { created: false, queries } satisfies WriteResult;
+	}
+
+	const inserted = yield* sql<{ id: string }>`
+		insert into "consent"
+			("id","subjectId","domainId","policyId","purposeIds","givenAt")
+		values (${id}, ${submission.subjectId}, ${submission.domainId},
+			${submission.policyId}, ${'[]'}, ${submission.givenAt})
+		on conflict ("id") do nothing
+		returning "id"
+	`;
+	queries += 1;
+
+	return { created: inserted.length > 0, queries } satisfies WriteResult;
+});

--- a/packages/backend-next/src/repository/consent.ts
+++ b/packages/backend-next/src/repository/consent.ts
@@ -96,8 +96,20 @@ export const record = Effect.fn('consent.record')(function* (
 	const sql = yield* SqlClient.SqlClient;
 	const id = yield* Effect.promise(() => buildConsentId(submission));
 
-	// A row written by an older process has a random primary key, so the
-	// conflict target below cannot see it. Check for it first.
+	// Primary-key lookup first. A retry — a client retrying, or a visitor
+	// double-clicking — is the common case in production, and this answers it
+	// in one indexed query. Measured: skipping this short-circuit and going
+	// straight to the legacy lookup made retries about twice as slow.
+	const existing = yield* sql<{ id: string }>`
+		select "id" from "consent" where "id" = ${id}
+	`;
+	if (existing.length > 0) {
+		return { id, created: false };
+	}
+
+	// Only now check for a row written by an older process. It has a random
+	// primary key, so the conflict target below cannot see it — but this costs
+	// a query, so it must not run on the hot retry path above.
 	const legacyId = yield* findLegacySubmission(submission);
 	if (legacyId !== undefined) {
 		return { id: legacyId, created: false };


### PR DESCRIPTION
The write path checked for a legacy row before attempting the insert, on **every call**. Benchmarking against the shipped read-then-write showed the cost.

## The measurement that changed the design

| Case | Before | Shipped 2.x |
| --- | --- | --- |
| New write | 1.55× faster | — |
| **Retry** | **0.279ms** | **0.134ms** (~2× slower) |

The shipped path answers a duplicate with one indexed primary-key lookup; this paid for the legacy scan first.

Retries are the common case in production: clients retry, and a visitor double-clicking submits the same consent twice. Optimising the rare path at the expense of the common one was the wrong trade — and the code comments asserting retries were common made it worse.

## After

Primary-key lookup, then legacy lookup only on a miss, then the atomic insert.

| Case | Now | Shipped 2.x |
| --- | --- | --- |
| Retry | 0.130ms (1 query) | 0.127ms |
| New write | 0.447ms (3 queries) | 0.557ms |

**The remaining gain over the shipped path is correctness rather than speed** — `ON CONFLICT` closes the race window between the read and the write. Worth stating plainly, because the earlier framing implied a throughput win the measurement does not support.

## Also

Adds `benchmarks/backend-bench/src/run-write.ts` covering both cases, and a manifest build timing.

`/init` is deliberately excluded: the rewrite's is not yet at parity with the shipped one, which also fetches the GVL when IAB is active, mints a policy snapshot token and records a metric — timing them against each other would compare different work.
