### PR TITLE
feat(backend-next): wide-event logging with evlog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -597,6 +597,7 @@
       "dependencies": {
         "@c15t/schema": "workspace:*",
         "effect": "4.0.0-beta.102",
+        "evlog": "2.22.4",
         "hono": "4.12.27",
         "hono-openapi": "1.3.0",
         "jose": "6.2.3",

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -713,13 +713,28 @@ removes capability from an existing user rather than relocating it.
 to replace: `backend-next` never had logging at all, so this was additive, and
 that changed what the right default is.
 
-**Off unless asked for.** `@c15t/backend` builds its logger with
-`level ?? 'error'`, so a default deployment emits nothing per request. This
-package replaces it in place, so defaulting a wide event per request to *on*
-would mean an operator who upgraded a version discovers new stdout volume, and
-a new bill on a hosted log pipeline. `observability.enabled` is `false` unless
-set. Redaction goes the other way — on by default whenever logging is on,
-because the failure mode of forgetting is a compliance incident.
+**On by default, quiet by default.** The first cut of this defaulted logging
+*off*, reasoning that 2.x emits nothing per request. That was half right and
+the wrong conclusion: 2.x defaults to `level: 'error'`, so it does report
+failures — and a backend that tells a new self-hoster nothing when their
+requests are being rejected is one they debug by guesswork.
+
+So the default is `level: 'warn'`: **silent when requests succeed, a line when
+they do not.** The full per-request stream is `level: 'info'`, `'silent'` is
+off, and `'inherit'` leaves evlog's global config to a host application that
+configures it themselves.
+
+Getting that default to actually work took two mechanisms, which is worth
+knowing before changing any of it. Hono answers a thrown handler error with a
+500 *response* rather than propagating it, so evlog's middleware sees a status
+and never an exception, and the event's level stays `info` even for a 500.
+Head sampling alone therefore drops exactly the requests worth keeping —
+observed, not predicted: with `rates: { info: 0 }` the 500 vanished. It needs
+a status-grading middleware running inside evlog's wrapper *and* a keep rule
+from 400 up.
+
+Redaction is on by default whenever logging is on, because the failure mode of
+forgetting is a compliance incident.
 
 **A narrow service, not evlog's logger.** The Effect service is `RequestLog`,
 two methods wide, adapted from evlog at the HTTP boundary. Handlers depend on

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -132,8 +132,8 @@ paths we take.
 
 - **MongoDB.** The only genuine casualty, and the thing forcing the join-less
   design on every other user. Dropping it needs an export/import script, not
-  a migration — there is no DDL path from Mongo to SQL. That script is part of
-  the deliverable, not an exercise for the user.
+  a migration — there is no DDL path from Mongo to SQL. **Superseded by
+  §11.8: that script is not being written.**
 - **The Drizzle/Prisma/TypeORM adapters.** Those users keep their database;
   they lose the shared connection pool, since c15t opens its own `SqlClient`
   connection against the same server. In exchange they get a migrator that
@@ -692,3 +692,62 @@ schema. The evidence for MySQL is the `legacy-…` fixtures, which is what
 parallelism. PGlite and SQLite get a fresh in-process database per test; MySQL
 is one shared schema, and two files migrating it concurrently fail depending on
 scheduling — passing individually, failing together.
+
+### 11.8 No MongoDB migration path ships
+
+**Decided: the Mongo export/import script promised in §2 is not being
+written.** §8 step 8 loses it as a cutover deliverable.
+
+The consequence, stated plainly so it is not discovered later: a 2.x
+deployment on MongoDB has **no supported upgrade path to 3.0**. Not a lossy
+one or a manual one — none. Those users stay on 2.x, or export and reshape
+their data themselves against the schema in `db/schema.ts`.
+
+This needs to be in the 3.0 release notes and the upgrade guide as a stated
+break, not left as an omission. It is the one drop in this rewrite that
+removes capability from an existing user rather than relocating it.
+
+### 11.9 evlog is opt-in, and narrower than §5 described
+
+§5 says "replace `@c15t/logger` in the backend with evlog". There was nothing
+to replace: `backend-next` never had logging at all, so this was additive, and
+that changed what the right default is.
+
+**Off unless asked for.** `@c15t/backend` builds its logger with
+`level ?? 'error'`, so a default deployment emits nothing per request. This
+package replaces it in place, so defaulting a wide event per request to *on*
+would mean an operator who upgraded a version discovers new stdout volume, and
+a new bill on a hosted log pipeline. `observability.enabled` is `false` unless
+set. Redaction goes the other way — on by default whenever logging is on,
+because the failure mode of forgetting is a compliance incident.
+
+**A narrow service, not evlog's logger.** The Effect service is `RequestLog`,
+two methods wide, adapted from evlog at the HTTP boundary. Handlers depend on
+"somewhere to record fields" rather than on evlog, the disabled case is a
+two-line no-op instead of a stub of someone else's interface, and tests assert
+against a recording implementation.
+
+§5's caveat about `useLogger()` was checked rather than assumed, and holds at
+2.22.4: the Hono integration only does `c.set('log', logger)` and sets up no
+async storage. `makeRun` therefore takes the Hono context and provides `Log`
+alongside `Tenant`, which is the same shape tenant scoping already uses.
+
+**Two things §5 promised that this does not do.**
+
+- **`log.audit` is not wired to the `auditLog` table.** That table is the
+  product's legal record, written transactionally beside the row it describes.
+  Making it depend on a logging library — sampled, drained, best-effort — would
+  be a regression dressed as an integration. Audit entries stay in the
+  database; the wide event records that one was written.
+- **No OTLP drain is configured.** `drain` is exposed as an option instead. A
+  library that picks its own telemetry destination is a library fighting its
+  host; the deployment chooses.
+
+**A vacuous test, caught.** The first redaction test asserted an IP header
+never appeared in the emitted event, and passed — but it also passed with
+`redact: false`, because no field this package sets carries PII and evlog does
+not put request headers in the event body. It proved nothing. Replaced with a
+direct assertion on the resolved default, which is the decision that can
+actually regress. Worth recording as the same failure mode as §11.7: a test
+that cannot fail is indistinguishable from coverage until someone tries to
+break it.

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -57,6 +57,7 @@
 	"dependencies": {
 		"@c15t/schema": "workspace:*",
 		"effect": "4.0.0-beta.102",
+		"evlog": "2.22.4",
 		"hono": "4.12.27",
 		"hono-openapi": "1.3.0",
 		"jose": "6.2.3",

--- a/packages/backend-next/src/http/app.ts
+++ b/packages/backend-next/src/http/app.ts
@@ -13,6 +13,7 @@ import type { ManagedRuntime } from 'effect';
 import type { SqlClient } from 'effect/unstable/sql';
 import { Hono } from 'hono';
 import { openAPIRouteHandler } from 'hono-openapi';
+import { middleware as observability } from '../observability/evlog';
 import { type AppOptions, makeRun, type RouteContext } from './context';
 import { register as registerConsent } from './routes/consent';
 import { register as registerInit } from './routes/init';
@@ -28,6 +29,13 @@ export function createApp(
 	options: AppOptions = {}
 ) {
 	const app = new Hono();
+
+	// First, so the wide event covers CORS rejections and preflights too — a
+	// blocked origin is exactly the kind of thing an operator needs to see.
+	const observe = observability(options.observability);
+	if (observe) {
+		app.use('*', observe);
+	}
 
 	app.use('*', async (c, next) => {
 		const origin = c.req.header('Origin');

--- a/packages/backend-next/src/http/app.ts
+++ b/packages/backend-next/src/http/app.ts
@@ -13,7 +13,10 @@ import type { ManagedRuntime } from 'effect';
 import type { SqlClient } from 'effect/unstable/sql';
 import { Hono } from 'hono';
 import { openAPIRouteHandler } from 'hono-openapi';
-import { middleware as observability } from '../observability/evlog';
+import {
+	gradeLevel,
+	middleware as observability,
+} from '../observability/evlog';
 import { type AppOptions, makeRun, type RouteContext } from './context';
 import { register as registerConsent } from './routes/consent';
 import { register as registerInit } from './routes/init';
@@ -35,6 +38,9 @@ export function createApp(
 	const observe = observability(options.observability);
 	if (observe) {
 		app.use('*', observe);
+		// Immediately after, so it runs inside evlog's wrapper and can grade
+		// the event from the final status before it is emitted.
+		app.use('*', gradeLevel);
 	}
 
 	app.use('*', async (c, next) => {

--- a/packages/backend-next/src/http/context.ts
+++ b/packages/backend-next/src/http/context.ts
@@ -101,8 +101,9 @@ export interface AppOptions {
 	/**
 	 * Wide-event logging (RFC 0004 §5).
 	 *
-	 * Off unless enabled — `@c15t/backend` emits nothing per request by
-	 * default, and a drop-in replacement must not change that on upgrade.
+	 * On by default at `level: 'warn'` — silent when requests succeed, a line
+	 * when they fail. `level: 'info'` gives the full per-request stream;
+	 * `'silent'` turns it off.
 	 */
 	readonly observability?: ObservabilityOptions;
 }

--- a/packages/backend-next/src/http/context.ts
+++ b/packages/backend-next/src/http/context.ts
@@ -21,38 +21,17 @@
  */
 
 import type { ConsentManifestConfig } from '@c15t/schema';
-import { getSubjectOutputSchema, listSubjectsOutputSchema } from '@c15t/schema';
-import {
-	getIpAddress,
-	type IpAddressConfig,
-	isOriginTrusted,
-} from '@c15t/schema/geo';
-import { Effect, type ManagedRuntime } from 'effect';
+import type { IpAddressConfig } from '@c15t/schema/geo';
+import { Effect, Layer, type ManagedRuntime } from 'effect';
 import type { SqlClient } from 'effect/unstable/sql';
-import * as v from 'valibot';
 import { type Tenant, layer as tenantLayer } from '../db/tenant';
-import {
-	LegalDocumentConflictError,
-	syncCurrent,
-} from '../repository/legal-document';
-import { submit } from '../repository/record-consent';
-import {
-	findById,
-	linkExternalId,
-	listByExternalId,
-} from '../repository/subject';
-import { validateRequestAuth } from './auth';
-import {
-	BadRequestError,
-	NotFoundError,
-	type RouteError,
-	toHttp,
-} from './errors';
+import type { ObservabilityOptions } from '../observability/evlog';
+import { toRequestLog } from '../observability/evlog';
+import { type Log, layer as logLayer, silent } from '../observability/log';
+import { type RouteError, toHttp } from './errors';
 import type { GvlOptions } from './gvl';
-import { buildInitResponse } from './init';
-import { buildManifestResponse, type ManifestCacheOptions } from './manifest';
+import type { ManifestCacheOptions } from './manifest';
 import type { PolicySnapshotOptions } from './policy-snapshot';
-import { status } from './status';
 
 export interface AppLayers {
 	readonly sql: SqlClient.SqlClient;
@@ -64,7 +43,7 @@ export interface AppLayers {
  * The runtime is constructed once by the caller and reused for every request —
  * building a layer per request would open a connection pool per request.
  */
-import type { Hono } from 'hono';
+import type { Context, Hono } from 'hono';
 
 export interface AppOptions {
 	/**
@@ -119,6 +98,13 @@ export interface AppOptions {
 	 * not configured keys should expose nothing, not everything.
 	 */
 	readonly apiKeys?: readonly string[];
+	/**
+	 * Wide-event logging (RFC 0004 §5).
+	 *
+	 * Off unless enabled — `@c15t/backend` emits nothing per request by
+	 * default, and a drop-in replacement must not change that on upgrade.
+	 */
+	readonly observability?: ObservabilityOptions;
 }
 
 /**
@@ -140,14 +126,25 @@ export const makeRun =
 		tenantId: string | undefined
 	) =>
 	async <A>(
-		effect: Effect.Effect<A, RouteError, SqlClient.SqlClient | Tenant>
+		c: Context,
+		effect: Effect.Effect<A, RouteError, SqlClient.SqlClient | Tenant | Log>
 	): Promise<
 		{ ok: true; value: A } | { ok: false; failure: ReturnType<typeof toHttp> }
 	> => {
-		// Provided here, once, rather than at each call site: a route cannot
-		// forget what it never has to remember.
+		// Both provided here, once, rather than at each call site: a route
+		// cannot forget what it never has to remember.
+		//
+		// The logger comes from the Hono context rather than a module-level
+		// singleton because it is per-request — evlog's Hono binding attaches
+		// it with `c.set('log', …)` and offers no async-storage lookup.
+		const log = toRequestLog(c.get('log'));
+		const request = Layer.merge(
+			tenantLayer(tenantId),
+			log === undefined ? silent : logLayer(log)
+		);
+
 		const result = await runtime.runPromise(
-			Effect.result(Effect.provide(effect, tenantLayer(tenantId)))
+			Effect.result(Effect.provide(effect, request))
 		);
 		return result._tag === 'Success'
 			? { ok: true, value: result.success }

--- a/packages/backend-next/src/http/routes/consent.ts
+++ b/packages/backend-next/src/http/routes/consent.ts
@@ -25,6 +25,7 @@ export function register({ app, options, run }: RouteContext): void {
 			const type = c.req.query('type');
 
 			const result = await run(
+				c,
 				Effect.gen(function* () {
 					if (!externalId) {
 						return yield* new BadRequestError({

--- a/packages/backend-next/src/http/routes/legal-document.ts
+++ b/packages/backend-next/src/http/routes/legal-document.ts
@@ -55,6 +55,7 @@ export function register({ app, options, run }: RouteContext): void {
 			}
 
 			const result = await run(
+				c,
 				syncCurrent({
 					type,
 					version: body.version,

--- a/packages/backend-next/src/http/routes/status.ts
+++ b/packages/backend-next/src/http/routes/status.ts
@@ -23,6 +23,7 @@ export function register({ app, options, run }: RouteContext): void {
 			// load balancer cannot reach without credentials is not a health check.
 			// It exposes only version and the caller's own request metadata.
 			const result = await run(
+				c,
 				status(c.req.raw.headers, options.version ?? '0.0.0', options.ipAddress)
 			);
 

--- a/packages/backend-next/src/http/routes/subject.ts
+++ b/packages/backend-next/src/http/routes/subject.ts
@@ -12,6 +12,7 @@ import { getIpAddress } from '@c15t/schema/geo';
 import { Effect } from 'effect';
 import { describeRoute } from 'hono-openapi';
 import * as v from 'valibot';
+import { setFields } from '../../observability/log';
 import { submit } from '../../repository/record-consent';
 import {
 	findById,
@@ -44,6 +45,7 @@ export function register({ app, options, run }: RouteContext): void {
 			const externalId = c.req.query('externalId');
 
 			const result = await run(
+				c,
 				Effect.gen(function* () {
 					if (externalId === undefined || externalId === '') {
 						// Matches 2.x's error shape exactly, code included.
@@ -54,6 +56,9 @@ export function register({ app, options, run }: RouteContext): void {
 					}
 
 					const subjects = yield* listByExternalId(externalId);
+					yield* setFields({
+						subject: { matched: subjects.length },
+					});
 
 					return {
 						subjects: subjects.map((subject) => ({
@@ -114,6 +119,7 @@ export function register({ app, options, run }: RouteContext): void {
 				.filter(Boolean);
 
 			const result = await run(
+				c,
 				Effect.gen(function* () {
 					const subject = yield* findById(subjectId);
 					if (subject === undefined) {
@@ -187,6 +193,7 @@ export function register({ app, options, run }: RouteContext): void {
 			const body = await c.req.json().catch(() => undefined);
 
 			const result = await run(
+				c,
 				Effect.gen(function* () {
 					if (!body?.subjectId) {
 						return yield* new BadRequestError({
@@ -227,6 +234,17 @@ export function register({ app, options, run }: RouteContext): void {
 						decision: body.decision,
 					});
 
+					// `created` is the fact worth querying on: a replay is a normal,
+					// expected outcome here, and telling the two apart is how you
+					// see a client stuck in a retry loop.
+					yield* setFields({
+						consent: {
+							created: submission.created,
+							id: submission.consentId,
+							decisionId: submission.decisionId ?? null,
+						},
+					});
+
 					return {
 						subjectId: submission.subjectId,
 						consentId: submission.consentId,
@@ -254,6 +272,7 @@ export function register({ app, options, run }: RouteContext): void {
 			const body = await c.req.json().catch(() => undefined);
 
 			const result = await run(
+				c,
 				Effect.gen(function* () {
 					if (!body?.externalId) {
 						return yield* new BadRequestError({

--- a/packages/backend-next/src/observability/evlog.test.ts
+++ b/packages/backend-next/src/observability/evlog.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Wide-event logging.
+ *
+ * Two properties matter here, and they pull in opposite directions.
+ *
+ * The first is that **the default is silence**. `@c15t/backend` builds its
+ * logger with `level ?? 'error'` and so emits nothing per request; this
+ * package replaces it in place, so an operator who upgrades a version must not
+ * discover a new line of stdout per request. That is a behaviour change, and a
+ * costed one on a hosted log pipeline.
+ *
+ * The second is that when it *is* on, the event has to carry the facts worth
+ * querying — otherwise it is a slower `console.log`. So these assert the
+ * domain fields land, not merely that something was emitted.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect, type Layer, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import type { DrainContext } from 'evlog';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { createApp } from '../http/app';
+import type { AppOptions } from '../http/context';
+import { resolveOptions } from './evlog';
+
+/** Every event a run produced, in order. */
+const collect = () => {
+	const events: Record<string, unknown>[] = [];
+	const drain = (ctx: DrainContext) => {
+		events.push(ctx.event as unknown as Record<string, unknown>);
+	};
+	return { events, drain };
+};
+
+const withApp = async <A>(
+	options: AppOptions,
+	use: (app: ReturnType<typeof createApp>) => Promise<A>
+): Promise<A> => {
+	const runtime = ManagedRuntime.make(
+		PgliteClient.layer({}) as unknown as Layer.Layer<SqlClient.SqlClient>
+	);
+	await runtime.runPromise(
+		Effect.gen(function* () {
+			yield* baseline;
+			const sql = yield* SqlClient.SqlClient;
+			yield* sql`
+				insert into ${sql('domain')} ${sql.insert({
+					id: 'dom_1',
+					name: 'example.com',
+					createdAt: new Date(1_800_000_000_000),
+					updatedAt: new Date(1_800_000_000_000),
+				})}
+			`;
+		})
+	);
+	try {
+		return await use(createApp(runtime, options));
+	} finally {
+		await runtime.dispose();
+	}
+};
+
+const seed = { appName: 'Example', policyPacks: [] } as const;
+
+describe('observability: off by default', () => {
+	it('emits nothing when unconfigured', async () => {
+		const { events, drain } = collect();
+
+		await withApp(
+			// `drain` is wired but `observability` is absent, so the middleware is
+			// never registered and the drain can never be called. If a future
+			// change flips the default, this fails rather than quietly costing
+			// someone money.
+			{ manifest: seed, observability: undefined },
+			async (app) => {
+				const response = await app.request('/status');
+				assert.strictEqual(response.status, 200);
+			}
+		);
+
+		void drain;
+		assert.strictEqual(events.length, 0);
+	}, 60_000);
+
+	it('emits nothing when explicitly disabled', async () => {
+		const { events, drain } = collect();
+
+		await withApp(
+			{ manifest: seed, observability: { enabled: false, drain } },
+			async (app) => {
+				await app.request('/status');
+			}
+		);
+
+		assert.strictEqual(events.length, 0);
+	});
+});
+
+describe('observability: enabled', () => {
+	it('emits one event per request', async () => {
+		const { events, drain } = collect();
+
+		await withApp(
+			{ manifest: seed, observability: { enabled: true, drain } },
+			async (app) => {
+				await app.request('/status');
+				await app.request('/status');
+			}
+		);
+
+		assert.strictEqual(events.length, 2);
+		assert.strictEqual(events[0]?.path, '/status');
+		assert.strictEqual(events[0]?.status, 200);
+		assert.strictEqual(events[0]?.method, 'GET');
+	}, 60_000);
+
+	it('records whether a consent was created or replayed', async () => {
+		const { events, drain } = collect();
+
+		const body = {
+			subjectId: 'sub_wide_event',
+			domainId: 'dom_1',
+			purposeIds: ['analytics'],
+			givenAt: new Date(1_800_000_000_000).toISOString(),
+		};
+		const post = () =>
+			new Request('http://localhost/subjects', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(body),
+			});
+
+		await withApp(
+			{ manifest: seed, observability: { enabled: true, drain } },
+			async (app) => {
+				const first = await app.request(post());
+				assert.strictEqual(first.status, 200, await first.text());
+				await app.request(post());
+			}
+		);
+
+		const consents = events
+			.map((event) => event.consent as { created?: boolean } | undefined)
+			.filter((consent): consent is { created?: boolean } => Boolean(consent));
+
+		// A replay is a normal outcome, not an error — the event has to
+		// distinguish them or a client stuck retrying looks like healthy traffic.
+		assert.strictEqual(consents.length, 2);
+		assert.strictEqual(consents[0]?.created, true);
+		assert.strictEqual(consents[1]?.created, false);
+	}, 60_000);
+
+	it('skips routes excluded by glob', async () => {
+		const { events, drain } = collect();
+
+		await withApp(
+			{
+				manifest: seed,
+				observability: { enabled: true, drain, exclude: ['/status'] },
+			},
+			async (app) => {
+				await app.request('/status');
+			}
+		);
+
+		// Health checks are the highest-volume, least-informative traffic a
+		// backend sees; being able to drop them is why `exclude` is exposed.
+		assert.strictEqual(events.length, 0);
+	}, 60_000);
+
+	it('defaults redaction on, and lets it be turned off deliberately', () => {
+		// A policy decision, and one nothing else can catch regressing: no field
+		// this package sets on an event contains PII today, so an end-to-end
+		// assertion would pass with redaction either way. Verified by trying —
+		// the earlier version of this test passed with `redact: false`.
+		//
+		// It still defaults on, because the failure mode of forgetting once a
+		// field *does* carry an IP is a compliance incident rather than an
+		// untidy log.
+		assert.strictEqual(resolveOptions({ enabled: true }).redact, true);
+		assert.strictEqual(
+			resolveOptions({ enabled: true, redact: false }).redact,
+			false
+		);
+	}, 60_000);
+
+	it('passes route filters through verbatim', () => {
+		const resolved = resolveOptions({
+			enabled: true,
+			include: ['/subjects/**'],
+			exclude: ['/status'],
+		});
+		assert.deepStrictEqual(resolved.include, ['/subjects/**']);
+		assert.deepStrictEqual(resolved.exclude, ['/status']);
+	});
+});

--- a/packages/backend-next/src/observability/evlog.test.ts
+++ b/packages/backend-next/src/observability/evlog.test.ts
@@ -1,17 +1,21 @@
 /**
  * Wide-event logging.
  *
- * Two properties matter here, and they pull in opposite directions.
+ * The default is the interesting case, and it is two claims at once: logging
+ * is **on**, so a new self-hoster is not debugging failures by guesswork, and
+ * a **successful request is silent**, so nobody upgrading discovers a line per
+ * request and a bigger log bill.
  *
- * The first is that **the default is silence**. `@c15t/backend` builds its
- * logger with `level ?? 'error'` and so emits nothing per request; this
- * package replaces it in place, so an operator who upgrades a version must not
- * discover a new line of stdout per request. That is a behaviour change, and a
- * costed one on a hosted log pipeline.
+ * That combination is not one setting. Hono answers a thrown handler error
+ * with a 500 *response* rather than propagating it, so evlog sees a status and
+ * never an exception, and the event's level stays `info` even for a 500 —
+ * head sampling alone drops exactly the requests worth keeping. It takes
+ * status-based grading *and* a keep rule, which is why both are asserted here
+ * rather than trusted.
  *
- * The second is that when it *is* on, the event has to carry the facts worth
- * querying — otherwise it is a slower `console.log`. So these assert the
- * domain fields land, not merely that something was emitted.
+ * When the full stream is on, the event also has to carry the facts worth
+ * querying, or it is a slower `console.log`. So the domain fields are asserted
+ * too.
  */
 
 import { PgliteClient } from '@effect/sql-pglite';
@@ -63,46 +67,68 @@ const withApp = async <A>(
 
 const seed = { appName: 'Example', policyPacks: [] } as const;
 
-describe('observability: off by default', () => {
-	it('emits nothing when unconfigured', async () => {
+describe('observability: the default', () => {
+	it('stays quiet on a successful request', async () => {
 		const { events, drain } = collect();
 
 		await withApp(
-			// `drain` is wired but `observability` is absent, so the middleware is
-			// never registered and the drain can never be called. If a future
-			// change flips the default, this fails rather than quietly costing
-			// someone money.
-			{ manifest: seed, observability: undefined },
+			// No `level` — the default must be quiet when nothing is wrong.
+			{ manifest: seed, observability: { drain } },
 			async (app) => {
 				const response = await app.request('/status');
 				assert.strictEqual(response.status, 200);
 			}
 		);
 
-		void drain;
 		assert.strictEqual(events.length, 0);
 	}, 60_000);
 
-	it('emits nothing when explicitly disabled', async () => {
+	it('reports a rejected request at warn', async () => {
 		const { events, drain } = collect();
 
 		await withApp(
-			{ manifest: seed, observability: { enabled: false, drain } },
+			{ manifest: seed, observability: { drain }, apiKeys: [] },
 			async (app) => {
-				await app.request('/status');
+				// 401: no API key configured, so nothing authenticates.
+				const response = await app.request('/subjects?externalId=ext_1');
+				assert.strictEqual(response.status, 401);
 			}
 		);
 
+		// Kept despite head sampling, and graded from the status rather than
+		// left at info — without both, a new self-hoster sees nothing at all
+		// when their requests are being rejected.
+		assert.strictEqual(events.length, 1);
+		assert.strictEqual(events[0]?.status, 401);
+		assert.strictEqual(events[0]?.level, 'warn');
+	}, 60_000);
+
+	it('emits nothing at all when silenced', async () => {
+		const { events, drain } = collect();
+
+		await withApp(
+			{
+				manifest: seed,
+				observability: { level: 'silent', drain },
+				apiKeys: [],
+			},
+			async (app) => {
+				await app.request('/status');
+				await app.request('/subjects?externalId=ext_1');
+			}
+		);
+
+		// Not even the failure. `silent` registers no middleware at all.
 		assert.strictEqual(events.length, 0);
-	});
+	}, 60_000);
 });
 
-describe('observability: enabled', () => {
+describe("observability: level 'info'", () => {
 	it('emits one event per request', async () => {
 		const { events, drain } = collect();
 
 		await withApp(
-			{ manifest: seed, observability: { enabled: true, drain } },
+			{ manifest: seed, observability: { level: 'info', drain } },
 			async (app) => {
 				await app.request('/status');
 				await app.request('/status');
@@ -132,7 +158,7 @@ describe('observability: enabled', () => {
 			});
 
 		await withApp(
-			{ manifest: seed, observability: { enabled: true, drain } },
+			{ manifest: seed, observability: { level: 'info', drain } },
 			async (app) => {
 				const first = await app.request(post());
 				assert.strictEqual(first.status, 200, await first.text());
@@ -157,7 +183,7 @@ describe('observability: enabled', () => {
 		await withApp(
 			{
 				manifest: seed,
-				observability: { enabled: true, drain, exclude: ['/status'] },
+				observability: { level: 'info', drain, exclude: ['/status'] },
 			},
 			async (app) => {
 				await app.request('/status');
@@ -178,16 +204,12 @@ describe('observability: enabled', () => {
 		// It still defaults on, because the failure mode of forgetting once a
 		// field *does* carry an IP is a compliance incident rather than an
 		// untidy log.
-		assert.strictEqual(resolveOptions({ enabled: true }).redact, true);
-		assert.strictEqual(
-			resolveOptions({ enabled: true, redact: false }).redact,
-			false
-		);
+		assert.strictEqual(resolveOptions({}).redact, true);
+		assert.strictEqual(resolveOptions({ redact: false }).redact, false);
 	}, 60_000);
 
 	it('passes route filters through verbatim', () => {
 		const resolved = resolveOptions({
-			enabled: true,
 			include: ['/subjects/**'],
 			exclude: ['/status'],
 		});

--- a/packages/backend-next/src/observability/evlog.ts
+++ b/packages/backend-next/src/observability/evlog.ts
@@ -4,19 +4,43 @@
  * Everything that knows evlog exists lives here and in `./log.ts`. The rest of
  * the package sees the `Log` service.
  *
- * ## Opt-in, and why
+ * ## On by default, quiet by default
  *
- * `@c15t/backend` builds its logger with `level ?? 'error'`, so a default
- * deployment emits nothing per request. This package is a drop-in replacement
- * for it, so turning on a wide event per request by default would change
- * observable behaviour at cutover — new stdout volume, and potentially new
- * cost, for someone who only upgraded a version. `observability.enabled` is
- * therefore `false` unless asked for.
+ * Logging is **on** out of the box, because a backend that tells a new
+ * self-hoster nothing when a request fails is a backend they debug with
+ * guesswork. `@c15t/backend` 2.x defaults its logger to `level: 'error'`, so
+ * it already reports failures; this keeps that and adds warnings.
  *
- * Redaction is the opposite: on by default whenever logging is on. This
- * service handles IP addresses and puts them on consent records, so the
- * failure mode of forgetting is a compliance incident rather than an untidy
- * log. Turning it off has to be deliberate.
+ * What it does *not* do by default is emit a line per successful request.
+ * That is the part which would be a real change on upgrade — new stdout
+ * volume and a bigger bill on a hosted log pipeline — and it is one option
+ * away (`level: 'info'`) for anyone who wants the full wide-event stream.
+ *
+ * So the default is: **silence when things work, a line when they do not.**
+ *
+ * ## How the level is actually enforced
+ *
+ * Two mechanisms, because one is not enough, and the reason is worth knowing
+ * before changing any of it.
+ *
+ * Hono catches a thrown handler error and turns it into a 500 *response*
+ * rather than letting it propagate, so evlog's middleware sees a status and
+ * never an exception. The wide event's level therefore stays `info` even for
+ * a 500 — head sampling alone would drop the very requests worth keeping.
+ *
+ * - `gradeLevel` runs inside evlog's wrapper, reads the final status, and
+ *   marks the event `warn` (4xx) or `error` (5xx) before it is emitted.
+ * - A `keep` callback force-keeps anything from 400 up, so a failure survives
+ *   head sampling regardless.
+ *
+ * Verified end to end rather than reasoned about: with `rates: { info: 0 }`
+ * alone, a 500 was silently dropped.
+ *
+ * ## Redaction
+ *
+ * On by default whenever logging is on. This service handles IP addresses and
+ * puts them on consent records, so the failure mode of forgetting is a
+ * compliance incident rather than an untidy log. Turning it off is deliberate.
  */
 
 import { type AuditableLogger, initLogger } from 'evlog';
@@ -24,22 +48,34 @@ import { type EvlogHonoOptions, evlog } from 'evlog/hono';
 import type { MiddlewareHandler } from 'hono';
 import type { RequestLog } from './log';
 
+/**
+ * How much of the request stream reaches the log.
+ *
+ * - `silent` — nothing. No middleware is registered at all.
+ * - `error` — failed requests only (5xx).
+ * - `warn` — failures and rejections (4xx and 5xx). **The default.**
+ * - `info` — every request, the full wide-event stream.
+ * - `inherit` — leave evlog's global configuration alone and log whatever the
+ *   host application already decided. For an app that configures evlog itself
+ *   and does not want a library overriding it.
+ */
+export type ObservabilityLevel =
+	| 'silent'
+	| 'error'
+	| 'warn'
+	| 'info'
+	| 'inherit';
+
 export interface ObservabilityOptions {
-	/**
-	 * Emit one wide event per request.
-	 *
-	 * Off by default, matching `@c15t/backend`'s error-only logger. See the
-	 * note at the top of this file.
-	 */
-	readonly enabled?: boolean;
+	/** Defaults to `'warn'` — failures and rejections, nothing else. */
+	readonly level?: ObservabilityLevel;
 	/**
 	 * Service name on every event.
 	 *
-	 * **Sets global evlog state** via `initLogger`, because evlog resolves the
-	 * service name from process-level configuration rather than per
-	 * middleware. Left unset, whatever the host application configured wins —
-	 * which is the right default for an embedded backend, and the reason this
-	 * is not defaulted to `'c15t'`.
+	 * **Sets global evlog state**, as does any `level` other than `'inherit'`:
+	 * evlog resolves sampling and service name from process-level
+	 * configuration rather than per middleware. Two instances in one process
+	 * share it, and the last one built wins. `level: 'inherit'` is the way out.
 	 */
 	readonly service?: string;
 	/** Route globs to log. Unset logs every route. */
@@ -56,22 +92,60 @@ export interface ObservabilityOptions {
 	readonly drain?: EvlogHonoOptions['drain'];
 	/** Adds fields to every event after emit, before drain. */
 	readonly enrich?: EvlogHonoOptions['enrich'];
-	/** Tail sampling — force-keep an event that would otherwise be dropped. */
+	/** Force-keeps an event that sampling would otherwise drop. */
 	readonly keep?: EvlogHonoOptions['keep'];
 }
+
+const DEFAULT_LEVEL: ObservabilityLevel = 'warn';
+
+/** The lowest status that counts as worth keeping, per level. */
+const keepFrom: Record<Exclude<ObservabilityLevel, 'silent'>, number> = {
+	error: 500,
+	warn: 400,
+	// Everything is kept anyway; the threshold is unreachable rather than
+	// special-cased.
+	info: 0,
+	inherit: Number.POSITIVE_INFINITY,
+};
+
+/**
+ * Head-sampling rates for a level.
+ *
+ * `undefined` means "do not touch the global configuration" — only
+ * `'inherit'`, whose whole purpose is to leave the host's settings alone.
+ */
+const ratesFor = (
+	level: ObservabilityLevel
+): Record<string, number> | undefined => {
+	switch (level) {
+		case 'error':
+			return { info: 0, debug: 0, warn: 0 };
+		case 'warn':
+			return { info: 0, debug: 0 };
+		case 'info':
+			return { info: 100, debug: 100, warn: 100 };
+		default:
+			return undefined;
+	}
+};
 
 /**
  * Turns our options into evlog's.
  *
- * Separate from `middleware` so the defaults are assertable directly. The one
- * that matters is `redact`, which is a policy decision rather than a
- * pass-through, and which nothing else can catch regressing: no field this
- * package currently sets on an event contains PII, so an end-to-end test of
- * redaction would pass whether it were on or off.
+ * Separate from `middleware` so the defaults are assertable directly. Two of
+ * them are policy rather than pass-through, and nothing else can catch either
+ * regressing: `redact`, because no field this package sets on an event
+ * contains PII today so an end-to-end test would pass either way; and `keep`,
+ * because it is what stops the default level discarding failures.
  */
 export function resolveOptions(
 	options: ObservabilityOptions
 ): EvlogHonoOptions {
+	const level = options.level ?? DEFAULT_LEVEL;
+	const threshold =
+		level === 'silent' ? Number.POSITIVE_INFINITY : keepFrom[level];
+	const caller = options.keep;
+
 	return {
 		include: options.include ? [...options.include] : undefined,
 		exclude: options.exclude ? [...options.exclude] : undefined,
@@ -79,36 +153,75 @@ export function resolveOptions(
 		redact: options.redact ?? true,
 		drain: options.drain,
 		enrich: options.enrich,
-		keep: options.keep,
+		keep: async (ctx) => {
+			if ((ctx.status ?? 200) >= threshold) {
+				ctx.shouldKeep = true;
+			}
+			// The caller's own rule runs too, and can only ever keep more.
+			await caller?.(ctx);
+		},
 	};
 }
 
 /**
- * The middleware, or `undefined` when observability is off.
+ * Marks the event `warn` or `error` from the response status.
  *
- * `undefined` rather than a pass-through middleware so the disabled path costs
- * nothing per request and does not appear in a stack trace.
+ * Registered immediately after evlog's middleware so it runs *inside* that
+ * wrapper: it needs the final status, and the event has to be graded before
+ * evlog emits it.
+ *
+ * Without this every event is `info`, including 500s, because Hono answers a
+ * thrown handler error with a response rather than propagating it.
+ */
+export const gradeLevel: MiddlewareHandler = async (c, next) => {
+	await next();
+
+	const log: AuditableLogger | undefined = c.get('log');
+	if (log === undefined) {
+		return;
+	}
+
+	const status = c.res.status;
+	if (status >= 500) {
+		log.setLevel('error');
+	} else if (status >= 400) {
+		log.setLevel('warn');
+	}
+};
+
+/**
+ * The middleware, or `undefined` when logging is off.
+ *
+ * `undefined` rather than a pass-through so `level: 'silent'` costs nothing
+ * per request and does not appear in a stack trace.
  */
 export function middleware(
 	options: ObservabilityOptions | undefined
 ): MiddlewareHandler | undefined {
-	if (options?.enabled !== true) {
+	const level = options?.level ?? DEFAULT_LEVEL;
+	if (level === 'silent') {
 		return undefined;
 	}
 
-	if (options.service !== undefined) {
-		initLogger({ env: { service: options.service } });
+	const rates = ratesFor(level);
+	if (rates !== undefined || options?.service !== undefined) {
+		initLogger({
+			...(options?.service === undefined
+				? {}
+				: { env: { service: options.service } }),
+			...(rates === undefined ? {} : { sampling: { rates } }),
+		});
 	}
 
-	return evlog(resolveOptions(options));
+	return evlog(resolveOptions(options ?? {}));
 }
 
 /**
  * Adapts evlog's request logger to the narrow `RequestLog` the app depends on.
  *
- * Tolerates its absence: when the middleware is not registered, or skipped the
- * route via `include`/`exclude`, `c.get('log')` is undefined and handlers
- * still need somewhere to write.
+ * Tolerates its absence: when logging is off, or the route was skipped via
+ * `include`/`exclude`, `c.get('log')` is undefined and handlers still need
+ * somewhere to write.
  */
 export function toRequestLog(
 	logger: AuditableLogger | undefined

--- a/packages/backend-next/src/observability/evlog.ts
+++ b/packages/backend-next/src/observability/evlog.ts
@@ -1,0 +1,123 @@
+/**
+ * evlog wiring for the Hono app.
+ *
+ * Everything that knows evlog exists lives here and in `./log.ts`. The rest of
+ * the package sees the `Log` service.
+ *
+ * ## Opt-in, and why
+ *
+ * `@c15t/backend` builds its logger with `level ?? 'error'`, so a default
+ * deployment emits nothing per request. This package is a drop-in replacement
+ * for it, so turning on a wide event per request by default would change
+ * observable behaviour at cutover — new stdout volume, and potentially new
+ * cost, for someone who only upgraded a version. `observability.enabled` is
+ * therefore `false` unless asked for.
+ *
+ * Redaction is the opposite: on by default whenever logging is on. This
+ * service handles IP addresses and puts them on consent records, so the
+ * failure mode of forgetting is a compliance incident rather than an untidy
+ * log. Turning it off has to be deliberate.
+ */
+
+import { type AuditableLogger, initLogger } from 'evlog';
+import { type EvlogHonoOptions, evlog } from 'evlog/hono';
+import type { MiddlewareHandler } from 'hono';
+import type { RequestLog } from './log';
+
+export interface ObservabilityOptions {
+	/**
+	 * Emit one wide event per request.
+	 *
+	 * Off by default, matching `@c15t/backend`'s error-only logger. See the
+	 * note at the top of this file.
+	 */
+	readonly enabled?: boolean;
+	/**
+	 * Service name on every event.
+	 *
+	 * **Sets global evlog state** via `initLogger`, because evlog resolves the
+	 * service name from process-level configuration rather than per
+	 * middleware. Left unset, whatever the host application configured wins —
+	 * which is the right default for an embedded backend, and the reason this
+	 * is not defaulted to `'c15t'`.
+	 */
+	readonly service?: string;
+	/** Route globs to log. Unset logs every route. */
+	readonly include?: readonly string[];
+	/** Route globs to skip. Takes precedence over `include`. */
+	readonly exclude?: readonly string[];
+	/**
+	 * PII auto-redaction — email, IPv4, JWT, bearer tokens.
+	 *
+	 * On unless explicitly disabled.
+	 */
+	readonly redact?: EvlogHonoOptions['redact'];
+	/** Where events go. Console when unset. */
+	readonly drain?: EvlogHonoOptions['drain'];
+	/** Adds fields to every event after emit, before drain. */
+	readonly enrich?: EvlogHonoOptions['enrich'];
+	/** Tail sampling — force-keep an event that would otherwise be dropped. */
+	readonly keep?: EvlogHonoOptions['keep'];
+}
+
+/**
+ * Turns our options into evlog's.
+ *
+ * Separate from `middleware` so the defaults are assertable directly. The one
+ * that matters is `redact`, which is a policy decision rather than a
+ * pass-through, and which nothing else can catch regressing: no field this
+ * package currently sets on an event contains PII, so an end-to-end test of
+ * redaction would pass whether it were on or off.
+ */
+export function resolveOptions(
+	options: ObservabilityOptions
+): EvlogHonoOptions {
+	return {
+		include: options.include ? [...options.include] : undefined,
+		exclude: options.exclude ? [...options.exclude] : undefined,
+		// Defaults on; see the file header.
+		redact: options.redact ?? true,
+		drain: options.drain,
+		enrich: options.enrich,
+		keep: options.keep,
+	};
+}
+
+/**
+ * The middleware, or `undefined` when observability is off.
+ *
+ * `undefined` rather than a pass-through middleware so the disabled path costs
+ * nothing per request and does not appear in a stack trace.
+ */
+export function middleware(
+	options: ObservabilityOptions | undefined
+): MiddlewareHandler | undefined {
+	if (options?.enabled !== true) {
+		return undefined;
+	}
+
+	if (options.service !== undefined) {
+		initLogger({ env: { service: options.service } });
+	}
+
+	return evlog(resolveOptions(options));
+}
+
+/**
+ * Adapts evlog's request logger to the narrow `RequestLog` the app depends on.
+ *
+ * Tolerates its absence: when the middleware is not registered, or skipped the
+ * route via `include`/`exclude`, `c.get('log')` is undefined and handlers
+ * still need somewhere to write.
+ */
+export function toRequestLog(
+	logger: AuditableLogger | undefined
+): RequestLog | undefined {
+	if (logger === undefined) {
+		return undefined;
+	}
+	return {
+		set: (fields) => logger.set(fields),
+		error: (error, fields) => logger.error(error, fields),
+	};
+}

--- a/packages/backend-next/src/observability/log.ts
+++ b/packages/backend-next/src/observability/log.ts
@@ -1,0 +1,83 @@
+/**
+ * The request log, as an Effect service.
+ *
+ * RFC 0004 §5 replaces `@c15t/logger` in the backend with evlog: one **wide
+ * event per request** carrying everything worth knowing about it, rather than
+ * `logger.debug` calls scattered across 22 files. A wide event is queryable
+ * in a way that a stream of prose lines is not — "which tenant's consent
+ * writes are slow" is a filter, not a grep.
+ *
+ * ## Why a narrow interface rather than evlog's logger
+ *
+ * The service shape is `RequestLog`, two methods wide, not evlog's
+ * `AuditableLogger`. Three reasons, in order of how much they matter:
+ *
+ * - Handlers depend on "somewhere to record fields", not on evlog. Swapping
+ *   the backend, or running with none, changes this file and nothing else.
+ * - The disabled case becomes a trivial no-op rather than a hand-written stub
+ *   of somebody else's interface that drifts when they add a method.
+ * - Tests assert against a recording implementation in three lines.
+ *
+ * ## Why it is a service and not a parameter
+ *
+ * evlog's Hono binding attaches the logger with `c.set('log', …)` and sets up
+ * no async storage, so `useLogger()` does not work there — verified against
+ * 2.22.4 rather than taken from the docs. The logger therefore has to be
+ * carried explicitly, and Effect's Context is how this package already
+ * carries request-scoped values (see `db/tenant.ts`). `makeRun` provides it
+ * once per request, so a handler that wants to record a field just asks.
+ */
+
+import { Context, Effect, Layer } from 'effect';
+
+/** Fields to merge into the current request's wide event. */
+export type LogFields = Record<string, unknown>;
+
+/**
+ * Somewhere to record what happened during a request.
+ *
+ * Deliberately not a log-level API. There is one event per request; handlers
+ * add facts to it and the middleware emits it once, so there is no `debug`
+ * or `info` to choose between.
+ */
+export interface RequestLog {
+	/** Merge fields into this request's event. */
+	readonly set: (fields: LogFields) => void;
+	/** Record that this request failed. */
+	readonly error: (error: Error, fields?: LogFields) => void;
+}
+
+export class Log extends Context.Service<Log, RequestLog>()('Log') {}
+
+/**
+ * Records nothing.
+ *
+ * The default. `@c15t/backend` defaults its logger to `level: 'error'`, so it
+ * emits nothing per request, and a deployment upgrading to this package must
+ * not suddenly start writing a line per request to stdout. Observability is
+ * opt-in for exactly that reason — see `AppOptions.observability`.
+ *
+ * Also what non-request code gets: migrations, benchmarks and repository
+ * tests have no wide event to attach to.
+ */
+export const silent: Layer.Layer<Log> = Layer.succeed(Log, {
+	set: () => {},
+	error: () => {},
+});
+
+/** Wraps a concrete logger — in practice evlog's, from `c.get('log')`. */
+export const layer = (log: RequestLog): Layer.Layer<Log> =>
+	Layer.succeed(Log, log);
+
+/**
+ * Records fields on the current request's event.
+ *
+ * @example
+ * ```ts
+ * yield* setFields({ consent: { created: true, id } });
+ * ```
+ */
+export const setFields = (fields: LogFields): Effect.Effect<void, never, Log> =>
+	Effect.map(Log, (log) => {
+		log.set(fields);
+	});


### PR DESCRIPTION
RFC 0004 §5. One wide event per request, carrying the facts worth querying — which tenant, which route, whether a consent was created or replayed — rather than prose lines to grep.

## The default: `warn`

My first pass defaulted this **off**, reasoning that new stdout volume (and a new bill on a hosted pipeline) for someone who only upgraded a version was the wrong surprise. That was half right and the wrong conclusion: `@c15t/backend` defaults to `level: 'error'`, so it *does* report failures — and a backend that tells a new self-hoster nothing when their requests are being rejected is one they debug by guesswork.

| Level | Behaviour |
| --- | --- |
| `silent` | off |
| `error` | failures only |
| **`warn`** (default) | silent when requests succeed, a line when they do not |
| `info` | full per-request stream |
| `inherit` | leaves evlog's global config alone, for a host that configures it itself |

`enabled` is gone — one knob rather than two that overlap. Redaction defaults **on**.

## Two mechanisms this needed

Hono answers a thrown handler error with a 500 response rather than propagating it, so evlog sees a status and never an exception, and the event level stays `info` even for a 500 — **head sampling alone drops exactly the requests worth keeping**. Observed rather than predicted: with `rates: { info: 0 }` the 500 vanished.

So a grading middleware runs inside evlog's wrapper and marks the event from the final status, and a keep rule force-keeps anything from 400 up. Verified against the built artifact: a 401 prints one WARN line, a 200 prints nothing.

## Boundaries

The Effect service is a two-method `RequestLog`, adapted from evlog at the HTTP boundary, so handlers depend on *somewhere to record fields* rather than on evlog, and the disabled case is a no-op rather than a stub of someone else's interface. evlog's Hono binding sets up no async storage — checked against 2.22.4, not assumed — so `makeRun` takes the Hono context and provides `Log` beside `Tenant`.

## Two things §5 promised that this deliberately does not do

- **`log.audit` is not wired to the `auditLog` table.** That table is the legal record, written transactionally beside the row it describes; routing it through a sampled best-effort logger would be a regression dressed as an integration.
- **No OTLP drain is configured.** `drain` is an option, so the deployment picks its destination rather than the library.

Also removes fifteen dead imports left in `http/context.ts` by the earlier route split.
