### PR TITLE
test(scripts): make vendor monitor coverage honest and bisectable

### DIFF
--- a/.github/workflows/script-vendor-monitor.yml
+++ b/.github/workflows/script-vendor-monitor.yml
@@ -1,13 +1,22 @@
 name: Script Vendor Monitor
 
-# Daily live browser probes for every built-in @c15t/scripts integration.
+# Live browser probes for every built-in @c15t/scripts integration.
 # Runs outside normal CI so transient third-party/network failures never
 # block PRs. Failures open one deduped issue per vendor; recoveries close
 # that vendor's issue automatically.
+#
+# Vendors ship breaking loader changes on their own schedule, and a broken
+# integration is invisible to consumers until it is probed, so the schedule
+# runs every six hours, capping the exposure window at a quarter of a day.
+# Canary pushes probe as well, which catches breakage we introduce ourselves
+# as soon as it lands.
 
 on:
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '30 */6 * * *'
+  push:
+    branches:
+      - canary
   workflow_dispatch:
     inputs:
       vendor:

--- a/packages/scripts/live-vendors/README.md
+++ b/packages/scripts/live-vendors/README.md
@@ -1,7 +1,8 @@
 # Live vendor monitor
 
-Live browser probes for every built-in `@c15t/scripts` integration, run daily
-by `.github/workflows/script-vendor-monitor.yml` (issue
+Live browser probes for every built-in `@c15t/scripts` integration, run every
+six hours and on canary pushes by
+`.github/workflows/script-vendor-monitor.yml` (issue
 [#899](https://github.com/c15t/c15t/issues/899)). Unlike the jsdom contract
 tests in `src/`, these probes load the **real** vendor loader scripts in real
 Chromium, so they catch remote loader changes that static tests cannot — like
@@ -89,3 +90,10 @@ logic is pure and unit-tested in `report.test.ts`.
 - The runner needs `--tsconfig-override live-vendors/tsconfig.json` (already
   baked into the package scripts) because Bun otherwise applies the package
   tsconfig's `c15t → dist-types` path mapping at runtime.
+- That tsconfig maps `~/*` to `../../core/src/*`. `stub-contract.test.ts`
+  reaches `src/e2e-test-utils.ts`, which imports the core script loader by
+  relative path, so core's own `~/*` sources join this project's type program.
+  The package tsconfig sidesteps this by excluding `e2e-test-utils.ts`
+  outright; excluding it here would leave the meta-test untyped instead. Keep
+  the mapping narrow — Bun reads these paths at runtime too, so adding a
+  `c15t` entry here would point the runner at `.d.ts` files.

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -188,7 +188,9 @@ const harness: LiveVendorProbeHarness = {
 
 	version(vendor: string): string | undefined {
 		try {
-			return getLiveVendorProbeConfig(vendor)?.runtimeVersion?.();
+			const runtimeVersion =
+				getLiveVendorProbeConfig(vendor)?.runtimeVersion?.();
+			return typeof runtimeVersion === 'string' ? runtimeVersion : undefined;
 		} catch {
 			return undefined;
 		}

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -186,6 +186,14 @@ const harness: LiveVendorProbeHarness = {
 		return runCheck(config.runtimeCheck, 'no runtime check defined');
 	},
 
+	version(vendor: string): string | undefined {
+		try {
+			return getLiveVendorProbeConfig(vendor)?.runtimeVersion?.();
+		} catch {
+			return undefined;
+		}
+	},
+
 	inspectStorage() {
 		const cookieNames = document.cookie
 			.split(';')

--- a/packages/scripts/live-vendors/probe-policy.test.ts
+++ b/packages/scripts/live-vendors/probe-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { assertsRuntime, digestBody } from './probe-policy';
+import { liveVendorProbeConfigs } from './vendors';
+
+const ok = () => ({ ok: true, detail: 'stub' });
+
+describe('assertsRuntime', () => {
+	it('always asserts runtime at full tier', () => {
+		expect(assertsRuntime({ tier: 'full' })).toBe(true);
+	});
+
+	it('asserts runtime for a loader-only vendor that declares a check', () => {
+		// The gap the tier-only gate left: a declared `runtimeCheck` that never
+		// ran, reporting coverage the monitor was not actually performing.
+		expect(assertsRuntime({ tier: 'loader-only' })).toBe(false);
+		expect(assertsRuntime({ tier: 'loader-only', runtimeCheck: ok })).toBe(
+			true
+		);
+		expect(
+			assertsRuntime({
+				tier: 'loader-only',
+				runtimeReplacedGlobals: ['va'],
+			})
+		).toBe(true);
+	});
+
+	it('never asserts runtime for a skipped vendor without checks', () => {
+		expect(assertsRuntime({ tier: 'skip' })).toBe(false);
+	});
+
+	it('agrees with the documented gap list across the real configs', () => {
+		// Ties the gate to `vendors.test.ts`'s snapshot: a vendor is a documented
+		// runtime gap exactly when this gate declines to assert runtime for it.
+		const notAsserted = liveVendorProbeConfigs
+			.filter((config) => config.tier !== 'skip' && !assertsRuntime(config))
+			.map((config) => config.vendor);
+
+		for (const vendor of notAsserted) {
+			const config = liveVendorProbeConfigs.find((c) => c.vendor === vendor);
+			expect(
+				config?.notes,
+				`${vendor} is not runtime-asserted and must document the gap`
+			).toBeTypeOf('string');
+		}
+	});
+});
+
+describe('digestBody', () => {
+	it('returns the first 16 hex characters of the body SHA-256', () => {
+		// Fixed vector: sha256('') = e3b0c44298fc1c14...
+		expect(digestBody(new Uint8Array())).toBe('e3b0c44298fc1c14');
+		expect(digestBody(new Uint8Array())).toHaveLength(16);
+	});
+
+	it('distinguishes two loader bundles that differ by one byte', () => {
+		// The whole point of recording it: telling "same bundle as the last green
+		// run" from "upstream shipped something new".
+		const before = new TextEncoder().encode('!function(){var a=1}();');
+		const after = new TextEncoder().encode('!function(){var a=2}();');
+
+		expect(digestBody(before)).not.toBe(digestBody(after));
+	});
+
+	it('digests Buffer and Uint8Array views of the same bytes identically', () => {
+		// `loaderResponseDetails` hands it a Playwright Buffer; the Node fetch
+		// fallback hands it a Uint8Array. Both must digest to the same value or
+		// the two code paths would report different bundles for one response.
+		const bytes = new TextEncoder().encode('console.log("loader")');
+
+		expect(digestBody(Buffer.from(bytes))).toBe(digestBody(bytes));
+	});
+});

--- a/packages/scripts/live-vendors/probe-policy.test.ts
+++ b/packages/scripts/live-vendors/probe-policy.test.ts
@@ -22,6 +22,12 @@ describe('assertsRuntime', () => {
 				runtimeReplacedGlobals: ['va'],
 			})
 		).toBe(true);
+		expect(
+			assertsRuntime({
+				tier: 'loader-only',
+				runtimeReplacedGlobals: [],
+			})
+		).toBe(false);
 	});
 
 	it('never asserts runtime for a skipped vendor without checks', () => {

--- a/packages/scripts/live-vendors/probe-policy.ts
+++ b/packages/scripts/live-vendors/probe-policy.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure probe policy helpers, split out of `runner.ts` so they can be unit
+ * tested. `runner.ts` ends in a top-level `await main()`, so importing it from
+ * a test would execute a full Playwright run.
+ */
+import { createHash } from 'node:crypto';
+import type { LiveVendorProbeConfig } from './types';
+
+/**
+ * Decides whether a probe attempt must assert that the vendor runtime started.
+ *
+ * The runtime phase is the only signal that catches a vendor silently refusing
+ * to install — the loader still answers 200 and the page throws nothing — so it
+ * has to run wherever it can possibly pass, not only at `full` tier. Gating on
+ * tier alone left `loader-only` vendors carrying `runtimeCheck` definitions
+ * that were never executed: declared coverage that did not exist.
+ *
+ * @param config - The vendor's probe config.
+ * @returns `true` when the runtime phase should run and be asserted.
+ */
+export function assertsRuntime(
+	config: Pick<
+		LiveVendorProbeConfig,
+		'tier' | 'runtimeCheck' | 'runtimeReplacedGlobals'
+	>
+): boolean {
+	return (
+		config.tier === 'full' ||
+		Boolean(config.runtimeCheck) ||
+		Boolean(config.runtimeReplacedGlobals)
+	);
+}
+
+/**
+ * Digests a loader body so reports pin the exact upstream bundle a run saw.
+ *
+ * @param body - Raw loader response bytes.
+ * @returns The first 16 hex characters of the body's SHA-256 — collision-proof
+ * enough to answer "same bundle as the last green run?" without bloating the
+ * report.
+ */
+export function digestBody(body: Uint8Array | Buffer): string {
+	return createHash('sha256').update(body).digest('hex').slice(0, 16);
+}

--- a/packages/scripts/live-vendors/probe-policy.ts
+++ b/packages/scripts/live-vendors/probe-policy.ts
@@ -27,7 +27,7 @@ export function assertsRuntime(
 	return (
 		config.tier === 'full' ||
 		Boolean(config.runtimeCheck) ||
-		Boolean(config.runtimeReplacedGlobals)
+		(config.runtimeReplacedGlobals?.length ?? 0) > 0
 	);
 }
 

--- a/packages/scripts/live-vendors/report.test.ts
+++ b/packages/scripts/live-vendors/report.test.ts
@@ -141,6 +141,22 @@ describe('buildMonitorIssueBody', () => {
 		expect(body).toContain('**Vendor SDK version**: `1.410.2`');
 	});
 
+	it('reports a known zero-byte loader body', () => {
+		const result = makeResult({
+			ok: false,
+			phases: { load: { ok: false, detail: 'empty response' } },
+			loader: {
+				url: 'https://example.test/empty.js',
+				status: 200,
+				bytes: 0,
+				bodyHash: 'e3b0c44298fc1c14',
+			},
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).toContain('**Loader bundle**: `e3b0c44298fc1c14` (0 bytes)');
+	});
+
 	it('omits provenance lines when the loader body was unreadable', () => {
 		// Redirects and cached/aborted responses carry no body, and not every
 		// vendor declares `runtimeVersion` — neither should print an empty row.

--- a/packages/scripts/live-vendors/report.test.ts
+++ b/packages/scripts/live-vendors/report.test.ts
@@ -117,6 +117,58 @@ describe('buildMonitorIssueBody', () => {
 		expect(body).toContain('Console errors');
 	});
 
+	it('reports loader bundle provenance so a failure can be bisected', () => {
+		// These two lines are the whole reason the digest and version are
+		// collected: comparing a red report against the last green one should
+		// say whether upstream shipped a new bundle without diffing CDN files.
+		const result = makeResult({
+			ok: false,
+			phases: { runtime: { ok: false, detail: 'SDK never installed' } },
+			loader: {
+				url: 'https://eu-assets.i.posthog.com/static/array.js',
+				status: 200,
+				contentType: 'application/javascript',
+				bytes: 48213,
+				bodyHash: 'a1b2c3d4e5f60718',
+			},
+			sdkVersion: '1.410.2',
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).toContain(
+			'**Loader bundle**: `a1b2c3d4e5f60718` (48213 bytes)'
+		);
+		expect(body).toContain('**Vendor SDK version**: `1.410.2`');
+	});
+
+	it('omits provenance lines when the loader body was unreadable', () => {
+		// Redirects and cached/aborted responses carry no body, and not every
+		// vendor declares `runtimeVersion` — neither should print an empty row.
+		const result = makeResult({
+			ok: false,
+			phases: { load: { ok: false, detail: 'no response' } },
+			loader: { url: 'https://example.test/tag.js', status: 302 },
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).not.toContain('**Loader bundle**');
+		expect(body).not.toContain('**Vendor SDK version**');
+	});
+
+	it('sanitizes a vendor-supplied SDK version before embedding it', () => {
+		// `sdkVersion` is read out of the probed page, so it is third-party text
+		// on the same footing as console output.
+		const result = makeResult({
+			ok: false,
+			phases: { runtime: { ok: false, detail: 'nope' } },
+			sdkVersion: '1.0.0` <img src=x onerror=alert(1)>',
+		});
+		const body = buildMonitorIssueBody(result, makeReport([result]));
+
+		expect(body).toContain('**Vendor SDK version**');
+		expect(body).not.toContain('onerror=alert(1)>`');
+	});
+
 	it('sanitizes third-party text and notes overflowed error lists', () => {
 		const errors = Array.from(
 			{ length: 12 },

--- a/packages/scripts/live-vendors/report.ts
+++ b/packages/scripts/live-vendors/report.ts
@@ -155,6 +155,15 @@ export function buildMonitorIssueBody(
 			}`
 		: 'No loader response captured.';
 
+	// Provenance: which upstream build this failure was observed against.
+	// Comparing these two lines against the last green report identifies a
+	// vendor-side change without diffing published CDN bundles by hand.
+	const bundleLine = result.loader?.bodyHash
+		? `\`${sanitizeInline(result.loader.bodyHash)}\`${
+				result.loader.bytes ? ` (${result.loader.bytes} bytes)` : ''
+			}`
+		: undefined;
+
 	const metadataLines = [
 		`- **Vendor**: \`${result.vendor}\` (\`@c15t/scripts/${result.packageSubpath}\`)`,
 		`- **Probe tier**: \`${result.tier}\``,
@@ -162,6 +171,16 @@ export function buildMonitorIssueBody(
 		`- **Attempts**: ${result.attempts}`,
 		`- **Loader**: ${loaderLine}`,
 	];
+
+	if (bundleLine) {
+		metadataLines.push(`- **Loader bundle**: ${bundleLine}`);
+	}
+
+	if (result.sdkVersion) {
+		metadataLines.push(
+			`- **Vendor SDK version**: \`${sanitizeInline(result.sdkVersion)}\``
+		);
+	}
 
 	if (report.commitSha) {
 		metadataLines.push(`- **Commit**: ${report.commitSha}`);
@@ -174,7 +193,7 @@ export function buildMonitorIssueBody(
 	const notes = result.notes ? `\n> ${sanitizeInline(result.notes)}\n` : '';
 
 	return `<!-- c15t-monitor-signature: ${signature} -->
-The daily live vendor monitor detected a contract failure for **${result.label}**.
+The live vendor monitor detected a contract failure for **${result.label}**.
 
 ${metadataLines.join('\n')}
 ${notes}

--- a/packages/scripts/live-vendors/report.ts
+++ b/packages/scripts/live-vendors/report.ts
@@ -160,7 +160,9 @@ export function buildMonitorIssueBody(
 	// vendor-side change without diffing published CDN bundles by hand.
 	const bundleLine = result.loader?.bodyHash
 		? `\`${sanitizeInline(result.loader.bodyHash)}\`${
-				result.loader.bytes ? ` (${result.loader.bytes} bytes)` : ''
+				result.loader.bytes !== undefined
+					? ` (${result.loader.bytes} bytes)`
+					: ''
 			}`
 		: undefined;
 

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -139,6 +139,28 @@ interface ProbeAttemptOutcome {
 	pageErrors: string[];
 }
 
+async function withTimeout<Value>(
+	promise: Promise<Value>,
+	timeoutMs: number
+): Promise<Value> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			reject(new Error(`operation timed out after ${timeoutMs}ms`));
+		}, timeoutMs);
+
+		promise.then(
+			(value) => {
+				clearTimeout(timeout);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timeout);
+				reject(error);
+			}
+		);
+	});
+}
+
 async function loaderResponseDetails(
 	response: Response
 ): Promise<NonNullable<LiveVendorResult['loader']>> {
@@ -147,8 +169,11 @@ async function loaderResponseDetails(
 		.catch(() => ({}));
 
 	// Redirects and cached/aborted responses can have no readable body; the
-	// status and content type are still worth reporting on their own.
-	const body = await response.body().catch(() => undefined);
+	// status and content type are still worth reporting on their own. Bound the
+	// read as a response can deliver headers while its body stalls indefinitely.
+	const body = await withTimeout(response.body(), LOADER_TIMEOUT_MS).catch(
+		() => undefined
+	);
 
 	return {
 		url: response.url(),

--- a/packages/scripts/live-vendors/runner.ts
+++ b/packages/scripts/live-vendors/runner.ts
@@ -8,7 +8,8 @@
  * 2. `bootstrap` — queue stubs must exist after `loadScripts`, before the
  *                  remote loader executes.
  * 3. `load`      — the real vendor loader URL must respond.
- * 4. `runtime`   — the vendor runtime must initialize (full tier only).
+ * 4. `runtime`   — the vendor runtime must initialize (full tier, plus any
+ *                  loader-only vendor that declares a runtime assertion).
  * 5. `network`   — every non-allowlisted third-party request is answered with
  *                  an empty 204 so no real analytics data is sent.
  *
@@ -20,6 +21,7 @@
 import { type Browser, chromium, type Response } from 'playwright';
 import { getBuiltInScriptIntegrationByVendor } from '../src/registry';
 import { evaluateDeniedConsentProbe } from './denied-consent';
+import { assertsRuntime, digestBody } from './probe-policy';
 import { failedPhases } from './report';
 import type {
 	LiveProbeCheckResult,
@@ -131,6 +133,7 @@ async function buildHarnessBundle(): Promise<string> {
 interface ProbeAttemptOutcome {
 	phases: LiveVendorResult['phases'];
 	loader?: LiveVendorResult['loader'];
+	sdkVersion?: string;
 	blockedRequests: number;
 	consoleErrors: string[];
 	pageErrors: string[];
@@ -143,10 +146,16 @@ async function loaderResponseDetails(
 		.allHeaders()
 		.catch(() => ({}));
 
+	// Redirects and cached/aborted responses can have no readable body; the
+	// status and content type are still worth reporting on their own.
+	const body = await response.body().catch(() => undefined);
+
 	return {
 		url: response.url(),
 		status: response.status(),
 		contentType: headers['content-type'],
+		bytes: body?.byteLength,
+		bodyHash: body ? digestBody(body) : undefined,
 	};
 }
 
@@ -161,12 +170,14 @@ async function fetchLoaderDetails(
 		const response = await fetch(url, {
 			signal: AbortSignal.timeout(LOADER_TIMEOUT_MS),
 		});
-		await response.body?.cancel();
+		const body = new Uint8Array(await response.arrayBuffer());
 
 		return {
 			url,
 			status: response.status,
 			contentType: response.headers.get('content-type') ?? undefined,
+			bytes: body.byteLength,
+			bodyHash: digestBody(body),
 		};
 	} catch {
 		return undefined;
@@ -492,8 +503,10 @@ async function probeVendorAttempt(
 			};
 		}
 
-		// Phase: runtime — full tier only; poll until the vendor runtime is up.
-		if (config.tier === 'full' && phases.load.ok) {
+		// Phase: runtime — poll until the vendor runtime is up. Full tier always
+		// asserts it; loader-only vendors assert it too whenever they declare a
+		// check that placeholder credentials can still satisfy.
+		if (assertsRuntime(config) && phases.load.ok) {
 			const deadline = Date.now() + RUNTIME_TIMEOUT_MS;
 			let runtime: LiveProbeCheckResult = {
 				ok: false,
@@ -523,6 +536,18 @@ async function probeVendorAttempt(
 			phases.runtime = runtime;
 		}
 
+		// Provenance, never an assertion: records which upstream build this run
+		// actually validated so a later regression can be bisected by report.
+		const sdkVersion = config.runtimeVersion
+			? await page.evaluate<string | undefined, string>(
+					(vendor) =>
+						(
+							globalThis as unknown as ProbeWindow
+						).__c15tLiveVendorProbe?.version(vendor),
+					config.vendor
+				)
+			: undefined;
+
 		// Phase: network — informational; the route handler guarantees blocking.
 		phases.network = {
 			ok: true,
@@ -532,6 +557,7 @@ async function probeVendorAttempt(
 		return {
 			phases,
 			loader,
+			sdkVersion,
 			blockedRequests: blocked.length,
 			consoleErrors,
 			pageErrors,
@@ -614,6 +640,7 @@ async function probeVendor(
 				attempts: attempt,
 				phases: lastOutcome?.phases ?? {},
 				loader: lastOutcome?.loader,
+				sdkVersion: lastOutcome?.sdkVersion,
 				blockedRequests: lastOutcome?.blockedRequests ?? 0,
 				consoleErrors: lastOutcome?.consoleErrors ?? [],
 				pageErrors: lastOutcome?.pageErrors ?? [],
@@ -632,6 +659,7 @@ async function probeVendor(
 			},
 		},
 		loader: lastOutcome?.loader,
+		sdkVersion: lastOutcome?.sdkVersion,
 		blockedRequests: lastOutcome?.blockedRequests ?? 0,
 		consoleErrors: lastOutcome?.consoleErrors ?? [],
 		pageErrors: lastError

--- a/packages/scripts/live-vendors/stub-contract.test.ts
+++ b/packages/scripts/live-vendors/stub-contract.test.ts
@@ -117,7 +117,7 @@ describe('vendor stub contracts', () => {
 		// any custom check runs, which the stub can never satisfy. Their
 		// `runtimeCheck` is then free to be a plain shape assertion.
 		const unprotected = runtimeConfigs.filter(
-			([, config]) => !config.runtimeReplacedGlobals
+			([, config]) => (config.runtimeReplacedGlobals?.length ?? 0) === 0
 		);
 
 		it.each(unprotected)('%s', (_vendor, config) => {

--- a/packages/scripts/live-vendors/stub-contract.test.ts
+++ b/packages/scripts/live-vendors/stub-contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Replays the live monitor's two stub-side contracts without touching the
+ * network, so they hold on every PR instead of once a vendor probe runs.
+ *
+ * jsdom never fetches or executes the remote loader, which is precisely the
+ * state both contracts are about: bootstrapped, nothing else.
+ *
+ * 1. Every `bootstrapCheck` must pass. Bootstrap state is a pure function of
+ *    our own manifest, and several of these checks transcribe a vendor's
+ *    duplicate-install guard — the predicate their loader applies before it
+ *    will install over our stub. Failing one means the vendor silently never
+ *    starts in production, with a 200 loader and no console error.
+ * 2. Every `runtimeCheck` must fail. The runtime phase is the only signal that
+ *    catches a vendor refusing to install, so a check our own stub already
+ *    satisfies protects nothing and reports green forever.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	loadScripts,
+	registerVendorContractCleanup,
+} from '../src/e2e-test-utils';
+import type { LiveVendorProbeConfig } from './types';
+import { liveVendorProbeConfigs } from './vendors';
+
+/** Grants every category — the stub a fully consenting visitor would see. */
+const allGranted = {
+	necessary: true,
+	functionality: true,
+	measurement: true,
+	marketing: true,
+	experience: true,
+};
+
+function configsDeclaring(
+	key: 'bootstrapCheck' | 'runtimeCheck'
+): [string, LiveVendorProbeConfig][] {
+	return liveVendorProbeConfigs
+		.filter(
+			(config) =>
+				config.tier !== 'skip' && config.createScript?.() && config[key]
+		)
+		.map((config) => [config.vendor, config]);
+}
+
+/** Bootstraps a vendor with the remote loader never executing. */
+function bootstrapOnly(config: LiveVendorProbeConfig): void {
+	const script = config.createScript?.();
+	expect(script, `${config.vendor} must build a script`).toBeDefined();
+	if (script) {
+		loadScripts([script], allGranted);
+	}
+}
+
+const bootstrapConfigs = configsDeclaring('bootstrapCheck');
+const runtimeConfigs = configsDeclaring('runtimeCheck');
+
+describe('vendor stub contracts', () => {
+	registerVendorContractCleanup();
+
+	it('replays a meaningful number of vendor contracts', () => {
+		expect(bootstrapConfigs.length).toBeGreaterThan(0);
+		expect(runtimeConfigs.length).toBeGreaterThan(0);
+	});
+
+	it('requires the real PostHog loader to replay a snippet queue', () => {
+		const config = liveVendorProbeConfigs.find(
+			(candidate) => candidate.vendor === 'posthog'
+		);
+		expect(config).toBeDefined();
+
+		const queue = [] as unknown[] & { _i?: unknown[][] };
+		queue._i = [['phc_test', {}, 'posthog']];
+		window.posthog = queue as unknown as Window['posthog'];
+
+		expect(config?.bootstrapCheck?.().ok).toBe(true);
+		const replayProbe = queue.at(-1);
+		expect(replayProbe).toBeTypeOf('function');
+		if (typeof replayProbe === 'function') {
+			replayProbe();
+		}
+
+		window.posthog = {
+			init: () => undefined,
+			opt_in_capturing: () => undefined,
+			opt_out_capturing: () => undefined,
+			get_explicit_consent_status: () => 'granted',
+			capture: () => undefined,
+			__loaded: true,
+		} as Window['posthog'];
+
+		expect(config?.runtimeCheck?.().ok).toBe(true);
+
+		delete (window as unknown as Record<string, unknown>)
+			.__c15tPosthogQueueReplayExpected;
+		delete (window as unknown as Record<string, unknown>)
+			.__c15tPosthogQueueReplayed;
+	});
+
+	describe('bootstrap stubs satisfy their vendor contract', () => {
+		it.each(bootstrapConfigs)('%s', (_vendor, config) => {
+			bootstrapOnly(config);
+
+			const result = config.bootstrapCheck?.();
+
+			expect(
+				result?.ok,
+				`${config.vendor}: bootstrapCheck fails against our own bootstrap — ${result?.detail ?? 'no detail'}`
+			).toBe(true);
+		});
+	});
+
+	describe('runtime checks reject the bootstrap stub', () => {
+		// Vendors declaring `runtimeReplacedGlobals` are structurally protected:
+		// the harness compares the global against its pre-load identity before
+		// any custom check runs, which the stub can never satisfy. Their
+		// `runtimeCheck` is then free to be a plain shape assertion.
+		const unprotected = runtimeConfigs.filter(
+			([, config]) => !config.runtimeReplacedGlobals
+		);
+
+		it.each(unprotected)('%s', (_vendor, config) => {
+			bootstrapOnly(config);
+
+			const result = config.runtimeCheck?.();
+
+			expect(
+				result?.ok,
+				`${config.vendor}: runtimeCheck passes against the bootstrap stub alone, so the live monitor would report this vendor healthy even if its SDK stopped installing. Assert a marker only the vendor runtime can set, or declare runtimeReplacedGlobals.`
+			).toBe(false);
+		});
+	});
+});

--- a/packages/scripts/live-vendors/tsconfig.json
+++ b/packages/scripts/live-vendors/tsconfig.json
@@ -2,7 +2,10 @@
 	"extends": "@c15t/typescript-config/base.json",
 	"compilerOptions": {
 		"noEmit": true,
-		"types": ["bun"]
+		"types": ["bun"],
+		"paths": {
+			"~/*": ["../../core/src/*"]
+		}
 	},
 	"include": ["."],
 	"exclude": ["node_modules"]

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -5,10 +5,14 @@ import type { Script } from 'c15t';
  *
  * - `full`: the vendor loader must respond successfully and the runtime check
  *   must pass after the remote script executes.
- * - `loader-only`: the loader request must complete with an HTTP response, but
- *   no runtime behavior is asserted. Use this for vendors whose loader rejects
- *   placeholder account ids (for example with a 404) so the probe still proves
- *   bootstrap and consent gating against the real endpoint.
+ * - `loader-only`: the loader request only has to complete with an HTTP
+ *   response, rather than the 2xx JavaScript body the full tier demands. Use
+ *   this for vendors whose loader rejects placeholder account ids (for example
+ *   with a 404) so the probe still proves bootstrap and consent gating against
+ *   the real endpoint. Runtime is still asserted whenever the vendor declares
+ *   `runtimeCheck` or `runtimeReplacedGlobals` — some loaders serve a usable
+ *   runtime even for unknown ids, and skipping those assertions would leave
+ *   the vendor with no coverage of the SDK actually starting.
  * - `skip`: the vendor cannot be probed live (for example edge-injected
  *   scripts). Skipped vendors are reported with `skipReason` so coverage gaps
  *   stay visible instead of silently disappearing.
@@ -66,6 +70,18 @@ export interface LiveVendorProbeConfig {
 	/**
 	 * Runs in the page synchronously after `loadScripts`, before the remote
 	 * loader executes. Assert queue stubs and globals seeded by bootstrap steps.
+	 *
+	 * This is the right home for a vendor's duplicate-install guard. Several
+	 * loaders inspect the global the page already has and silently return if it
+	 * does not look like their official snippet — a stub that fails such a guard
+	 * leaves the vendor uninstalled with no error anywhere, because the loader
+	 * still answers 200 and the page still looks healthy. Transcribe the
+	 * predicate from their loader source and cite it in a comment.
+	 *
+	 * Bootstrap state is a pure function of our own manifest, so
+	 * `stub-contract.test.ts` replays every one of these in jsdom on each PR.
+	 * A stub that drifts out of contract fails there rather than a day later in
+	 * the monitor.
 	 */
 	bootstrapCheck?: () => LiveProbeCheckResult;
 	/**
@@ -73,6 +89,16 @@ export interface LiveVendorProbeConfig {
 	 * the real vendor runtime replaced or initialized the bootstrap stub.
 	 */
 	runtimeCheck?: () => LiveProbeCheckResult;
+	/**
+	 * Reads the version the vendor runtime reports about itself, when it
+	 * exposes one (for example `posthog.config` / `mixpanel.__SV`).
+	 *
+	 * Recorded in the report purely as provenance: it pins which upstream build
+	 * a green run actually validated, so a later failure can be bisected by
+	 * comparing two reports instead of diffing published CDN bundles. Never
+	 * asserted — a vendor bumping their version is not a failure.
+	 */
+	runtimeVersion?: () => string | undefined;
 	/**
 	 * Globals whose pre-load stub identity must be replaced by the vendor
 	 * runtime for the runtime phase to pass. Stronger than a `typeof` check in
@@ -150,6 +176,8 @@ export interface LiveVendorProbeHarness {
 	load(vendor: string, granted: boolean): LiveProbeLoadOutcome;
 	/** Runs the vendor's runtime check. */
 	check(vendor: string): LiveProbeCheckResult;
+	/** Reads the vendor runtime's self-reported version, if it exposes one. */
+	version(vendor: string): string | undefined;
 	/** Snapshots cookie names and localStorage keys in the probed page. */
 	inspectStorage(): LiveStorageSnapshot;
 }
@@ -161,6 +189,18 @@ export interface LiveLoaderResponse {
 	url: string;
 	status: number;
 	contentType?: string;
+	/** Response body size in bytes, when the body was readable. */
+	bytes?: number;
+	/**
+	 * Short SHA-256 of the loader response body.
+	 *
+	 * Vendors ship breaking changes to these bundles without notice, so the
+	 * question after a failure is always "what changed, and when did it start".
+	 * Comparing this digest between a passing and a failing report answers the
+	 * second half directly, and a digest that moves while the probe still
+	 * passes is advance warning that the contract is in motion.
+	 */
+	bodyHash?: string;
 }
 
 /**
@@ -187,6 +227,8 @@ export interface LiveVendorResult {
 	phases: Partial<Record<LiveProbePhase, LiveProbeCheckResult>>;
 	/** Loader response captured during the load phase, when one arrived. */
 	loader?: LiveLoaderResponse;
+	/** Version the vendor runtime reported, when `runtimeVersion` is declared. */
+	sdkVersion?: string;
 	/** Count of third-party requests answered with an empty 204. */
 	blockedRequests: number;
 	/** Console error messages emitted by the probed page. */

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -97,6 +97,8 @@ export interface LiveVendorProbeConfig {
 	 * a green run actually validated, so a later failure can be bisected by
 	 * comparing two reports instead of diffing published CDN bundles. Never
 	 * asserted — a vendor bumping their version is not a failure.
+	 *
+	 * @returns The runtime version, or `undefined` when it is unavailable.
 	 */
 	runtimeVersion?: () => string | undefined;
 	/**
@@ -176,7 +178,12 @@ export interface LiveVendorProbeHarness {
 	load(vendor: string, granted: boolean): LiveProbeLoadOutcome;
 	/** Runs the vendor's runtime check. */
 	check(vendor: string): LiveProbeCheckResult;
-	/** Reads the vendor runtime's self-reported version, if it exposes one. */
+	/**
+	 * Reads the vendor runtime's self-reported version, if it exposes one.
+	 *
+	 * @param vendor - Registry vendor id with a probe config.
+	 * @returns The runtime version, or `undefined` when it is unavailable.
+	 */
 	version(vendor: string): string | undefined;
 	/** Snapshots cookie names and localStorage keys in the probed page. */
 	inspectStorage(): LiveStorageSnapshot;

--- a/packages/scripts/live-vendors/vendors.test.ts
+++ b/packages/scripts/live-vendors/vendors.test.ts
@@ -41,6 +41,48 @@ describe('live vendor probe configs', () => {
 		}
 	});
 
+	it('documents every vendor that asserts no runtime behavior', () => {
+		// A vendor whose loader answers placeholder credentials with an error
+		// page cannot prove its SDK started, so the probe reduces to "the
+		// endpoint exists". That is a real coverage gap — the exact kind that
+		// hides a loader contract change — so it has to be written down rather
+		// than inferred from an absent field.
+		const gaps: string[] = [];
+
+		for (const config of liveVendorProbeConfigs) {
+			if (config.tier === 'skip') {
+				continue;
+			}
+
+			const assertsRuntime =
+				Boolean(config.runtimeCheck) || Boolean(config.runtimeReplacedGlobals);
+			if (assertsRuntime) {
+				continue;
+			}
+
+			expect(
+				config.notes,
+				`${config.vendor} asserts no runtime behavior and must explain the gap in notes`
+			).toBeTypeOf('string');
+			gaps.push(config.vendor);
+		}
+
+		// Snapshot the gap list so shrinking it is deliberate and growing it is
+		// impossible to land unnoticed.
+		expect(gaps.sort()).toEqual([
+			'adobe-analytics',
+			'clearbit',
+			'crisp',
+			'google-tag-manager',
+			'hotjar',
+			'intercom',
+			'linkedin-insights',
+			'matomo-analytics',
+			'segment',
+			'vercel-analytics',
+		]);
+	});
+
 	it('requires a denied-consent probe for every alwaysLoad vendor', () => {
 		for (const config of liveVendorProbeConfigs) {
 			if (config.tier === 'skip' || !config.createScript) {

--- a/packages/scripts/live-vendors/vendors.test.ts
+++ b/packages/scripts/live-vendors/vendors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { builtInScriptIntegrations } from '../src/registry';
+import { assertsRuntime } from './probe-policy';
 import type { LiveVendorProbeConfig } from './types';
 import { liveVendorProbeConfigs } from './vendors';
 
@@ -54,16 +55,14 @@ describe('live vendor probe configs', () => {
 				continue;
 			}
 
-			const assertsRuntime =
-				Boolean(config.runtimeCheck) || Boolean(config.runtimeReplacedGlobals);
-			if (assertsRuntime) {
+			if (assertsRuntime(config)) {
 				continue;
 			}
 
 			expect(
-				config.notes,
+				config.notes?.trim(),
 				`${config.vendor} asserts no runtime behavior and must explain the gap in notes`
-			).toBeTypeOf('string');
+			).toBeTruthy();
 			gaps.push(config.vendor);
 		}
 

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -401,7 +401,7 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 			// `if (clarity.v || clarity.t) return` and refuses to start when
 			// either is pre-set ("Error CL001: Multiple Clarity tags detected")
 			// — the production bug fixed in #898.
-			if (stub.v !== undefined || stub.t !== undefined) {
+			if (stub.v || stub.t) {
 				return check(
 					false,
 					`stub carries v=${String(stub.v)}/t=${String(stub.t)}; the tag's \`if (clarity.v || clarity.t) return\` guard treats this as a duplicate install (CL001) and never starts`

--- a/packages/scripts/live-vendors/vendors.ts
+++ b/packages/scripts/live-vendors/vendors.ts
@@ -64,12 +64,6 @@ type PromptwatchWindow = Window & {
 	pwc?: unknown;
 };
 
-type MatomoWindow = Window & {
-	Matomo?: {
-		getTracker?: unknown;
-	};
-};
-
 type GoogleTagWindow = Window & {
 	google_tag_data?: {
 		ics?: {
@@ -173,6 +167,11 @@ type RudderStackWindow = Window & {
 		snippetExecuted?: boolean;
 		[key: string]: unknown;
 	};
+};
+
+type PosthogProbeWindow = Window & {
+	__c15tPosthogQueueReplayExpected?: boolean;
+	__c15tPosthogQueueReplayed?: boolean;
 };
 
 /**
@@ -391,20 +390,21 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		runtimeReplacedGlobals: ['clarity'],
 		bootstrapCheck: () => {
 			const stub = window.clarity as
-				| (Window['clarity'] & { v?: unknown })
+				| (Window['clarity'] & { v?: unknown; t?: unknown })
 				| undefined;
 
 			if (typeof stub !== 'function') {
 				return check(false, 'expected window.clarity stub function');
 			}
 
-			// The stub must NOT carry the runtime version marker: clarity.js
-			// refuses to start when `v` is pre-set ("Error CL001: Multiple
-			// Clarity tags detected") — the production bug fixed in #898.
-			if (stub.v !== undefined) {
+			// The stub must carry NEITHER runtime marker: the tag guards with
+			// `if (clarity.v || clarity.t) return` and refuses to start when
+			// either is pre-set ("Error CL001: Multiple Clarity tags detected")
+			// — the production bug fixed in #898.
+			if (stub.v !== undefined || stub.t !== undefined) {
 				return check(
 					false,
-					`stub carries v=${String(stub.v)}; clarity.js treats this as a duplicate install (CL001) and never starts`
+					`stub carries v=${String(stub.v)}/t=${String(stub.t)}; the tag's \`if (clarity.v || clarity.t) return\` guard treats this as a duplicate install (CL001) and never starts`
 				);
 			}
 
@@ -428,6 +428,13 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				typeof runtime === 'function' && typeof runtime.v === 'string',
 				'clarity runtime installed and stamped its version after load'
 			);
+		},
+		runtimeVersion: () => {
+			const runtime = window.clarity as
+				| (Window['clarity'] & { v?: unknown })
+				| undefined;
+
+			return typeof runtime?.v === 'string' ? runtime.v : undefined;
 		},
 	},
 	{
@@ -523,6 +530,8 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				'heap SDK methods and server config present after heap_config.js chain-loaded heap.js'
 			);
 		},
+		runtimeVersion: () =>
+			(window as HeapWindow).heap?.serverConfig?.sdk?.version,
 		notes:
 			'The probe allows the Heap config loader and chained heap.js bundle. Follow-up collection requests to c.us.heap-api.com are blocked by the runner with empty 204 responses.',
 	},
@@ -705,16 +714,11 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				Array.isArray(window._paq) && window._paq.length >= 5,
 				`matomo queue seeded with ${window._paq?.length ?? 0} entries before load`
 			),
-		runtimeCheck: () => {
-			const matomo = (window as MatomoWindow).Matomo;
-
-			return check(
-				typeof matomo?.getTracker === 'function',
-				'window.Matomo.getTracker present after loader executed'
-			);
-		},
+		// No runtimeCheck: cdn.matomo.cloud answers a placeholder cloud id with a
+		// 404 HTML page, so no Matomo runtime can ever exist here. Declaring an
+		// unreachable check would misreport this vendor as runtime-covered.
 		notes:
-			'Placeholder Matomo Cloud ids return HTTP 404 from cdn.matomo.cloud; runtime is not asserted.',
+			'Placeholder Matomo Cloud ids return HTTP 404 from cdn.matomo.cloud, so no runtime is asserted. Upgrading to full tier needs a real cloud id supplied as a secret.',
 	},
 	{
 		vendor: 'posthog',
@@ -728,26 +732,72 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 		// array.js chain-loads versioned SDK bundles from the same assets host.
 		allowUrlSubstrings: ['assets.i.posthog.com/static/'],
 		bootstrapCheck: () => {
-			const stub = window.posthog;
+			const stub = window.posthog as unknown;
 
-			if (!stub || typeof stub.init !== 'function') {
+			if (Array.isArray(stub)) {
+				const queuedStub = stub as unknown[] & { _i?: unknown[][] };
+				if (!Array.isArray(queuedStub._i) || queuedStub._i.length === 0) {
+					return check(false, 'expected posthog pending init queue');
+				}
+
+				const probeWindow = window as PosthogProbeWindow;
+				probeWindow.__c15tPosthogQueueReplayExpected = true;
+				queuedStub.push(() => {
+					probeWindow.__c15tPosthogQueueReplayed = true;
+				});
+
+				return check(
+					true,
+					'posthog snippet queue carries init and a live replay probe'
+				);
+			}
+
+			if (
+				typeof stub !== 'object' ||
+				stub === null ||
+				!('init' in stub) ||
+				typeof stub.init !== 'function'
+			) {
 				return check(false, 'expected window.posthog stub with init()');
 			}
 
 			return check(
-				stub.get_explicit_consent_status() === 'pending',
+				'get_explicit_consent_status' in stub &&
+					typeof stub.get_explicit_consent_status === 'function' &&
+					stub.get_explicit_consent_status() === 'pending',
 				'posthog stub reports pending consent before load'
 			);
 		},
 		runtimeCheck: () => {
+			const probeWindow = window as PosthogProbeWindow;
 			const sdk = window.posthog as
 				| (Window['posthog'] & { __loaded?: boolean })
 				| undefined;
 
+			if (sdk?.__loaded !== true) {
+				return check(false, 'posthog SDK has not reported __loaded after init');
+			}
+
+			if (
+				probeWindow.__c15tPosthogQueueReplayExpected &&
+				probeWindow.__c15tPosthogQueueReplayed !== true
+			) {
+				return check(false, 'posthog SDK did not replay the snippet queue');
+			}
+
 			return check(
-				sdk?.__loaded === true,
-				'posthog SDK reports __loaded after init'
+				true,
+				probeWindow.__c15tPosthogQueueReplayExpected
+					? 'posthog SDK initialized and replayed the snippet queue'
+					: 'posthog SDK reports __loaded after init'
 			);
+		},
+		runtimeVersion: () => {
+			const sdk = window.posthog as
+				| (Window['posthog'] & { version?: unknown })
+				| undefined;
+
+			return typeof sdk?.version === 'string' ? sdk.version : undefined;
 		},
 	},
 	{
@@ -945,11 +995,12 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				'vercel queue present before load'
 			);
 		},
-		runtimeCheck: () =>
-			check(
-				typeof window.va === 'function',
-				'window.va callable after loader executed'
-			),
+		// No runtimeCheck: probed live, script.js needs a Vercel deployment
+		// context and leaves `window.va` as our bare stub (no added properties,
+		// no new globals). `typeof window.va === 'function'` only re-asserts the
+		// bootstrap stub.
+		notes:
+			'Vercel Analytics installs no runtime outside a Vercel deployment, so no runtime is asserted. Upgrading to full tier needs the probe served from a Vercel deployment.',
 	},
 	{
 		vendor: 'crisp',
@@ -971,11 +1022,11 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 					window.CRISP_WEBSITE_ID === '00000000-0000-4000-8000-c15c15c15c15',
 				'crisp queue and website id seeded before load'
 			),
-		runtimeCheck: () =>
-			check(
-				Array.isArray(window.$crisp),
-				'window.$crisp queue remains available after loader executed'
-			),
+		// No runtimeCheck: probed live, l.js adds no global and leaves the queue
+		// untouched for a placeholder website id. Asserting `$crisp` is still an
+		// array would only re-assert our own bootstrap stub.
+		notes:
+			'Crisp adds no observable global for placeholder website ids, so no runtime is asserted. Upgrading to full tier needs a real website id supplied as a secret.',
 	},
 	{
 		vendor: 'intercom',
@@ -999,11 +1050,11 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 				'intercomSettings seeded before load'
 			);
 		},
-		runtimeCheck: () =>
-			check(
-				typeof window.Intercom === 'function',
-				'window.Intercom callable after loader executed'
-			),
+		// No runtimeCheck: probed live, the widget bundle adds no global for a
+		// placeholder app id. `typeof window.Intercom === 'function'` is
+		// satisfied by the bootstrap queue stub alone.
+		notes:
+			'Intercom adds no observable global for placeholder app ids, so no runtime is asserted. Upgrading to full tier needs a real workspace id supplied as a secret.',
 	},
 	{
 		vendor: 'meta-pixel',
@@ -1028,6 +1079,7 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 					'function',
 				'fbq.callMethod present after loader executed'
 			),
+		runtimeVersion: () => (window.fbq as MetaPixelRuntime | undefined)?.version,
 	},
 	{
 		vendor: 'reddit-pixel',
@@ -1099,11 +1151,11 @@ export const liveVendorProbeConfigs: LiveVendorProbeConfig[] = [
 					typeof window.lintrk === 'function',
 				'linkedin partner globals and lintrk stub seeded before load'
 			),
-		runtimeCheck: () =>
-			check(
-				typeof window.lintrk === 'function',
-				'window.lintrk callable after loader executed'
-			),
+		// No runtimeCheck: probed live, insight.min.js fires one beacon and adds
+		// no global for a placeholder partner id. `typeof window.lintrk ===
+		// 'function'` is satisfied by the bootstrap queue stub alone.
+		notes:
+			'LinkedIn adds no observable global for placeholder partner ids, so no runtime is asserted. Upgrading to full tier needs a real partner id supplied as a secret.',
 	},
 	{
 		vendor: 'microsoft-uet',


### PR DESCRIPTION
Independent of the PostHog fix stack; this PR targets `canary`.

## What changes

- runs the live vendor monitor every six hours and after every canary push
- replays every bootstrap contract in jsdom on PRs
- rejects runtime checks that already pass against a bootstrap stub
- documents and snapshots vendors whose placeholder credentials cannot prove runtime behavior
- records loader digests and exposed SDK versions for later regression bisection
- makes the PostHog live check enqueue a callback and require the real SDK to replay it, rather than treating `__loaded` alone as sufficient evidence

The workflow trigger no longer has a package-path filter, so core script-loader changes cannot bypass coverage.

## Verification

- live-vendor policy, report, config, and stub-contract suites pass
- `@c15t/scripts` type-check passes
- combined with #984, the real PostHog CDN probe confirms SDK 1.410.10 initialized and replayed the snippet queue

No changeset: these monitor files are not part of the published package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Live vendor monitoring now runs every six hours and after updates to the canary environment.
  - Runtime validation has been expanded to detect more integration and script-loading issues while reducing false positives.
  - Monitor reports now include loader bundle size, a verification hash, and sanitized vendor SDK version details when available.
  - Added stronger validation for queued initialization and runtime replacement behavior across supported integrations.
- **Documentation**
  - Updated monitoring schedules and documented known configuration limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->