### PR TITLE
fix(backend-next): make MySQL and SQLite actually work

### DIFF
--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -646,3 +646,49 @@ they need the bare column indexes, and keeping both sets serves both shapes.
 Unlike the foreign key indexes, this rests on reading the query code rather
 than on measurement — the benchmark has no multi-tenant arm yet, and adding
 one is what should settle the composite question.
+
+### 11.7 Two of the three supported engines did not work
+
+The suite reached 180 passing tests, ~95% statement coverage, and a
+cross-backend conformance runner while **the package could not execute a single
+statement against MySQL, and could not write to SQLite at all.**
+
+Every test used PGlite. SQLite appeared covered, but only for DDL and adoption;
+MySQL had no arm at all. So the suite proved that Postgres worked and was read
+as proving that the package worked.
+
+What was actually broken:
+
+| Defect | Effect |
+| --- | --- |
+| Identifiers quoted `"like this"` | MySQL rejects the syntax. Nothing ran. |
+| `on conflict … do nothing returning` | MySQL 8 has neither clause. Every idempotent write. |
+| `create index if not exists` | MySQL has no such clause for indexes. Migration 2. |
+| Indexed and foreign key columns declared `text` | MySQL cannot index TEXT. The baseline itself failed. |
+| `information_schema` read unaliased | MySQL uppercases the labels, so adoption saw an *empty* database, added no columns, and stamped the ledger as baseline anyway. |
+| `consent.metadata` used to detect fumadb | Legacy MySQL declares it `json`, so a legacy database classified as fumadb 1.0.0. |
+| `Date` and `boolean` bound directly | `node:sqlite` binds neither. Every SQLite write. |
+
+Two are worth calling out beyond "it did not run". The adoption one is silent:
+a legacy MySQL database would be *marked* as migrated while missing most of its
+2.0.0 columns. And `mysql.timestamp` was mapped to MySQL's `timestamp` type,
+which stops at 2038 and shifts through the session time zone — a `validUntil`
+past 2038 and a time-zone-dependent `givenAt` on a legal record. It is now
+`datetime(3)`, which is also what every legacy MySQL database already holds.
+
+The fix that matters is not any of the above; it is
+`repository/cross-engine.test.ts`. Behaviour is asserted against every engine
+present, MySQL joining when `C15T_TEST_MYSQL_URL` is set. Not one of these
+defects can recur silently, and none of them were findable by reading the code
+— each was found by running it.
+
+**Revision to §3.5.** That section says fumadb cannot migrate MySQL. True, and
+incomplete: the MySQL column of the physical type table had no fixture behind
+it, because the fumadb-era MySQL fixtures record a failure rather than a
+schema. The evidence for MySQL is the `legacy-…` fixtures, which is what
+`dialect.ts` now cites.
+
+**Testing note for §6.** Opting into MySQL also disables vitest's file
+parallelism. PGlite and SQLite get a fresh in-process database per test; MySQL
+is one shared schema, and two files migrating it concurrently fail depending on
+scheduling — passing individually, failing together.

--- a/packages/backend-next/src/__tests__/engines.ts
+++ b/packages/backend-next/src/__tests__/engines.ts
@@ -1,0 +1,108 @@
+/**
+ * The engines a behavioural test should run against.
+ *
+ * Most of this package's tests use PGlite, because it runs in-process and is
+ * fast. That is a reasonable default and a poor place to stop: the three
+ * supported engines disagree about identifier quoting, upsert syntax,
+ * `RETURNING`, boolean representation, and what a timestamp column even is.
+ * A suite that only ever sees Postgres proves Postgres works.
+ *
+ * It was exactly that gap that hid MySQL being unable to run *any* statement
+ * this package emitted — every table name was double-quoted, which MySQL
+ * rejects outright — while 180 tests passed.
+ *
+ * So repository behaviour is asserted against every engine available in the
+ * environment:
+ *
+ * - **PGlite** and **SQLite** run in-process and are always included.
+ * - **MySQL** needs a server, so it joins only when `C15T_TEST_MYSQL_URL` is
+ *   set. CI therefore stays Docker-free (RFC 0004 §7) while a release can be
+ *   checked against all three:
+ *
+ * ```
+ * docker run --rm -d -p 3399:3306 -e MYSQL_ROOT_PASSWORD=c15t \
+ *   -e MYSQL_DATABASE=c15t --name c15t-test mysql:8
+ * C15T_TEST_MYSQL_URL=mysql://root:c15t@127.0.0.1:3399/c15t bun run test
+ * ```
+ *
+ * @example
+ * ```ts
+ * for (const engine of ENGINES) {
+ * 	describe(engine.name, () => {
+ * 		it.effect('does the thing', () =>
+ * 			myTest.pipe(Effect.provide(engine.layer)));
+ * 	});
+ * }
+ * ```
+ */
+
+import { MysqlClient } from '@effect/sql-mysql2';
+import { PgliteClient } from '@effect/sql-pglite';
+import { SqliteClient } from '@effect/sql-sqlite-node';
+import { Effect, Layer, Redacted } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { singleTenant, type Tenant, layer as tenantLayer } from '../db/tenant';
+
+const MYSQL_URL = process.env.C15T_TEST_MYSQL_URL;
+
+export interface TestEngine {
+	readonly name: 'pglite' | 'sqlite' | 'mysql';
+	/** A client plus a single-tenant scope, which most tests want. */
+	readonly layer: Layer.Layer<SqlClient.SqlClient | Tenant>;
+	/** The same client, scoped to a named tenant. */
+	readonly asTenant: (
+		tenantId: string | undefined
+	) => Layer.Layer<SqlClient.SqlClient | Tenant>;
+}
+
+const client = {
+	pglite: () => PgliteClient.layer({}),
+	sqlite: () => SqliteClient.layer({ filename: ':memory:' }),
+	// Redacted, not a plain string: the URL carries credentials, and Effect
+	// keeps them out of logs and error messages by construction.
+	mysql: () => MysqlClient.layer({ url: Redacted.make(MYSQL_URL ?? '') }),
+} as const;
+
+const engine = (name: TestEngine['name']): TestEngine => ({
+	name,
+	layer: Layer.merge(client[name](), singleTenant),
+	asTenant: (tenantId) => Layer.merge(client[name](), tenantLayer(tenantId)),
+});
+
+/** Every engine this environment can exercise. */
+export const ENGINES: readonly TestEngine[] = [
+	engine('pglite'),
+	engine('sqlite'),
+	...(MYSQL_URL ? [engine('mysql')] : []),
+];
+
+/**
+ * Drops every table, so a case starts from an empty database.
+ *
+ * PGlite and in-memory SQLite get a fresh database each time their layer is
+ * built, making this a no-op there. MySQL is a real shared server and does
+ * not, so without this a case would inherit the previous one's schema.
+ *
+ * Worth doing rather than assuming: while generating the migration fixtures,
+ * reusing one MySQL database across cases changed the migration *path* and
+ * produced both a spurious failure and a spurious pass.
+ */
+export const resetDatabase = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+
+	yield* sql.onDialectOrElse({
+		mysql: () =>
+			Effect.gen(function* () {
+				yield* sql`set foreign_key_checks = 0`;
+				const tables = yield* sql<{ name: string }>`
+					select table_name as name from information_schema.tables
+					where table_schema = database()
+				`;
+				for (const table of tables) {
+					yield* sql.unsafe(`drop table if exists \`${table.name}\``);
+				}
+				yield* sql`set foreign_key_checks = 1`;
+			}),
+		orElse: () => Effect.void,
+	});
+});

