### PR TITLE
fix(scripts): seed PostHog snippet init queue so array.js installs

### DIFF
--- a/.changeset/posthog-snippet-init-queue.md
+++ b/.changeset/posthog-snippet-init-queue.md
@@ -1,0 +1,5 @@
+---
+'@c15t/scripts': patch
+---
+
+Fix the PostHog integration loading no analytics runtime at all. Since posthog-js 1.410.2, `array.js` refuses to install itself over an existing `window.posthog` that has no snippet-shaped pending-init queue, so c15t's bootstrap stub was left in place and every call — including `init` — silently became a no-op. The stub now seeds `_i` like the official snippet does.

--- a/packages/scripts/src/posthog.e2e.test.ts
+++ b/packages/scripts/src/posthog.e2e.test.ts
@@ -74,4 +74,32 @@ describe('posthog contract', () => {
 		]);
 		expect(consentCalls).toEqual(['opt_out']);
 	});
+
+	it('bootstraps a snippet-shaped stub that array.js will install over', () => {
+		let acceptedBySnippetGuard: boolean | undefined;
+
+		installHeadProbe((node, win) => {
+			if (!node.src.includes('posthog.com/static/array.js')) {
+				return;
+			}
+
+			// The guard `array.js` applies before installing its runtime over an
+			// existing global (posthog-js >= 1.410.2). A stub that fails it is
+			// left in place, so every call — including `init` — becomes a no-op.
+			const stub = win.posthog as Window['posthog'] | undefined;
+			acceptedBySnippetGuard = !stub || Array.isArray(stub._i);
+		});
+
+		loadScripts(
+			[
+				{
+					...posthog({ id: 'phc_snippet_guard' }),
+					id: 'posthog-snippet-guard',
+				},
+			],
+			deniedConsents
+		);
+
+		expect(acceptedBySnippetGuard).toBe(true);
+	});
 });

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -19,6 +19,12 @@ declare global {
 			opt_out_capturing: () => void;
 			get_explicit_consent_status: () => string;
 			capture: (event: string, properties?: Record<string, unknown>) => void;
+			/**
+			 * Pending `init(...)` argument tuples, as seeded by the official
+			 * PostHog snippet. `array.js` only installs its runtime over an
+			 * existing `window.posthog` when this is an array.
+			 */
+			_i?: unknown[][];
 		};
 	}
 }
@@ -152,9 +158,13 @@ export const posthogManifest = {
 	alwaysLoad: true,
 	bootstrap: [
 		{
+			// `_i` must be an array: since posthog-js 1.410.2, `array.js` skips
+			// installing its runtime entirely when `window.posthog` already
+			// exists without a snippet-shaped pending-init queue, which would
+			// leave the stub methods below in place and drop every event.
 			type: 'setGlobal',
 			name: 'posthog',
-			value: {},
+			value: { _i: [] },
 			ifUndefined: true,
 		},
 		{


### PR DESCRIPTION
Fixes #981.

## What broke

PostHog JS 1.410.2 added a duplicate-loader guard. When `window.posthog` already exists, `array.js` only installs its runtime if `posthog._i` is an array. The c15t bootstrap stub had no `_i`, so the CDN script returned successfully but left the noop stub installed and every event was dropped.

## Minimal fix

Seed the pending-init registry as `{ _i: [] }`. This is the smallest change that satisfies the upstream loader guard while preserving the existing c15t lifecycle: the real SDK installs first, then the existing load callback calls `posthog.init(...)`.

This PR intentionally contains only the hotfix, its regression test, and a patch changeset. The unrelated Turbo cache change was moved to #994.

## Verification

- focused PostHog contract and unit tests: 11 passing
- live CDN probe: PostHog runtime installs successfully
- regression test transcribes the upstream `Array.isArray(posthog._i)` guard
