### PR TITLE
feat(backend-next): give the package a public API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -615,6 +615,7 @@
         "@effect/sql-sqlite-node": "4.0.0-beta.102",
         "@effect/vitest": "4.0.0-beta.102",
         "@types/node": "^24.10.1",
+        "genversion": "3.2.0",
         "typescript": "7.0.2",
       },
       "peerDependencies": {

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -766,3 +766,57 @@ direct assertion on the resolved default, which is the decision that can
 actually regress. Worth recording as the same failure mode as §11.7: a test
 that cannot fail is indistinguishable from coverage until someone tries to
 break it.
+
+### 11.10 The cutover blocker was a missing public API, not the rename
+
+§8 step 8 describes cutover as "rename to `@c15t/backend`, join the linked
+group, major release". Checking what the rename would actually require turned
+up something that section assumes and never states: **`backend-next` had no
+public API at all.** Its `index.ts` was `export {}`. A complete, tested backend
+with no way to use it — and no internal coverage could have caught that,
+because every test reached past the entry point.
+
+The nine dependents import `c15tInstance`, `policyPackPresets`, `composePacks`,
+`policyBuilder`, `defineConfig` and `C15TOptions`. None existed.
+
+**Now built** (`instance.ts`, `db/connect.ts`, `define-config.ts`,
+`policy/builder.ts`, a real `index.ts`):
+
+- `c15tInstance(options).handler(request)` — deliberately the same two-call
+  shape as 2.x, so no host integration is rewritten by the cutover.
+- **`database` replaces `adapter`.** Either `{ dialect, url }` or a `SqlClient`
+  layer. The config form exists so a self-hoster never has to learn `Layer`,
+  `Redacted` and `@effect/sql-pg` to point the backend at a database; the layer
+  form exists so that config form is not a dead end for anyone sharing a pool
+  or embedding this in an Effect application. Drivers load dynamically, so a
+  Postgres deployment does not pull `mysql2`.
+- Policy authoring is **re-exported from `@c15t/schema`**, not reimplemented.
+  Only `composePacks` and `policyBuilder` had to move; the matchers, presets
+  and `inspectPolicies` were already shared, which is why a policy pack means
+  the same thing in the browser and on the server.
+
+**Decided: the adapter subpaths are removed outright**, not stubbed. There is
+no `@c15t/backend/db/adapters/*` in 3.0 for Drizzle, Prisma, TypeORM, Kysely or
+Mongo.
+
+### 11.11 What cutover still needs
+
+Mapped rather than estimated, by grepping every subpath import in the repo.
+
+**`@c15t/cli` is the real remaining work.** Its `self-host migrate` command is
+built on v2's internals — `db/migrator` in four files, `db/schema`, and all
+five `db/adapters/*` in `ensure-backend-config.ts`. None of those exist here:
+this package's migrator is `db/adopt.ts` plus Effect's `Migrator`, and there
+are no adapters. That command needs rewriting against the new surface, and it
+is a piece of work in its own right rather than a step in a rename.
+
+Also outstanding:
+
+- `@c15t/logger` reaches for `@c15t/backend/telemetry`.
+- The rename itself: directory move, `private` removed, joining the linked
+  version group, a major changeset.
+- The benchmark and conformance harnesses import the real `@c15t/backend`,
+  which is the point of them. Deleting the old package deletes the A/B. If the
+  comparison is worth keeping past cutover, they need to depend on the
+  published 2.x under an alias instead of on the workspace.
+- Docs, which land before the 3.0 release.

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -2,7 +2,7 @@
 	"name": "@c15t/backend-next",
 	"version": "0.0.0",
 	"private": true,
-	"description": "Effect rewrite of @c15t/backend, developed in parallel until it reaches parity. Renamed to @c15t/backend at cutover — see internals/rfcs/0004-backend-effect-rewrite.md.",
+	"description": "Effect rewrite of @c15t/backend, developed in parallel until it reaches parity. Renamed to @c15t/backend at cutover \u2014 see internals/rfcs/0004-backend-effect-rewrite.md.",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/c15t/c15t.git",
@@ -52,7 +52,8 @@
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",
 		"test": "vitest run --passWithNoTests",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"prebuild": "genversion --esm --semi src/version.ts"
 	},
 	"dependencies": {
 		"@c15t/schema": "workspace:*",
@@ -75,6 +76,7 @@
 		"@effect/sql-sqlite-node": "4.0.0-beta.102",
 		"@effect/vitest": "4.0.0-beta.102",
 		"@types/node": "^24.10.1",
+		"genversion": "3.2.0",
 		"typescript": "7.0.2"
 	},
 	"peerDependencies": {

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -2,7 +2,7 @@
 	"name": "@c15t/backend-next",
 	"version": "0.0.0",
 	"private": true,
-	"description": "Effect rewrite of @c15t/backend, developed in parallel until it reaches parity. Renamed to @c15t/backend at cutover \u2014 see internals/rfcs/0004-backend-effect-rewrite.md.",
+	"description": "Effect rewrite of @c15t/backend, developed in parallel until it reaches parity. Renamed to @c15t/backend at cutover — see internals/rfcs/0004-backend-effect-rewrite.md.",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/c15t/c15t.git",
@@ -46,14 +46,14 @@
 		"dist-types"
 	],
 	"scripts": {
+		"prebuild": "genversion --esm --semi src/version.ts",
 		"build": "rslib build && bun ../../scripts/normalize-dist-types.mjs",
 		"check-types": "tsc --noEmit",
 		"dev": "sh -c 'rslib build --no-dts --no-clean && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",
 		"test": "vitest run --passWithNoTests",
-		"test:watch": "vitest",
-		"prebuild": "genversion --esm --semi src/version.ts"
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@c15t/schema": "workspace:*",

--- a/packages/backend-next/src/db/connect.ts
+++ b/packages/backend-next/src/db/connect.ts
@@ -1,0 +1,155 @@
+/**
+ * Turning configuration into a database connection.
+ *
+ * `@c15t/backend` 2.x took a fumadb adapter — `adapter: kyselyAdapter({ db,
+ * provider })` — so booting the backend meant installing Kysely, constructing
+ * a dialect, and handing it over. That signature cannot survive the rewrite:
+ * storage here is an Effect `SqlClient`, not an ORM adapter.
+ *
+ * Two ways in, because there are two audiences:
+ *
+ * - **A config object.** `{ dialect: 'postgres', url }`. The common case, and
+ *   it must not require knowing that Effect exists. A self-hoster running the
+ *   backend should not have to learn `Layer`, `Redacted` and
+ *   `@effect/sql-pg` to point it at a database.
+ * - **A `Layer` directly.** For anyone embedding this in an Effect
+ *   application, sharing a pool, or pointing tests at PGlite. The config path
+ *   just builds one of these, so nothing is reachable only through it.
+ *
+ * ## Why the drivers are imported dynamically
+ *
+ * `@effect/sql-pg`, `@effect/sql-mysql2` and `@effect/sql-sqlite-node` are
+ * optional peers: a deployment installs the one driver it needs. A static
+ * import of all three would make every install pull all three, and a
+ * Postgres-only deployment would fail to resolve `mysql2`. So the driver is
+ * imported when its dialect is chosen, and only then.
+ *
+ * `Layer.unwrap` is what makes that composable — the import is an `Effect`
+ * producing a `Layer`, flattened into a `Layer` the runtime can build.
+ */
+
+import { Effect, Layer, Redacted } from 'effect';
+import type { SqlClient } from 'effect/unstable/sql';
+
+/** A database this backend can connect to, described rather than constructed. */
+export type DatabaseConfig =
+	| {
+			readonly dialect: 'postgres';
+			/** e.g. `postgres://user:pass@host:5432/db` */
+			readonly url: string;
+	  }
+	| {
+			readonly dialect: 'mysql';
+			/** e.g. `mysql://user:pass@host:3306/db` */
+			readonly url: string;
+	  }
+	| {
+			readonly dialect: 'sqlite';
+			/** A path, or `':memory:'`. */
+			readonly filename: string;
+	  };
+
+/**
+ * Either a description of a database or a client layer for one.
+ *
+ * The layer's error and requirement types are deliberately loose: a caller
+ * supplying their own client may have whatever error channel their driver
+ * has, and constraining it here would reject valid layers for no benefit.
+ */
+export type DatabaseOption =
+	| DatabaseConfig
+	// biome-ignore lint/suspicious/noExplicitAny: a caller's layer may carry any
+	// error type; narrowing it would reject valid clients.
+	| Layer.Layer<SqlClient.SqlClient, any, never>;
+
+const isConfig = (database: DatabaseOption): database is DatabaseConfig =>
+	'dialect' in database;
+
+/**
+ * Raised when the driver for a configured dialect is not installed.
+ *
+ * A missing optional peer is a setup mistake with an obvious fix, so it says
+ * what to install rather than surfacing a bare module-resolution failure.
+ */
+export class DriverNotInstalledError extends Error {
+	constructor(dialect: DatabaseConfig['dialect'], packageName: string) {
+		super(
+			`c15t is configured for ${dialect}, but ${packageName} is not installed. ` +
+				'Install it with your package manager — drivers are optional peer ' +
+				'dependencies so a deployment only pulls the one it uses.'
+		);
+		this.name = 'DriverNotInstalledError';
+	}
+}
+
+const driver = {
+	postgres: '@effect/sql-pg',
+	mysql: '@effect/sql-mysql2',
+	sqlite: '@effect/sql-sqlite-node',
+} as const;
+
+const load = <A>(
+	dialect: DatabaseConfig['dialect'],
+	importer: () => Promise<A>
+): Effect.Effect<A> =>
+	Effect.tryPromise({
+		try: importer,
+		catch: () => new DriverNotInstalledError(dialect, driver[dialect]),
+	}).pipe(
+		// A missing driver is a configuration error the operator must fix, not a
+		// condition the backend can recover from, so it is a defect rather than
+		// a typed failure every caller would have to thread through.
+		Effect.orDie
+	);
+
+const fromConfig = (
+	config: DatabaseConfig
+	// The three drivers do not agree on an error channel — MySQL's adds
+	// `ConfigError` — and unifying them here would buy nothing: a caller can do
+	// nothing useful with the distinction between "bad config" and "cannot
+	// connect" at layer-construction time.
+	// biome-ignore lint/suspicious/noExplicitAny: see above.
+): Layer.Layer<SqlClient.SqlClient, any> => {
+	switch (config.dialect) {
+		case 'postgres':
+			return Layer.unwrap(
+				Effect.map(
+					load('postgres', () => import('@effect/sql-pg')),
+					// Redacted because the URL carries credentials, and Effect keeps
+					// them out of logs and error messages by construction.
+					({ PgClient }) => PgClient.layer({ url: Redacted.make(config.url) })
+				)
+			);
+		case 'mysql':
+			return Layer.unwrap(
+				Effect.map(
+					load('mysql', () => import('@effect/sql-mysql2')),
+					({ MysqlClient }) =>
+						MysqlClient.layer({ url: Redacted.make(config.url) })
+				)
+			);
+		case 'sqlite':
+			return Layer.unwrap(
+				Effect.map(
+					load('sqlite', () => import('@effect/sql-sqlite-node')),
+					({ SqliteClient }) =>
+						SqliteClient.layer({ filename: config.filename })
+				)
+			);
+	}
+};
+
+/**
+ * The client layer for whichever form of configuration was given.
+ *
+ * @example
+ * ```ts
+ * toLayer({ dialect: 'postgres', url: process.env.DATABASE_URL });
+ * toLayer(PgClient.layer({ url: Redacted.make(url) }));
+ * ```
+ */
+export const toLayer = (
+	database: DatabaseOption
+	// biome-ignore lint/suspicious/noExplicitAny: mirrors `DatabaseOption`.
+): Layer.Layer<SqlClient.SqlClient, any> =>
+	isConfig(database) ? fromConfig(database) : database;

--- a/packages/backend-next/src/define-config.ts
+++ b/packages/backend-next/src/define-config.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed configuration for `c15t-backend.config.ts`.
+ *
+ * An identity function. Its whole job is to give the object a type, so an
+ * editor completes it and a typo is a compile error rather than a runtime
+ * surprise in production.
+ */
+
+import type { C15TOptions } from './instance';
+
+/**
+ * Backend configuration accepted by {@link defineConfig}.
+ *
+ * An intersection with `C15TOptions` rather than an `Omit`, so TypeScript
+ * keeps the property-level documentation in editor completions — an `Omit`
+ * flattens it away, which is the whole point of the helper.
+ */
+export type C15TConfig = C15TOptions & {
+	/**
+	 * Not configurable from a config file.
+	 *
+	 * Observability needs a drain function, and a config file that has to
+	 * export executable callbacks stops being configuration. Pass
+	 * `observability` to `c15tInstance` directly instead.
+	 */
+	observability?: never;
+};
+
+/**
+ * @example
+ * ```ts
+ * // c15t-backend.config.ts
+ * import { defineConfig } from '@c15t/backend';
+ *
+ * export default defineConfig({
+ * 	database: { dialect: 'postgres', url: process.env.DATABASE_URL },
+ * 	trustedOrigins: ['https://app.example.com'],
+ * });
+ * ```
+ */
+export const defineConfig = (config: C15TConfig): C15TConfig => config;

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -5,6 +5,17 @@
  * `@c15t/backend` at cutover. The design, the staging, and the reasoning
  * behind each decision live in `internals/rfcs/0004-backend-effect-rewrite.md`.
  *
+ * ```ts
+ * import { c15tInstance } from '@c15t/backend';
+ *
+ * const instance = c15tInstance({
+ * 	database: { dialect: 'postgres', url: process.env.DATABASE_URL },
+ * 	trustedOrigins: ['https://app.example.com'],
+ * });
+ *
+ * export const POST = (request: Request) => instance.handler(request);
+ * ```
+ *
  * Two invariants hold for everything in this package:
  *
  * - **The 2.0.0 schema is frozen.** No schema changes before cutover. That is
@@ -14,9 +25,48 @@
  * - **Wire compatibility with `@c15t/backend` 2.x is a hard requirement.** No
  *   new endpoints, no response-shape changes.
  *
- * Database drivers are reached through the `./sql/*` subpaths, each of which
- * isolates one optional peer dependency. Domain code depends on `SqlClient`
- * from `effect/unstable/sql`, never on a driver package directly.
+ * ## What changes for a caller at cutover
+ *
+ * The entry point is deliberately identical —
+ * `c15tInstance(options).handler(request)` — so no host integration has to be
+ * rewritten. Two things do change:
+ *
+ * - **`database` replaces `adapter`.** 2.x took a fumadb adapter; storage here
+ *   is a SQL client. Either `{ dialect, url }` or a `SqlClient` layer. See
+ *   `db/connect.ts`.
+ * - **The adapter subpaths are gone.** `@c15t/backend/db/adapters/*` no longer
+ *   exists — Drizzle, Prisma, TypeORM, Kysely or Mongo. Those users keep their
+ *   database and change only how c15t connects to it. MongoDB has no migration
+ *   path at all (RFC §11.8).
+ *
+ * Database drivers are optional peers, reached through `./sql/*` or loaded on
+ * demand by `database: { dialect }`. Domain code depends on `SqlClient` from
+ * `effect/unstable/sql`, never on a driver package directly.
+ *
+ * Policy authoring is re-exported rather than reimplemented: the matchers,
+ * presets and runtime inspection live in `@c15t/schema` and are shared with
+ * every client framework, so a policy pack means the same thing on both sides
+ * of the wire.
  */
 
-export {};
+// Shared with the client packages, so a policy pack authored against these
+// resolves identically in the browser and on the server.
+export type { PolicyMatch, PolicyPackPresets } from '@c15t/schema';
+export {
+	EEA_COUNTRY_CODES,
+	EU_COUNTRY_CODES,
+	inspectPolicies,
+	policyMatchers,
+	policyPackPresets,
+	UK_COUNTRY_CODES,
+} from '@c15t/schema';
+export type { DatabaseConfig, DatabaseOption } from './db/connect';
+export { DriverNotInstalledError } from './db/connect';
+export { defineConfig } from './define-config';
+export type { AppOptions } from './http/context';
+export type { C15TInstance, C15TOptions } from './instance';
+export { c15tInstance } from './instance';
+export type { ObservabilityOptions } from './observability/evlog';
+export type { PolicyBuilderInput } from './policy/builder';
+export { composePacks, policyBuilder } from './policy/builder';
+export { version } from './version';

--- a/packages/backend-next/src/instance.test.ts
+++ b/packages/backend-next/src/instance.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The public entry point.
+ *
+ * Everything else in this package is reachable only through `c15tInstance`, so
+ * these are the tests that speak for a consumer. Until this file existed the
+ * package's `index.ts` was literally `export {}` — a fully working backend
+ * with no way to use it, which no amount of internal coverage would have
+ * surfaced.
+ *
+ * The cases are chosen around the one thing the cutover changes for callers:
+ * `database` replaces 2.x's `adapter`. Both accepted forms are exercised,
+ * because the config object is what a self-hoster writes and the layer is what
+ * makes the config object not a dead end.
+ */
+
+import { PgliteClient } from '@effect/sql-pglite';
+import { assert, describe, it } from '@effect/vitest';
+import { Effect, Layer, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { toLayer } from './db/connect';
+import { up as baseline } from './db/migrations/1-baseline';
+import { c15tInstance } from './instance';
+import { composePacks, policyBuilder } from './policy/builder';
+
+/**
+ * A migrated database, as a layer that hands out the *same* client.
+ *
+ * `PgliteClient.layer({})` cannot be shared by passing it twice: each build
+ * creates a fresh in-process database, so an instance handed that layer would
+ * connect to an empty one and every request would 503. Learned by doing
+ * exactly that.
+ *
+ * Building the client once and wrapping it in `Layer.succeed` is also the
+ * honest version of the case being tested — "the caller already has a pool and
+ * wants c15t to use it" is precisely why the layer form exists.
+ */
+const migrated = async () => {
+	const runtime = ManagedRuntime.make(
+		PgliteClient.layer({}) as unknown as Layer.Layer<SqlClient.SqlClient, never>
+	);
+	await runtime.runPromise(baseline);
+
+	const client = await runtime.runPromise(
+		Effect.gen(function* () {
+			return yield* SqlClient.SqlClient;
+		})
+	);
+	return {
+		layer: Layer.succeed(SqlClient.SqlClient, client),
+		dispose: () => runtime.dispose(),
+	};
+};
+
+describe('c15tInstance', () => {
+	it('serves a request through a supplied client layer', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({ database: layer });
+
+		try {
+			const response = await instance.handler(
+				new Request('http://localhost/status')
+			);
+			assert.strictEqual(response.status, 200);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+
+	it('accepts a plain config object without the caller touching Effect', async () => {
+		// The point of the config form: no Layer, no Redacted, no driver
+		// import at the call site. SQLite because it needs no server.
+		const instance = c15tInstance({
+			database: { dialect: 'sqlite', filename: ':memory:' },
+		});
+
+		try {
+			const layer = toLayer({ dialect: 'sqlite', filename: ':memory:' });
+			assert.isDefined(layer);
+
+			// The database is empty — no migration has run — so this answers
+			// unhealthy rather than throwing. That it answers at all is the
+			// assertion: the driver resolved and a connection was made from
+			// nothing but `{ dialect, filename }`.
+			const response = await instance.handler(
+				new Request('http://localhost/status')
+			);
+			assert.oneOf(response.status, [200, 503]);
+		} finally {
+			await instance.dispose();
+		}
+	}, 60_000);
+
+	it('releases its pool on dispose', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({ database: layer });
+		await instance.handler(new Request('http://localhost/status'));
+
+		await instance.dispose();
+		await dispose();
+
+		// Nothing to assert beyond "this did not hang or throw" — a pool that
+		// cannot be released is a leak in every test and script that builds
+		// an instance, which is why `dispose` is on the public interface.
+		assert.isTrue(true);
+	}, 60_000);
+
+	it('passes app options through to the routes', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({
+			database: layer,
+			// Listing subjects is key-only; with no keys configured nothing
+			// authenticates, which is the documented safe default.
+			apiKeys: [],
+		});
+
+		try {
+			const response = await instance.handler(
+				new Request('http://localhost/subjects?externalId=ext_1')
+			);
+			assert.strictEqual(response.status, 401);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+});
+
+describe('policy authoring', () => {
+	it('builds and composes packs', () => {
+		const pack = policyBuilder.createPack([
+			{ id: 'eu', countries: ['DE'], model: 'opt-in' },
+			{ id: 'us', countries: ['US'], model: 'opt-out' },
+		]);
+
+		const composed = composePacks(pack, [
+			// A duplicate id must lose to the earlier pack rather than shadow it,
+			// or composition order silently changes which policy a visitor gets.
+			...policyBuilder.createPack([{ id: 'eu', countries: ['FR'] }]),
+		]);
+
+		assert.deepStrictEqual(
+			composed.map((policy) => policy.id),
+			['eu', 'us']
+		);
+		assert.deepStrictEqual(composed[0]?.match?.countries, ['DE']);
+	});
+});

--- a/packages/backend-next/src/instance.ts
+++ b/packages/backend-next/src/instance.ts
@@ -1,0 +1,102 @@
+/**
+ * The package's entry point.
+ *
+ * `c15tInstance(options).handler(request)` — the same two-call shape
+ * `@c15t/backend` 2.x has, because every host integration is written against
+ * it: the Next.js route handler, the Node adapter, the demo apps. Changing the
+ * shape would make the cutover a rewrite for every consumer rather than a
+ * configuration change.
+ *
+ * What *does* change is how storage is configured, and it has to: 2.x took a
+ * fumadb adapter and this does not have one. See `db/connect.ts`.
+ *
+ * ```ts
+ * // 2.x
+ * c15tInstance({ adapter: kyselyAdapter({ db, provider: 'postgresql' }) })
+ *
+ * // 3.x
+ * c15tInstance({ database: { dialect: 'postgres', url } })
+ * ```
+ *
+ * ## The runtime is built once
+ *
+ * `ManagedRuntime` holds the connection pool, so it is constructed per
+ * instance and reused for every request. Building it per request would open a
+ * pool per request — which is the kind of mistake that only shows up under
+ * load, so the API does not offer a way to make it.
+ *
+ * The cost is that an instance owns a resource. `dispose()` releases it, and
+ * a long-lived server never needs to call it; a test or a script that creates
+ * instances in a loop does.
+ */
+
+import type { Layer } from 'effect';
+import { ManagedRuntime } from 'effect';
+import type { SqlClient } from 'effect/unstable/sql';
+import { type DatabaseOption, toLayer } from './db/connect';
+import { createApp } from './http/app';
+import type { AppOptions } from './http/context';
+
+export interface C15TOptions extends AppOptions {
+	/**
+	 * Where consent records live.
+	 *
+	 * Either a description — `{ dialect: 'postgres', url }` — or a `SqlClient`
+	 * layer for anyone embedding this in an Effect application or sharing a
+	 * pool.
+	 */
+	readonly database: DatabaseOption;
+}
+
+export interface C15TInstance {
+	/**
+	 * Handles one HTTP request.
+	 *
+	 * Framework-agnostic by construction: web `Request` in, web `Response`
+	 * out, so it drops into Next.js route handlers, Node adapters, Bun, and
+	 * workers without a shim.
+	 *
+	 * @example
+	 * ```ts
+	 * export const POST = (request: Request) => instance.handler(request);
+	 * ```
+	 */
+	readonly handler: (request: Request) => Promise<Response>;
+	/**
+	 * Closes the connection pool.
+	 *
+	 * A long-lived server does not need this. Tests and scripts that build
+	 * instances repeatedly do, or they leak connections until the database
+	 * refuses more.
+	 */
+	readonly dispose: () => Promise<void>;
+}
+
+/**
+ * Builds a c15t backend.
+ *
+ * @example
+ * ```ts
+ * const instance = c15tInstance({
+ * 	database: { dialect: 'postgres', url: process.env.DATABASE_URL },
+ * 	trustedOrigins: ['https://app.example.com'],
+ * 	apiKeys: [process.env.C15T_API_KEY],
+ * });
+ *
+ * export const POST = (request: Request) => instance.handler(request);
+ * ```
+ */
+export const c15tInstance = (options: C15TOptions): C15TInstance => {
+	const { database, ...app } = options;
+
+	const runtime = ManagedRuntime.make(
+		toLayer(database) as Layer.Layer<SqlClient.SqlClient, never>
+	);
+	const hono = createApp(runtime, app);
+
+	return {
+		// `fetch` may answer synchronously; the contract is a promise.
+		handler: async (request) => hono.fetch(request),
+		dispose: () => runtime.dispose(),
+	};
+};

--- a/packages/backend-next/src/policy/builder.ts
+++ b/packages/backend-next/src/policy/builder.ts
@@ -1,0 +1,254 @@
+/**
+ * Policy pack authoring helpers.
+ *
+ * Ported from `@c15t/backend`'s `policies/builder.ts` unchanged apart from two
+ * imports. This is pure input normalisation — it turns the flatter shape that
+ * reads well in a config file into runtime `PolicyConfig` objects — so it has
+ * nothing to do with the storage rewrite and no reason to be rewritten by it.
+ *
+ * The matchers and presets it builds on already live in `@c15t/schema`, which
+ * is why only these two functions had to move: everything else was shared
+ * already.
+ */
+
+import {
+	compactDefined,
+	dedupeTrimmedStrings,
+	policyMatchers,
+} from '@c15t/schema';
+import type {
+	PolicyConfig,
+	PolicyModel,
+	PolicyScopeMode,
+	PolicyUiMode,
+	PolicyUiSurfaceConfig,
+} from '@c15t/schema/types';
+
+/**
+ * High-level builder input for creating a backend policy config.
+ *
+ * @remarks
+ * This shape is intentionally flatter than {@link PolicyConfig} so backend
+ * configuration stays readable in `c15tInstance({ policyPacks })` setup files.
+ * Use the builder helpers to normalize this input into runtime-ready policy
+ * configs.
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ * @see {@link https://c15t.com/docs/frameworks/react/concepts/policy-packs}
+ */
+export interface PolicyBuilderInput {
+	id: string;
+	/**
+	 * @deprecated Metadata-only label. Not used at runtime, not sent to clients,
+	 * and not fingerprinted. Will be removed in a future version.
+	 */
+	name?: string;
+	countries?: string[];
+	regions?: Array<{ country: string; region: string }>;
+	isDefault?: boolean;
+	model?: PolicyModel;
+	expiryDays?: number;
+	scopeMode?: PolicyScopeMode;
+	/**
+	 * Consent categories scoped by the policy.
+	 */
+	categories?: string[];
+	preselectedCategories?: string[];
+	/**
+	 * Whether the policy should respect the Global Privacy Control signal.
+	 */
+	gpc?: boolean;
+	uiMode?: PolicyUiMode;
+	banner?: PolicyUiSurfaceConfig;
+	dialog?: PolicyUiSurfaceConfig;
+	i18n?: {
+		language?: string;
+		messageProfile?: string;
+	};
+	proof?: {
+		storeIp?: boolean;
+		storeUserAgent?: boolean;
+		storeLanguage?: boolean;
+	};
+}
+
+const DEFAULT_FALLBACK_POLICY_INPUT: PolicyBuilderInput = {
+	id: 'world_no_banner',
+	isDefault: true,
+	model: 'none',
+	uiMode: 'none',
+};
+
+function mergeMatch(input: PolicyBuilderInput): PolicyConfig['match'] {
+	return policyMatchers.merge(
+		input.countries?.length ? policyMatchers.countries(input.countries) : {},
+		input.regions?.length ? policyMatchers.regions(input.regions) : {},
+		input.isDefault ? policyMatchers.default() : {}
+	);
+}
+
+function compactUiSurface(
+	value?: PolicyUiSurfaceConfig
+): PolicyUiSurfaceConfig | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	return compactDefined({
+		allowedActions: dedupeTrimmedStrings(value.allowedActions) as
+			| PolicyUiSurfaceConfig['allowedActions']
+			| undefined,
+		primaryActions: value.primaryActions,
+		layout: value.layout,
+		direction: value.direction,
+		uiProfile: value.uiProfile,
+		scrollLock: value.scrollLock,
+	});
+}
+
+/**
+ * Converts a single {@link PolicyBuilderInput} into a normalized
+ * backend-compatible {@link PolicyConfig}.
+ *
+ * @remarks
+ * Empty optional fields are removed from the final output, matcher input is
+ * merged into `match`, and duplicate string arrays are deduplicated.
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ */
+export function buildPolicyConfig(input: PolicyBuilderInput): PolicyConfig {
+	const categories = dedupeTrimmedStrings(input.categories);
+	const preselectedCategories = dedupeTrimmedStrings(
+		input.preselectedCategories
+	);
+
+	return {
+		id: input.id,
+		match: mergeMatch(input),
+		i18n: input.i18n,
+		consent: compactDefined({
+			model: input.model,
+			expiryDays: input.expiryDays,
+			scopeMode: input.scopeMode,
+			categories,
+			preselectedCategories,
+			gpc: input.gpc,
+		}),
+		ui: compactDefined({
+			mode: input.uiMode,
+			banner: compactUiSurface(input.banner),
+			dialog: compactUiSurface(input.dialog),
+		}),
+		proof: compactDefined({
+			storeIp: input.proof?.storeIp,
+			storeUserAgent: input.proof?.storeUserAgent,
+			storeLanguage: input.proof?.storeLanguage,
+		}),
+	};
+}
+
+/**
+ * Converts an ordered list of builder inputs into a policy pack.
+ *
+ * @remarks
+ * The resulting array preserves input order. That order matters because
+ * duplicate region/country matchers use first-match-wins semantics within the
+ * same matcher type.
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ */
+export function buildPolicyPack(inputs: PolicyBuilderInput[]): PolicyConfig[] {
+	return inputs.map((input) => buildPolicyConfig(input));
+}
+
+/**
+ * Creates a policy pack and guarantees that it ends with a default policy.
+ *
+ * @remarks
+ * If the provided inputs already contain a default matcher, the pack is
+ * returned unchanged. Otherwise c15t appends either:
+ *
+ * - the supplied `defaultPolicy`, coerced to `match.isDefault = true`
+ * - or the built-in "World No Banner" fallback
+ *
+ * When `defaultPolicy` is provided, its `countries` and `regions` fields are
+ * stripped and replaced with `match.isDefault = true`.
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ */
+export function buildPolicyPackWithDefault(
+	inputs: PolicyBuilderInput[],
+	defaultPolicy?: PolicyBuilderInput
+): PolicyConfig[] {
+	const pack = buildPolicyPack(inputs);
+	const hasDefault = pack.some((policy) => policy.match.isDefault);
+
+	if (hasDefault) {
+		return pack;
+	}
+
+	const fallbackInput = defaultPolicy
+		? {
+				...defaultPolicy,
+				isDefault: true,
+				countries: undefined,
+				regions: undefined,
+			}
+		: DEFAULT_FALLBACK_POLICY_INPUT;
+
+	return [...pack, buildPolicyConfig(fallbackInput)];
+}
+
+/**
+ * Merges multiple policy packs or individual policies into a single pack.
+ *
+ * @remarks
+ * Useful for combining preset packs with custom policies without manual
+ * spread and deduplication. Policies are deduplicated by `id` — the first
+ * occurrence wins.
+ *
+ * @example
+ * ```ts
+ * import { composePacks, policyPackPresets, policyBuilder } from '@c15t/backend';
+ *
+ * const pack = composePacks(
+ *   [policyPackPresets.europeOptIn()],
+ *   [policyPackPresets.californiaOptOut()],
+ *   [policyBuilder.create({ id: 'custom', countries: ['JP'], model: 'opt-in' })],
+ *   [policyPackPresets.worldNoBanner()],
+ * );
+ * ```
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ */
+export function composePacks(...packs: PolicyConfig[][]): PolicyConfig[] {
+	const seen = new Set<string>();
+	const result: PolicyConfig[] = [];
+
+	for (const pack of packs) {
+		for (const policy of pack) {
+			if (!seen.has(policy.id)) {
+				seen.add(policy.id);
+				result.push(policy);
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Convenience namespace for the policy builder helpers.
+ *
+ * @remarks
+ * Useful when you prefer a grouped API such as `policyBuilder.createPack()`
+ * inside backend config files.
+ *
+ * @see {@link https://c15t.com/docs/self-host/guides/policy-packs}
+ */
+export const policyBuilder = {
+	create: buildPolicyConfig,
+	createPack: buildPolicyPack,
+	createPackWithDefault: buildPolicyPackWithDefault,
+	composePacks,
+};


### PR DESCRIPTION
Its `index.ts` was `export {}`. A complete, tested backend with **no way to use it** — and nothing internal could have caught that, because every test reached past the entry point. The nine dependents import `c15tInstance`, `policyPackPresets`, `composePacks`, `policyBuilder`, `defineConfig` and `C15TOptions`; none existed.

## The shape stays; storage config changes

`c15tInstance(options).handler(request)` keeps 2.x's shape deliberately, so no host integration is rewritten by the cutover. What changes is storage config, which it must — there is no fumadb adapter to pass:

```ts
// 2.x
c15tInstance({ adapter: kyselyAdapter({ db, provider }) })

// 3.x
c15tInstance({ database: { dialect: 'postgres', url } })
```

## Two forms, for two audiences

`database` also accepts a `SqlClient` layer.

- The **config form** exists so a self-hoster never has to learn `Layer`, `Redacted` and `@effect/sql-pg` to point the backend at a database.
- The **layer form** exists so that config form is not a dead end for anyone sharing a pool or embedding this in an Effect application.

Drivers load dynamically, so a Postgres deployment does not pull `mysql2`, and a missing one says what to install rather than failing module resolution.

## Policy authoring is re-exported, not reimplemented

From `@c15t/schema` — only `composePacks` and `policyBuilder` had to move, because the matchers, presets and `inspectPolicies` were already shared. That is what makes a policy pack mean the same thing on both sides of the wire.

Adds the `genversion` prebuild the other packages have, so `version` can be exported as 2.x exports it.