--- a/packages/backend-next/src/db/adopt.ts
+++ b/packages/backend-next/src/db/adopt.ts
@@ -42,7 +42,7 @@
  */
 
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { classify, type Shape } from './classify';
 import * as Dialect from './dialect';
 import {
@@ -52,6 +52,7 @@ import {
 	TABLES,
 	type TableSpec,
 } from './schema';
+import { encodeRow, encoder } from './values';
 
 /** Name of the ledger this package owns, distinct from fumadb's marker. */
 export const LEDGER_TABLE = 'c15t_migrations';
@@ -99,9 +100,15 @@ const observeExisting = Effect.fn('adopt.observe')(function* () {
 				join pragma_table_info(m.name) c
 				where m.type = 'table'
 			`,
+		// Aliased explicitly. MySQL returns `information_schema` labels
+		// uppercased (`TABLE_NAME`) whatever case the query used, so an
+		// unaliased projection reads back as `undefined` here — which looks
+		// exactly like an empty database, and would have adoption stamp a
+		// legacy MySQL schema as baseline without adding a single column.
 		mysql: () =>
 			sql<{ table_name: string; column_name: string }>`
-				select table_name, column_name from information_schema.columns
+				select table_name as table_name, column_name as column_name
+				from information_schema.columns
 				where table_schema = database()
 			`,
 		orElse: () =>
@@ -130,8 +137,10 @@ const observeExisting = Effect.fn('adopt.observe')(function* () {
 				`,
 			mysql: () =>
 				sql<{ table_name: string; column_name: string }>`
-					select table_name, column_name from information_schema.key_column_usage
-					where table_schema = database() and referenced_table_name is not null
+					select table_name as table_name, column_name as column_name
+					from information_schema.key_column_usage
+					where table_schema = database()
+						and referenced_table_name is not null
 				`,
 			orElse: () =>
 				sql<{ table_name: string; column_name: string }>`
@@ -160,14 +169,14 @@ const countOrphans = Effect.fn('adopt.countOrphans')(function* (
 	fk: ForeignKeySpec
 ) {
 	const sql = yield* SqlClient.SqlClient;
-	const rows = yield* sql<{ orphans: number | string }>`${sql.unsafe(`
+	const rows = yield* sql<{ orphans: number | string }>`
 		select count(*) as orphans
-		from "${table.name}" child
-		left join "${fk.referencesTable}" parent
-			on parent."${fk.referencesColumn}" = child."${fk.column}"
-		where child."${fk.column}" is not null
-			and parent."${fk.referencesColumn}" is null
-	`)}`;
+		from ${sql(table.name)} child
+		left join ${sql(fk.referencesTable)} parent
+			on ${sql(`parent.${fk.referencesColumn}`)} = ${sql(`child.${fk.column}`)}
+		where ${sql(`child.${fk.column}`)} is not null
+			and ${sql(`parent.${fk.referencesColumn}`)} is null
+	`;
 	return Number(rows[0]?.orphans ?? 0);
 });
 
@@ -183,6 +192,7 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 			Effect.orElseSucceed(() => 'postgres' as const)
 		);
 		const types = Dialect.typesFor(dialect);
+		const quote = Dialect.escaperFor(dialect);
 		const existing = yield* observeExisting();
 
 		if (shape._tag === 'Unknown') {
@@ -213,7 +223,7 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 				steps.push({
 					kind: 'create-table',
 					description: `Create "${table.name}"`,
-					sql: createTableSql(table, types),
+					sql: createTableSql(table, types, quote),
 				});
 				continue;
 			}
@@ -224,7 +234,7 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 				steps.push({
 					kind: 'add-column',
 					description: `Add "${table.name}"."${column.name}"`,
-					sql: addColumnSql(table.name, column, types),
+					sql: addColumnSql(table.name, column, types, quote),
 				});
 			}
 
@@ -253,7 +263,11 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 				steps.push({
 					kind: 'add-foreign-key',
 					description: `Add foreign key "${table.name}"."${fk.column}" -> "${fk.referencesTable}"`,
-					sql: `alter table "${table.name}" add foreign key ("${fk.column}") references "${fk.referencesTable}"("${fk.referencesColumn}")`,
+					sql: `alter table ${quote(table.name)} add foreign key (${quote(
+						fk.column
+					)}) references ${quote(fk.referencesTable)}(${quote(
+						fk.referencesColumn
+					)})`,
 				});
 			}
 		}
@@ -261,7 +275,11 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 		steps.push({
 			kind: 'stamp',
 			description: 'Record the baseline in the migration ledger',
-			sql: `create table if not exists "${LEDGER_TABLE}" ("id" integer primary key, "name" ${types.text} not null, "appliedAt" ${types.timestamp} not null)`,
+			sql: `create table if not exists ${quote(LEDGER_TABLE)} (${quote(
+				'id'
+			)} integer primary key, ${quote('name')} ${types.text} not null, ${quote(
+				'appliedAt'
+			)} ${types.timestamp} not null)`,
 		});
 
 		const specTables = new Set(TABLES.map((table) => table.name));
@@ -363,7 +381,15 @@ export const apply = Effect.fn('adopt.apply')(function* (
 		yield* sql.unsafe(step.sql);
 	}
 
-	yield* sql`insert into ${sql.unsafe(`"${LEDGER_TABLE}"`)} ("id", "name", "appliedAt") values (1, '1-baseline', ${new Date()})`.pipe(
+	yield* sql`
+		insert into ${sql(LEDGER_TABLE)} ${sql.insert(
+			encodeRow(yield* encoder, {
+				id: 1,
+				name: '1-baseline',
+				appliedAt: new Date(),
+			})
+		)}
+	`.pipe(
 		// Re-running adoption should not fail on the ledger row it already
 		// wrote. Idempotency matters here: RFC §3.3 requires the step be safe
 		// to re-run after a mid-flight failure.

--- a/packages/backend-next/src/db/classify.ts
+++ b/packages/backend-next/src/db/classify.ts
@@ -34,7 +34,7 @@
  */
 
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
 
 /** A database shape the migrator knows how to handle. */
 export type Shape =
@@ -112,9 +112,9 @@ const markerVersion = Effect.fn('classify.markerVersion')(function* (
 	table: string
 ) {
 	const sql = yield* SqlClient.SqlClient;
-	const rows = yield* sql<{ key: string; value: string }>`${sql.unsafe(
-		`select "key", "value" from "${table}"`
-	)}`;
+	const rows = yield* sql<{ key: string; value: string }>`
+		select ${sql('key')}, ${sql('value')} from ${sql(table)}
+	`;
 	return rows.find((row) => row.key === 'version')?.value;
 });
 
@@ -139,6 +139,16 @@ const looksLikeFumadb = Effect.fn('classify.looksLikeFumadb')(function* () {
 				return type === undefined ? undefined : type === 'json';
 			}),
 		sqlite: () => Effect.succeed(undefined),
+		// On MySQL the question does not arise: fumadb cannot migrate MySQL in
+		// either era, so no fumadb-shaped MySQL database exists to confuse this
+		// with. Both `fumadb-1.0.0/mysql` and `fumadb-2.0.0/mysql` fixtures
+		// record a migration failure rather than a schema.
+		//
+		// Answering by column type would get it wrong rather than merely be
+		// unhelpful: legacy MySQL declares `consent.metadata` as `json`, the
+		// same as the `orElse` branch treats as proof of fumadb. Postgres is
+		// where that test works, because legacy declares `jsonb` there.
+		mysql: () => Effect.succeed(false),
 	});
 });
 
@@ -210,8 +220,9 @@ export const classify: Effect.Effect<
 		_tag: 'Unknown',
 		tables: [...observed.tables].sort(),
 		why:
-			'No version marker, and this engine cannot distinguish a legacy schema ' +
-			'from an ORM-applied fumadb 1.0.0 by column type (SQLite collapses both ' +
-			'to TEXT). Re-run with --assume-shape to state which it is.',
+			'No version marker, and a legacy schema cannot be told apart from an ' +
+			'ORM-applied fumadb 1.0.0 by column type here — SQLite collapses both ' +
+			'to TEXT, and elsewhere the deciding column is missing. Re-run with ' +
+			'--assume-shape to state which it is.',
 	} as const;
 });

--- a/packages/backend-next/src/db/dialect.ts
+++ b/packages/backend-next/src/db/dialect.ts
@@ -7,28 +7,52 @@
  * in `@c15t/backend`; the fix is to write real SQL and name the few concrete
  * divergences, not to build another abstraction over them.
  *
- * **Every mapping here is taken from the committed 2.0.0 fixtures**
- * (`internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json`), not from what
- * the engines would allow. The baseline has to land a fresh database on the
- * same physical shape an existing 2.0.0 database already has, or adopting an
- * existing database would mean rewriting columns for no behavioural gain.
+ * **Every mapping here is taken from a committed fixture**, not from what the
+ * engines would allow. The baseline has to land a fresh database on the same
+ * physical shape an existing database already has, or adopting one would mean
+ * rewriting columns for no behavioural gain.
  *
- * Observed there:
- *
- * | Logical  | postgres    | sqlite    | mysql        |
- * | -------- | ----------- | --------- | ------------ |
- * | id       | `varchar`   | `TEXT`    | `varchar`    |
- * | string   | `text`      | `TEXT`    | `text`       |
- * | json     | `json`      | `TEXT`    | `json`       |
- * | bool     | `bool`      | `INTEGER` | `boolean`    |
- * | timestamp| `timestamp` | `INTEGER` | `timestamp`  |
+ * | Logical  | postgres    | sqlite    | mysql         |
+ * | -------- | ----------- | --------- | ------------- |
+ * | id       | `varchar`   | `TEXT`    | `varchar`     |
+ * | string   | `text`      | `TEXT`    | `text`        |
+ * | json     | `json`      | `TEXT`    | `json`        |
+ * | bool     | `bool`      | `INTEGER` | `tinyint`     |
+ * | timestamp| `timestamp` | `INTEGER` | `datetime(3)` |
  *
  * SQLite collapses everything into `TEXT` and `INTEGER` — notably timestamps
  * are epoch integers there, which the row decoders have to account for.
+ *
+ * ## Where the MySQL column comes from
+ *
+ * Not from the 2.0.0 fixtures, because there are none: fumadb cannot migrate
+ * MySQL at all, so `fixtures/fumadb-2.0.0/mysql.unsupported.json` records a
+ * failure rather than a schema (§3.5). The only real MySQL databases c15t has
+ * ever produced are **legacy** ones, from the pre-fumadb migrator that did
+ * work there, so the `mysql.json` files under the three `fixtures/legacy-…`
+ * directories are the evidence used instead.
+ *
+ * Those fixtures are why `timestamp` maps to `datetime` and not to MySQL's
+ * `timestamp` type. Two independent reasons agree:
+ *
+ * - Every legacy MySQL database already holds `datetime`, so adoption adds
+ *   columns that match the ones beside them.
+ * - MySQL's `timestamp` is a four-byte epoch that stops at 2038-01-19 and
+ *   silently converts through the session time zone. `consent.validUntil` can
+ *   legitimately fall past 2038, and shifting a legal record's `givenAt` by
+ *   whatever `time_zone` a connection happened to have is not acceptable for
+ *   an audit trail. `datetime` has neither behaviour.
+ *
+ * The `(3)` is millisecond precision. Bare `datetime` truncates to whole
+ * seconds, which would make MySQL the one engine that fails to return the
+ * instant it was given — Postgres keeps microseconds and SQLite stores epoch
+ * milliseconds. Consent ids are derived from `givenAt`, so a truncating
+ * round-trip would produce a value that no longer hashes to its own id.
+ * Introspection reports `datetime` either way, so this stays fixture-clean.
  */
 
 import { Data, Effect } from 'effect';
-import { SqlClient } from 'effect/unstable/sql';
+import { SqlClient, Statement } from 'effect/unstable/sql';
 
 /** The SQL engines c15t supports. MongoDB is not among them — RFC 0004 §2. */
 export type Dialect = 'postgres' | 'mysql' | 'sqlite';
@@ -76,18 +100,28 @@ export interface PhysicalTypes {
 	/** String column with no index on it. */
 	readonly text: string;
 	/**
-	 * String column carrying an index or unique constraint.
+	 * String column that something indexes.
 	 *
-	 * MySQL cannot index `TEXT` without a prefix length, which is exactly why
-	 * fumadb cannot migrate MySQL at all (RFC 0004 §3.5):
+	 * Three overlapping cases, all of which reduce to the same requirement:
+	 * a unique constraint (`dedupeKey`), an entry in `2-hot-path-indexes`
+	 * (`externalId`, `tenantId`, `code`, …), or a foreign key column, which
+	 * MySQL indexes implicitly whether or not we ask it to.
+	 *
+	 * MySQL cannot index `TEXT` without a prefix length:
 	 *
 	 * ```
 	 * BLOB/TEXT column 'dedupeKey' used in key specification without a key length
 	 * ```
 	 *
+	 * That single restriction is why fumadb cannot migrate MySQL at all
+	 * (RFC 0004 §3.5), and the legacy migrator that *could* worked precisely
+	 * because it declared these columns `varchar` — which the legacy MySQL
+	 * fixtures confirm.
+	 *
 	 * Postgres and SQLite have no such restriction and existing databases
 	 * already hold plain text there, so only MySQL pays for the constraint
-	 * that only MySQL has.
+	 * that only MySQL has, and the fixture parity tests for the other two are
+	 * unaffected.
 	 */
 	readonly indexedText: string;
 	readonly json: string;
@@ -111,8 +145,12 @@ const TYPES: Readonly<Record<Dialect, PhysicalTypes>> = {
 		text: 'text',
 		indexedText: 'varchar(255)',
 		json: 'json',
+		// An alias for `tinyint(1)`, which is what legacy MySQL databases
+		// introspect as.
 		bool: 'boolean',
-		timestamp: 'timestamp',
+		// Not `timestamp` — see the note on the 2038 cut-off and time-zone
+		// conversion at the top of this file.
+		timestamp: 'datetime(3)',
 	},
 	sqlite: {
 		// SQLite reports the declared type verbatim, and 2.0.0 databases
@@ -130,4 +168,30 @@ const TYPES: Readonly<Record<Dialect, PhysicalTypes>> = {
 
 export function typesFor(dialect: Dialect): PhysicalTypes {
 	return TYPES[dialect];
+}
+
+/**
+ * Quotes an identifier the way the engine expects.
+ *
+ * MySQL delimits with backticks; Postgres and SQLite with double quotes. A
+ * `create table "subject"` that works on two engines is a syntax error on the
+ * third, which is precisely how MySQL support was found to be broken.
+ *
+ * **Only for the two places that assemble DDL as a raw string** — the baseline
+ * and the index migration, which build statements from `TABLES`/`INDEXES`
+ * rather than from a template literal. Everywhere else, write
+ * `` sql`select ${sql('subject.id')} from ${sql('subject')}` `` and let the
+ * dialect's own compiler escape it; that path is checked by the type system
+ * and this one is not.
+ *
+ * @example
+ * ```ts
+ * const quote = escaperFor('mysql');
+ * quote('subject'); // `subject`
+ * ```
+ */
+export function escaperFor(dialect: Dialect): (name: string) => string {
+	return dialect === 'mysql'
+		? Statement.defaultEscape('`')
+		: Statement.defaultEscape('"');
 }

--- a/packages/backend-next/src/db/insert-once.ts
+++ b/packages/backend-next/src/db/insert-once.ts
@@ -1,0 +1,117 @@
+/**
+ * Inserting a row that might already be there.
+ *
+ * Three write paths need the same guarantee — consent, subject and runtime
+ * policy decision. Each has a deterministic primary key, so a retry, a
+ * double-click, or two requests racing from the same visitor all compute the
+ * *same* id. The insert must therefore succeed quietly when the row exists,
+ * and still report which caller actually created it, because the audit entry
+ * is written exactly once on the strength of that answer.
+ *
+ * ## Why this is not one statement for all three engines
+ *
+ * Postgres and SQLite express it directly:
+ *
+ * ```sql
+ * insert into … on conflict ("id") do nothing returning "id"
+ * ```
+ *
+ * MySQL 8 supports **neither** clause. `on conflict` is Postgres/SQLite
+ * syntax, and `returning` is MariaDB's, not MySQL's. Its equivalent is
+ * `insert ignore`, which reports the outcome out-of-band as `affectedRows`
+ * rather than as a result set.
+ *
+ * So the shape of the answer genuinely differs per engine and the branch is
+ * real rather than incidental. It is confined to this one function, and the
+ * three call sites just get a boolean.
+ *
+ * ## Why not catch the duplicate-key error instead
+ *
+ * Effect normalises duplicate keys into `UniqueViolation` on all three
+ * engines, so `insert` + `catch` would need no branch at all. It is still the
+ * wrong choice here: on Postgres a failed statement poisons the enclosing
+ * transaction, and every one of these inserts runs inside one. Recovering
+ * would mean a `SAVEPOINT` and a `RELEASE` around each write — a round trip
+ * added to the hottest path in the service to avoid a branch in one file.
+ *
+ * The old `@c15t/backend` did read-then-write and then string-matched adapter
+ * error codes (`23505`, `ER_DUP_ENTRY`, `SQLITE_CONSTRAINT…`) to decide
+ * whether a failure was a duplicate. Both forms of that are gone: the database
+ * decides, in one statement, and nothing parses an error message.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { encodeRow, encoder } from './values';
+
+/**
+ * How many rows MySQL actually wrote.
+ *
+ * `insert ignore` returns an OK packet rather than rows: 1 when it inserted,
+ * 0 when it skipped a duplicate. Read defensively — this is driver-shaped
+ * data crossing into typed code, and a missing field must read as "did not
+ * insert" rather than throw.
+ */
+const affectedRows = (result: unknown): number =>
+	typeof result === 'object' &&
+	result !== null &&
+	'affectedRows' in result &&
+	typeof result.affectedRows === 'number'
+		? result.affectedRows
+		: 0;
+
+export interface InsertOnceOptions {
+	/** Table to insert into. */
+	readonly into: string;
+	/**
+	 * The unique column that decides whether this is a duplicate.
+	 *
+	 * A single column, because every caller conflicts on exactly one: the
+	 * deterministic primary key, or `dedupeKey`.
+	 */
+	readonly conflictOn: string;
+	/** Column values. JSON columns must already be serialised. */
+	readonly values: Record<string, unknown>;
+}
+
+/**
+ * Inserts a row unless its unique column is already taken.
+ *
+ * @returns `true` when this call created the row, `false` when it already
+ * existed — including when a concurrent request created it a moment earlier.
+ *
+ * @example
+ * ```ts
+ * const created = yield* insertOnce({
+ * 	into: 'consent',
+ * 	conflictOn: 'id',
+ * 	values: { id, subjectId, givenAt },
+ * });
+ * ```
+ */
+export const insertOnce = Effect.fn('db.insertOnce')(function* (
+	options: InsertOnceOptions
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const into = sql(options.into);
+	// SQLite can bind neither a Date nor a boolean; see `./values.ts`.
+	const values = sql.insert(encodeRow(yield* encoder, options.values));
+	const conflictOn = sql(options.conflictOn);
+
+	return yield* sql.onDialectOrElse({
+		mysql: () =>
+			Effect.map(
+				sql`insert ignore into ${into} ${values}`.raw,
+				(result) => affectedRows(result) > 0
+			),
+		orElse: () =>
+			Effect.map(
+				sql`
+					insert into ${into} ${values}
+					on conflict (${conflictOn}) do nothing
+					returning ${conflictOn}
+				`,
+				(rows) => rows.length > 0
+			),
+	});
+});

--- a/packages/backend-next/src/db/migrations/1-baseline.ts
+++ b/packages/backend-next/src/db/migrations/1-baseline.ts
@@ -42,8 +42,9 @@ export const up = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient;
 	const dialect = yield* Dialect.current;
 	const types = Dialect.typesFor(dialect);
+	const quote = Dialect.escaperFor(dialect);
 
 	for (const table of TABLES) {
-		yield* sql.unsafe(createTableSql(table, types));
+		yield* sql.unsafe(createTableSql(table, types, quote));
 	}
 });

--- a/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
+++ b/packages/backend-next/src/db/migrations/2-hot-path-indexes.ts
@@ -151,16 +151,105 @@ export const INDEXES: readonly IndexSpec[] = [
 	})),
 ] as const;
 
