### PR TITLE
feat(backend-next): API key authentication on GET /subjects

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -591,6 +591,7 @@
         "valibot": "1.4.2",
       },
       "devDependencies": {
+        "@c15t/backend": "workspace:*",
         "@c15t/migration-fixtures": "workspace:*",
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -61,6 +61,7 @@
 		"valibot": "1.4.2"
 	},
 	"devDependencies": {
+		"@c15t/backend": "workspace:*",
 		"@c15t/migration-fixtures": "workspace:*",
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",

--- a/packages/backend-next/src/http/app.test.ts
+++ b/packages/backend-next/src/http/app.test.ts
@@ -21,6 +21,9 @@ import { createApp } from './app';
 let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
 let app: ReturnType<typeof createApp>;
 
+const API_KEY = 'sk_test_key';
+const authed = { headers: { Authorization: `Bearer ${API_KEY}` } };
+
 beforeEach(async () => {
 	runtime = ManagedRuntime.make(PgliteClient.layer({}));
 	await runtime.runPromise(
@@ -29,7 +32,7 @@ beforeEach(async () => {
 			yield* indexes;
 		})
 	);
-	app = createApp(runtime);
+	app = createApp(runtime, { apiKeys: [API_KEY] });
 });
 
 afterEach(async () => {
@@ -58,7 +61,7 @@ describe('GET /subjects', () => {
 	it('returns a body satisfying the shared output schema', async () => {
 		await seed();
 
-		const response = await app.request('/subjects?externalId=ext_1');
+		const response = await app.request('/subjects?externalId=ext_1', authed);
 		assert.strictEqual(response.status, 200);
 
 		const body = await response.json();
@@ -89,7 +92,7 @@ describe('GET /subjects', () => {
 	});
 
 	it('reports a missing externalId the way 2.x does', async () => {
-		const response = await app.request('/subjects');
+		const response = await app.request('/subjects', authed);
 
 		assert.strictEqual(response.status, 400);
 		assert.deepStrictEqual(await response.json(), {
@@ -101,13 +104,16 @@ describe('GET /subjects', () => {
 	it('treats an empty externalId as missing rather than matching nothing', async () => {
 		// A bare `?externalId=` is a client bug, and answering it with an empty
 		// list would hide that. 2.x rejects it, so this does too.
-		const response = await app.request('/subjects?externalId=');
+		const response = await app.request('/subjects?externalId=', authed);
 		assert.strictEqual(response.status, 400);
 	});
 
 	it('returns an empty list for an externalId nobody has', async () => {
 		await seed();
-		const response = await app.request('/subjects?externalId=ext_absent');
+		const response = await app.request(
+			'/subjects?externalId=ext_absent',
+			authed
+		);
 
 		assert.strictEqual(response.status, 200);
 		assert.deepStrictEqual(await response.json(), { subjects: [] });
@@ -122,7 +128,7 @@ describe('GET /subjects', () => {
 			})
 		);
 
-		const response = await app.request('/subjects?externalId=ext_1');
+		const response = await app.request('/subjects?externalId=ext_1', authed);
 		const body = await response.json();
 
 		assert.strictEqual(response.status, 500);
@@ -133,5 +139,33 @@ describe('GET /subjects', () => {
 			cause: { code: 'DATABASE_ERROR' },
 		});
 		assert.notInclude(JSON.stringify(body), 'consent');
+	});
+
+	it('refuses a request with no API key', async () => {
+		await seed();
+		const response = await app.request('/subjects?externalId=ext_1');
+
+		// Listing subjects exposes consent records for a named person, so an
+		// unauthenticated caller must get nothing — not an empty list, which
+		// would imply the person has no consents.
+		assert.strictEqual(response.status, 401);
+		assert.deepStrictEqual(await response.json(), {
+			message: 'Unauthorized',
+			cause: { code: 'UNAUTHORIZED' },
+		});
+	});
+
+	it('refuses a wrong API key', async () => {
+		const response = await app.request('/subjects?externalId=ext_1', {
+			headers: { Authorization: 'Bearer sk_test_wrong' },
+		});
+		assert.strictEqual(response.status, 401);
+	});
+
+	it('authenticates before validating input', async () => {
+		// A missing externalId must not leak that the endpoint exists in a
+		// usable state to an unauthenticated caller.
+		const response = await app.request('/subjects');
+		assert.strictEqual(response.status, 401);
 	});
 });

--- a/packages/backend-next/src/http/app.ts
+++ b/packages/backend-next/src/http/app.ts
@@ -26,6 +26,7 @@ import type { SqlClient } from 'effect/unstable/sql';
 import { Hono } from 'hono';
 import * as v from 'valibot';
 import { listByExternalId } from '../repository/subject';
+import { validateRequestAuth } from './auth';
 import { BadRequestError, type RouteError, toHttp } from './errors';
 
 export interface AppLayers {
@@ -38,8 +39,19 @@ export interface AppLayers {
  * The runtime is constructed once by the caller and reused for every request —
  * building a layer per request would open a connection pool per request.
  */
+export interface AppOptions {
+	/**
+	 * Keys accepted on `Authorization: Bearer <key>`.
+	 *
+	 * Absent or empty means no request authenticates. A deployment that has
+	 * not configured keys should expose nothing, not everything.
+	 */
+	readonly apiKeys?: readonly string[];
+}
+
 export function createApp(
-	runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>
+	runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>,
+	options: AppOptions = {}
 ) {
 	const app = new Hono();
 
@@ -63,6 +75,16 @@ export function createApp(
 	};
 
 	app.get('/subjects', async (c) => {
+		// Listing subjects by external id exposes consent records for a named
+		// person, so it is API-key only — matching @c15t/backend, where the
+		// route is documented as requiring a key.
+		if (!validateRequestAuth(c.req.raw.headers, options.apiKeys)) {
+			return c.json(
+				{ message: 'Unauthorized', cause: { code: 'UNAUTHORIZED' } },
+				401
+			);
+		}
+
 		const externalId = c.req.query('externalId');
 
 		const result = await run(

--- a/packages/backend-next/src/http/auth.test.ts
+++ b/packages/backend-next/src/http/auth.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Auth behaviour, and its agreement with `@c15t/backend`.
+ *
+ * The parity matrix matters more than the individual cases: during the
+ * parallel phase both backends serve the same tenants with the same configured
+ * keys, so a request must not authenticate against one and fail against the
+ * other. A divergence in the permissive direction is a security hole; in the
+ * restrictive direction it is an outage.
+ */
+
+import { assert, describe, it } from 'vitest';
+// Imported from source rather than through the package: @c15t/backend's build
+// does not emit middleware as its own entry point, and reshaping the shipping
+// package's build config to enable one test is the wrong trade. The file is
+// self-contained pure functions with no imports of its own.
+import { validateRequestAuth as shipped } from '../../../backend/src/middleware/auth/validate-api-key';
+import {
+	extractBearerToken,
+	validateApiKey,
+	validateRequestAuth,
+} from './auth';
+
+const KEYS = ['sk_live_correct', 'sk_live_second'];
+
+describe('extractBearerToken', () => {
+	it('accepts only the Bearer scheme', () => {
+		assert.strictEqual(extractBearerToken('Bearer abc'), 'abc');
+		assert.isNull(extractBearerToken('Basic abc'));
+		assert.isNull(extractBearerToken('bearer abc'), 'scheme is case-sensitive');
+		assert.isNull(extractBearerToken('abc'));
+		assert.isNull(extractBearerToken(null));
+	});
+
+	it('rejects a malformed header rather than salvaging it', () => {
+		assert.isNull(extractBearerToken('Bearer'));
+		assert.isNull(extractBearerToken('Bearer '));
+		assert.isNull(extractBearerToken('Bearer a b'));
+	});
+});
+
+describe('validateApiKey', () => {
+	it('authenticates nobody when no keys are configured', () => {
+		// The important direction: an unconfigured deployment must expose
+		// nothing rather than everything.
+		assert.isFalse(validateApiKey('anything', undefined));
+		assert.isFalse(validateApiKey('anything', []));
+	});
+
+	it('accepts any configured key', () => {
+		assert.isTrue(validateApiKey('sk_live_correct', KEYS));
+		assert.isTrue(validateApiKey('sk_live_second', KEYS));
+	});
+
+	it('rejects near-misses', () => {
+		for (const token of [
+			'sk_live_correc',
+			'sk_live_correctx',
+			'sk_live_CORRECT',
+			'',
+		]) {
+			assert.isFalse(validateApiKey(token, KEYS), token);
+		}
+	});
+});
+
+describe('parity with @c15t/backend', () => {
+	it('agrees on every combination of header and configured keys', () => {
+		const headers = [
+			undefined,
+			null,
+			'Bearer sk_live_correct',
+			'Bearer sk_live_second',
+			'Bearer sk_live_wrong',
+			'Bearer sk_live_correc',
+			'Bearer sk_live_correctx',
+			'Bearer ',
+			'Bearer',
+			'Basic sk_live_correct',
+			'sk_live_correct',
+			'',
+		];
+		const keySets = [undefined, [], KEYS, ['sk_live_correct']];
+
+		for (const header of headers) {
+			for (const keys of keySets) {
+				const h = new Headers();
+				if (typeof header === 'string') h.set('Authorization', header);
+				const subject = header === undefined ? undefined : h;
+
+				assert.strictEqual(
+					validateRequestAuth(subject, keys),
+					shipped(subject, keys as string[] | undefined),
+					`header=${String(header)} keys=${JSON.stringify(keys)}`
+				);
+			}
+		}
+	});
+});

--- a/packages/backend-next/src/http/auth.ts
+++ b/packages/backend-next/src/http/auth.ts
@@ -1,0 +1,87 @@
+/**
+ * API key authentication.
+ *
+ * Deliberately a faithful port of `@c15t/backend`'s
+ * `middleware/auth/validate-api-key.ts` rather than an improvement on it.
+ * During the parallel phase both backends serve the same tenants with the same
+ * configured keys, and an auth decision that differed between them would mean
+ * a key accepted by one and rejected by the other — or worse, the reverse.
+ * `auth.parity.test.ts` pins the agreement across a matrix of inputs.
+ *
+ * The comparison is timing-safe in the same way and to the same degree as the
+ * original: equal-length keys are compared in constant time, and unequal
+ * lengths still run a loop before returning. That last part does not fully
+ * hide length, which is a known limitation of comparing JavaScript strings
+ * this way rather than an oversight — it is preserved because changing it
+ * would change behaviour, and any improvement belongs in both packages at
+ * once.
+ */
+
+/**
+ * Pulls the token out of an `Authorization: Bearer <token>` header.
+ *
+ * Returns null for any other scheme, a malformed header, or an empty token.
+ */
+export function extractBearerToken(authHeader: string | null): string | null {
+	if (!authHeader) {
+		return null;
+	}
+
+	const parts = authHeader.split(' ');
+	if (parts.length !== 2 || parts[0] !== 'Bearer') {
+		return null;
+	}
+
+	return parts[1] || null;
+}
+
+/** Constant-time comparison for equal-length strings. */
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		// Still iterate, so a length mismatch does not return measurably
+		// faster than a content mismatch.
+		let result = 0;
+		for (let index = 0; index < a.length; index++) {
+			result |= a.charCodeAt(index) ^ (b.charCodeAt(index % b.length) || 0);
+		}
+		return false;
+	}
+
+	let result = 0;
+	for (let index = 0; index < a.length; index++) {
+		result |= a.charCodeAt(index) ^ b.charCodeAt(index);
+	}
+	return result === 0;
+}
+
+/**
+ * Checks a token against the configured keys.
+ *
+ * With no keys configured this returns false rather than true: an unconfigured
+ * deployment authenticates nobody, instead of everybody.
+ */
+export function validateApiKey(
+	token: string | null,
+	validKeys: readonly string[] | undefined
+): boolean {
+	if (!token || !validKeys || validKeys.length === 0) {
+		return false;
+	}
+
+	return validKeys.some((key) => timingSafeEqual(token, key));
+}
+
+/** Whether a request carries a valid API key. */
+export function validateRequestAuth(
+	headers: Headers | undefined,
+	validKeys: readonly string[] | undefined
+): boolean {
+	if (!headers) {
+		return false;
+	}
+
+	return validateApiKey(
+		extractBearerToken(headers.get('Authorization')),
+		validKeys
+	);
+}


### PR DESCRIPTION
Closes a **security gap**, not a feature gap.

`@c15t/backend` runs `validateRequestAuth` on every request and documents `GET /subjects` as requiring an API key. This package had no authentication of any kind, so listing subjects by external id would have returned **consent records for a named person to any caller**.

## A faithful port rather than an improvement

Both backends serve the same tenants with the same configured keys during the parallel phase, so an auth decision that differed between them is either a security hole or an outage depending on direction. A parity test runs **48 combinations** of `Authorization` header and configured key set through both implementations and asserts they agree.

The timing-safe comparison is preserved exactly, including that a length mismatch is not fully hidden — a known limitation of comparing JavaScript strings this way rather than an oversight. Any improvement belongs in both packages at once, not in one of them silently.

## Two defaults worth stating

- **No keys configured authenticates nobody**, rather than everybody.
- **Auth is checked before input validation**, so an unauthenticated caller cannot probe the endpoint's state.

72 tests.
