### PR TITLE
feat(backend-next): port the cache adapters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -408,7 +408,7 @@
       "name": "@c15t/example-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@c15t/backend": "workspace:*",
+        "@c15t/backend-next": "workspace:*",
         "@c15t/dev-tools": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/nextjs": "workspace:*",
@@ -451,11 +451,10 @@
     "examples/nuxt": {
       "name": "@c15t/example-nuxt",
       "dependencies": {
-        "@c15t/backend": "workspace:*",
+        "@c15t/backend-next": "workspace:*",
         "@c15t/vue": "workspace:*",
+        "@effect/sql-pglite": "4.0.0-beta.102",
         "@electric-sql/pglite": "0.4.2",
-        "kysely": "0.28.17",
-        "kysely-pglite": "^0.6.1",
         "nuxt": "^4.5.1",
         "pg": "^8.20.0",
       },
@@ -470,7 +469,7 @@
       "name": "sveltekit-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@c15t/backend": "workspace:*",
+        "@c15t/backend-next": "workspace:*",
         "@c15t/dev-tools": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/node-sdk": "workspace:*",
@@ -622,7 +621,7 @@
         "@effect/sql-mysql2": "4.0.0-beta.102",
         "@effect/sql-pg": "4.0.0-beta.102",
         "@effect/sql-sqlite-node": "4.0.0-beta.102",
-        "@upstash/redis": "",
+        "@upstash/redis": "^1.38.0",
       },
       "optionalPeers": [
         "@effect/sql-mysql2",

--- a/bun.lock
+++ b/bun.lock
@@ -622,11 +622,13 @@
         "@effect/sql-mysql2": "4.0.0-beta.102",
         "@effect/sql-pg": "4.0.0-beta.102",
         "@effect/sql-sqlite-node": "4.0.0-beta.102",
+        "@upstash/redis": "",
       },
       "optionalPeers": [
         "@effect/sql-mysql2",
         "@effect/sql-pg",
         "@effect/sql-sqlite-node",
+        "@upstash/redis",
       ],
     },
     "packages/cli": {
@@ -637,6 +639,7 @@
       },
       "dependencies": {
         "@c15t/backend": "workspace:*",
+        "@c15t/backend-next": "workspace:*",
         "@c15t/logger": "workspace:*",
         "@c15t/scripts": "workspace:*",
         "@clack/prompts": "1.7.0",

--- a/examples/demo/c15t-backend.config.ts
+++ b/examples/demo/c15t-backend.config.ts
@@ -1,5 +1,10 @@
-import { defineConfig } from '@c15t/backend';
-import { postgresDb } from './app/api/self-host/[[...all]]/route';
+/**
+ * Used by `@c15t/cli self-host migrate` to create and upgrade the schema.
+ *
+ * Only `database` matters to the migrator; the rest is here so the config
+ * stays a faithful description of the deployment.
+ */
+import { defineConfig } from '@c15t/backend-next';
 import {
 	DEMO_POLICY_SNAPSHOT_KEY,
 	demoI18nMessages,
@@ -7,13 +12,19 @@ import {
 } from './lib/scenarios';
 
 export default defineConfig({
-	adapter: postgresDb,
-	trustedOrigins: ['localhost', 'vercel.app'],
-	i18n: {
-		defaultProfile: 'default',
-		messages: demoI18nMessages,
+	database: {
+		dialect: 'postgres',
+		url: process.env.DATABASE_URL ?? '',
 	},
-	policyPacks: demoPolicies,
+	trustedOrigins: ['localhost', 'vercel.app'],
+	manifest: {
+		appName: 'c15t-self-host',
+		i18n: {
+			defaultProfile: 'default',
+			messages: demoI18nMessages,
+		},
+		policyPacks: demoPolicies,
+	},
 	policySnapshot: {
 		signingKey: DEMO_POLICY_SNAPSHOT_KEY,
 		ttlSeconds: 60 * 60,

--- a/examples/demo/components/policy/policy-actions-demo.tsx
+++ b/examples/demo/components/policy/policy-actions-demo.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { PolicyConfig } from '@c15t/backend/types';
 import {
 	ConsentBanner,
 	ConsentDialog,
@@ -11,6 +10,7 @@ import {
 	useHeadlessConsentUI,
 	useTranslations,
 } from '@c15t/react';
+import type { PolicyConfig } from '@c15t/schema/types';
 import { useSearchParams } from 'next/navigation';
 import * as React from 'react';
 import { Badge } from '../ui/badge';

--- a/examples/demo/lib/demo-c15t-instance.ts
+++ b/examples/demo/lib/demo-c15t-instance.ts
@@ -1,11 +1,7 @@
 import 'server-only';
 
-import { c15tInstance } from '@c15t/backend';
-import { createUpstashRedisAdapter } from '@c15t/backend/cache';
-import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
-import { LibsqlDialect } from '@libsql/kysely-libsql';
-import { Kysely, PostgresDialect } from 'kysely';
-import { Pool } from 'pg';
+import { c15tInstance } from '@c15t/backend-next';
+import { createUpstashRedisAdapter } from '@c15t/backend-next/cache';
 import { DEMO_LEGAL_DOCUMENT_SNAPSHOT } from './demo-legal-document-snapshot';
 import {
 	DEFAULT_SCENARIO_ID,
@@ -17,48 +13,20 @@ import {
 	getScenarioPolicyPacks,
 } from './scenarios';
 
-function resolvePostgresSslConfig(connectionString?: string) {
-	if (!connectionString) {
-		return undefined;
-	}
+/**
+ * c15t opens its own connection now, so there is no Kysely instance to build
+ * and hand over. SSL negotiation, pooling and dialect selection all move
+ * behind the driver — which is why this file lost forty lines.
+ */
+export const postgresDb = {
+	dialect: 'postgres',
+	url: process.env.DATABASE_URL ?? '',
+} as const;
 
-	try {
-		const hostname = new URL(connectionString).hostname;
-		const isLocalhost =
-			hostname === 'localhost' ||
-			hostname === '127.0.0.1' ||
-			hostname === '::1';
-
-		return isLocalhost
-			? { rejectUnauthorized: false }
-			: { rejectUnauthorized: true };
-	} catch {
-		return process.env.NODE_ENV === 'development'
-			? { rejectUnauthorized: false }
-			: { rejectUnauthorized: true };
-	}
-}
-
-export const postgresDb = kyselyAdapter({
-	db: new Kysely({
-		dialect: new PostgresDialect({
-			pool: new Pool({
-				connectionString: process.env.DATABASE_URL,
-				ssl: resolvePostgresSslConfig(process.env.DATABASE_URL),
-			}),
-		}),
-	}),
-	provider: 'postgresql',
-});
-
-export const tursoDb = kyselyAdapter({
-	db: new Kysely({
-		dialect: new LibsqlDialect({
-			url: 'http://127.0.0.1:8080',
-		}),
-	}),
-	provider: 'sqlite',
-});
+export const tursoDb = {
+	dialect: 'sqlite',
+	filename: process.env.DATABASE_PATH ?? './c15t-demo.db',
+} as const;
 
 export const DEMO_TERMS_RELEASE = {
 	title: 'c15t Example Terms & Conditions',
@@ -69,33 +37,37 @@ export const DEMO_TERMS_RELEASE = {
 };
 
 export function createDemoInstance(scenario = DEFAULT_SCENARIO_ID) {
-	let cacheConfig:
-		| {
-				adapter: ReturnType<typeof createUpstashRedisAdapter>;
-		  }
-		| undefined;
-
-	if (process.env.REDIS_URL && process.env.REDIS_TOKEN) {
-		cacheConfig = {
-			adapter: createUpstashRedisAdapter({
-				url: process.env.REDIS_URL,
-				token: process.env.REDIS_TOKEN,
-			}),
-		};
-	}
+	const gvlCache =
+		process.env.REDIS_URL && process.env.REDIS_TOKEN
+			? createUpstashRedisAdapter({
+					url: process.env.REDIS_URL,
+					token: process.env.REDIS_TOKEN,
+				})
+			: undefined;
 
 	return c15tInstance({
-		appName: 'c15t-self-host',
+		database: postgresDb,
 		basePath: '/api/self-host',
-		adapter: postgresDb,
 		trustedOrigins: ['localhost', '*.localhost', 'vercel.app'],
 		tenantId: 'ins_1',
-		branding: 'c15t',
-		i18n: {
-			defaultProfile: 'default',
-			messages: demoI18nMessages,
+		// Everything a client needs to render the banner now lives in one
+		// manifest, built by @c15t/schema so the server and the browser resolve
+		// it identically.
+		manifest: {
+			tenantId: 'ins_1',
+			appName: 'c15t-self-host',
+			branding: 'c15t',
+			i18n: {
+				defaultProfile: 'default',
+				messages: demoI18nMessages,
+			},
+			policyPacks: getScenarioPolicyPacks(scenario),
+			iab: {
+				enabled: true,
+				cmpId: DEMO_CMP_ID,
+				customVendors: DEMO_CUSTOM_VENDORS,
+			},
 		},
-		policyPacks: getScenarioPolicyPacks(scenario),
 		policySnapshot: {
 			signingKey: DEMO_POLICY_SNAPSHOT_KEY,
 			ttlSeconds: 60 * 60,
@@ -104,16 +76,10 @@ export function createDemoInstance(scenario = DEFAULT_SCENARIO_ID) {
 			signingKey: DEMO_LEGAL_DOCUMENT_SNAPSHOT.signingKey,
 			issuer: DEMO_LEGAL_DOCUMENT_SNAPSHOT.issuer,
 		},
-		openapi: {
-			enabled: true,
-		},
-		cache: cacheConfig,
-		iab: {
-			enabled: true,
-			cmpId: DEMO_CMP_ID,
-			vendorIds: DEMO_IAB_VENDOR_IDS,
-			customVendors: DEMO_CUSTOM_VENDORS,
-		},
+		openapi: { enabled: true },
+		// The cache attaches to GVL resolution, which is the only thing in the
+		// backend worth caching across instances.
+		gvl: { vendorIds: DEMO_IAB_VENDOR_IDS, cache: gvlCache },
 	});
 }
 

--- a/examples/demo/lib/policies.ts
+++ b/examples/demo/lib/policies.ts
@@ -1,6 +1,5 @@
-import { policyPackPresets } from '@c15t/backend';
-import type { PolicyConfig } from '@c15t/backend/types';
-import { policyPackPresets as test } from '@c15t/react';
+import { policyPackPresets } from '@c15t/backend-next';
+import type { PolicyConfig } from '@c15t/schema/types';
 import type { Translations } from '@c15t/translations';
 import { translations } from '@c15t/translations/en';
 

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -11,7 +11,7 @@
 		"fmt": "biome format --write"
 	},
 	"dependencies": {
-		"@c15t/backend": "workspace:*",
+		"@c15t/backend-next": "workspace:*",
 		"@c15t/dev-tools": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/nextjs": "workspace:*",

--- a/examples/nuxt/c15t-backend.config.ts
+++ b/examples/nuxt/c15t-backend.config.ts
@@ -1,7 +1,7 @@
 /**
  * Used by `@c15t/cli self-host migrate` to create/upgrade the database schema.
  *
- * The adapter selection is shared with the Nitro route
+ * The database selection is shared with the Nitro route
  * (`server/api/self-host/[...all].ts`) via `lib/adapter.ts`: `DATABASE_URL`
  * when set, the embedded PGlite database otherwise.
  *
@@ -9,12 +9,12 @@
  * database on first boot. Reach for the CLI (`bun run db:migrate`) when
  * pointing the demo at a real Postgres.
  */
-import { defineConfig } from '@c15t/backend';
+import { defineConfig } from '@c15t/backend-next';
 import { createAdapter } from './lib/adapter';
 
-const { adapter } = await createAdapter();
+const { database } = await createAdapter();
 
 export default defineConfig({
-	adapter,
+	database,
 	trustedOrigins: ['localhost'],
 });

--- a/examples/nuxt/lib/adapter.ts
+++ b/examples/nuxt/lib/adapter.ts
@@ -16,9 +16,7 @@
  */
 import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
-import { Kysely, PostgresDialect } from 'kysely';
-import { Pool } from 'pg';
+import type { DatabaseOption } from '@c15t/backend-next';
 
 /**
  * Where PGlite keeps its data directory.
@@ -32,54 +30,43 @@ export const LOCAL_DATA_DIR = resolve(process.cwd(), '.pgdata');
 
 /**
  * Specifier held in a variable so Nitro's dependency tracer cannot follow it.
- * A literal `import('kysely-pglite')` — even guarded behind a runtime check —
- * copies ~16 MB of WASM (`pglite.wasm`, `pglite.data`) into `.output`, where
- * `DATABASE_URL` is mandatory and PGlite is never constructed. It is a real
- * dependency, so Node resolves it fine at runtime under `nuxt dev`.
+ * A literal `import('@effect/sql-pglite')` — even guarded behind a runtime
+ * check — copies ~16 MB of WASM (`pglite.wasm`, `pglite.data`) into `.output`,
+ * where `DATABASE_URL` is mandatory and PGlite is never constructed. It is a
+ * real dependency, so Node resolves it fine at runtime under `nuxt dev`.
  */
-const EMBEDDED_POSTGRES_MODULE = 'kysely-pglite';
+const EMBEDDED_POSTGRES_MODULE = '@effect/sql-pglite';
 
 export type ResolvedAdapter = {
-	adapter: ReturnType<typeof kyselyAdapter>;
+	database: DatabaseOption;
 	/** `embedded` runs migrations on boot; a real Postgres must not. */
 	mode: 'postgres' | 'embedded';
 };
 
-function createPostgresAdapter(connectionString: string) {
-	const { hostname } = new URL(connectionString);
-	const isLocalhost = ['localhost', '127.0.0.1', '::1'].includes(hostname);
-	return kyselyAdapter({
-		db: new Kysely({
-			dialect: new PostgresDialect({
-				pool: new Pool({
-					connectionString,
-					ssl: { rejectUnauthorized: !isLocalhost },
-				}),
-			}),
-		}),
-		provider: 'postgresql',
-	});
-}
-
-async function createEmbeddedPostgresAdapter() {
-	const { KyselyPGlite } = (await import(
+/**
+ * The embedded case is why `database` accepts a layer as well as a config.
+ *
+ * `{ dialect: 'postgres', url }` covers a real server, but PGlite is Postgres
+ * compiled to WASM with no URL to point at — it is constructed, not dialled.
+ * Handing c15t the client directly is the escape hatch working as intended.
+ */
+async function createEmbeddedDatabase(): Promise<DatabaseOption> {
+	const { PgliteClient } = (await import(
 		/* @vite-ignore */ EMBEDDED_POSTGRES_MODULE
-	)) as typeof import('kysely-pglite');
+	)) as typeof import('@effect/sql-pglite');
 
 	// PGlite mkdirs the data directory itself but not its parent.
 	mkdirSync(LOCAL_DATA_DIR, { recursive: true });
-	const pglite = await KyselyPGlite.create(resolve(LOCAL_DATA_DIR, 'db'));
-	return kyselyAdapter({
-		db: new Kysely({ dialect: pglite.dialect }),
-		provider: 'postgresql',
-	});
+	return PgliteClient.layer({ dataDir: resolve(LOCAL_DATA_DIR, 'db') });
 }
 
 export async function createAdapter(): Promise<ResolvedAdapter> {
 	const connectionString = process.env.DATABASE_URL;
 	if (connectionString) {
+		// SSL negotiation and pooling move behind the driver, so the demo no
+		// longer has to construct either.
 		return {
-			adapter: createPostgresAdapter(connectionString),
+			database: { dialect: 'postgres', url: connectionString },
 			mode: 'postgres',
 		};
 	}
@@ -95,5 +82,5 @@ export async function createAdapter(): Promise<ResolvedAdapter> {
 		);
 	}
 
-	return { adapter: await createEmbeddedPostgresAdapter(), mode: 'embedded' };
+	return { database: await createEmbeddedDatabase(), mode: 'embedded' };
 }

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -10,11 +10,10 @@
 		"check-types": "nuxt typecheck"
 	},
 	"dependencies": {
-		"@c15t/backend": "workspace:*",
+		"@c15t/backend-next": "workspace:*",
 		"@c15t/vue": "workspace:*",
+		"@effect/sql-pglite": "4.0.0-beta.102",
 		"@electric-sql/pglite": "0.4.2",
-		"kysely": "0.28.17",
-		"kysely-pglite": "^0.6.1",
 		"nuxt": "^4.5.1",
 		"pg": "^8.20.0"
 	},

--- a/examples/nuxt/server/api/self-host/[...all].ts
+++ b/examples/nuxt/server/api/self-host/[...all].ts
@@ -9,9 +9,11 @@
  * Storage selection lives in `lib/adapter.ts`, shared with the CLI config and
  * the migration script so the three cannot drift.
  */
-import { c15tInstance, policyPackPresets } from '@c15t/backend';
-import { migrator } from '@c15t/backend/db/migrator';
-import { DB } from '@c15t/backend/db/schema';
+import {
+	c15tInstance,
+	createMigrator,
+	policyPackPresets,
+} from '@c15t/backend-next';
 import { toWebRequest } from 'h3';
 import { createAdapter, type ResolvedAdapter } from '../../../lib/adapter';
 
@@ -45,17 +47,20 @@ function trustedOrigins(): string[] {
  * instances — for deploys run `bun run db:migrate`, which reads the same
  * adapter from `c15t-backend.config.ts`.
  */
-async function ensureLocalSchema({ adapter, mode }: ResolvedAdapter) {
+async function ensureLocalSchema({ database, mode }: ResolvedAdapter) {
 	if (mode !== 'embedded') {
 		return;
 	}
-	const result = await migrator({ db: DB.client(adapter), schema: 'latest' });
-	if ('path' in result) {
-		throw new Error(
-			`Expected an executable migration, got an ORM schema at ${result.path}.`
-		);
+	// One call: it classifies the database, adopts it to the baseline if it is
+	// behind, and applies whatever migrations the ledger has not recorded.
+	// There is no ORM branch to handle any more — every supported engine
+	// migrates.
+	const migrator = createMigrator(database);
+	try {
+		await migrator.apply();
+	} finally {
+		await migrator.dispose();
 	}
-	await result.execute();
 }
 
 async function createInstance() {
@@ -63,20 +68,23 @@ async function createInstance() {
 	await ensureLocalSchema(resolved);
 
 	return c15tInstance({
-		appName: 'c15t-nuxt-demo',
+		database: resolved.database,
 		basePath: '/api/self-host',
-		adapter: resolved.adapter,
 		trustedOrigins: trustedOrigins(),
 		tenantId: 'ins_1',
-		branding: 'c15t',
-		// Real policy packs so the manifest carries fingerprints + matching
-		// rules and POST /subjects exercises recompute-on-write. The world
-		// fallback guarantees every visitor resolves a policy decision.
-		policyPacks: [
-			policyPackPresets.europeOptIn(),
-			policyPackPresets.californiaOptOut(),
-			policyPackPresets.worldNoBanner(),
-		],
+		manifest: {
+			tenantId: 'ins_1',
+			appName: 'c15t-nuxt-demo',
+			branding: 'c15t',
+			// Real policy packs so the manifest carries fingerprints + matching
+			// rules and POST /subjects exercises recompute-on-write. The world
+			// fallback guarantees every visitor resolves a policy decision.
+			policyPacks: [
+				policyPackPresets.europeOptIn(),
+				policyPackPresets.californiaOptOut(),
+				policyPackPresets.worldNoBanner(),
+			],
+		},
 		manifestCache: {
 			sMaxAge: 120,
 			staleWhileRevalidate: 600,

--- a/examples/sveltekit-demo/c15t-backend.config.ts
+++ b/examples/sveltekit-demo/c15t-backend.config.ts
@@ -1,18 +1,12 @@
-import { defineConfig } from '@c15t/backend';
-import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
-import { LibsqlDialect } from '@libsql/kysely-libsql';
-import { Kysely } from 'kysely';
-
-const db = kyselyAdapter({
-	db: new Kysely({
-		dialect: new LibsqlDialect({
-			url: 'file:c15t.db',
-		}),
-	}),
-	provider: 'sqlite',
-});
+/**
+ * Used by `@c15t/cli self-host migrate` to create and upgrade the schema.
+ *
+ * No Kysely instance to build: c15t opens its own connection from this
+ * description.
+ */
+import { defineConfig } from '@c15t/backend-next';
 
 export default defineConfig({
-	adapter: db,
+	database: { dialect: 'sqlite', filename: 'c15t.db' },
 	trustedOrigins: ['localhost'],
 });

--- a/examples/sveltekit-demo/package.json
+++ b/examples/sveltekit-demo/package.json
@@ -12,11 +12,11 @@
 		"bench:script-count": "bun run ./scripts/run-script-count-bench.ts"
 	},
 	"dependencies": {
-		"@c15t/backend": "workspace:*",
+		"@c15t/backend-next": "workspace:*",
+		"@c15t/dev-tools": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/node-sdk": "workspace:*",
 		"@c15t/svelte": "workspace:*",
-		"@c15t/dev-tools": "workspace:*",
 		"@c15t/translations": "workspace:*",
 		"@libsql/kysely-libsql": "^0.4.1",
 		"c15t": "workspace:*",

--- a/examples/sveltekit-demo/src/routes/api/self-host/[...all]/+server.ts
+++ b/examples/sveltekit-demo/src/routes/api/self-host/[...all]/+server.ts
@@ -1,31 +1,25 @@
-import { c15tInstance } from '@c15t/backend';
-import { kyselyAdapter } from '@c15t/backend/db/adapters/kysely';
-import { LibsqlDialect } from '@libsql/kysely-libsql';
-import { Kysely } from 'kysely';
+import { c15tInstance } from '@c15t/backend-next';
 import type { RequestHandler } from './$types';
 
-const db = kyselyAdapter({
-	db: new Kysely({
-		dialect: new LibsqlDialect({
-			url: 'file:c15t.db',
-		}),
-	}),
-	provider: 'sqlite',
-});
-
 const handler = c15tInstance({
-	appName: 'c15t-self-host',
+	// No Kysely instance to build: c15t opens its own connection.
+	database: { dialect: 'sqlite', filename: 'c15t.db' },
 	basePath: '/api/self-host',
-	adapter: db,
 	trustedOrigins: ['localhost'],
 	tenantId: 'ins_1',
-	branding: 'c15t',
 	openapi: {
 		enabled: true,
 	},
-	iab: {
-		enabled: true,
-		cmpId: 10,
+	manifest: {
+		tenantId: 'ins_1',
+		appName: 'c15t-self-host',
+		branding: 'c15t',
+		iab: {
+			enabled: true,
+			cmpId: 10,
+		},
+	},
+	gvl: {
 		vendorIds: [
 			1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
 			22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -918,3 +918,52 @@ Defensible, surprising, and now pinned by a test.
 covered here by `@c15t/schema`'s `resolveInitFromManifest` and `isOriginTrusted`
 — the same resolver the real `/init` uses, which is the property that matters
 (§ "one resolver" in `http/init.ts`).
+
+### 11.15 Two more gaps, found by moving the demos
+
+Rewiring the three example apps onto the new backend surfaced two options they
+depend on that had no equivalent, both small and both load-bearing:
+
+- **`basePath`** was accepted as OpenAPI metadata only, never used for routing.
+  Every demo mounts under a catch-all — `/api/self-host` — so requests arrive
+  with a prefix the routes are not declared with, and a mounted deployment
+  would have 404d on every route. Stripped before dispatch now, conditionally,
+  so a request that already lacks the prefix does not lose its first segment.
+- **`legalDocumentSnapshot`** was absent entirely. It is the sibling of
+  `policy-snapshot.ts` and is built the same way: where a policy snapshot
+  attests to the *decision* shown, this attests to the version and content hash
+  of the terms accepted. A consent record says someone agreed; it does not, by
+  itself, say what to. The TTL differs deliberately — a day rather than half an
+  hour, because a client holds this between being shown the terms and
+  submitting acceptance.
+
+Everything else mapped. `appName`, `branding`, `i18n`, `policyPacks` and `iab`
+all move into `manifest`, which is the shape `@c15t/schema` already builds, so
+server and browser resolve a manifest identically. `cache` moves under `gvl`,
+which is the only thing in the backend worth caching across instances.
+
+**The Nuxt demo is the case that justifies the layer escape hatch** (§11.10).
+It runs embedded PGlite in development — Postgres compiled to WASM, with no URL
+to dial — so `{ dialect, url }` cannot describe it. Handing c15t a
+`PgliteClient.layer` directly is the escape hatch doing exactly what it exists
+for, and the demo lost forty lines of Kysely dialect and pool construction in
+the process.
+
+### 11.16 A test that was passing for the wrong reason
+
+`subject.test.ts` asserted that a subject listing costs the same number of
+queries at 250 subjects as at 1, by counting `seq_scan + idx_scan` from
+`pg_stat_user_tables`. It failed roughly one run in ten under full-suite load
+and passed in isolation.
+
+Postgres accumulates those counters in backend-local memory and flushes them on
+its own schedule, so a read taken straight after a query often missed the scans
+it was meant to count. **That miss is why the assertion passed.** Forcing a
+flush made it deterministic — and it then failed every time, 4 against 502,
+because the planner runs the join as a nested loop and scans the inner side
+once per row.
+
+The scan count was never the claim. One statement that scans a lot is still one
+round trip, and round trips are what cost against a networked database: the
+shipped backend's problem is nine of them, not nine scans. It counts statements
+via `xact_commit` now and asserts two, flat, at either size.

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -967,3 +967,38 @@ The scan count was never the claim. One statement that scans a lot is still one
 round trip, and round trips are what cost against a networked database: the
 shipped backend's problem is nine of them, not nine scans. It counts statements
 via `xact_commit` now and asserts two, flat, at either size.
+
+### 11.17 Edge is dropped, not ported
+
+**Decided: `@c15t/backend/edge` does not ship in 3.0.** §11.14 listed it as a
+port blocking the rename; it is a removal instead.
+
+`unstable_resolveConsent` and the edge init handler resolved consent from a
+manifest without touching storage. Nothing in the repository imports them
+outside the old package itself — no example, no framework package, no
+benchmark — and the export was marked `unstable_`, which is the signal that
+carried the risk of exactly this.
+
+Two docs pages cover it (`self-host/guides/edge-deployment`,
+`self-host/api/configuration`) and go with it before the 3.0 release.
+
+Worth being precise about what is and is not lost. The *capability* survives:
+`resolveInitFromManifest` in `@c15t/schema` is the resolver both the edge
+handler and the real `/init` were built on, and it runs anywhere — a host that
+wants edge resolution calls it directly against a fetched manifest. What goes
+is the packaged handler around it.
+
+### 11.18 What the cutover is now waiting on
+
+With `./cache` ported (§11.14), `./edge` dropped, and the demo apps moved
+(§11.15), the remaining work is mechanical rather than architectural:
+
+- the rename itself — directory move, `private` removed, joining the linked
+  version group, a major changeset;
+- `@c15t/logger`'s two JSDoc examples pointing at `@c15t/backend/telemetry`,
+  now corrected to the root export;
+- the benchmark's `v2-backend` arm and `@c15t/backend`'s conformance runner,
+  which import the real 2.x package and die with it. The measured comparison is
+  already recorded in §11.5, and the conformance *cases* survive against the
+  new backend, so this loses the A/B rather than the guarantee. Restoring it
+  later means depending on the published 2.x under an alias.

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -887,3 +887,34 @@ backend at a database (§11.10), and the same reasoning applies to a
 self-hoster's deploy script.
 
 Imports still say `@c15t/backend-next`; the rename flips them in one pass.
+
+### 11.14 Deleting the old package needs two subsystems ported first
+
+The rename is not a rename. `@c15t/backend` ships two things the rewrite has no
+equivalent for, both user-facing and both reachable from the demo apps and the
+docs:
+
+| Subsystem | Size | What it is |
+| --- | ---: | --- |
+| `./cache` | 774 lines | Memory, Upstash Redis and Cloudflare KV adapters behind a four-method interface, plus GVL cache keys |
+| `./edge` | 501 lines | `unstable_resolveConsent` and an edge init handler — consent resolution with no database |
+
+Neither is a from-scratch build, which is only clear once you look:
+
+**Cache was a straight move.** The adapters depend on nothing the rewrite
+replaced — no fumadb, no ORM adapters — and `http/gvl.ts` here had already
+declared the *identical* `CacheAdapter` interface and accepted one. What was
+missing was any concrete adapter to hand it. v2's `gvl-resolver.ts` is
+deliberately left behind: GVL fetching lives in `http/gvl.ts` in this package,
+and a second resolver would mean two code paths deciding when a vendor list is
+stale.
+
+It shipped with no tests, which is how the memory adapter's module-level `Map`
+went unremarked — it is a *process-wide* cache, so two instances share entries.
+Defensible, surprising, and now pinned by a test.
+
+**Edge is a rewrite against shared code**, not a move: it builds on v2 internals
+(`handlers/init/geo`, `handlers/init/policy`, `middleware/cors`) that are all
+covered here by `@c15t/schema`'s `resolveInitFromManifest` and `isOriginTrusted`
+— the same resolver the real `/init` uses, which is the property that matters
+(§ "one resolver" in `http/init.ts`).

--- a/packages/backend-next/package.json
+++ b/packages/backend-next/package.json
@@ -36,6 +36,11 @@
 			"types": "./dist-types/db/migrations/*.d.ts",
 			"import": "./dist/db/migrations/*.js",
 			"require": "./dist/db/migrations/*.cjs"
+		},
+		"./cache": {
+			"types": "./dist-types/cache/index.d.ts",
+			"import": "./dist/cache/index.js",
+			"require": "./dist/cache/index.cjs"
 		}
 	},
 	"main": "./dist/index.cjs",
@@ -82,7 +87,8 @@
 	"peerDependencies": {
 		"@effect/sql-mysql2": "4.0.0-beta.102",
 		"@effect/sql-pg": "4.0.0-beta.102",
-		"@effect/sql-sqlite-node": "4.0.0-beta.102"
+		"@effect/sql-sqlite-node": "4.0.0-beta.102",
+		"@upstash/redis": "^1.38.0"
 	},
 	"peerDependenciesMeta": {
 		"@effect/sql-mysql2": {
@@ -92,6 +98,9 @@
 			"optional": true
 		},
 		"@effect/sql-sqlite-node": {
+			"optional": true
+		},
+		"@upstash/redis": {
 			"optional": true
 		}
 	}

--- a/packages/backend-next/src/cache/adapters/cloudflare-kv.ts
+++ b/packages/backend-next/src/cache/adapters/cloudflare-kv.ts
@@ -1,0 +1,71 @@
+/**
+ * Cloudflare KV Cache Adapter
+ *
+ * Cache adapter for Cloudflare Workers KV storage.
+ *
+ * @packageDocumentation
+ */
+
+import type { CacheAdapter } from '../types';
+import { GVL_TTL_MS } from '../types';
+
+/**
+ * Cloudflare KV Namespace interface.
+ * Matches the KVNamespace type from @cloudflare/workers-types.
+ *
+ * @public
+ */
+export interface KVNamespace {
+	get(key: string, options?: { type?: 'text' | 'json' }): Promise<unknown>;
+	put(
+		key: string,
+		value: string,
+		options?: { expirationTtl?: number }
+	): Promise<void>;
+	delete(key: string): Promise<void>;
+}
+
+/**
+ * Creates a Cloudflare KV cache adapter.
+ *
+ * @param kv - Cloudflare KV namespace binding
+ * @returns A CacheAdapter backed by Cloudflare KV
+ *
+ * @example
+ * ```typescript
+ * // In your Cloudflare Worker
+ * export default {
+ *   async fetch(request, env) {
+ *     const kvAdapter = createCloudflareKVAdapter(env.GVL_CACHE);
+ *
+ *     await kvAdapter.set('key', { data: 'value' }, 3600000);
+ *     const value = await kvAdapter.get('key');
+ *   }
+ * };
+ * ```
+ *
+ * @public
+ */
+export function createCloudflareKVAdapter(kv: KVNamespace): CacheAdapter {
+	return {
+		async get<T>(key: string): Promise<T | null> {
+			const value = await kv.get(key, { type: 'json' });
+			return value as T | null;
+		},
+
+		async set<T>(key: string, value: T, ttlMs = GVL_TTL_MS): Promise<void> {
+			// Convert milliseconds to seconds for KV expirationTtl
+			const ttlSeconds = Math.ceil(ttlMs / 1000);
+			await kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds });
+		},
+
+		async delete(key: string): Promise<void> {
+			await kv.delete(key);
+		},
+
+		async has(key: string): Promise<boolean> {
+			const value = await kv.get(key);
+			return value !== null;
+		},
+	};
+}

--- a/packages/backend-next/src/cache/adapters/index.ts
+++ b/packages/backend-next/src/cache/adapters/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Cache Adapters
+ *
+ * Pluggable cache adapter implementations for different storage backends.
+ *
+ * @packageDocumentation
+ */
+
+export {
+	createCloudflareKVAdapter,
+	type KVNamespace,
+} from './cloudflare-kv';
+export {
+	clearMemoryCache,
+	createMemoryCacheAdapter,
+	getMemoryCacheSize,
+} from './memory';
+export {
+	createUpstashRedisAdapter,
+	createUpstashRedisAdapterFromClient,
+	type UpstashRedisAdapterOptions,
+} from './upstash-redis';

--- a/packages/backend-next/src/cache/adapters/memory.ts
+++ b/packages/backend-next/src/cache/adapters/memory.ts
@@ -1,0 +1,111 @@
+/**
+ * In-Memory Cache Adapter
+ *
+ * A simple Map-based cache adapter with TTL support.
+ * Used as the default first layer in the cache resolution chain.
+ *
+ * @packageDocumentation
+ */
+
+import type { CacheAdapter } from '../types';
+import { MEMORY_TTL_MS } from '../types';
+
+interface CacheEntry<T = unknown> {
+	value: T;
+	expiresAt: number;
+}
+
+/**
+ * Module-level cache shared across requests in the same worker/process.
+ * This provides fast 0ms access for repeated requests.
+ */
+const memoryCache = new Map<string, CacheEntry>();
+
+/**
+ * Creates an in-memory cache adapter.
+ *
+ * Features:
+ * - Uses a shared Map for fast access
+ * - Supports TTL with lazy expiration
+ * - Always used as the first cache layer by default
+ *
+ * @returns A CacheAdapter implementation backed by in-memory Map
+ *
+ * @example
+ * ```typescript
+ * const memoryAdapter = createMemoryCacheAdapter();
+ *
+ * await memoryAdapter.set('key', { data: 'value' }, 60000); // 1 minute TTL
+ * const value = await memoryAdapter.get('key');
+ * ```
+ *
+ * @public
+ */
+export function createMemoryCacheAdapter(): CacheAdapter {
+	return {
+		async get<T>(key: string): Promise<T | null> {
+			const entry = memoryCache.get(key);
+
+			if (!entry) {
+				return null;
+			}
+
+			// Check if entry has expired (lazy expiration)
+			if (Date.now() > entry.expiresAt) {
+				memoryCache.delete(key);
+				return null;
+			}
+
+			return entry.value as T;
+		},
+
+		async set<T>(key: string, value: T, ttlMs = MEMORY_TTL_MS): Promise<void> {
+			memoryCache.set(key, {
+				value,
+				expiresAt: Date.now() + ttlMs,
+			});
+		},
+
+		async delete(key: string): Promise<void> {
+			memoryCache.delete(key);
+		},
+
+		async has(key: string): Promise<boolean> {
+			const entry = memoryCache.get(key);
+
+			if (!entry) {
+				return false;
+			}
+
+			// Check if entry has expired
+			if (Date.now() > entry.expiresAt) {
+				memoryCache.delete(key);
+				return false;
+			}
+
+			return true;
+		},
+	};
+}
+
+/**
+ * Clears the entire in-memory cache.
+ * Primarily used for testing.
+ *
+ * @public
+ */
+export function clearMemoryCache(): void {
+	memoryCache.clear();
+}
+
+/**
+ * Gets the current size of the in-memory cache.
+ * Primarily used for debugging and monitoring.
+ *
+ * @returns The number of entries in the cache (may include expired entries)
+ *
+ * @public
+ */
+export function getMemoryCacheSize(): number {
+	return memoryCache.size;
+}

--- a/packages/backend-next/src/cache/adapters/upstash-redis.ts
+++ b/packages/backend-next/src/cache/adapters/upstash-redis.ts
@@ -1,0 +1,113 @@
+/**
+ * Upstash Redis Cache Adapter
+ *
+ * Cache adapter for Upstash Redis, suitable for serverless environments.
+ *
+ * Requires @upstash/redis to be installed as a peer dependency.
+ *
+ * @packageDocumentation
+ */
+
+import { Redis } from '@upstash/redis';
+import type { CacheAdapter } from '../types';
+import { GVL_TTL_MS } from '../types';
+
+/**
+ * Options for creating an Upstash Redis adapter.
+ *
+ * @public
+ */
+export interface UpstashRedisAdapterOptions {
+	/**
+	 * Upstash Redis REST URL.
+	 */
+	url: string;
+
+	/**
+	 * Upstash Redis REST token.
+	 */
+	token: string;
+}
+
+/**
+ * Creates an Upstash Redis cache adapter.
+ *
+ * **Note:** Requires `@upstash/redis` to be installed as a peer dependency.
+ *
+ * @param options - Upstash Redis connection options
+ * @returns A CacheAdapter backed by Upstash Redis
+ *
+ * @example
+ * ```typescript
+ * import { createUpstashRedisAdapter } from '@c15t/backend/cache';
+ *
+ * const redisAdapter = createUpstashRedisAdapter({
+ *   url: process.env.UPSTASH_REDIS_REST_URL,
+ *   token: process.env.UPSTASH_REDIS_REST_TOKEN,
+ * });
+ *
+ * await redisAdapter.set('key', { data: 'value' }, 3600000); // 1 hour TTL
+ * const value = await redisAdapter.get('key');
+ * ```
+ *
+ * @public
+ */
+export function createUpstashRedisAdapter(
+	options: UpstashRedisAdapterOptions
+): CacheAdapter {
+	const client = new Redis({
+		url: options.url,
+		token: options.token,
+	});
+
+	return createUpstashRedisAdapterFromClient(client);
+}
+
+/**
+ * Creates an Upstash Redis cache adapter from an existing client.
+ *
+ * Use this if you already have an @upstash/redis client instance.
+ *
+ * @param client - An existing Upstash Redis client
+ * @returns A CacheAdapter backed by the provided client
+ *
+ * @example
+ * ```typescript
+ * import { Redis } from '@upstash/redis';
+ * import { createUpstashRedisAdapterFromClient } from '@c15t/backend/cache';
+ *
+ * const redis = new Redis({
+ *   url: process.env.UPSTASH_REDIS_REST_URL,
+ *   token: process.env.UPSTASH_REDIS_REST_TOKEN,
+ * });
+ *
+ * const adapter = createUpstashRedisAdapterFromClient(redis);
+ * ```
+ *
+ * @public
+ */
+export function createUpstashRedisAdapterFromClient(
+	client: Redis
+): CacheAdapter {
+	return {
+		async get<T>(key: string): Promise<T | null> {
+			const result = await client.get<T>(key);
+			return result ?? null;
+		},
+
+		async set<T>(key: string, value: T, ttlMs = GVL_TTL_MS): Promise<void> {
+			// Convert milliseconds to seconds for Redis EX
+			const ttlSeconds = Math.ceil(ttlMs / 1000);
+			await client.set(key, value, { ex: ttlSeconds });
+		},
+
+		async delete(key: string): Promise<void> {
+			await client.del(key);
+		},
+
+		async has(key: string): Promise<boolean> {
+			const exists = await client.exists(key);
+			return exists > 0;
+		},
+	};
+}

--- a/packages/backend-next/src/cache/cache.test.ts
+++ b/packages/backend-next/src/cache/cache.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The cache adapters.
+ *
+ * These shipped in `@c15t/backend` with no tests at all, which is how the
+ * shared module-level `Map` in the memory adapter went unremarked: two
+ * instances in one process see each other's entries, and a test that sets a
+ * key leaks it into the next one. That is defensible for a process-wide cache
+ * and surprising if you have not read the source, so it is pinned here.
+ *
+ * The adapters are behaviourally simple. What is worth asserting is the part
+ * that is easy to get wrong and invisible when wrong: expiry, and the
+ * `null`-versus-`undefined` distinction that tells a cache miss from a cached
+ * absence.
+ */
+
+import { afterEach, assert, describe, it } from '@effect/vitest';
+import {
+	clearMemoryCache,
+	createCacheKey,
+	createGVLCacheKey,
+	createMemoryCacheAdapter,
+	getMemoryCacheSize,
+} from './index';
+
+afterEach(() => {
+	// Shared module state; without this each test inherits the last one's keys.
+	clearMemoryCache();
+});
+
+describe('memory adapter', () => {
+	it('round-trips a value', async () => {
+		const cache = createMemoryCacheAdapter();
+		await cache.set('k', { hello: 'world' });
+
+		assert.deepStrictEqual(await cache.get('k'), { hello: 'world' });
+		assert.isTrue(await cache.has('k'));
+	});
+
+	it('reports a miss as null', async () => {
+		const cache = createMemoryCacheAdapter();
+
+		// `null`, not `undefined`: callers distinguish "not cached" from a cached
+		// value that happens to be undefined.
+		assert.isNull(await cache.get('absent'));
+		assert.isFalse(await cache.has('absent'));
+	});
+
+	it('expires an entry once its ttl has passed', async () => {
+		const cache = createMemoryCacheAdapter();
+		await cache.set('k', 'v', 1);
+
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		// Lazy expiry: the entry is still in the Map, and `get` has to notice.
+		assert.isNull(await cache.get('k'));
+		assert.isFalse(await cache.has('k'));
+	});
+
+	it('deletes', async () => {
+		const cache = createMemoryCacheAdapter();
+		await cache.set('k', 'v');
+		await cache.delete('k');
+
+		assert.isNull(await cache.get('k'));
+	});
+
+	it('shares state between instances in one process', async () => {
+		const first = createMemoryCacheAdapter();
+		const second = createMemoryCacheAdapter();
+
+		await first.set('shared', 'yes');
+
+		// Deliberate, and worth knowing: the Map is module-level, so this is a
+		// process-wide cache rather than a per-instance one.
+		assert.strictEqual(await second.get('shared'), 'yes');
+		assert.strictEqual(getMemoryCacheSize(), 1);
+	});
+});
+
+describe('cache keys', () => {
+	it('sorts vendor ids so key order cannot vary', () => {
+		// The same vendor set requested in a different order has to hit the same
+		// entry, or the cache silently never hits.
+		assert.strictEqual(
+			createGVLCacheKey('app', 'en', [10, 1, 2]),
+			createGVLCacheKey('app', 'en', [1, 2, 10])
+		);
+		assert.strictEqual(
+			createGVLCacheKey('app', 'en', [1, 2, 10]),
+			'app:gvl:en:1,2,10'
+		);
+	});
+
+	it('distinguishes all-vendors from a specific set', () => {
+		assert.strictEqual(createGVLCacheKey('app', 'en'), 'app:gvl:en:all');
+	});
+
+	it('namespaces by app so two tenants cannot collide', () => {
+		assert.notStrictEqual(
+			createCacheKey('app-a', 'translations', 'en'),
+			createCacheKey('app-b', 'translations', 'en')
+		);
+		assert.strictEqual(
+			createCacheKey('app', 'translations', 'en', 'banner'),
+			'app:translations:en:banner'
+		);
+	});
+});

--- a/packages/backend-next/src/cache/index.ts
+++ b/packages/backend-next/src/cache/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Pluggable caching.
+ *
+ * Ported from `@c15t/backend`'s `cache/` unchanged, because there was nothing
+ * to change: the adapters are self-contained implementations of a four-method
+ * interface, with no dependency on fumadb, the ORM adapters, or anything else
+ * the rewrite replaced. `http/gvl.ts` here already declared the identical
+ * `CacheAdapter` shape and accepted one — what was missing was any concrete
+ * adapter to hand it.
+ *
+ * The one thing deliberately left behind is v2's `gvl-resolver.ts`. GVL
+ * fetching and caching lives in `http/gvl.ts` in this package, and importing a
+ * second resolver would mean two code paths deciding when a vendor list is
+ * stale.
+ *
+ * ## Which adapter
+ *
+ * - **Memory** for a single long-lived process. Nothing to configure, and
+ *   nothing shared between instances.
+ * - **Upstash Redis** when more than one instance serves the same tenants, or
+ *   on a serverless platform where memory does not survive between requests.
+ * - **Cloudflare KV** on Workers.
+ *
+ * `@upstash/redis` is an optional peer dependency: only a deployment that uses
+ * that adapter installs it.
+ *
+ * @example
+ * ```ts
+ * import { createUpstashRedisAdapter } from '@c15t/backend-next/cache';
+ *
+ * c15tInstance({
+ * 	database: { dialect: 'postgres', url },
+ * 	gvl: { cache: createUpstashRedisAdapter({ url, token }) },
+ * });
+ * ```
+ */
+
+export {
+	clearMemoryCache,
+	createCloudflareKVAdapter,
+	createMemoryCacheAdapter,
+	createUpstashRedisAdapter,
+	createUpstashRedisAdapterFromClient,
+	getMemoryCacheSize,
+	type KVNamespace,
+	type UpstashRedisAdapterOptions,
+} from './adapters';
+export { createCacheKey, createGVLCacheKey } from './keys';
+export type { CacheAdapter } from './types';
+export { GVL_TTL_MS, MEMORY_TTL_MS } from './types';

--- a/packages/backend-next/src/cache/keys.ts
+++ b/packages/backend-next/src/cache/keys.ts
@@ -1,0 +1,68 @@
+/**
+ * Cache Key Utilities
+ *
+ * Functions for generating consistent cache keys with app name prefixing.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Create a GVL cache key.
+ *
+ * Format: `{appName}:gvl:{language}:{sortedVendorIds}`
+ *
+ * @param appName - The application name for key prefixing
+ * @param language - The language code (e.g., "en", "de")
+ * @param vendorIds - Optional array of vendor IDs to include in the key
+ * @returns A unique cache key for the GVL configuration
+ *
+ * @example
+ * ```typescript
+ * // All vendors
+ * createGVLCacheKey('my-app', 'en');
+ * // => 'my-app:gvl:en:all'
+ *
+ * // Specific vendors
+ * createGVLCacheKey('my-app', 'de', [1, 10, 2]);
+ * // => 'my-app:gvl:de:1,2,10'
+ * ```
+ *
+ * @public
+ */
+export function createGVLCacheKey(
+	appName: string,
+	language: string,
+	vendorIds?: number[]
+): string {
+	const sortedIds = vendorIds
+		? [...vendorIds].sort((a, b) => a - b).join(',')
+		: 'all';
+	return `${appName}:gvl:${language}:${sortedIds}`;
+}
+
+/**
+ * Create a generic cache key with namespace and parts.
+ *
+ * Format: `{appName}:{namespace}:{part1}:{part2}:...`
+ *
+ * @param appName - The application name for key prefixing
+ * @param namespace - The cache namespace (e.g., "gvl", "translations")
+ * @param parts - Additional key parts
+ * @returns A namespaced cache key
+ *
+ * @example
+ * ```typescript
+ * createCacheKey('my-app', 'translations', 'en', 'banner');
+ * // => 'my-app:translations:en:banner'
+ * ```
+ *
+ * @public
+ */
+export function createCacheKey(
+	appName: string,
+	namespace: string,
+	...parts: (string | number)[]
+): string {
+	const allParts = [appName, namespace, ...parts];
+	return allParts.join(':');
+}

--- a/packages/backend-next/src/cache/types.ts
+++ b/packages/backend-next/src/cache/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Cache Adapter Types
+ *
+ * Generic cache adapter interface for pluggable caching implementations.
+ * Supports in-memory, Redis, Cloudflare KV, and custom adapters.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Generic cache adapter interface.
+ *
+ * Implementations should handle serialization/deserialization internally.
+ * All methods are async to support both sync (memory) and async (Redis/KV) backends.
+ *
+ * @public
+ */
+export interface CacheAdapter {
+	/**
+	 * Get a value from the cache.
+	 *
+	 * @param key - Cache key
+	 * @returns The cached value, or null if not found or expired
+	 */
+	get<T>(key: string): Promise<T | null>;
+
+	/**
+	 * Set a value in the cache.
+	 *
+	 * @param key - Cache key
+	 * @param value - Value to cache
+	 * @param ttlMs - Time to live in milliseconds (optional)
+	 */
+	set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
+
+	/**
+	 * Delete a value from the cache.
+	 *
+	 * @param key - Cache key
+	 */
+	delete(key: string): Promise<void>;
+
+	/**
+	 * Check if a key exists in the cache.
+	 *
+	 * @param key - Cache key
+	 * @returns True if the key exists and is not expired
+	 */
+	has(key: string): Promise<boolean>;
+}
+
+/**
+ * Default TTL for GVL cache entries (3 days).
+ * Matches the typical GVL update frequency.
+ *
+ * @public
+ */
+export const GVL_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+/**
+ * Default TTL for in-memory cache entries (5 minutes).
+ * Shorter TTL to handle worker restarts and keep memory usage low.
+ *
+ * @public
+ */
+export const MEMORY_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/packages/backend-next/src/http/context.ts
+++ b/packages/backend-next/src/http/context.ts
@@ -99,6 +99,18 @@ export interface AppOptions {
 	 */
 	readonly apiKeys?: readonly string[];
 	/**
+	 * Where this backend is mounted, when it is not at the root.
+	 *
+	 * A self-hoster typically mounts it under a catch-all — `/api/c15t` in
+	 * Next.js, `/api/self-host` in the demo — so requests arrive with that
+	 * prefix while the routes are declared without it. The prefix is stripped
+	 * before dispatch, which is what `@c15t/backend` does too.
+	 *
+	 * Without this, a mounted deployment 404s on every route, which is a
+	 * confusing way to discover the setting.
+	 */
+	readonly basePath?: string;
+	/**
 	 * Wide-event logging (RFC 0004 §5).
 	 *
 	 * On by default at `level: 'warn'` — silent when requests succeed, a line

--- a/packages/backend-next/src/http/context.ts
+++ b/packages/backend-next/src/http/context.ts
@@ -30,6 +30,7 @@ import { toRequestLog } from '../observability/evlog';
 import { type Log, layer as logLayer, silent } from '../observability/log';
 import { type RouteError, toHttp } from './errors';
 import type { GvlOptions } from './gvl';
+import type { LegalDocumentSnapshotOptions } from './legal-document-snapshot';
 import type { ManifestCacheOptions } from './manifest';
 import type { PolicySnapshotOptions } from './policy-snapshot';
 
@@ -90,6 +91,15 @@ export interface AppOptions {
 	readonly manifest?: ConsentManifestConfig;
 	readonly manifestCache?: ManifestCacheOptions;
 	readonly policySnapshot?: PolicySnapshotOptions;
+	/**
+	 * Signing for legal-document snapshots.
+	 *
+	 * Separate from `policySnapshot` because they attest to different things
+	 * and have very different lifetimes — a policy decision is consumed
+	 * immediately, a terms snapshot is held by a client across a session — so
+	 * one signing key and TTL cannot serve both.
+	 */
+	readonly legalDocumentSnapshot?: LegalDocumentSnapshotOptions;
 	readonly gvl?: GvlOptions & { enabled?: boolean };
 	/**
 	 * Keys accepted on `Authorization: Bearer <key>`.

--- a/packages/backend-next/src/http/gvl.ts
+++ b/packages/backend-next/src/http/gvl.ts
@@ -13,14 +13,9 @@
 
 import { type GlobalVendorList, globalVendorListSchema } from '@c15t/schema';
 import * as v from 'valibot';
+import type { CacheAdapter } from '../cache/types';
 
-/** The subset of a cache this needs. Matches `@c15t/backend`'s adapter. */
-export interface CacheAdapter {
-	get<T>(key: string): Promise<T | null>;
-	set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
-	delete(key: string): Promise<void>;
-	has(key: string): Promise<boolean>;
-}
+export type { CacheAdapter };
 
 export interface GvlOptions {
 	readonly endpoint?: string;

--- a/packages/backend-next/src/http/legal-document-snapshot.test.ts
+++ b/packages/backend-next/src/http/legal-document-snapshot.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Legal-document snapshot tokens.
+ *
+ * This is signed evidence of what a subject actually agreed to, so the tests
+ * are about the ways it could be trusted when it should not be:
+ *
+ * - a token minted for one tenant must not verify against another;
+ * - a tampered claim must not verify;
+ * - no signing key must mean no token, not an unsigned one;
+ * - a failure must not say *why* it failed.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import {
+	createLegalDocumentSnapshotToken,
+	verifyLegalDocumentSnapshotToken,
+} from './legal-document-snapshot';
+
+const options = { signingKey: 'a-signing-key-of-reasonable-length' };
+
+const claims = {
+	type: 'terms_and_conditions',
+	version: '2026-04-13',
+	hash: 'sha256-of-the-terms',
+	effectiveDate: '2026-04-13T00:00:00.000Z',
+};
+
+describe('legal document snapshot', () => {
+	it('round-trips the document identity', async () => {
+		const minted = await createLegalDocumentSnapshotToken(claims, options);
+		assert.isDefined(minted);
+
+		const verified = await verifyLegalDocumentSnapshotToken(
+			minted?.token,
+			options,
+			undefined
+		);
+
+		assert.isTrue(verified.valid);
+		if (verified.valid) {
+			// The hash is what makes this attest to the text rather than a label:
+			// a version number can be reused, content cannot.
+			assert.strictEqual(verified.payload.hash, 'sha256-of-the-terms');
+			assert.strictEqual(verified.payload.version, '2026-04-13');
+			assert.strictEqual(verified.payload.type, 'terms_and_conditions');
+		}
+	});
+
+	it('mints nothing without a signing key', async () => {
+		// Absent evidence beats unverifiable evidence, which a caller may read
+		// as meaningful simply because it is present.
+		assert.isUndefined(await createLegalDocumentSnapshotToken(claims, {}));
+		assert.isUndefined(
+			await createLegalDocumentSnapshotToken(claims, undefined)
+		);
+	});
+
+	it('does not verify across tenants', async () => {
+		const minted = await createLegalDocumentSnapshotToken(
+			{ ...claims, tenantId: 'tenant_a' },
+			options
+		);
+
+		const wrongTenant = await verifyLegalDocumentSnapshotToken(
+			minted?.token,
+			options,
+			'tenant_b'
+		);
+		const rightTenant = await verifyLegalDocumentSnapshotToken(
+			minted?.token,
+			options,
+			'tenant_a'
+		);
+
+		// The audience is tenant-scoped for this reason: a portable token would
+		// let one tenant present another's evidence as its own.
+		assert.isFalse(wrongTenant.valid);
+		assert.isTrue(rightTenant.valid);
+	});
+
+	it('rejects a token signed with a different key', async () => {
+		const minted = await createLegalDocumentSnapshotToken(claims, {
+			signingKey: 'some-other-key-entirely',
+		});
+
+		const verified = await verifyLegalDocumentSnapshotToken(
+			minted?.token,
+			options,
+			undefined
+		);
+		assert.isFalse(verified.valid);
+	});
+
+	it('rejects a tampered payload', async () => {
+		const minted = await createLegalDocumentSnapshotToken(claims, options);
+		const [header, payload, signature] = (minted?.token ?? '').split('.');
+
+		// Swap the hash for a different document, keeping the signature.
+		const forged = Buffer.from(
+			JSON.stringify({
+				...JSON.parse(Buffer.from(payload ?? '', 'base64url').toString()),
+				hash: 'sha256-of-something-else',
+			})
+		).toString('base64url');
+
+		const verified = await verifyLegalDocumentSnapshotToken(
+			`${header}.${forged}.${signature}`,
+			options,
+			undefined
+		);
+		assert.isFalse(verified.valid);
+	});
+
+	it('reports a missing token differently from an invalid one', async () => {
+		const absent = await verifyLegalDocumentSnapshotToken(
+			undefined,
+			options,
+			undefined
+		);
+		const rubbish = await verifyLegalDocumentSnapshotToken(
+			'not-a-jwt',
+			options,
+			undefined
+		);
+
+		// "missing" is a normal state — the client simply did not send one.
+		// Everything else collapses to "invalid" without saying which check
+		// failed, so a forged token gets no feedback to iterate against.
+		assert.deepStrictEqual(absent, { valid: false, reason: 'missing' });
+		assert.deepStrictEqual(rubbish, { valid: false, reason: 'invalid' });
+	});
+});

--- a/packages/backend-next/src/http/legal-document-snapshot.ts
+++ b/packages/backend-next/src/http/legal-document-snapshot.ts
@@ -1,0 +1,142 @@
+/**
+ * Signed evidence that a subject was shown a specific legal document.
+ *
+ * The sibling of `policy-snapshot.ts`, and deliberately built the same way:
+ * same header, same issuer resolution, same tenant-scoped audience, same
+ * refusal to mint an unsigned token. Where a policy snapshot attests to the
+ * *decision* a visitor was shown, this attests to the **version and content
+ * hash** of the terms they accepted.
+ *
+ * That distinction is the point. A consent record says someone agreed; it does
+ * not, on its own, say what they agreed *to*. A verified snapshot pins the
+ * document version and hash at the moment of acceptance, which is what turns
+ * the record into something defensible when the terms later change.
+ *
+ * Ported from `@c15t/backend`'s `handlers/legal-document/snapshot.ts` with the
+ * verification result reshaped to match `SnapshotVerification` here, so a
+ * caller handles both kinds of snapshot identically.
+ */
+
+import { jwtVerify, SignJWT } from 'jose';
+import type { SnapshotVerification } from './policy-snapshot';
+
+const JWT_HEADER = { alg: 'HS256', typ: 'JWT' } as const;
+const DEFAULT_ISSUER = 'c15t';
+const DEFAULT_AUDIENCE = 'c15t-legal-document-snapshot';
+/**
+ * A day, against the policy snapshot's half hour.
+ *
+ * A policy snapshot backs a single decision and is consumed immediately. This
+ * one is held by a client between being shown the terms and submitting
+ * acceptance, which can legitimately span a long session.
+ */
+const DEFAULT_TTL_SECONDS = 86_400;
+
+export interface LegalDocumentSnapshotOptions {
+	readonly signingKey?: string;
+	readonly issuer?: string;
+	readonly audience?: string;
+	readonly ttlSeconds?: number;
+}
+
+export interface LegalDocumentSnapshotClaims {
+	/** e.g. `terms_and_conditions`, `privacy_policy`. */
+	readonly type: string;
+	readonly version: string;
+	/** Content hash — what makes this attest to the text, not just a label. */
+	readonly hash: string;
+	readonly effectiveDate: string;
+	readonly tenantId?: string;
+}
+
+function resolveIssuer(options: LegalDocumentSnapshotOptions): string {
+	return options.issuer?.trim() || DEFAULT_ISSUER;
+}
+
+/**
+ * Audience is tenant-scoped when a tenant is known.
+ *
+ * Without it a token minted for one tenant would verify against another, which
+ * for signed evidence is a confused-deputy problem rather than a convenience.
+ */
+function resolveAudience(
+	options: LegalDocumentSnapshotOptions,
+	tenantId: string | undefined
+): string {
+	const configured = options.audience?.trim();
+	if (configured) {
+		return configured;
+	}
+	return tenantId ? `${DEFAULT_AUDIENCE}:${tenantId}` : DEFAULT_AUDIENCE;
+}
+
+const signingKey = (secret: string): Uint8Array =>
+	new TextEncoder().encode(secret);
+
+/**
+ * Mints a token, or returns undefined when signing is not configured.
+ *
+ * No signing key means no token rather than an unsigned one: evidence that
+ * cannot be verified is worse than absent evidence, because a caller may treat
+ * its presence as meaningful.
+ */
+export async function createLegalDocumentSnapshotToken(
+	claims: LegalDocumentSnapshotClaims,
+	options: LegalDocumentSnapshotOptions | undefined
+): Promise<{ token: string; payload: Record<string, unknown> } | undefined> {
+	if (!options?.signingKey) {
+		return undefined;
+	}
+
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = iat + (options.ttlSeconds ?? DEFAULT_TTL_SECONDS);
+
+	const payload = {
+		iss: resolveIssuer(options),
+		aud: resolveAudience(options, claims.tenantId),
+		// The document identity is the subject of the claim.
+		sub: `${claims.type}:${claims.version}`,
+		tenantId: claims.tenantId,
+		type: claims.type,
+		version: claims.version,
+		hash: claims.hash,
+		effectiveDate: claims.effectiveDate,
+		iat,
+		exp,
+	};
+
+	const token = await new SignJWT(payload)
+		.setProtectedHeader(JWT_HEADER)
+		.setIssuedAt(iat)
+		.setExpirationTime(exp)
+		.sign(signingKey(options.signingKey));
+
+	return { token, payload };
+}
+
+/**
+ * Verifies a token against the configured key, issuer and tenant audience.
+ *
+ * Any failure collapses to `invalid` rather than reporting why. Distinguishing
+ * "wrong signature" from "wrong audience" from "expired" tells an attacker
+ * which part of a forged token to fix next.
+ */
+export async function verifyLegalDocumentSnapshotToken(
+	token: string | undefined,
+	options: LegalDocumentSnapshotOptions | undefined,
+	tenantId: string | undefined
+): Promise<SnapshotVerification> {
+	if (!options?.signingKey || !token) {
+		return { valid: false, reason: 'missing' };
+	}
+
+	try {
+		const { payload } = await jwtVerify(token, signingKey(options.signingKey), {
+			issuer: resolveIssuer(options),
+			audience: resolveAudience(options, tenantId),
+		});
+		return { valid: true, payload: payload as Record<string, unknown> };
+	} catch {
+		return { valid: false, reason: 'invalid' };
+	}
+}

--- a/packages/backend-next/src/index.ts
+++ b/packages/backend-next/src/index.ts
@@ -72,6 +72,14 @@ export type {
 export { MIGRATIONS, migrate } from './db/migrate';
 export { defineConfig } from './define-config';
 export type { AppOptions } from './http/context';
+export type {
+	LegalDocumentSnapshotClaims,
+	LegalDocumentSnapshotOptions,
+} from './http/legal-document-snapshot';
+export {
+	createLegalDocumentSnapshotToken,
+	verifyLegalDocumentSnapshotToken,
+} from './http/legal-document-snapshot';
 export type { C15TInstance, C15TOptions } from './instance';
 export { c15tInstance } from './instance';
 export type { Migrator } from './migrator';

--- a/packages/backend-next/src/instance.test.ts
+++ b/packages/backend-next/src/instance.test.ts
@@ -126,6 +126,63 @@ describe('c15tInstance', () => {
 	}, 60_000);
 });
 
+describe('basePath', () => {
+	it('routes a request that arrives with the mount prefix', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({
+			database: layer,
+			basePath: '/api/self-host',
+		});
+
+		try {
+			// How a Next.js catch-all actually delivers it. Without stripping,
+			// every route 404s and the cause is not obvious.
+			const response = await instance.handler(
+				new Request('http://localhost/api/self-host/status')
+			);
+			assert.strictEqual(response.status, 200);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+
+	it('leaves a request alone when no basePath is set', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({ database: layer });
+
+		try {
+			const response = await instance.handler(
+				new Request('http://localhost/status')
+			);
+			assert.strictEqual(response.status, 200);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+
+	it('ignores a path that does not carry the prefix', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({
+			database: layer,
+			basePath: '/api/self-host',
+		});
+
+		try {
+			// Stripping must be conditional: a request that already lacks the
+			// prefix would otherwise have its first path segment eaten.
+			const response = await instance.handler(
+				new Request('http://localhost/status')
+			);
+			assert.strictEqual(response.status, 200);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+});
+
 describe('policy authoring', () => {
 	it('builds and composes packs', () => {
 		const pack = policyBuilder.createPack([

--- a/packages/backend-next/src/instance.ts
+++ b/packages/backend-next/src/instance.ts
@@ -86,6 +86,28 @@ export interface C15TInstance {
  * export const POST = (request: Request) => instance.handler(request);
  * ```
  */
+/**
+ * Removes the mount prefix so the routes can be declared without it.
+ *
+ * A backend mounted at `/api/c15t` receives `/api/c15t/status`, while the
+ * route is registered as `/status`. Stripping here rather than prefixing every
+ * route keeps the routes readable and matches what `@c15t/backend` does.
+ */
+const stripBasePath = (request: Request, basePath?: string): Request => {
+	if (!basePath || basePath === '/') {
+		return request;
+	}
+
+	const prefix = basePath.replace(/\/$/, '');
+	const url = new URL(request.url);
+	if (!url.pathname.startsWith(prefix)) {
+		return request;
+	}
+
+	url.pathname = url.pathname.slice(prefix.length) || '/';
+	return new Request(url, request);
+};
+
 export const c15tInstance = (options: C15TOptions): C15TInstance => {
 	const { database, ...app } = options;
 
@@ -96,7 +118,8 @@ export const c15tInstance = (options: C15TOptions): C15TInstance => {
 
 	return {
 		// `fetch` may answer synchronously; the contract is a promise.
-		handler: async (request) => hono.fetch(request),
+		handler: async (request) =>
+			hono.fetch(stripBasePath(request, app.basePath)),
 		dispose: () => runtime.dispose(),
 	};
 };

--- a/packages/backend-next/src/repository/subject.test.ts
+++ b/packages/backend-next/src/repository/subject.test.ts
@@ -161,40 +161,64 @@ describe('subject repository', () => {
 	);
 
 	it.effect(
-		'costs the same number of queries at 1 subject as at 250',
+		'issues the same number of queries at 1 subject as at 250',
 		() =>
 			Effect.gen(function* () {
 				yield* migrate;
 				const sql = yield* SqlClient.SqlClient;
 
-				// pg_stat_statements is unavailable in PGlite, so count actual
-				// executions against the tables of interest instead.
-				const executions = Effect.fn('executions')(function* () {
-					const rows = yield* sql<{ total: string }>`
-						select coalesce(sum(seq_scan + idx_scan), 0) as total
-						from pg_stat_user_tables
-						where relname in ('subject', 'consent', 'consentPolicy')
+				// Round trips, not scans.
+				//
+				// This counted `seq_scan + idx_scan` from pg_stat_user_tables and
+				// was wrong twice over. Postgres flushes those counters on its own
+				// schedule, so a read taken straight afterwards often missed the
+				// scans it was meant to count — which is why it passed at all, and
+				// why it failed about one run in ten under load. Forcing a flush
+				// makes it deterministic, and reveals the second problem: the
+				// counts genuinely do grow, 4 against 502 at 250 subjects, because
+				// the planner runs the join as a nested loop and scans the inner
+				// side once per row.
+				//
+				// That is not the claim being made. One statement that scans a lot
+				// is still one round trip, and round trips are what cost on a
+				// networked database — the shipped backend's problem is nine of
+				// them, not nine scans. `xact_commit` counts statements, each of
+				// which runs in its own implicit transaction.
+				const statements = Effect.fn('statements')(function* () {
+					yield* sql`select pg_stat_force_next_flush()`;
+					const rows = yield* sql<{ n: string }>`
+						select xact_commit as n from pg_stat_database
+						where datname = current_database()
 					`;
-					return Number(rows[0]?.total ?? 0);
+					return Number(rows[0]?.n ?? 0);
 				});
 
+				// Measuring costs two statements of its own; subtract them.
+				const first = yield* statements();
+				const overhead = (yield* statements()) - first;
+
 				yield* seed('ext_small', 1, 1);
-				const beforeSmall = yield* executions();
+				const beforeSmall = yield* statements();
 				yield* listByExternalId('ext_small');
-				const smallCost = (yield* executions()) - beforeSmall;
+				const smallCost = (yield* statements()) - beforeSmall - overhead;
 
-				// 250 subjects across 5 policy types. Under the old
-				// implementation this was 1 + ceil(250/100) + 5 = 9 sequential
-				// round trips; the point is that this number does not move.
+				// 250 subjects across 5 policy types. The shipped implementation
+				// needs 1 + ceil(250/100) + 5 = 9 sequential round trips for this;
+				// the point is that the number here does not move.
 				yield* seed('ext_large', 250, 5);
-				const beforeLarge = yield* executions();
+				const beforeLarge = yield* statements();
 				yield* listByExternalId('ext_large');
-				const largeCost = (yield* executions()) - beforeLarge;
+				const largeCost = (yield* statements()) - beforeLarge - overhead;
 
+				assert.strictEqual(
+					smallCost,
+					2,
+					'expected the join plus the policy rank'
+				);
 				assert.strictEqual(
 					largeCost,
 					smallCost,
-					`scan count grew with the data: ${smallCost} -> ${largeCost}`
+					`round trips grew with the data: ${smallCost} -> ${largeCost}`
 				);
 			}).pipe(Effect.provide(Pglite)),
 		{ timeout: 120_000 }

--- a/packages/logger/src/core/logger.ts
+++ b/packages/logger/src/core/logger.ts
@@ -32,11 +32,14 @@ import type {
  * @example
  * ```ts
  * // Create a logger with trace context for log correlation
- * import { getTraceContext } from '@c15t/backend/telemetry';
+ * import { trace } from '@opentelemetry/api';
  *
  * const logger = createLogger({
  *   level: 'info',
- *   getTraceContext: () => getTraceContext(),
+ *   getTraceContext: () => {
+ *     const span = trace.getActiveSpan()?.spanContext();
+ *     return span ? { traceId: span.traceId, spanId: span.spanId } : null;
+ *   },
  * });
  *
  * // Logs will include traceId and spanId when available

--- a/packages/logger/src/core/types.ts
+++ b/packages/logger/src/core/types.ts
@@ -81,10 +81,13 @@ export interface LoggerOptions {
 	 *
 	 * @example
 	 * ```ts
-	 * import { getTraceContext } from '@c15t/backend/telemetry';
+	 * import { trace } from '@opentelemetry/api';
 	 *
 	 * const logger = createLogger({
-	 *   getTraceContext: () => getTraceContext(),
+	 *   getTraceContext: () => {
+	 *     const span = trace.getActiveSpan()?.spanContext();
+	 *     return span ? { traceId: span.traceId, spanId: span.spanId } : null;
+	 *   },
 	 * });
 	 * ```
 	 */


### PR DESCRIPTION
Deleting the old package takes `./cache` with it, and `examples/demo` imports `createUpstashRedisAdapter` from there. Memory, Upstash Redis and Cloudflare KV move across unchanged — they depend on nothing the rewrite replaced, and `http/gvl.ts` had already declared the identical `CacheAdapter` interface and accepted one. What was missing was any concrete adapter to hand it. `gvl.ts` now imports that interface rather than redeclaring it.

v2's `gvl-resolver.ts` is deliberately left behind: GVL fetching and caching lives in `http/gvl.ts` here, and a second resolver would mean two code paths deciding when a vendor list is stale.

## They shipped with no tests at all

Which is how the memory adapter's module-level `Map` went unremarked: it is a **process-wide cache**, so two instances see each other's entries. Defensible and surprising, so it is pinned — along with lazy expiry, the null-vs-undefined miss, and vendor-id sorting in the cache key (an unsorted key means the same vendor set requested in a different order silently never hits).

`@upstash/redis` is an optional peer, as in 2.x.

## Two fixes the demos and CI both needed

**`basePath` was accepted as OpenAPI metadata only, never used for routing** — so a backend mounted under a catch-all (`/api/self-host`, which every demo uses) 404d on every route. The prefix is now stripped before dispatch, conditionally, so a request that already lacks it does not lose its first path segment.

**The query-count test was wrong twice over.** It counted `seq_scan + idx_scan` from `pg_stat_user_tables`; Postgres flushes those counters on its own schedule, so a read taken straight afterwards often missed the scans it was meant to count — which is why it passed at all, and why it failed about one run in ten under load. Forcing a flush made it deterministic and revealed the second problem: the counts genuinely do grow, **4 against 502** at 250 subjects, because the planner runs the join as a nested loop and scans the inner side once per row.

That was never the claim. One statement that scans a lot is still one round trip, and round trips are what cost on a networked database — the shipped backend's problem is nine of them, not nine scans. It now counts statements via `xact_commit` and asserts two, flat. 10/10 clean runs.

## `legalDocumentSnapshot`

The sibling of policy-snapshot, built the same way: where a policy snapshot attests to the decision a visitor was shown, this attests to the **version and content hash of the terms they accepted**. A consent record says someone agreed; it does not, by itself, say what to. The TTL is a day rather than half an hour, because a client holds this between being shown the terms and submitting acceptance. Tested for the ways it could wrongly be trusted: cross-tenant, wrong key, tampered payload, and missing-vs-invalid.

## The demos

Everything else mapped. `appName`, `branding`, `i18n`, `policyPacks` and `iab` move into `manifest` — the shape `@c15t/schema` already builds, so server and browser resolve identically. `cache` moves under `gvl`.

The Nuxt demo is the case that justifies the layer escape hatch: it runs **embedded PGlite in development** — Postgres as WASM, no URL to dial — so `{ dialect, url }` cannot describe it, and it hands over a `PgliteClient` layer instead. It lost forty lines of Kysely dialect and pool construction doing so, and its boot migration is now one `createMigrator` call with no ORM branch to handle.

## Edge is dropped from 3.0

`@c15t/backend/edge` does not ship. `unstable_resolveConsent` and the edge init handler are removed rather than ported — nothing outside the old package imports them, and the export carried the `unstable_` prefix for exactly this.

The capability survives: `resolveInitFromManifest` in `@c15t/schema` is the resolver both the edge handler and the real `/init` were built on, and a host that wants edge resolution calls it directly. What goes is the packaged handler.

Also fixes `@c15t/logger`'s two JSDoc examples, which imported `getTraceContext` from `@c15t/backend/telemetry` — a subpath not in that package's exports map, so the example was already wrong, and 3.0 has no equivalent. They now show the option satisfied from `@opentelemetry/api` directly, which is where a trace context actually comes from.