+/**
+ * Index names already present, for the engine that cannot say
+ * `if not exists`.
+ *
+ * MySQL supports `create index if not exists` for nothing — re-running the
+ * migration would fail with "Duplicate key name" rather than no-op — so the
+ * check has to happen before the DDL. Postgres and SQLite both accept the
+ * clause and get an empty set, keeping one code path for all three.
+ */
+const existingIndexNames = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	return yield* sql.onDialectOrElse({
+		mysql: () =>
+			Effect.map(
+				sql<{ name: string }>`
+					select distinct index_name as name
+					from information_schema.statistics
+					where table_schema = database()
+				`,
+				(rows) => new Set(rows.map((row) => row.name))
+			),
+		orElse: () => Effect.succeed(new Set<string>()),
+	});
+});
+
+/**
+ * How many leading characters of a MySQL `TEXT` column to index.
+ *
+ * 191 is the largest prefix that fits the 767-byte index limit of InnoDB's
+ * older `COMPACT` row format under `utf8mb4` (191 × 4 = 764). Modern
+ * `DYNAMIC` tables allow far more, but the smaller bound works on both and
+ * this is a selectivity aid, not a uniqueness constraint.
+ */
+const TEXT_PREFIX = 191;
+
+/**
+ * The MySQL columns that must be indexed by prefix rather than whole.
+ *
+ * A **fresh** MySQL install has no such columns: the baseline declares
+ * everything indexed here as `varchar(255)`. An **adopted** one can, because
+ * adoption is add-only and the legacy migrator declared `subject.externalId`
+ * and `consentPurpose.code` as `TEXT` — which MySQL refuses to index without
+ * a length.
+ *
+ * Widening those columns instead would be the tidier schema and the wrong
+ * trade: `alter table … modify` rewrites the table under a lock, on exactly
+ * the tables most likely to be large, to buy nothing this index does not
+ * already buy.
+ */
+const blobColumns = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	return yield* sql.onDialectOrElse({
+		mysql: () =>
+			Effect.map(
+				// Aliased explicitly: MySQL uppercases `information_schema`
+				// labels regardless of the case written here.
+				sql<{ table_name: string; column_name: string }>`
+					select table_name as table_name, column_name as column_name
+					from information_schema.columns
+					where table_schema = database()
+						and data_type in ('tinytext', 'text', 'mediumtext', 'longtext',
+							'tinyblob', 'blob', 'mediumblob', 'longblob')
+				`,
+				(rows) =>
+					new Set(rows.map((row) => `${row.table_name}.${row.column_name}`))
+			),
+		orElse: () => Effect.succeed(new Set<string>()),
+	});
+});
+
 export const up = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient;
 	// Resolved so an unsupported dialect fails here rather than part-way
 	// through emitting DDL.
-	yield* Dialect.current;
+	const dialect = yield* Dialect.current;
+	const quote = Dialect.escaperFor(dialect);
+	const existing = yield* existingIndexNames;
+	const needsPrefix = yield* blobColumns;
+
+	// MySQL rejects the clause outright; the pre-flight check above covers it.
+	const ifNotExists = dialect === 'mysql' ? '' : 'if not exists ';
 
 	for (const index of INDEXES) {
-		const columns = index.columns.map((column) => `"${column}"`).join(', ');
+		if (existing.has(index.name)) {
+			continue;
+		}
+
+		const columns = index.columns
+			.map((column) =>
+				needsPrefix.has(`${index.table}.${column}`)
+					? `${quote(column)}(${TEXT_PREFIX})`
+					: quote(column)
+			)
+			.join(', ');
+
 		yield* sql.unsafe(
-			`create index if not exists "${index.name}" on "${index.table}" (${columns})`
+			`create index ${ifNotExists}${quote(index.name)} on ${quote(
+				index.table
+			)} (${columns})`
 		);
 	}
 });

--- a/packages/backend-next/src/db/mysql.test.ts
+++ b/packages/backend-next/src/db/mysql.test.ts
@@ -1,0 +1,277 @@
+/**
+ * MySQL, against a real server.
+ *
+ * Opt-in, because MySQL cannot run in-process the way SQLite and PGlite can:
+ *
+ * ```
+ * docker run --rm -d -p 3399:3306 -e MYSQL_ROOT_PASSWORD=c15t \
+ *   -e MYSQL_DATABASE=c15t --name c15t-test mysql:8
+ * C15T_TEST_MYSQL_URL=mysql://root:c15t@127.0.0.1:3399/c15t bun run test
+ * ```
+ *
+ * Skipped when that variable is absent, so CI stays free of a Docker
+ * dependency (RFC 0004 §7) while the engine still gets exercised before a
+ * release.
+ *
+ * This file holds only what is **specific to MySQL**. Behaviour that should be
+ * identical on every engine lives in `../repository/cross-engine.test.ts`,
+ * which picks MySQL up from the same environment variable.
+ *
+ * Worth testing rather than assuming, because MySQL is where this project's
+ * engine differences have actually bitten: fumadb cannot migrate it at all
+ * (§3.5), it delimits identifiers with backticks rather than double quotes, it
+ * supports neither `on conflict` nor `returning`, an indexed string column must
+ * be a bounded varchar, and its DDL is not transactional.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import { apply, plan } from './adopt';
+import { classify } from './classify';
+import { up as baseline } from './migrations/1-baseline';
+import { up as indexes } from './migrations/2-hot-path-indexes';
+
+const mysql = ENGINES.find((engine) => engine.name === 'mysql');
+const suite = mysql ? describe : describe.skip;
+const Mysql = mysql?.layer ?? ENGINES[0]?.layer;
+
+const reset = resetDatabase;
+
+suite('mysql', () => {
+	it.effect(
+		'applies the baseline',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+
+				const sql = yield* SqlClient.SqlClient;
+				const tables = yield* sql<{ name: string }>`
+					select table_name as name from information_schema.tables
+					where table_schema = database()
+				`;
+				assert.strictEqual(tables.length, 7);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'creates the unique index fumadb cannot',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+
+				// The exact thing that makes fumadb unable to migrate MySQL:
+				// dedupeKey is unique, and MySQL cannot index TEXT without a
+				// prefix length. Our dialect mapping bounds it to varchar here
+				// and only here.
+				const sql = yield* SqlClient.SqlClient;
+				const columns = yield* sql<{ DATA_TYPE: string }>`
+					select data_type as DATA_TYPE from information_schema.columns
+					where table_schema = database()
+						and table_name = 'runtimePolicyDecision'
+						and column_name = 'dedupeKey'
+				`;
+				assert.strictEqual(
+					String(columns[0]?.DATA_TYPE).toLowerCase(),
+					'varchar'
+				);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'applies the hot-path indexes',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+				yield* indexes;
+
+				const sql = yield* SqlClient.SqlClient;
+				const found = yield* sql<{ INDEX_NAME: string }>`
+					select distinct index_name as INDEX_NAME
+					from information_schema.statistics
+					where table_schema = database() and index_name like 'c15t_%'
+				`;
+				assert.isAbove(found.length, 10);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'classifies and adopts an empty database',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+
+				assert.strictEqual((yield* classify)._tag, 'Empty');
+				yield* apply(yield* plan);
+				assert.strictEqual((yield* classify)._tag, 'Baseline');
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'adoption emits nothing destructive on mysql',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				const sql = yield* SqlClient.SqlClient;
+				yield* sql.unsafe(
+					'create table `subject` (`id` varchar(255) primary key, `externalId` text)'
+				);
+				yield* sql.unsafe(
+					'create table `consent` (`id` varchar(255) primary key, `status` text)'
+				);
+
+				// MySQL DDL is not transactional, so a destructive step here
+				// could not be rolled back — the add-only guarantee matters more
+				// on this engine than on the others.
+				for (const step of (yield* plan).steps) {
+					assert.notMatch(
+						step.sql,
+						/\b(drop|truncate)\b|\bdelete\s+from\b/i,
+						step.description
+					);
+				}
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'indexes a legacy TEXT column by prefix',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+				const sql = yield* SqlClient.SqlClient;
+
+				// Stand in for a column adoption inherited. A legacy MySQL
+				// database declares `subject.externalId` as TEXT, and adoption is
+				// add-only so it stays TEXT — which MySQL refuses to index whole.
+				// The index migration has to cope rather than fail.
+				yield* sql.unsafe('alter table `subject` modify `externalId` text');
+
+				yield* indexes;
+
+				const prefixed = yield* sql<{
+					INDEX_NAME: string;
+					SUB_PART: number | null;
+				}>`
+					select index_name as INDEX_NAME, sub_part as SUB_PART
+					from information_schema.statistics
+					where table_schema = database()
+						and index_name = 'c15t_subject_externalId_idx'
+				`;
+
+				// Indexed, and indexed by prefix rather than whole.
+				assert.strictEqual(prefixed.length, 1);
+				assert.strictEqual(Number(prefixed[0]?.SUB_PART), 191);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'indexes a fresh varchar column whole',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+				yield* indexes;
+
+				const sql = yield* SqlClient.SqlClient;
+				const fresh = yield* sql<{ SUB_PART: number | null }>`
+					select sub_part as SUB_PART from information_schema.statistics
+					where table_schema = database()
+						and index_name = 'c15t_subject_externalId_idx'
+				`;
+
+				// A fresh install declares the column varchar(255), so no prefix
+				// is needed and none should be used — the prefix exists only to
+				// accommodate columns adoption inherited.
+				assert.strictEqual(fresh.length, 1);
+				assert.isNull(fresh[0]?.SUB_PART ?? null);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+
+	it.effect(
+		'is idempotent on a second index run',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+				yield* indexes;
+
+				// MySQL has no `create index if not exists`; re-running would
+				// fail with "Duplicate key name" without the pre-flight check.
+				yield* indexes;
+
+				const sql = yield* SqlClient.SqlClient;
+				const found = yield* sql<{ total: number | string }>`
+					select count(distinct index_name) as total
+					from information_schema.statistics
+					where table_schema = database() and index_name like 'c15t_%'
+				`;
+				assert.isAbove(Number(found[0]?.total), 10);
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+	it.effect(
+		'adopting a legacy database adds its missing columns',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				const sql = yield* SqlClient.SqlClient;
+
+				// A legacy MySQL shape: no ledger, no fumadb marker, and
+				// `consentRecord` still present. `subject` is missing every column
+				// 2.0.0 added.
+				yield* sql.unsafe(
+					'create table `subject` (`id` varchar(255) primary key, ' +
+						'`externalId` text)'
+				);
+				yield* sql.unsafe(
+					'create table `consent` (`id` varchar(255) primary key, ' +
+						'`subjectId` varchar(255))'
+				);
+				yield* sql.unsafe(
+					'create table `consentRecord` (`id` varchar(255) primary key)'
+				);
+
+				assert.strictEqual((yield* classify)._tag, 'Legacy');
+
+				const adoption = yield* plan;
+				const added = adoption.steps
+					.filter((step) => step.kind === 'add-column')
+					.map((step) => step.description);
+
+				// The regression this guards: MySQL returns `information_schema`
+				// labels uppercased, so an unaliased projection read back as
+				// `undefined` and every existing table looked absent. Adoption
+				// then planned zero column additions and stamped the ledger
+				// anyway, leaving a database marked as baseline while missing
+				// most of its columns.
+				assert.include(added, 'Add "subject"."tenantId"');
+				assert.include(added, 'Add "subject"."createdAt"');
+				assert.include(added, 'Add "consent"."purposeIds"');
+
+				yield* apply(adoption);
+
+				const columns = yield* sql<{ name: string }>`
+					select column_name as name from information_schema.columns
+					where table_schema = database() and table_name = 'subject'
+				`;
+				const names = columns.map((column) => column.name);
+				assert.include(names, 'tenantId');
+				// Add-only: the legacy column is still there, untouched.
+				assert.include(names, 'externalId');
+				assert.strictEqual((yield* classify)._tag, 'Baseline');
+			}).pipe(Effect.provide(Mysql)),
+		{ timeout: 120_000 }
+	);
+});

--- a/packages/backend-next/src/db/schema.ts
+++ b/packages/backend-next/src/db/schema.ts
@@ -8,9 +8,23 @@
  * install and an adopted database would eventually disagree and nothing would
  * catch it.
  *
- * Every column and type is verified against
- * `internals/migration-fixtures/fixtures/fumadb-2.0.0/*.json`, captured from
- * the real published `@c15t/backend@2.1.0`.
+ * Every column and type is verified against the `fumadb-2.0.0` fixtures under
+ * `internals/migration-fixtures`, captured from the real published
+ * `@c15t/backend@2.1.0` — except on MySQL, which fumadb cannot migrate, and
+ * where the `legacy-…` fixtures are the evidence instead. See `./dialect.ts`.
+ *
+ * ## `text` versus `indexedText`
+ *
+ * A column is `indexedText` when something indexes it: a unique constraint, an
+ * entry in `2-hot-path-indexes`, or a foreign key — MySQL indexes the
+ * referencing side implicitly, and cannot do so on a `TEXT` column. The two
+ * logical types are identical on Postgres and SQLite and differ only on MySQL,
+ * so this distinction costs the other two engines nothing and is the
+ * difference between MySQL working and not.
+ *
+ * Getting it wrong is loud rather than subtle — `create table` fails with
+ * "BLOB/TEXT column … used in key specification without a key length" — so
+ * `db/mysql.test.ts` catches a column that should have been marked.
  */
 
 import type { PhysicalTypes } from './dialect';
