### PR TITLE
feat(backend-next): a migration runner, so migration 2 can actually run

### DIFF
--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -820,3 +820,39 @@ Also outstanding:
   comparison is worth keeping past cutover, they need to depend on the
   published 2.x under an alias instead of on the workspace.
 - Docs, which land before the 3.0 release.
+
+### 11.12 Migration 2 was never actually runnable
+
+Adoption stamped `1-baseline` and stopped. Nothing walked the numbered
+migrations, so `2-hot-path-indexes` — the change worth roughly 1.35× on the
+read path, and the answer to §11.6's unindexed tenant scoping — ran only in its
+own tests. A migration nothing invokes is not shipped.
+
+`db/migrate.ts` closes that: classify, adopt to the baseline if behind, then
+apply whatever the ledger has not recorded. It is what the CLI will call and
+what a self-hoster can call programmatically, and it takes `dryRun` because
+this is the one code path in the package that touches other people's data.
+
+**Not Effect's `Migrator`**, despite each `@effect/sql-*` exporting one. They
+own a second ledger table — and `c15t_migrations` already exists, so two
+ledgers would mean two disagreeing answers to "what has been applied" — and
+they resolve migrations by scanning a directory at runtime, which does not
+survive a consumer's bundler. Migrations are an explicit, statically imported
+array instead.
+
+**A driver bug found on the way.** `@effect/sql-sqlite-node` caches prepared
+statements by SQL text and caches the **failures**: probing a table that does
+not exist yet poisons that exact query for the life of the connection, so it
+keeps failing after the table is created. Demonstrated directly — the same
+query with one character of different whitespace succeeds, which is what a
+cache-key collision looks like.
+
+That is squarely in `migrate`'s path, since it reads the ledger before creating
+it. Worked around by asking whether the ledger exists before reading it, which
+is better code regardless. Worth reporting upstream.
+
+Also corrected while testing this: a bare `subject` table is **not**
+unclassifiable on MySQL. §11.7 made MySQL answer "legacy" by elimination,
+because fumadb cannot migrate MySQL in either era — so the "refuse rather than
+guess" case needs a fumadb marker naming an unknown schema version, which is
+unrecognisable on all three engines.