@@ -48,9 +62,9 @@ export const TABLES: readonly TableSpec[] = [
 		name: 'subject',
 		columns: [
 			id,
-			{ name: 'externalId', type: 'text', nullable: true },
+			{ name: 'externalId', type: 'indexedText', nullable: true },
 			{ name: 'identityProvider', type: 'text', nullable: true },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'createdAt', type: 'timestamp', nullable: false },
 			{ name: 'updatedAt', type: 'timestamp', nullable: false },
 		],
@@ -60,8 +74,8 @@ export const TABLES: readonly TableSpec[] = [
 		name: 'domain',
 		columns: [
 			id,
-			{ name: 'name', type: 'text', nullable: false },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'name', type: 'indexedText', nullable: false },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'createdAt', type: 'timestamp', nullable: false },
 			{ name: 'updatedAt', type: 'timestamp', nullable: false },
 		],
@@ -72,11 +86,11 @@ export const TABLES: readonly TableSpec[] = [
 		columns: [
 			id,
 			{ name: 'version', type: 'text', nullable: false },
-			{ name: 'type', type: 'text', nullable: false },
+			{ name: 'type', type: 'indexedText', nullable: false },
 			{ name: 'hash', type: 'text', nullable: true },
 			{ name: 'effectiveDate', type: 'timestamp', nullable: false },
 			{ name: 'isActive', type: 'bool', nullable: false },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'createdAt', type: 'timestamp', nullable: false },
 		],
 		foreignKeys: [],
@@ -85,8 +99,8 @@ export const TABLES: readonly TableSpec[] = [
 		name: 'consentPurpose',
 		columns: [
 			id,
-			{ name: 'code', type: 'text', nullable: false },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'code', type: 'indexedText', nullable: false },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'createdAt', type: 'timestamp', nullable: false },
 			{ name: 'updatedAt', type: 'timestamp', nullable: false },
 		],
@@ -96,7 +110,7 @@ export const TABLES: readonly TableSpec[] = [
 		name: 'runtimePolicyDecision',
 		columns: [
 			id,
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'policyId', type: 'text', nullable: false },
 			{ name: 'fingerprint', type: 'text', nullable: false },
 			{ name: 'matchedBy', type: 'text', nullable: false },
@@ -128,9 +142,9 @@ export const TABLES: readonly TableSpec[] = [
 		name: 'consent',
 		columns: [
 			id,
-			{ name: 'subjectId', type: 'text', nullable: false },
-			{ name: 'domainId', type: 'text', nullable: false },
-			{ name: 'policyId', type: 'text', nullable: true },
+			{ name: 'subjectId', type: 'indexedText', nullable: false },
+			{ name: 'domainId', type: 'indexedText', nullable: false },
+			{ name: 'policyId', type: 'indexedText', nullable: true },
 			{ name: 'purposeIds', type: 'json', nullable: false },
 			{ name: 'metadata', type: 'json', nullable: true },
 			{ name: 'ipAddress', type: 'text', nullable: true },
@@ -142,9 +156,9 @@ export const TABLES: readonly TableSpec[] = [
 			{ name: 'tcString', type: 'text', nullable: true },
 			{ name: 'uiSource', type: 'text', nullable: true },
 			{ name: 'consentAction', type: 'text', nullable: true },
-			{ name: 'runtimePolicyDecisionId', type: 'text', nullable: true },
+			{ name: 'runtimePolicyDecisionId', type: 'indexedText', nullable: true },
 			{ name: 'runtimePolicySource', type: 'text', nullable: true },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 		],
 		foreignKeys: [
 			{
@@ -172,12 +186,12 @@ export const TABLES: readonly TableSpec[] = [
 			{ name: 'entityType', type: 'text', nullable: false },
 			{ name: 'entityId', type: 'text', nullable: false },
 			{ name: 'actionType', type: 'text', nullable: false },
-			{ name: 'subjectId', type: 'text', nullable: true },
+			{ name: 'subjectId', type: 'indexedText', nullable: true },
 			{ name: 'ipAddress', type: 'text', nullable: true },
 			{ name: 'userAgent', type: 'text', nullable: true },
 			{ name: 'changes', type: 'json', nullable: true },
 			{ name: 'metadata', type: 'json', nullable: true },
-			{ name: 'tenantId', type: 'text', nullable: true },
+			{ name: 'tenantId', type: 'indexedText', nullable: true },
 			{ name: 'createdAt', type: 'timestamp', nullable: false },
 		],
 		foreignKeys: [
@@ -190,22 +204,34 @@ export const TABLES: readonly TableSpec[] = [
 	},
 ] as const;
 
-/** `create table` for one spec, in the given dialect's physical types. */
-export function createTableSql(table: TableSpec, types: PhysicalTypes): string {
+/**
+ * `create table` for one spec, in the given dialect's physical types.
+ *
+ * `quote` comes from `Dialect.escaperFor` rather than being hardcoded to `"`:
+ * MySQL delimits identifiers with backticks and rejects double-quoted ones
+ * outright.
+ */
+export function createTableSql(
+	table: TableSpec,
+	types: PhysicalTypes,
+	quote: (name: string) => string
+): string {
 	const columns = table.columns.map((column) => {
 		const physical = types[column.type];
 		const nullability = column.nullable ? '' : ' not null';
 		const primary = column.name === 'id' ? ' primary key' : '';
 		const unique = column.unique ? ' unique' : '';
-		return `"${column.name}" ${physical}${nullability}${primary}${unique}`;
+		return `${quote(column.name)} ${physical}${nullability}${primary}${unique}`;
 	});
 
 	const foreignKeys = table.foreignKeys.map(
 		(fk) =>
-			`foreign key ("${fk.column}") references "${fk.referencesTable}"("${fk.referencesColumn}")`
+			`foreign key (${quote(fk.column)}) references ${quote(
+				fk.referencesTable
+			)}(${quote(fk.referencesColumn)})`
 	);
 
-	return `create table if not exists "${table.name}" (\n\t${[
+	return `create table if not exists ${quote(table.name)} (\n\t${[
 		...columns,
 		...foreignKeys,
 	].join(',\n\t')}\n)`;
@@ -223,7 +249,10 @@ export function createTableSql(table: TableSpec, types: PhysicalTypes): string {
 export function addColumnSql(
 	table: string,
 	column: ColumnSpec,
-	types: PhysicalTypes
+	types: PhysicalTypes,
+	quote: (name: string) => string
 ): string {
-	return `alter table "${table}" add column "${column.name}" ${types[column.type]}`;
+	return `alter table ${quote(table)} add column ${quote(column.name)} ${
+		types[column.type]
+	}`;
 }

--- a/packages/backend-next/src/db/tenant.ts
+++ b/packages/backend-next/src/db/tenant.ts
@@ -72,9 +72,11 @@ export const tenantScope = Effect.fn('tenant.scope')(function* (
 > {
 	const sql = yield* SqlClient.SqlClient;
 	const { tenantId } = yield* Tenant;
-	const column = table
-		? sql.unsafe(`"${table}"."tenantId"`)
-		: sql.unsafe('"tenantId"');
+	// `sql(name)` rather than `sql.unsafe('"name"')`: the dialect's own
+	// compiler picks the delimiter, so this is backticked on MySQL and
+	// double-quoted on Postgres and SQLite. It also splits on the dot, so
+	// `subject.tenantId` becomes a qualified pair rather than one odd name.
+	const column = table ? sql(`${table}.tenantId`) : sql('tenantId');
 
 	return tenantId === undefined
 		? sql`${column} is null`

--- a/packages/backend-next/src/db/values.ts
+++ b/packages/backend-next/src/db/values.ts
@@ -1,0 +1,99 @@
+/**
+ * Converting between JavaScript values and what each engine can actually
+ * store.
+ *
+ * Postgres and MySQL drivers accept a `Date` and a `boolean` and do the right
+ * thing. SQLite does not: `node:sqlite` binds only `null`, `number`, `bigint`,
+ * `string` and `Uint8Array`, and rejects anything else outright —
+ *
+ * ```
+ * TypeError: Provided value cannot be bound to SQLite parameter 3.
+ * ```
+ *
+ * — which meant that until `repository/cross-engine.test.ts` existed, no write
+ * in this package could reach a SQLite database. Every SQLite test covered
+ * DDL and adoption, so the whole suite passed.
+ *
+ * ## The representation is not ours to choose
+ *
+ * `dialect.ts` maps SQLite timestamps to `integer` and booleans to `integer`
+ * because that is what a real 2.0.0 SQLite database already holds. So this is
+ * a translation to an existing format, not a storage decision: a `Date`
+ * becomes epoch **milliseconds** and a `boolean` becomes `0` or `1`, and both
+ * come back the same way.
+ *
+ * Reads therefore have to translate too, which is what `toDate` and friends
+ * are for. They are written to accept either representation rather than to
+ * assume SQLite, so one decoder serves all three engines and no read path has
+ * to know which one it is talking to.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+
+/** Encodes one value for the connected engine. */
+export type Encoder = (value: unknown) => unknown;
+
+const passthrough: Encoder = (value) => value;
+
+const forSqlite: Encoder = (value) => {
+	if (value instanceof Date) {
+		// Milliseconds, matching what 2.0.0 SQLite databases hold. Seconds
+		// would silently truncate, and a consent's id is derived from its
+		// `givenAt` — a truncated round trip stops hashing to its own id.
+		return value.getTime();
+	}
+	if (typeof value === 'boolean') {
+		return value ? 1 : 0;
+	}
+	return value;
+};
+
+/**
+ * The encoder for the connected engine.
+ *
+ * Resolved from the client rather than from configuration, so it cannot
+ * disagree with the database actually in use.
+ */
+export const encoder: Effect.Effect<Encoder, never, SqlClient.SqlClient> =
+	Effect.gen(function* () {
+		const sql = yield* SqlClient.SqlClient;
+		return yield* sql.onDialectOrElse({
+			sqlite: () => Effect.succeed(forSqlite),
+			orElse: () => Effect.succeed(passthrough),
+		});
+	});
+
+/** Applies an encoder across a row of column values. */
+export const encodeRow = (
+	encode: Encoder,
+	values: Record<string, unknown>
+): Record<string, unknown> => {
+	const encoded: Record<string, unknown> = {};
+	for (const [column, value] of Object.entries(values)) {
+		encoded[column] = encode(value);
+	}
+	return encoded;
+};
+
+/**
+ * A timestamp column, whichever way the engine returned it.
+ *
+ * Postgres and MySQL hand back a `Date`; SQLite hands back epoch
+ * milliseconds as a number.
+ */
+export const toDate = (value: unknown): Date =>
+	value instanceof Date ? value : new Date(Number(value));
+
+/** As `toDate`, preserving a genuinely absent value. */
+export const toDateOrNull = (value: unknown): Date | null =>
+	value === null || value === undefined ? null : toDate(value);
+
+/**
+ * A boolean column, whichever way the engine returned it.
+ *
+ * Postgres gives `true`/`false`, MySQL gives a `tinyint` `1`/`0`, SQLite gives
+ * an `integer` `1`/`0`.
+ */
+export const toBoolean = (value: unknown): boolean =>
+	value === true || value === 1 || value === '1';

--- a/packages/backend-next/src/http/status.ts
+++ b/packages/backend-next/src/http/status.ts
@@ -11,7 +11,7 @@
 
 import { getIpAddress, type IpAddressConfig } from '@c15t/schema/geo';
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { readInitSignals } from './init';
 
 export interface StatusResponse {
@@ -49,7 +49,7 @@ export const status = Effect.fn('status')(function* (
 	// The cheapest query that proves the connection works and the schema is
 	// present. `limit 1` rather than a count so it stays constant-time on a
 	// large table.
-	yield* sql`select 1 from "subject" limit 1`;
+	yield* sql`select 1 from ${sql('subject')} limit 1`;
 
 	return {
 		version,

--- a/packages/backend-next/src/repository/consent.ts
+++ b/packages/backend-next/src/repository/consent.ts
@@ -15,10 +15,11 @@
  * read and the write, and it treats "is this a duplicate?" as a question to be
  * answered by parsing prose.
  *
- * Here the database answers it. `insert … on conflict do nothing returning *`
- * is atomic: either this call inserted the row or someone already had, and the
- * return value says which. No window, and no error-string sniffing — the error
- * never happens.
+ * Here the database answers it, in one atomic statement: either this call
+ * inserted the row or someone already had, and the return value says which. No
+ * window, and no error-string sniffing — the error never happens. See
+ * `db/insert-once.ts`, which also explains why that statement is spelled
+ * differently on MySQL.
  *
  * The legacy identity lookup is kept, because it is not redundant: rows
  * written before deterministic ids existed have unrelated primary keys, and
@@ -27,7 +28,9 @@
 
 import { buildConsentId, type ConsentSubmissionIdentity } from '@c15t/schema';
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
+import { insertOnce } from '../db/insert-once';
+import { encoder } from '../db/values';
 
 export interface ConsentSubmission extends ConsentSubmissionIdentity {
 	readonly purposeIds: readonly string[];
@@ -59,21 +62,23 @@ const findLegacySubmission = Effect.fn('consent.findLegacy')(function* (
 	identity: ConsentSubmissionIdentity
 ) {
 	const sql = yield* SqlClient.SqlClient;
+	// SQLite stores this column as epoch milliseconds and cannot bind a Date.
+	const encode = yield* encoder;
 
 	const rows = yield* sql<{ id: string }>`
-		select "id" from "consent"
-		where "subjectId" = ${identity.subjectId}
-			and "domainId" = ${identity.domainId}
-			and "givenAt" = ${identity.givenAt}
+		select ${sql('id')} from ${sql('consent')}
+		where ${sql('subjectId')} = ${identity.subjectId}
+			and ${sql('domainId')} = ${identity.domainId}
+			and ${sql('givenAt')} = ${encode(identity.givenAt)}
 			and ${
 				identity.policyId === undefined || identity.policyId === null
-					? sql`"policyId" is null`
-					: sql`"policyId" = ${identity.policyId}`
+					? sql`${sql('policyId')} is null`
+					: sql`${sql('policyId')} = ${identity.policyId}`
 			}
 			and ${
 				identity.tenantId === undefined
-					? sql`"tenantId" is null`
-					: sql`"tenantId" = ${identity.tenantId}`
+					? sql`${sql('tenantId')} is null`
+					: sql`${sql('tenantId')} = ${identity.tenantId}`
 			}
 		limit 1
 	`;
@@ -101,7 +106,7 @@ export const record = Effect.fn('consent.record')(function* (
 	// in one indexed query. Measured: skipping this short-circuit and going
 	// straight to the legacy lookup made retries about twice as slow.
 	const existing = yield* sql<{ id: string }>`
-		select "id" from "consent" where "id" = ${id}
+		select ${sql('id')} from ${sql('consent')} where ${sql('id')} = ${id}
 	`;
 	if (existing.length > 0) {
 		return { id, created: false };
@@ -115,28 +120,28 @@ export const record = Effect.fn('consent.record')(function* (
 		return { id: legacyId, created: false };
 	}
 
-	const inserted = yield* sql<{ id: string }>`
-		insert into "consent" (
-			"id", "subjectId", "domainId", "policyId", "purposeIds",
-			"metadata", "ipAddress", "userAgent", "givenAt", "tenantId"
-		) values (
-			${id},
-			${submission.subjectId},
-			${submission.domainId},
-			${submission.policyId ?? null},
-			${JSON.stringify(submission.purposeIds)},
-			${submission.metadata === undefined ? null : JSON.stringify(submission.metadata)},
-			${submission.ipAddress ?? null},
-			${submission.userAgent ?? null},
-			${submission.givenAt},
-			${submission.tenantId ?? null}
-		)
-		on conflict ("id") do nothing
-		returning "id"
-	`;
-
-	// An empty result means the conflict target matched — someone else wrote
-	// this exact submission, possibly concurrently. That is success, not
+	// `created: false` here means the conflict target matched — someone else
+	// wrote this exact submission, possibly concurrently. That is success, not
 	// failure, and it is the whole reason this is one statement.
-	return inserted.length > 0 ? { id, created: true } : { id, created: false };
+	const created = yield* insertOnce({
+		into: 'consent',
+		conflictOn: 'id',
+		values: {
+			id,
+			subjectId: submission.subjectId,
+			domainId: submission.domainId,
+			policyId: submission.policyId ?? null,
+			purposeIds: JSON.stringify(submission.purposeIds),
+			metadata:
+				submission.metadata === undefined
+					? null
+					: JSON.stringify(submission.metadata),
+			ipAddress: submission.ipAddress ?? null,
+			userAgent: submission.userAgent ?? null,
+			givenAt: submission.givenAt,
+			tenantId: submission.tenantId ?? null,
+		},
+	});
+
+	return { id, created };
 });

--- a/packages/backend-next/src/repository/cross-engine.test.ts
+++ b/packages/backend-next/src/repository/cross-engine.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Every repository behaviour, on every engine.
+ *
+ * The rest of the repository suite runs on PGlite and asserts semantics in
+ * depth. This file asserts something narrower and, it turns out, more
+ * load-bearing: that the SQL this package emits **executes at all**, and means
+ * the same thing, on Postgres, SQLite and MySQL alike.
+ *
+ * That was not true. Every statement quoted identifiers as `"subject"`, which
+ * MySQL rejects, so not one query in this package could run there — while the
+ * suite was green, because nothing ever pointed it at MySQL.
+ *
+ * The cases below are therefore chosen for where engines actually diverge,
+ * rather than for behavioural coverage that `record-consent.test.ts` and
+ * `subject.test.ts` already provide:
+ *
+ * | Case | What only this can catch |
+ * | --- | --- |
+ * | idempotent writes | `on conflict … returning` vs `insert ignore` |
+ * | the joined read | identifier quoting through aliases and joins |
+ * | latest policy per type | `row_number() over (partition by …)` |
+ * | booleans | `bool` on Postgres, `tinyint` on MySQL, `0/1` on SQLite |
+ * | timestamps | `timestamp` vs epoch integers vs `datetime(3)` |
+ * | transactions | rollback semantics under a real client |
+ *
+ * MySQL joins in only when `C15T_TEST_MYSQL_URL` is set; see `../__tests__/engines`.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import { layer as tenantLayer } from '../db/tenant';
+import { encodeRow, encoder } from '../db/values';
+import { syncCurrent } from './legal-document';
+import { submit } from './record-consent';
+import { recordDecision } from './runtime-policy-decision';
+import {
+	countByExternalId,
+	findById,
+	findOrCreate,
+	latestPolicyIdByType,
+	linkExternalId,
+	listByExternalId,
+} from './subject';
+
+/** Fixed rather than `new Date()` so the assertion can be exact. */
+const GIVEN_AT = new Date(1_800_000_000_123);
+
+const setup = Effect.gen(function* () {
+	yield* resetDatabase;
+	yield* baseline;
+	// Included because the index migration is itself engine-divergent — MySQL
+	// has no `create index if not exists` and cannot index a bare TEXT column.
+	yield* indexes;
+
+	const sql = yield* SqlClient.SqlClient;
+	// Seed rows go through the same encoder as production writes: SQLite can
+	// bind neither a Date nor a boolean.
+	yield* sql`
+		insert into ${sql('domain')} ${sql.insert(
+			encodeRow(yield* encoder, {
+				id: 'dom_1',
+				name: 'example.com',
+				createdAt: GIVEN_AT,
+				updatedAt: GIVEN_AT,
+			})
+		)}
+	`;
+});
+
+const submission = {
+	subjectId: 'sub_1',
+	domainId: 'dom_1',
+	purposeIds: ['analytics'],
+	givenAt: GIVEN_AT,
+	ipAddress: '203.0.113.0',
+	userAgent: 'test-agent',
+};
+
+const countOf = Effect.fn('countOf')(function* (table: string) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{
+		total: number | string;
+	}>`select count(*) as total from ${sql(table)}`;
+	return Number(rows[0]?.total ?? 0);
+});
+
+for (const engine of ENGINES) {
+	describe(`repository on ${engine.name}`, () => {
+		it.effect(
+			'records a consent, and a replay adds nothing',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+
+					const first = yield* submit(submission);
+					const replay = yield* submit(submission);
+
+					assert.isTrue(first.created);
+					assert.isFalse(replay.created, 'replay created a second consent');
+					assert.strictEqual(replay.consentId, first.consentId);
+
+					// One legal record and one audit entry, whichever engine and
+					// whichever upsert syntax that engine required.
+					assert.strictEqual(yield* countOf('consent'), 1);
+					assert.strictEqual(yield* countOf('subject'), 1);
+					assert.strictEqual(yield* countOf('auditLog'), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'races to a single consent',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+
+					const results = yield* Effect.all(
+						[submit(submission), submit(submission), submit(submission)],
+						{ concurrency: 'unbounded' }
+					);
+
+					// Exactly one caller may believe it created the row, or the
+					// audit trail claims the subject consented three times.
+					assert.strictEqual(
+						results.filter((result) => result.created).length,
+						1
+					);
+					assert.strictEqual(yield* countOf('consent'), 1);
+					assert.strictEqual(yield* countOf('auditLog'), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'creates a subject once',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+
+					const first = yield* findOrCreate({ subjectId: 'sub_x' });
+					const second = yield* findOrCreate({ subjectId: 'sub_x' });
+
+					assert.isTrue(first.created);
+					assert.isFalse(second.created);
+					assert.strictEqual(yield* countOf('subject'), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'deduplicates a decision on its unique key',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+
+					const input = {
+						policyId: 'pol_1',
+						fingerprint: 'fp_1',
+						matchedBy: 'country',
+						jurisdiction: 'gdpr',
+						model: 'opt_in',
+						dedupeKey: 'default|fp_1|country|DE|none|gdpr',
+					};
+
+					const first = yield* recordDecision(input);
+					const again = yield* recordDecision(input);
+
+					// `dedupeKey` is the unique column MySQL cannot index as TEXT —
+					// the constraint that stops fumadb migrating MySQL at all.
+					assert.isTrue(first.created);
+					assert.isFalse(again.created);
+					assert.strictEqual(again.id, first.id);
+					assert.strictEqual(yield* countOf('runtimePolicyDecision'), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'reads a subject back through the join',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+					yield* submit({ ...submission, externalId: 'ext_1' });
+					yield* linkExternalId({
+						subjectId: 'sub_1',
+						externalId: 'ext_1',
+						identityProvider: 'auth0',
+						ipAddress: null,
+						userAgent: null,
+					});
+
+					const listed = yield* listByExternalId('ext_1');
+					const found = yield* findById('sub_1');
+
+					assert.strictEqual(listed.length, 1);
+					assert.strictEqual(listed[0]?.consents.length, 1);
+					assert.strictEqual(found?.id, 'sub_1');
+					assert.strictEqual(yield* countByExternalId('ext_1'), 1);
+
+					// A timestamp has to survive the round trip intact on all three
+					// storage representations — Postgres `timestamp`, SQLite epoch
+					// integers, MySQL `datetime(3)`. Bare MySQL `datetime` would
+					// truncate the milliseconds and fail here, which matters because
+					// a consent's id is derived from this value.
+					assert.strictEqual(
+						listed[0]?.consents[0]?.givenAt.getTime(),
+						GIVEN_AT.getTime()
+					);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'ranks the latest policy per type',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+
+					yield* syncCurrent({
+						type: 'cookie',
+						version: '1.0',
+						hash: 'sha256-one',
+						effectiveDate: new Date(1_700_000_000_000),
+					});
+					const second = yield* syncCurrent({
+						type: 'cookie',
+						version: '2.0',
+						hash: 'sha256-two',
+						effectiveDate: new Date(1_800_000_000_000),
+					});
+
+					// `row_number() over (partition by …)` and the boolean column it
+					// filters on: `bool` here, `tinyint` on MySQL, `0`/`1` on SQLite.
+					const latest = yield* latestPolicyIdByType();
+					assert.strictEqual(latest.get('cookie'), second.id);
+					assert.strictEqual(latest.size, 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'supersedes a policy inside one transaction',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+					const sql = yield* SqlClient.SqlClient;
+
+					yield* syncCurrent({
+						type: 'cookie',
+						version: '1.0',
+						hash: 'sha256-one',
+						effectiveDate: new Date(1_700_000_000_000),
+					});
+					yield* syncCurrent({
+						type: 'cookie',
+						version: '2.0',
+						hash: 'sha256-two',
+						effectiveDate: new Date(1_800_000_000_000),
+					});
+
+					// Exactly one active policy per type is the invariant every
+					// `isLatestPolicy` answer depends on.
+					const active = yield* sql<{ total: number | string }>`
+						select count(*) as total from ${sql('consentPolicy')}
+						where ${sql('isActive')} = ${(yield* encoder)(true)}
+					`;
+					assert.strictEqual(Number(active[0]?.total), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'keeps two tenants apart',
+			() =>
+				Effect.gen(function* () {
+					yield* setup;
+					const sql = yield* SqlClient.SqlClient;
+
+					const encode = yield* encoder;
+					for (const tenant of ['tenant_a', 'tenant_b']) {
+						yield* sql`
+							insert into ${sql('subject')} ${sql.insert(
+								encodeRow(encode, {
+									id: `sub_${tenant}`,
+									externalId: 'shared_external_id',
+									tenantId: tenant,
+									createdAt: GIVEN_AT,
+									updatedAt: GIVEN_AT,
+								})
+							)}
+						`;
+					}
+
+					// Only the tenant scope is overridden. Providing the engine layer
+					// again would build a second, empty database and the assertion
+					// would pass for the wrong reason.
+					const seen = yield* listByExternalId('shared_external_id').pipe(
+						Effect.provide(tenantLayer('tenant_a'))
+					);
+
+					// The tenant predicate is a fragment built per dialect; a
+					// mis-quoted column here would either error or, worse, match
+					// nothing and silently return an empty list.
+					assert.strictEqual(seen.length, 1, 'leaked another tenant');
+					assert.strictEqual(seen[0]?.id, 'sub_tenant_a');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+	});
+}

--- a/packages/backend-next/src/repository/legal-document.ts
+++ b/packages/backend-next/src/repository/legal-document.ts
@@ -13,8 +13,9 @@
 
 import { hashSha256Hex } from '@c15t/schema';
 import { Data, Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { type Tenant, tenantScope } from '../db/tenant';
+import { encodeRow, encoder, toBoolean, toDate } from '../db/values';
 
 export interface LegalDocumentRelease {
 	readonly tenantId?: string;
@@ -80,6 +81,8 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 	SyncedPolicy
 > {
 	const sql = yield* SqlClient.SqlClient;
+	// SQLite binds neither a Date nor a boolean; see `../db/values.ts`.
+	const encode = yield* encoder;
 	const id = yield* Effect.promise(() =>
 		buildLegalDocumentPolicyId({
 			tenantId: release.tenantId,
@@ -97,9 +100,12 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 				type: string;
 				version: string;
 				hash: string | null;
-				effectiveDate: Date;
-				isActive: boolean;
-			}>`select * from "consentPolicy" where "id" = ${id} and ${scope}`;
+				// Engine-shaped rather than decoded: SQLite returns epoch
+				// milliseconds and `0`/`1` where the others return a Date and a
+				// boolean.
+				effectiveDate: unknown;
+				isActive: unknown;
+			}>`select * from ${sql('consentPolicy')} where ${sql('id')} = ${id} and ${scope}`;
 
 			const found = existing[0];
 
@@ -108,7 +114,8 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 				// two different ideas about what this document says.
 				if (
 					found.version !== release.version ||
-					found.effectiveDate.getTime() !== release.effectiveDate.getTime()
+					toDate(found.effectiveDate).getTime() !==
+						release.effectiveDate.getTime()
 				) {
 					return yield* new LegalDocumentConflictError({
 						message: 'Release metadata conflicts with existing consent policy',
@@ -118,13 +125,17 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 				// Scoped: without this, syncing a release for one tenant would
 				// deactivate another tenant's active policy of the same type.
 				yield* sql`
-					update "consentPolicy" set "isActive" = ${false}
-					where "type" = ${release.type} and "isActive" = ${true}
-						and "id" <> ${id} and ${scope}
+					update ${sql('consentPolicy')} set ${sql('isActive')} = ${encode(false)}
+					where ${sql('type')} = ${release.type}
+						and ${sql('isActive')} = ${encode(true)}
+						and ${sql('id')} <> ${id} and ${scope}
 				`;
 
-				if (!found.isActive) {
-					yield* sql`update "consentPolicy" set "isActive" = ${true} where "id" = ${id} and ${scope}`;
+				if (!toBoolean(found.isActive)) {
+					yield* sql`
+						update ${sql('consentPolicy')} set ${sql('isActive')} = ${encode(true)}
+						where ${sql('id')} = ${id} and ${scope}
+					`;
 				}
 
 				return {
@@ -132,21 +143,31 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 					type: found.type,
 					version: found.version,
 					hash: found.hash ?? release.hash,
-					effectiveDate: found.effectiveDate,
+					effectiveDate: toDate(found.effectiveDate),
 					isActive: true,
 				};
 			}
 
 			yield* sql`
-				update "consentPolicy" set "isActive" = ${false}
-				where "type" = ${release.type} and "isActive" = ${true} and ${scope}
+				update ${sql('consentPolicy')} set ${sql('isActive')} = ${encode(false)}
+				where ${sql('type')} = ${release.type}
+					and ${sql('isActive')} = ${encode(true)}
+					and ${scope}
 			`;
 
 			yield* sql`
-				insert into "consentPolicy"
-					("id","version","type","hash","effectiveDate","isActive","createdAt","tenantId")
-				values (${id}, ${release.version}, ${release.type}, ${release.hash},
-					${release.effectiveDate}, ${true}, ${new Date()}, ${release.tenantId ?? null})
+				insert into ${sql('consentPolicy')} ${sql.insert(
+					encodeRow(encode, {
+						id,
+						version: release.version,
+						type: release.type,
+						hash: release.hash,
+						effectiveDate: release.effectiveDate,
+						isActive: true,
+						createdAt: new Date(),
+						tenantId: release.tenantId ?? null,
+					})
+				)}
 			`;
 
 			return {

--- a/packages/backend-next/src/repository/record-consent.ts
+++ b/packages/backend-next/src/repository/record-consent.ts
@@ -22,7 +22,8 @@
 
 import { generateEntityId } from '@c15t/schema';
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
+import { encodeRow, encoder } from '../db/values';
 import { type ConsentSubmission, record } from './consent';
 import { type DecisionInput, recordDecision } from './runtime-policy-decision';
 import { findOrCreate } from './subject';
@@ -89,22 +90,25 @@ export const submit = Effect.fn('consent.submit')(function* (
 		// than per *event* would make the trail assert the subject consented
 		// twice, which is precisely the claim the trail exists to get right.
 		yield* sql`
-			insert into "auditLog" (
-				"id","subjectId","entityType","entityId","actionType",
-				"ipAddress","userAgent","changes","metadata","tenantId","createdAt"
-			) values (
-				${generateEntityId('auditLog')},
-				${subject.id}, ${'consent'}, ${consent.id}, ${'consent_given'},
-				${request.ipAddress}, ${request.userAgent},
-				${JSON.stringify({ purposeIds: request.purposeIds })},
-				${JSON.stringify({
-					policyId: request.policyId ?? null,
-					domainId: request.domainId,
-					decisionId: decision?.id ?? null,
-				})},
-				${request.tenantId ?? null},
-				${new Date()}
-			)
+			insert into ${sql('auditLog')} ${sql.insert(
+				encodeRow(yield* encoder, {
+					id: generateEntityId('auditLog'),
+					subjectId: subject.id,
+					entityType: 'consent',
+					entityId: consent.id,
+					actionType: 'consent_given',
+					ipAddress: request.ipAddress,
+					userAgent: request.userAgent,
+					changes: JSON.stringify({ purposeIds: request.purposeIds }),
+					metadata: JSON.stringify({
+						policyId: request.policyId ?? null,
+						domainId: request.domainId,
+						decisionId: decision?.id ?? null,
+					}),
+					tenantId: request.tenantId ?? null,
+					createdAt: new Date(),
+				})
+			)}
 		`;
 	}
 
@@ -114,8 +118,9 @@ export const submit = Effect.fn('consent.submit')(function* (
 	// make an otherwise identical resubmission look like a different consent.
 	if (decision && consent.created) {
 		yield* sql`
-			update "consent" set "runtimePolicyDecisionId" = ${decision.id}
-			where "id" = ${consent.id}
+			update ${sql('consent')}
+			set ${sql('runtimePolicyDecisionId')} = ${decision.id}
+			where ${sql('id')} = ${consent.id}
 		`;
 	}
 

--- a/packages/backend-next/src/repository/runtime-policy-decision.ts
+++ b/packages/backend-next/src/repository/runtime-policy-decision.ts
@@ -15,6 +15,7 @@
 import { generateEntityId } from '@c15t/schema';
 import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
+import { insertOnce } from '../db/insert-once';
 
 export interface DecisionInput {
 	readonly tenantId?: string | null;
@@ -52,33 +53,42 @@ export const recordDecision = Effect.fn('decision.record')(function* (
 	const sql = yield* SqlClient.SqlClient;
 	const id = generateEntityId('runtimePolicyDecision');
 
-	const inserted = yield* sql<{ id: string }>`
-		insert into "runtimePolicyDecision" (
-			"id","tenantId","policyId","fingerprint","matchedBy","countryCode",
-			"regionCode","jurisdiction","language","model","policyI18n","uiMode",
-			"bannerUi","dialogUi","categories","preselectedCategories",
-			"proofConfig","dedupeKey","createdAt"
-		) values (
-			${id}, ${input.tenantId ?? null}, ${input.policyId}, ${input.fingerprint},
-			${input.matchedBy}, ${input.countryCode ?? null}, ${input.regionCode ?? null},
-			${input.jurisdiction}, ${input.language ?? null}, ${input.model},
-			${json(input.policyI18n)}, ${input.uiMode ?? null}, ${json(input.bannerUi)},
-			${json(input.dialogUi)}, ${json(input.categories)},
-			${json(input.preselectedCategories)}, ${json(input.proofConfig)},
-			${input.dedupeKey}, ${new Date()}
-		)
-		on conflict ("dedupeKey") do nothing
-		returning "id"
-	`;
+	const created = yield* insertOnce({
+		into: 'runtimePolicyDecision',
+		conflictOn: 'dedupeKey',
+		values: {
+			id,
+			tenantId: input.tenantId ?? null,
+			policyId: input.policyId,
+			fingerprint: input.fingerprint,
+			matchedBy: input.matchedBy,
+			countryCode: input.countryCode ?? null,
+			regionCode: input.regionCode ?? null,
+			jurisdiction: input.jurisdiction,
+			language: input.language ?? null,
+			model: input.model,
+			policyI18n: json(input.policyI18n),
+			uiMode: input.uiMode ?? null,
+			bannerUi: json(input.bannerUi),
+			dialogUi: json(input.dialogUi),
+			categories: json(input.categories),
+			preselectedCategories: json(input.preselectedCategories),
+			proofConfig: json(input.proofConfig),
+			dedupeKey: input.dedupeKey,
+			createdAt: new Date(),
+		},
+	});
 
-	const created = inserted[0];
 	if (created) {
-		return { id: created.id, created: true };
+		return { id, created: true };
 	}
 
-	// Lost the conflict: someone already recorded this exact decision.
+	// Lost the conflict: someone already recorded this exact decision. Unlike
+	// consent, the id here is random rather than derived, so the existing
+	// row's id has to be read back rather than recomputed.
 	const existing = yield* sql<{ id: string }>`
-		select "id" from "runtimePolicyDecision" where "dedupeKey" = ${input.dedupeKey}
+		select ${sql('id')} from ${sql('runtimePolicyDecision')}
+		where ${sql('dedupeKey')} = ${input.dedupeKey}
 	`;
 
 	return { id: existing[0]?.id ?? id, created: false };

--- a/packages/backend-next/src/repository/subject.ts
+++ b/packages/backend-next/src/repository/subject.ts
@@ -23,12 +23,20 @@
  * The second could be folded into the first, but keeping it separate means it
  * is cacheable per tenant and independent of the subject being queried — the
  * shape of the data, not an accident of the query.
+ *
+ * ## On the identifier noise
+ *
+ * Columns are written `${sql('s.externalId')}` rather than `s."externalId"`.
+ * The literal form is a syntax error on MySQL, which delimits identifiers with
+ * backticks; `sql(…)` defers the choice to the connected dialect's compiler.
  */
 
 import { generateEntityId } from '@c15t/schema';
 import { Effect } from 'effect';
-import { SqlClient, SqlError } from 'effect/unstable/sql';
+import { SqlClient, type SqlError, Statement } from 'effect/unstable/sql';
+import { insertOnce } from '../db/insert-once';
 import { tenantScope } from '../db/tenant';
+import { encodeRow, encoder, toDate, toDateOrNull } from '../db/values';
 
 export interface ConsentRow {
 	readonly id: string;
@@ -60,19 +68,112 @@ export interface SubjectWithConsents {
 interface JoinedRow {
 	readonly subject_id: string;
 	readonly subject_externalId: string | null;
-	readonly subject_createdAt: Date;
+	// Engine-shaped: SQLite returns epoch milliseconds where the others
+	// return a Date. Decoded on the way out by `groupSubjects`.
+	readonly subject_createdAt: unknown;
 	readonly consent_id: string | null;
 	readonly consent_policyId: string | null;
 	readonly consent_purposeIds: unknown;
-	readonly consent_givenAt: Date | null;
+	readonly consent_givenAt: unknown;
 	readonly policy_type: string | null;
 	readonly policy_version: string | null;
 	readonly policy_hash: string | null;
-	readonly policy_effectiveDate: Date | null;
+	readonly policy_effectiveDate: unknown;
 }
 
 /** Valibot `optional` means absent, not null; the database means null. */
 const orUndefined = <T>(value: T | null): T | undefined => value ?? undefined;
+
+/**
+ * The joined column list, as `[column, alias]` pairs.
+ *
+ * Shared by both read paths so their projections cannot drift — `JoinedRow`
+ * describes one row shape, and two hand-written select lists would eventually
+ * stop agreeing with it in different ways.
+ */
+const JOINED_COLUMNS: readonly (readonly [column: string, alias: string])[] = [
+	['s.id', 'subject_id'],
+	['s.externalId', 'subject_externalId'],
+	['s.createdAt', 'subject_createdAt'],
+	['c.id', 'consent_id'],
+	['c.policyId', 'consent_policyId'],
+	['c.purposeIds', 'consent_purposeIds'],
+	['c.givenAt', 'consent_givenAt'],
+	['p.type', 'policy_type'],
+	['p.version', 'policy_version'],
+	['p.hash', 'policy_hash'],
+	['p.effectiveDate', 'policy_effectiveDate'],
+];
+
+/**
+ * `select … from subject left join consent left join consentPolicy`, up to but
+ * not including the `where`.
+ *
+ * Both read paths differ only in how they filter and order, so the join itself
+ * is built once.
+ */
+const joinedSelect = Effect.fn('repository.joinedSelect')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const projection = Statement.csv(
+		JOINED_COLUMNS.map(
+			([column, alias]) => sql`${sql(column)} as ${sql(alias)}`
+		)
+	);
+
+	return sql`
+		select ${projection}
+		from ${sql('subject')} s
+		left join ${sql('consent')} c on ${sql('c.subjectId')} = ${sql('s.id')}
+		left join ${sql('consentPolicy')} p on ${sql('p.id')} = ${sql('c.policyId')}
+	`;
+});
+
+/**
+ * Turns joined rows into subjects, each with its consents.
+ *
+ * A left join yields one all-null consent row for a subject with no consents;
+ * that is an absence, not a record. Insertion order is preserved, so the
+ * caller's `order by` decides the result order.
+ */
+const groupSubjects = (
+	rows: readonly JoinedRow[],
+	latestIds: ReadonlySet<string>
+): SubjectWithConsents[] => {
+	const bySubject = new Map<string, SubjectWithConsents>();
+
+	for (const row of rows) {
+		const subject: SubjectWithConsents = bySubject.get(row.subject_id) ?? {
+			id: row.subject_id,
+			externalId: row.subject_externalId,
+			createdAt: toDate(row.subject_createdAt),
+			consents: [],
+		};
+
+		if (row.consent_id !== null && row.consent_givenAt !== null) {
+			(subject.consents as ConsentRow[]).push({
+				id: row.consent_id,
+				subjectId: row.subject_id,
+				// A consent whose policy row is gone still has to satisfy the
+				// contract's required `type`; '' is the honest answer rather
+				// than inventing one.
+				type: row.policy_type ?? '',
+				policyId: orUndefined(row.consent_policyId),
+				policyVersion: orUndefined(row.policy_version),
+				policyHash: orUndefined(row.policy_hash),
+				policyEffectiveDate:
+					orUndefined(toDateOrNull(row.policy_effectiveDate)) ?? undefined,
+				purposeIds: row.consent_purposeIds,
+				givenAt: toDate(row.consent_givenAt),
+				isLatestPolicy:
+					row.consent_policyId !== null && latestIds.has(row.consent_policyId),
+			});
+		}
+
+		bySubject.set(row.subject_id, subject);
+	}
+
+	return [...bySubject.values()];
+};
 
 /**
  * The newest active policy for each type, in one query.
@@ -85,22 +186,32 @@ export const latestPolicyIdByType = Effect.fn(
 	'repository.latestPolicyIdByType'
 )(function* () {
 	const sql = yield* SqlClient.SqlClient;
+	// SQLite has no boolean to bind; `true` has to become `1` there.
+	const encode = yield* encoder;
+	const scope = yield* tenantScope();
+
 	const rows = yield* sql<{ id: string; type: string }>`
-			select "id", "type"
-			from (
-				select
-					"id",
-					"type",
-					row_number() over (
-						partition by "type" order by "effectiveDate" desc
-					) as rn
-				from "consentPolicy"
-				where "isActive" = ${true} and ${yield* tenantScope()}
-			) ranked
-			where rn = 1
-		`;
+		select ${sql('id')}, ${sql('type')}
+		from (
+			select
+				${sql('id')},
+				${sql('type')},
+				row_number() over (
+					partition by ${sql('type')} order by ${sql('effectiveDate')} desc
+				) as rn
+			from ${sql('consentPolicy')}
+			where ${sql('isActive')} = ${encode(true)} and ${scope}
+		) ranked
+		where rn = 1
+	`;
 
 	return new Map(rows.map((row) => [row.type, row.id]));
+});
+
+/** The ids of the newest active policy of every type, for `isLatestPolicy`. */
+const latestPolicyIds = Effect.fn('repository.latestPolicyIds')(function* () {
+	const latest = yield* latestPolicyIdByType();
+	return new Set(latest.values());
 });
 
 /**
@@ -112,66 +223,15 @@ export const latestPolicyIdByType = Effect.fn(
 export const listByExternalId = Effect.fn('repository.listByExternalId')(
 	function* (externalId: string) {
 		const sql = yield* SqlClient.SqlClient;
+		const select = yield* joinedSelect();
 
 		const rows = yield* sql<JoinedRow>`
-			select
-				s."id"          as "subject_id",
-				s."externalId"  as "subject_externalId",
-				s."createdAt"   as "subject_createdAt",
-				c."id"          as "consent_id",
-				c."policyId"    as "consent_policyId",
-				c."purposeIds"  as "consent_purposeIds",
-				c."givenAt"     as "consent_givenAt",
-				p."type"          as "policy_type",
-				p."version"       as "policy_version",
-				p."hash"          as "policy_hash",
-				p."effectiveDate" as "policy_effectiveDate"
-			from "subject" s
-			left join "consent" c on c."subjectId" = s."id"
-			left join "consentPolicy" p on p."id" = c."policyId"
-			where s."externalId" = ${externalId} and ${yield* tenantScope('s')}
-			order by s."id", c."givenAt" desc
+			${select}
+			where ${sql('s.externalId')} = ${externalId} and ${yield* tenantScope('s')}
+			order by ${sql('s.id')}, ${sql('c.givenAt')} desc
 		`;
 
-		const latest = yield* latestPolicyIdByType();
-		const latestIds = new Set(latest.values());
-
-		const bySubject = new Map<string, SubjectWithConsents>();
-		for (const row of rows) {
-			const existing = bySubject.get(row.subject_id);
-			const subject: SubjectWithConsents = existing ?? {
-				id: row.subject_id,
-				externalId: row.subject_externalId,
-				createdAt: row.subject_createdAt,
-				consents: [],
-			};
-
-			// A left join yields one all-null consent row for a subject with no
-			// consents; that is an absence, not a record.
-			if (row.consent_id !== null && row.consent_givenAt !== null) {
-				(subject.consents as ConsentRow[]).push({
-					id: row.consent_id,
-					subjectId: row.subject_id,
-					// A consent whose policy row is gone still has to satisfy the
-					// contract's required `type`; '' is the honest answer rather
-					// than inventing one.
-					type: row.policy_type ?? '',
-					policyId: orUndefined(row.consent_policyId),
-					policyVersion: orUndefined(row.policy_version),
-					policyHash: orUndefined(row.policy_hash),
-					policyEffectiveDate: orUndefined(row.policy_effectiveDate),
-					purposeIds: row.consent_purposeIds,
-					givenAt: row.consent_givenAt,
-					isLatestPolicy:
-						row.consent_policyId !== null &&
-						latestIds.has(row.consent_policyId),
-				});
-			}
-
-			bySubject.set(row.subject_id, subject);
-		}
-
-		return [...bySubject.values()];
+		return groupSubjects(rows, yield* latestPolicyIds());
 	}
 );
 
@@ -186,8 +246,8 @@ export const countByExternalId = Effect.fn('repository.countByExternalId')(
 	function* (externalId: string) {
 		const sql = yield* SqlClient.SqlClient;
 		const rows = yield* sql<{ total: number | string }>`
-			select count(*) as total from "subject"
-			where "externalId" = ${externalId} and ${yield* tenantScope()}
+			select count(*) as total from ${sql('subject')}
+			where ${sql('externalId')} = ${externalId} and ${yield* tenantScope()}
 		`;
 		return Number(rows[0]?.total ?? 0);
 	}
@@ -206,59 +266,20 @@ export const findById = Effect.fn('repository.findById')(function* (
 	subjectId: string
 ) {
 	const sql = yield* SqlClient.SqlClient;
+	const select = yield* joinedSelect();
 
 	const rows = yield* sql<JoinedRow>`
-		select
-			s."id"          as "subject_id",
-			s."externalId"  as "subject_externalId",
-			s."createdAt"   as "subject_createdAt",
-			c."id"          as "consent_id",
-			c."policyId"    as "consent_policyId",
-			c."purposeIds"  as "consent_purposeIds",
-			c."givenAt"     as "consent_givenAt",
-			p."type"          as "policy_type",
-			p."version"       as "policy_version",
-			p."hash"          as "policy_hash",
-			p."effectiveDate" as "policy_effectiveDate"
-		from "subject" s
-		left join "consent" c on c."subjectId" = s."id"
-		left join "consentPolicy" p on p."id" = c."policyId"
-		where s."id" = ${subjectId} and ${yield* tenantScope('s')}
-		order by c."givenAt" desc
+		${select}
+		where ${sql('s.id')} = ${subjectId} and ${yield* tenantScope('s')}
+		order by ${sql('c.givenAt')} desc
 	`;
 
-	const first = rows[0];
-	if (first === undefined) {
+	if (rows.length === 0) {
 		return undefined;
 	}
 
-	const latest = yield* latestPolicyIdByType();
-	const latestIds = new Set(latest.values());
-
-	const consents: ConsentRow[] = [];
-	for (const row of rows) {
-		if (row.consent_id === null || row.consent_givenAt === null) continue;
-		consents.push({
-			id: row.consent_id,
-			subjectId: row.subject_id,
-			type: row.policy_type ?? '',
-			policyId: orUndefined(row.consent_policyId),
-			policyVersion: orUndefined(row.policy_version),
-			policyHash: orUndefined(row.policy_hash),
-			policyEffectiveDate: orUndefined(row.policy_effectiveDate),
-			purposeIds: row.consent_purposeIds,
-			givenAt: row.consent_givenAt,
-			isLatestPolicy:
-				row.consent_policyId !== null && latestIds.has(row.consent_policyId),
-		});
-	}
-
-	return {
-		id: first.subject_id,
-		externalId: first.subject_externalId,
-		createdAt: first.subject_createdAt,
-		consents,
-	} satisfies SubjectWithConsents;
+	// A primary-key lookup, so the join can only produce rows for one subject.
+	return groupSubjects(rows, yield* latestPolicyIds())[0];
 });
 
 /**
@@ -278,15 +299,17 @@ export const linkExternalId = Effect.fn('repository.linkExternalId')(
 		userAgent: string | null;
 	}) {
 		const sql = yield* SqlClient.SqlClient;
+		const encode = yield* encoder;
 		const scope = yield* tenantScope();
 
 		const found = yield* sql<{
 			externalId: string | null;
 			identityProvider: string | null;
 		}>`
-		select "externalId", "identityProvider" from "subject"
-		where "id" = ${input.subjectId} and ${scope}
-	`;
+			select ${sql('externalId')}, ${sql('identityProvider')}
+			from ${sql('subject')}
+			where ${sql('id')} = ${input.subjectId} and ${scope}
+		`;
 		const before = found[0];
 		if (before === undefined) {
 			return undefined;
@@ -295,38 +318,41 @@ export const linkExternalId = Effect.fn('repository.linkExternalId')(
 		yield* sql.withTransaction(
 			Effect.gen(function* () {
 				yield* sql`
-				update "subject" set
-					"externalId" = ${input.externalId},
-					"identityProvider" = ${input.identityProvider},
-					"updatedAt" = ${new Date()}
-				where "id" = ${input.subjectId} and ${scope}
-			`;
+					update ${sql('subject')} set
+						${sql('externalId')} = ${input.externalId},
+						${sql('identityProvider')} = ${input.identityProvider},
+						${sql('updatedAt')} = ${encode(new Date())}
+					where ${sql('id')} = ${input.subjectId} and ${scope}
+				`;
 
 				// Records what changed, not just that something did: a trail that
-				// cannot answer "from what?" cannot support a subject access request.
+				// cannot answer "from what?" cannot support a subject access
+				// request.
 				yield* sql`
-				insert into "auditLog" (
-					"id","subjectId","entityType","entityId","actionType",
-					"ipAddress","userAgent","changes","metadata","createdAt"
-				) values (
-					${generateEntityId('auditLog')},
-					${input.subjectId}, ${'subject'}, ${input.subjectId},
-					${'identify_user'},
-					${input.ipAddress}, ${input.userAgent},
-					${JSON.stringify({
-						externalId: { from: before.externalId, to: input.externalId },
-						identityProvider: {
-							from: before.identityProvider,
-							to: input.identityProvider,
-						},
-					})},
-					${JSON.stringify({
-						externalId: input.externalId,
-						identityProvider: input.identityProvider,
-					})},
-					${new Date()}
-				)
-			`;
+					insert into ${sql('auditLog')} ${sql.insert(
+						encodeRow(encode, {
+							id: generateEntityId('auditLog'),
+							subjectId: input.subjectId,
+							entityType: 'subject',
+							entityId: input.subjectId,
+							actionType: 'identify_user',
+							ipAddress: input.ipAddress,
+							userAgent: input.userAgent,
+							changes: JSON.stringify({
+								externalId: { from: before.externalId, to: input.externalId },
+								identityProvider: {
+									from: before.identityProvider,
+									to: input.identityProvider,
+								},
+							}),
+							metadata: JSON.stringify({
+								externalId: input.externalId,
+								identityProvider: input.identityProvider,
+							}),
+							createdAt: new Date(),
+						})
+					)}
+				`;
 			})
 		);
 
@@ -342,9 +368,9 @@ export const linkExternalId = Effect.fn('repository.linkExternalId')(
  * Finds a subject by client-supplied id, or creates it.
  *
  * The v2.0 flow has the client generate the subject id, so this is an upsert
- * keyed on it. `on conflict do nothing` rather than read-then-create: two
- * requests from the same device arriving together must produce one subject,
- * and the returning clause tells us which call won without a second query.
+ * keyed on it. Insert-if-absent rather than read-then-create: two requests
+ * from the same device arriving together must produce one subject, and the
+ * statement itself reports which call won without a second query.
  *
  * A subject that already exists is returned untouched. Overwriting its
  * externalId here would silently re-identify someone as a side effect of
@@ -357,23 +383,23 @@ export const findOrCreate = Effect.fn('repository.findOrCreate')(
 		identityProvider?: string | null;
 		tenantId?: string | null;
 	}) {
-		const sql = yield* SqlClient.SqlClient;
 		const now = new Date();
 
-		const inserted = yield* sql<{ id: string }>`
-		insert into "subject"
-			("id","externalId","identityProvider","tenantId","createdAt","updatedAt")
-		values (
-			${input.subjectId},
-			${input.externalId ?? null},
-			${input.externalId ? (input.identityProvider ?? 'external') : 'anonymous'},
-			${input.tenantId ?? null},
-			${now}, ${now}
-		)
-		on conflict ("id") do nothing
-		returning "id"
-	`;
+		const created = yield* insertOnce({
+			into: 'subject',
+			conflictOn: 'id',
+			values: {
+				id: input.subjectId,
+				externalId: input.externalId ?? null,
+				identityProvider: input.externalId
+					? (input.identityProvider ?? 'external')
+					: 'anonymous',
+				tenantId: input.tenantId ?? null,
+				createdAt: now,
+				updatedAt: now,
+			},
+		});
 
-		return { id: input.subjectId, created: inserted.length > 0 };
+		return { id: input.subjectId, created };
 	}
 );

--- a/packages/backend-next/vitest.config.ts
+++ b/packages/backend-next/vitest.config.ts
@@ -16,6 +16,12 @@ export default mergeConfig(
 		},
 		test: {
 			environment: 'node',
+			// PGlite and SQLite get a fresh in-process database per test, so files
+			// cannot interfere and run in parallel. MySQL is a real server sharing
+			// one schema, so two files migrating it at once produce failures that
+			// depend on scheduling — the tests pass individually and fail
+			// together. Opting into MySQL therefore opts into sequential files.
+			fileParallelism: process.env.C15T_TEST_MYSQL_URL === undefined,
 			// No coverage thresholds yet: the package has no behaviour to cover.
 			// RFC 0004 §6 sets the floor at the old package's 55% once the first
 			// handlers land, and it ratchets up from there — it never ships below


### PR DESCRIPTION
The suite was at **180 passing tests and ~95% statement coverage** while the package could not run a single statement against MySQL, and could not write to SQLite at all. Every test used PGlite; SQLite was covered only for DDL and adoption, and MySQL had no arm at all.

That is the failure mode this PR is really about: coverage measured against one engine says nothing about the other two.

## MySQL

| Problem | Fix |
| --- | --- |
| Identifiers quoted `"like this"`, which MySQL rejects outright — so nothing ran | `sql('table.column')`, letting the dialect's compiler pick the delimiter; the two raw-DDL builders take an escaper |
| MySQL 8 supports neither `on conflict` nor `returning` | The three idempotent writes move behind `insertOnce`, which uses `insert ignore` and `affectedRows` there |
| No `create index if not exists` for indexes | Migration 2 checks first |
| Adopted legacy databases keep `TEXT` in indexed columns, which MySQL cannot index whole | 191-character prefix |
| Foreign key and indexed columns declared `text` — MySQL cannot index `TEXT`, so **the baseline itself failed** | `indexedText`, unchanged on Postgres and SQLite |
| `information_schema` read unaliased; MySQL uppercases those labels | Explicit aliases |
| Legacy MySQL declares `consent.metadata` as `json` — the same value the fumadb check treats as proof | Both fumadb eras are unsupported on MySQL, so the answer there is always `Legacy` |
| `timestamp` mapped to MySQL's `timestamp`, which stops at 2038 and shifts through the session time zone | `datetime(3)` |

Two of these were silent rather than loud, which is worse:

- **Adoption saw an empty database**, added no columns, and stamped the ledger as baseline anyway.
- The `timestamp` mapping is wrong for a `validUntil` past 2038 and for a legal record's `givenAt`. That column of the type table had no fixture behind it — the fumadb-era MySQL fixtures record a *migration failure* rather than a schema.

Error-driven recovery was rejected as an approach for the write path: a failed statement poisons the enclosing Postgres transaction.

## SQLite

`node:sqlite` binds neither `Date` nor `boolean`, so **every write failed**. `db/values.ts` encodes to epoch milliseconds and 0/1 on the way in and decodes on the way out, matching what 2.0.0 SQLite databases hold.

## Also

Folds the duplicated subject projection and row mapping into one definition, so the two read paths cannot drift from `JoinedRow`.