--- a/packages/backend-next/src/db/migrate.test.ts
+++ b/packages/backend-next/src/db/migrate.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The migration runner, on every engine.
+ *
+ * These are the tests standing between a self-hoster and a broken database, so
+ * they are written around what can actually go wrong rather than around the
+ * happy path:
+ *
+ * - a **fresh** database reaches the current schema in one call;
+ * - a **second** call does nothing, because re-running a migration is a normal
+ *   operational event, not an error;
+ * - an **already-adopted** database picks up only the migrations it is missing,
+ *   which is the case that did not work at all before this file existed —
+ *   adoption stamped `1-baseline` and the hot-path indexes never ran;
+ * - an **unrecognised** database is refused rather than guessed at;
+ * - a **dry run** changes nothing, which has to be true or the flag is a lie.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import { LEDGER_TABLE } from './adopt';
+import * as Dialect from './dialect';
+import { MIGRATIONS, migrate } from './migrate';
+
+/**
+ * Ledger ids, or `[]` when there is no ledger yet.
+ *
+ * `select *`, not `select "id"`, and that is not arbitrary.
+ * `@effect/sql-sqlite-node` caches prepared statements by SQL text including
+ * failures, so the exact query `migrate` uses internally is already poisoned
+ * on a connection where the ledger did not exist at first probe. Reading it
+ * with different SQL keeps this assertion measuring the database rather than
+ * the driver's cache.
+ */
+const ledger = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	return yield* sql<{ id: number | string }>`
+		select * from ${sql(LEDGER_TABLE)}
+	`.pipe(
+		Effect.map((rows) => rows.map((row) => Number(row.id)).sort()),
+		Effect.orElseSucceed(() => [] as number[])
+	);
+});
+
+const tableCount = Effect.fn('tableCount')(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{
+				name: string;
+			}>`select name from sqlite_master where type = 'table'`,
+		mysql: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = database()
+			`,
+		orElse: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = 'public' and table_type = 'BASE TABLE'
+			`,
+	});
+	return rows.length;
+});
+
+for (const engine of ENGINES) {
+	describe(`migrate on ${engine.name}`, () => {
+		it.effect(
+			'takes an empty database to the current schema',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+
+					const report = yield* migrate();
+
+					assert.strictEqual(report.shape._tag, 'Empty');
+					assert.isTrue(report.applied);
+					assert.isUndefined(report.blocked);
+					// Every migration is recorded, not just the baseline. Before this
+					// runner existed the ledger stopped at 1 and the hot-path indexes
+					// were unreachable outside tests.
+					assert.deepStrictEqual(
+						yield* ledger,
+						MIGRATIONS.map((migration) => migration.id)
+					);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'does nothing on a second run',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* migrate();
+
+					const again = yield* migrate();
+
+					// Re-running is a normal operational event — a redeploy, a
+					// restart, a retried job — and must not be an error or a
+					// duplicate.
+					assert.strictEqual(again.shape._tag, 'Baseline');
+					assert.deepStrictEqual(again.adoption, []);
+					assert.deepStrictEqual(again.pending, []);
+					assert.deepStrictEqual(
+						yield* ledger,
+						MIGRATIONS.map((migration) => migration.id)
+					);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'applies only what an adopted database is missing',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+
+					// A database adopted before migration 2 existed: at the baseline,
+					// ledger stamped 1, no hot-path indexes. This is the state every
+					// early adopter would have been stuck in.
+					yield* migrate();
+					yield* sql`delete from ${sql(LEDGER_TABLE)} where ${sql('id')} = ${2}`;
+
+					const report = yield* migrate();
+
+					assert.deepStrictEqual(report.adoption, []);
+					assert.deepStrictEqual(report.pending, ['2-hot-path-indexes']);
+					assert.deepStrictEqual(yield* ledger, [1, 2]);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'refuses a database it does not recognise',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					const quote = Dialect.escaperFor(yield* Dialect.current);
+
+					// A fumadb marker naming a schema version we have no fixture for.
+					// Chosen over a bare `subject` table because that is genuinely
+					// *not* ambiguous on MySQL — fumadb cannot migrate MySQL in either
+					// era, so a marker-less database there is legacy by elimination.
+					// A version from the future is unrecognisable everywhere.
+					//
+					// `key` is reserved on MySQL, hence the escaper.
+					yield* sql.unsafe(
+						`create table ${quote('subject')} (${quote('id')} varchar(255) primary key)`
+					);
+					yield* sql.unsafe(
+						`create table ${quote('private_c15t_settings')} (` +
+							`${quote('key')} varchar(255), ${quote('value')} varchar(255))`
+					);
+					yield* sql`
+						insert into ${sql('private_c15t_settings')} ${sql.insert({
+							key: 'version',
+							value: '9.9.9',
+						})}
+					`;
+
+					const report = yield* migrate();
+
+					// Refusing beats guessing: the wrong guess here rewrites someone's
+					// consent records.
+					assert.isDefined(report.blocked);
+					assert.include(report.blocked ?? '', '9.9.9');
+					assert.isFalse(report.applied);
+					assert.deepStrictEqual(yield* ledger, []);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+
+		it.effect(
+			'a dry run changes nothing',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+
+					const report = yield* migrate({ dryRun: true });
+
+					assert.isFalse(report.applied);
+					assert.isAbove(report.adoption.length, 0);
+					assert.deepStrictEqual(report.pending, ['2-hot-path-indexes']);
+
+					// The assertion that makes the flag mean something: no tables, no
+					// ledger, nothing.
+					assert.strictEqual(yield* tableCount(), 0);
+					assert.deepStrictEqual(yield* ledger, []);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 120_000 }
+		);
+	});
+}

--- a/packages/backend-next/src/db/migrate.ts
+++ b/packages/backend-next/src/db/migrate.ts
@@ -1,0 +1,232 @@
+/**
+ * Bringing any c15t database up to date, in one call.
+ *
+ * `db/adopt.ts` gets an existing database to the frozen 2.0.0 baseline and
+ * stamps the ledger. That is the hard, one-time half. This is the ordinary
+ * half around it: work out where the database is, adopt it if it is behind,
+ * then apply whatever numbered migrations it has not seen.
+ *
+ * Until this existed there was no way to run migration 2 at all. Adoption
+ * stamped `1-baseline` and stopped, so the hot-path indexes — the change worth
+ * roughly 1.35× on the read path (RFC §11.5) — only ever ran in tests. A
+ * migration that nothing invokes is not shipped.
+ *
+ * ## Why not Effect's `Migrator`
+ *
+ * `@effect/sql-*` each export one, and they are perfectly good. They also own
+ * their own ledger table and resolve migrations by scanning a directory of
+ * files at runtime.
+ *
+ * Neither fits. `adopt.ts` already writes `c15t_migrations`, and a second
+ * ledger would mean two disagreeing answers to "what has been applied".
+ * Directory scanning also does not survive bundling — this package ships as
+ * `dist/index.js`, and a self-hoster's bundler will not carry a directory of
+ * `.js` files that nothing imports.
+ *
+ * So migrations are an explicit array, imported statically, applied in order.
+ * The list is short and the property that matters is that it is the *same*
+ * list everywhere — the tests, the CLI and a programmatic call all walk this
+ * one.
+ */
+
+import { Effect } from 'effect';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
+import { type ApplyOptions, apply, LEDGER_TABLE, plan } from './adopt';
+import { classify, type Shape } from './classify';
+import type { UnsupportedDialectError } from './dialect';
+import { up as baselineUp } from './migrations/1-baseline';
+import { up as indexesUp } from './migrations/2-hot-path-indexes';
+import { encodeRow, encoder } from './values';
+
+export interface Migration {
+	/** Ledger id. Ordered, and never reused once shipped. */
+	readonly id: number;
+	readonly name: string;
+	/**
+	 * Resolving the dialect can fail as well as the SQL, so the error channel
+	 * is wider than `SqlError` alone.
+	 */
+	readonly up: Effect.Effect<
+		unknown,
+		SqlError.SqlError | UnsupportedDialectError,
+		SqlClient.SqlClient
+	>;
+}
+
+/**
+ * Every migration, in order.
+ *
+ * `1-baseline` is here for completeness and is applied by adoption rather than
+ * by the loop below — reaching the baseline is what adoption *is*, and doing
+ * it twice would try to create tables that exist.
+ */
+export const MIGRATIONS: readonly Migration[] = [
+	{ id: 1, name: '1-baseline', up: baselineUp },
+	{ id: 2, name: '2-hot-path-indexes', up: indexesUp },
+];
+
+export interface MigrateOptions extends ApplyOptions {
+	/**
+	 * Report what would happen and change nothing.
+	 *
+	 * The default is `false`, but every caller that runs against a database it
+	 * did not create should offer it — this is the one code path in the
+	 * package that touches other people's data.
+	 */
+	readonly dryRun?: boolean;
+}
+
+export interface MigrateReport {
+	/** What the database looked like before anything ran. */
+	readonly shape: Shape;
+	/** Adoption steps applied, or that would be, reaching the baseline. */
+	readonly adoption: readonly string[];
+	/** Numbered migrations applied, or that would be, after the baseline. */
+	readonly pending: readonly string[];
+	/** Tables and columns kept because adoption never deletes. */
+	readonly retained: readonly string[];
+	/** Set when nothing ran because the database is not safe to migrate. */
+	readonly blocked: string | undefined;
+	/** False when this was a dry run. */
+	readonly applied: boolean;
+}
+
+/**
+ * Whether the ledger table exists.
+ *
+ * Asked before reading it, rather than reading it and treating the failure as
+ * "empty". That would be the shorter code and it is not safe on SQLite:
+ * `@effect/sql-sqlite-node` caches prepared statements by SQL text and caches
+ * the *failures* too, so probing a table that does not exist yet poisons that
+ * exact query for the life of the connection — it keeps failing after the
+ * table is created. Verified directly; the same query with different
+ * whitespace succeeds, which is what a cache-key collision looks like.
+ *
+ * `migrate` creates the ledger part-way through, so it is precisely the code
+ * that would trip over this.
+ */
+const ledgerExists = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{ name: string }>`
+				select name from sqlite_master
+				where type = 'table' and name = ${LEDGER_TABLE}
+			`,
+		mysql: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = database() and table_name = ${LEDGER_TABLE}
+			`,
+		orElse: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = 'public' and table_name = ${LEDGER_TABLE}
+			`,
+	});
+	return rows.length > 0;
+});
+
+/** Migration ids already recorded in the ledger. */
+const appliedIds = Effect.gen(function* () {
+	if (!(yield* ledgerExists)) {
+		// The state of every database that has not been adopted yet.
+		return new Set<number>();
+	}
+
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ id: number | string }>`
+		select ${sql('id')} from ${sql(LEDGER_TABLE)}
+	`;
+	return new Set(rows.map((row) => Number(row.id)));
+});
+
+const stamp = Effect.fn('migrate.stamp')(function* (migration: Migration) {
+	const sql = yield* SqlClient.SqlClient;
+	yield* sql`
+		insert into ${sql(LEDGER_TABLE)} ${sql.insert(
+			encodeRow(yield* encoder, {
+				id: migration.id,
+				name: migration.name,
+				appliedAt: new Date(),
+			})
+		)}
+	`;
+});
+
+/**
+ * Migrates a database to the current schema.
+ *
+ * Safe to re-run: a database already up to date does nothing and reports an
+ * empty plan. Safe to run against an unknown one: it refuses and says why
+ * rather than guessing (RFC §3.3).
+ *
+ * @example
+ * ```ts
+ * const report = yield* migrate({ dryRun: true });
+ * if (report.blocked) {
+ * 	// nothing ran; report.blocked says what is wrong
+ * }
+ * ```
+ */
+export const migrate = Effect.fn('db.migrate')(function* (
+	options: MigrateOptions = {}
+) {
+	const shape = yield* classify;
+	const adoption = yield* plan;
+
+	// A blocked plan is reported, not attempted. The caller decides whether to
+	// re-run with `skipForeignKeys`, which is the only blocker that can be
+	// opted out of.
+	const skippable =
+		adoption.orphans.length > 0 && options.skipForeignKeys === true;
+	if (adoption.blocked !== undefined && !skippable) {
+		return {
+			shape,
+			adoption: [],
+			pending: [],
+			retained: adoption.retained,
+			blocked: adoption.blocked,
+			applied: false,
+		} satisfies MigrateReport;
+	}
+
+	// Read before adopting: adoption stamps id 1, so asking afterwards would
+	// always report the baseline as already applied and tell us nothing about
+	// what the database looked like.
+	const already = yield* appliedIds;
+	const pending = MIGRATIONS.filter(
+		(migration) => migration.id > 1 && !already.has(migration.id)
+	);
+
+	const adoptionSteps = adoption.steps.map((step) => step.description);
+
+	if (options.dryRun === true) {
+		return {
+			shape,
+			adoption: adoptionSteps,
+			pending: pending.map((migration) => migration.name),
+			retained: adoption.retained,
+			blocked: undefined,
+			applied: false,
+		} satisfies MigrateReport;
+	}
+
+	if (adoptionSteps.length > 0) {
+		yield* apply(adoption, options);
+	}
+
+	for (const migration of pending) {
+		yield* migration.up;
+		yield* stamp(migration);
+	}
+
+	return {
+		shape,
+		adoption: adoptionSteps,
+		pending: pending.map((migration) => migration.name),
+		retained: adoption.retained,
+		blocked: undefined,
+		applied: true,
+	} satisfies MigrateReport;
+});

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -63,7 +63,7 @@ export {
 export type { Shape } from './db/classify';
 export { classify } from './db/classify';
 export type { DatabaseConfig, DatabaseOption } from './db/connect';
-export { DriverNotInstalledError } from './db/connect';
+export { DriverNotInstalledError, toLayer } from './db/connect';
 export type {
 	MigrateOptions,
 	MigrateReport,
@@ -74,6 +74,8 @@ export { defineConfig } from './define-config';
 export type { AppOptions } from './http/context';
 export type { C15TInstance, C15TOptions } from './instance';
 export { c15tInstance } from './instance';
+export type { Migrator } from './migrator';
+export { createMigrator } from './migrator';
 export type { ObservabilityOptions } from './observability/evlog';
 export type { PolicyBuilderInput } from './policy/builder';
 export { composePacks, policyBuilder } from './policy/builder';

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -60,8 +60,16 @@ export {
 	policyPackPresets,
 	UK_COUNTRY_CODES,
 } from '@c15t/schema';
+export type { Shape } from './db/classify';
+export { classify } from './db/classify';
 export type { DatabaseConfig, DatabaseOption } from './db/connect';
 export { DriverNotInstalledError } from './db/connect';
+export type {
+	MigrateOptions,
+	MigrateReport,
+	Migration,
+} from './db/migrate';
+export { MIGRATIONS, migrate } from './db/migrate';
 export { defineConfig } from './define-config';
 export type { AppOptions } from './http/context';
 export type { C15TInstance, C15TOptions } from './instance';

--- a/packages/backend-next/src/migrator.ts
+++ b/packages/backend-next/src/migrator.ts
@@ -1,0 +1,65 @@
+/**
+ * Migrating from outside Effect.
+ *
+ * `db/migrate.ts` is an `Effect`, which is right for anything already inside
+ * one. The two callers that matter most are not: the CLI, and a self-hoster's
+ * deploy script. Making them construct a `ManagedRuntime` and learn what a
+ * `Layer` is to run one migration would be the same mistake as requiring it to
+ * point the backend at a database — see `db/connect.ts`.
+ *
+ * So this is the promise-shaped face of the same function. It owns a runtime,
+ * which owns a connection pool, which is why `dispose` exists and why a
+ * process that forgets to call it will not exit.
+ *
+ * @example
+ * ```ts
+ * const migrator = createMigrator({ dialect: 'postgres', url });
+ * try {
+ * 	const planned = await migrator.plan();
+ * 	if (!planned.blocked) await migrator.apply();
+ * } finally {
+ * 	await migrator.dispose();
+ * }
+ * ```
+ */
+
+import { type Layer, ManagedRuntime } from 'effect';
+import type { SqlClient } from 'effect/unstable/sql';
+import { type DatabaseOption, toLayer } from './db/connect';
+import { type MigrateOptions, type MigrateReport, migrate } from './db/migrate';
+
+export interface Migrator {
+	/**
+	 * Works out what migrating would do, and changes nothing.
+	 *
+	 * Always available, and worth calling first: `MigrateReport.blocked` is
+	 * how a database that must not be migrated says so.
+	 */
+	readonly plan: (
+		options?: Omit<MigrateOptions, 'dryRun'>
+	) => Promise<MigrateReport>;
+	/** Migrates the database. */
+	readonly apply: (
+		options?: Omit<MigrateOptions, 'dryRun'>
+	) => Promise<MigrateReport>;
+	/** Closes the connection pool. */
+	readonly dispose: () => Promise<void>;
+}
+
+/**
+ * A migrator for a database, described the same way `c15tInstance` describes
+ * one.
+ */
+export const createMigrator = (database: DatabaseOption): Migrator => {
+	const runtime = ManagedRuntime.make(
+		toLayer(database) as Layer.Layer<SqlClient.SqlClient, never>
+	);
+
+	return {
+		plan: (options) =>
+			runtime.runPromise(migrate({ ...options, dryRun: true })),
+		apply: (options) =>
+			runtime.runPromise(migrate({ ...options, dryRun: false })),
+		dispose: () => runtime.dispose(),
+	};
+};


### PR DESCRIPTION
Adoption stamped `1-baseline` and stopped. Nothing walked the numbered migrations, so `2-hot-path-indexes` — worth ~1.35× on the read path, and the fix for unindexed tenant scoping — ran only in its own tests. **A migration nothing invokes is not shipped.**

## `migrate()`

Classifies, adopts to the baseline if the database is behind, then applies whatever the ledger has not recorded. Takes `dryRun`, because this is the one path in the package that touches other people's data. Exported alongside `classify`, so the CLI and a self-hoster can both call it.

## Not Effect's `Migrator`, despite each `@effect/sql-*` shipping one

Two reasons:

- They own a **second ledger table**, and `c15t_migrations` already exists — two would mean two disagreeing answers to what has been applied.
- They resolve migrations by **scanning a directory at runtime**, which does not survive a consumer's bundler.

## `createMigrator(database)`

Wraps `migrate()` with `plan`/`apply`/`dispose`. The two callers that matter most — the CLI and a self-hoster's deploy script — are not inside Effect, and making them build a `ManagedRuntime` to run one migration would be the same mistake as requiring it to point the backend at a database.

## An upstream bug found on the way

`@effect/sql-sqlite-node` caches prepared statements by SQL text **and caches the failures too**, so probing a table before it exists poisons that query for the life of the connection — it keeps failing after the table is created. The same query with one character of different whitespace succeeds.

That is squarely in `migrate`'s path, since it reads the ledger before creating it, so it now asks whether the ledger exists first. Worth reporting upstream.

## Tests

241 across Postgres, SQLite and MySQL.
