### PR TITLE
fix(scripts): preserve PostHog pre-load captures

### DIFF
--- a/.changeset/posthog-snippet-fidelity.md
+++ b/.changeset/posthog-snippet-fidelity.md
@@ -1,0 +1,7 @@
+---
+'@c15t/scripts': patch
+---
+
+Preserve `posthog.capture(...)` calls made after c15t bootstraps PostHog but before its SDK finishes loading.
+
+The helper now uses PostHog's root snippet queue and pending init tuple, with the current consent decision queued before captured events replay. It also leaves an already-installed PostHog SDK unchanged during later consent revoke and re-grant cycles.

--- a/changelog/2.2.0.mdx
+++ b/changelog/2.2.0.mdx
@@ -32,6 +32,7 @@ This is a minor release with no breaking changes.
 - Eight new built-in providers: Adobe Analytics, Amplitude, Clearbit, Heap, Hightouch, LogRocket, Pirsch, and RudderStack
 - RudderStack pre-consent buffering with category-to-consent-ID mapping
 - Microsoft Clarity Consent V2 support and a corrected Mixpanel bootstrap
+- PostHog initialization and pre-load event queue fixes
 - Policy-aware primary action styling, including IAB consent surfaces
 - New `nonce` option applying your CSP nonce to injected styles and scripts
 - Reliable offline IAB GVL loading and language refreshes
@@ -131,7 +132,7 @@ The default remains the stricter load gate. Pre-consent mode is opt-in because i
 
 → [RudderStack](/docs/integrations/rudderstack)
 
-## Microsoft Clarity and Mixpanel fixes
+## Microsoft Clarity, Mixpanel, and PostHog fixes
 
 The Microsoft Clarity helper now uses Consent V2. c15t maps `marketing` consent to `ad_Storage` and `measurement` consent to `analytics_Storage`, and `defaultConsent` accepts a Consent V2 payload.
 
@@ -139,9 +140,11 @@ The helper also no longer adds Clarity's `v` marker before the vendor runtime lo
 
 The Mixpanel helper now implements the official snippet contract, including the `__SV` version marker and `_i` initialization registry. This prevents the SDK from reporting a version mismatch and dropping events queued before it finishes loading.
 
+The PostHog helper now seeds the pending initialization tuple expected by current `array.js` releases. It also keeps `posthog.capture(...)` calls made before the SDK arrives in PostHog's root queue and applies the consent decision before those events replay. Existing installed SDK methods remain untouched if an `after-consent` integration loads again after consent is revoked and restored.
+
 The core script loader also now preserves an explicit `async: false`, which is required by synchronous vendor embeds such as legacy Adobe Tags configurations.
 
-→ [Microsoft Clarity](/docs/integrations/microsoft-clarity) · [Mixpanel](/docs/integrations/mixpanel-analytics)
+→ [Microsoft Clarity](/docs/integrations/microsoft-clarity) · [Mixpanel](/docs/integrations/mixpanel-analytics) · [PostHog](/docs/integrations/posthog)
 
 ## Policy-aware primary action styling
 

--- a/docs/integrations/posthog.mdx
+++ b/docs/integrations/posthog.mdx
@@ -102,7 +102,7 @@ If you want to load PostHog via a script tag, it's recommended to use this appro
   <Step>
     ### Choose a region and loading mode
 
-    The c15t helper loads PostHog's bootstrap script, calls `posthog.init()` for you, and then synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
+    The c15t helper seeds PostHog's initialization queue, loads the bootstrap script, and synchronizes consent through `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()`. You do not need to call `posthog.init()` separately.
 
     Use `region` to keep PostHog's API, UI, and bootstrap script hosts aligned. c15t defaults to `region: 'eu'`; set `region: 'us'` for PostHog Cloud US. You can still pass `apiHost`, `uiHost`, or `scriptUrl` for self-hosted or proxied setups.
 
@@ -267,7 +267,7 @@ posthog({
 The behavior depends on which pattern you chose:
 
 - **SDK Implementation** — your app loaded `posthog-js` itself, so `posthog.capture(...)` is available once your SDK setup has run. c15t calls `opt_in_capturing()` / `opt_out_capturing()` for you. Pending events before c15t syncs consent may be dropped; after denial, PostHog captures cookieless events.
-- **Script Implementation with `loadMode: 'always'`** — `window.posthog` is defined early. c15t calls `opt_in_capturing()` / `opt_out_capturing()` based on consent. Pending events before the PostHog bootstrap finishes may be dropped; after denial, PostHog captures cookieless events when your PostHog project supports cookieless mode.
+- **Script Implementation with `loadMode: 'always'`** — `window.posthog` is defined early as a queue. Calls to `posthog.capture(...)` before the bootstrap finishes are replayed after the SDK installs instead of being dropped. c15t queues the current consent decision ahead of those calls, then keeps calling `opt_in_capturing()` / `opt_out_capturing()` as consent changes. After denial, PostHog captures cookieless events when your PostHog project supports cookieless mode.
 - **Script Implementation with `loadMode: 'after-consent'`** — PostHog is unavailable until measurement consent is granted. Guard `posthog.capture(...)` calls or call them only after consent.
 
 <Callout type="warning">

--- a/packages/scripts/src/engine.test.ts
+++ b/packages/scripts/src/engine.test.ts
@@ -845,6 +845,73 @@ describe('scripts engine', () => {
 		delete globalRef.vendorQueue;
 	});
 
+	it('limits snippet-only properties and methods to queue globals', () => {
+		const globalRef = globalThis as TestGlobal;
+		const manifest = createManifest({
+			vendor: 'guarded-queue-bootstrap',
+			category: 'measurement',
+			bootstrap: [
+				{
+					type: 'setGlobal',
+					name: 'guardedQueue',
+					value: [],
+					ifUndefined: true,
+				},
+				{
+					type: 'setGlobalPath',
+					path: ['guardedQueue', 'pending'],
+					value: [['init']],
+					ifGlobalIsQueue: true,
+				},
+				{
+					type: 'defineGlobalMethods',
+					target: 'guardedQueue',
+					ifGlobalIsQueue: true,
+					methods: [
+						{
+							name: 'status',
+							behavior: 'return',
+							value: 'pending',
+						},
+					],
+				},
+			],
+			install: [],
+		});
+		const script = resolvedManifestToScript(compileManifest(manifest));
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		const queue = globalRef.guardedQueue as unknown[] & {
+			pending: unknown[][];
+			status: () => string;
+		};
+		expect(queue.pending).toEqual([['init']]);
+		expect(queue.status()).toBe('pending');
+
+		const liveStatus = vi.fn(() => 'granted');
+		const installed = { status: liveStatus };
+		globalRef.guardedQueue = installed;
+
+		script.onBeforeLoad?.(
+			createCallbackInfo({
+				id: script.id,
+				consents: grantedMeasurementConsentState,
+			})
+		);
+
+		expect(globalRef.guardedQueue).toBe(installed);
+		expect(installed.status()).toBe('granted');
+		expect(installed).not.toHaveProperty('pending');
+
+		delete globalRef.guardedQueue;
+	});
+
 	it('partitions consent IDs for the rudderstack consent signal', () => {
 		const globalRef = globalThis as TestGlobal;
 		const consentCalls: unknown[][] = [];

--- a/packages/scripts/src/engine/runtime.ts
+++ b/packages/scripts/src/engine/runtime.ts
@@ -240,6 +240,14 @@ function executeStep(step: ManifestStep): void {
 		}
 
 		case 'setGlobalPath': {
+			const rootGlobal = step.path[0];
+			if (
+				step.ifGlobalIsQueue &&
+				(!rootGlobal || !Array.isArray(win[rootGlobal]))
+			) {
+				break;
+			}
+
 			const pathTarget = getPathTarget(win, step.path);
 			if (!pathTarget) {
 				break;
@@ -379,6 +387,9 @@ function executeStep(step: ManifestStep): void {
 				target === null ||
 				(typeof target !== 'object' && typeof target !== 'function')
 			) {
+				break;
+			}
+			if (step.ifGlobalIsQueue && !Array.isArray(target)) {
 				break;
 			}
 

--- a/packages/scripts/src/posthog.e2e.test.ts
+++ b/packages/scripts/src/posthog.e2e.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	deniedConsents,
+	grantedMeasurementConsents,
 	installHeadProbe,
 	loadScripts,
 	registerVendorContractCleanup,
@@ -15,9 +16,9 @@ describe('posthog contract', () => {
 	registerVendorContractCleanup();
 
 	it('boots with the loader attributes intact and denied consent mapped to opt-out', () => {
-		const initCalls: unknown[][] = [];
 		const consentCalls: string[] = [];
 		let attributes: Record<string, string | null> | undefined;
+		let queuedInit: unknown;
 
 		installHeadProbe((node, win) => {
 			if (!node.src.includes('posthog.com/static/array.js')) {
@@ -30,10 +31,10 @@ describe('posthog contract', () => {
 				dataUiHost: node.getAttribute('data-ui-host'),
 			};
 
+			queuedInit = win.posthog._i;
+
 			win.posthog = {
-				init: (...args: unknown[]) => {
-					initCalls.push(args);
-				},
+				init: () => undefined,
 				opt_in_capturing: () => {
 					consentCalls.push('opt_in');
 				},
@@ -41,6 +42,7 @@ describe('posthog contract', () => {
 					consentCalls.push('opt_out');
 				},
 				get_explicit_consent_status: () => 'pending',
+				capture: () => undefined,
 			};
 
 			node.dispatchEvent(new Event('load'));
@@ -61,7 +63,7 @@ describe('posthog contract', () => {
 			dataApiHost: 'https://eu.i.posthog.com',
 			dataUiHost: 'https://eu.posthog.com',
 		});
-		expect(initCalls).toEqual([
+		expect(queuedInit).toEqual([
 			[
 				'phc_contract',
 				{
@@ -70,9 +72,53 @@ describe('posthog contract', () => {
 					api_host: 'https://eu.i.posthog.com',
 					ui_host: 'https://eu.posthog.com',
 				},
+				'posthog',
 			],
 		]);
 		expect(consentCalls).toEqual(['opt_out']);
+	});
+
+	it('queues capture calls until the loader installs', () => {
+		loadScripts([posthog({ id: 'phc_queue' })], grantedMeasurementConsents);
+
+		window.posthog.capture('signup', { plan: 'pro' });
+
+		expect(Array.from(window.posthog as unknown as unknown[])).toEqual([
+			['opt_in_capturing', { captureEventName: null }],
+			['capture', 'signup', { plan: 'pro' }],
+		]);
+	});
+
+	it('queues opt-out ahead of capture when measurement consent is denied', () => {
+		loadScripts([posthog({ id: 'phc_denied' })], deniedConsents);
+
+		window.posthog.capture('signup');
+
+		expect(Array.from(window.posthog as unknown as unknown[])).toEqual([
+			['opt_out_capturing'],
+			['capture', 'signup'],
+		]);
+	});
+
+	it('leaves an installed SDK intact when bootstrap runs again', () => {
+		const liveInit = () => undefined;
+		const liveCapture = () => undefined;
+		const installed = {
+			init: liveInit,
+			capture: liveCapture,
+			opt_in_capturing: () => undefined,
+			opt_out_capturing: () => undefined,
+			get_explicit_consent_status: () => 'granted',
+		};
+		window.posthog = installed;
+
+		loadScripts([posthog({ id: 'phc_regrant' })], grantedMeasurementConsents);
+
+		expect(window.posthog).toBe(installed);
+		expect(window.posthog.init).toBe(liveInit);
+		expect(window.posthog.capture).toBe(liveCapture);
+		expect(window.posthog.get_explicit_consent_status()).toBe('granted');
+		expect(window.posthog._i).toBeUndefined();
 	});
 
 	it('bootstraps a snippet-shaped stub that array.js will install over', () => {

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -135,6 +135,8 @@ export interface SetGlobalPathStep {
 	path: string[];
 	/** Value to assign at the target path */
 	value: unknown;
+	/** Only assign while the root global is still a snippet queue array. */
+	ifGlobalIsQueue?: boolean;
 }
 
 export interface DefineQueueMethodsStep {
@@ -205,6 +207,8 @@ export interface DefineGlobalMethodsStep {
 	/** Global object name to receive the methods */
 	target: string;
 	methods: Array<GlobalMethodBehavior>;
+	/** Only define methods while the target is still a snippet queue array. */
+	ifGlobalIsQueue?: boolean;
 }
 
 export interface ConstructGlobalStep {

--- a/packages/scripts/src/vendors/analytics/posthog.test.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.test.ts
@@ -8,27 +8,35 @@ import {
 } from '../../__tests__/helpers';
 import { posthog } from './posthog';
 
+type PosthogStub = Window['posthog'] & { _i?: unknown[][] };
+
+function bootstrapPosthog(script: ReturnType<typeof posthog>): PosthogStub {
+	script.onBeforeLoad?.(
+		createCallbackInfo({ id: script.id, consents: deniedConsentState })
+	);
+
+	return getTestGlobal().posthog as PosthogStub;
+}
+
+function installSdkSpies() {
+	const globalRef = getTestGlobal();
+	const optIn = vi.fn();
+	const optOut = vi.fn();
+	globalRef.posthog = {
+		init: vi.fn(),
+		opt_in_capturing: optIn,
+		opt_out_capturing: optOut,
+		get_explicit_consent_status: vi.fn(() => 'pending'),
+		capture: vi.fn(),
+	};
+
+	return { optIn, optOut };
+}
+
 describe('posthog', () => {
 	setupScriptHelperTest();
 
-	it('keeps init options as an object and syncs consent state', () => {
-		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		const optIn = vi.fn();
-		const optOut = vi.fn();
-		globalRef.posthog = {
-			init: function initWithReceiver(
-				token: string,
-				options: Record<string, unknown>
-			) {
-				init(this, token, options);
-			},
-			opt_in_capturing: optIn,
-			opt_out_capturing: optOut,
-			get_explicit_consent_status: vi.fn(() => 'pending'),
-			capture: vi.fn(),
-		};
-
+	it('queues init options as an object and syncs consent state', () => {
 		const script = posthog({
 			id: 'phc_123',
 			apiHost: 'https://eu.i.posthog.com',
@@ -49,6 +57,22 @@ describe('posthog', () => {
 			'data-ui-host': 'https://eu.posthog.com',
 		});
 
+		expect(bootstrapPosthog(script)._i).toEqual([
+			[
+				'phc_123',
+				{
+					api_host: 'https://eu.i.posthog.com',
+					ui_host: 'https://eu.posthog.com',
+					autocapture: false,
+					person_profiles: 'identified_only',
+					cookieless_mode: 'on_reject',
+					defaults: '2026-01-30',
+				},
+				'posthog',
+			],
+		]);
+
+		const { optIn, optOut } = installSdkSpies();
 		script.onLoad?.(
 			createCallbackInfo({
 				id: script.id,
@@ -56,14 +80,6 @@ describe('posthog', () => {
 			})
 		);
 
-		expect(init).toHaveBeenCalledWith(globalRef.posthog, 'phc_123', {
-			api_host: 'https://eu.i.posthog.com',
-			ui_host: 'https://eu.posthog.com',
-			autocapture: false,
-			person_profiles: 'identified_only',
-			cookieless_mode: 'on_reject',
-			defaults: '2026-01-30',
-		});
 		expect(optOut).toHaveBeenCalledTimes(1);
 
 		script.onConsentChange?.(
@@ -78,16 +94,6 @@ describe('posthog', () => {
 	});
 
 	it('uses consent-aware defaults when optional options are omitted', () => {
-		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		globalRef.posthog = {
-			init,
-			opt_in_capturing: vi.fn(),
-			opt_out_capturing: vi.fn(),
-			get_explicit_consent_status: vi.fn(() => 'pending'),
-			capture: vi.fn(),
-		};
-
 		const script = posthog({
 			id: 'phc_defaults',
 		});
@@ -99,32 +105,21 @@ describe('posthog', () => {
 			'data-ui-host': 'https://eu.posthog.com',
 		});
 
-		script.onLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: grantedMeasurementConsentState,
-			})
-		);
-
-		expect(init).toHaveBeenCalledWith('phc_defaults', {
-			api_host: 'https://eu.i.posthog.com',
-			ui_host: 'https://eu.posthog.com',
-			defaults: '2026-01-30',
-			cookieless_mode: 'on_reject',
-		});
+		expect(bootstrapPosthog(script)._i).toEqual([
+			[
+				'phc_defaults',
+				{
+					api_host: 'https://eu.i.posthog.com',
+					ui_host: 'https://eu.posthog.com',
+					defaults: '2026-01-30',
+					cookieless_mode: 'on_reject',
+				},
+				'posthog',
+			],
+		]);
 	});
 
 	it('derives US hosts from the region option', () => {
-		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		globalRef.posthog = {
-			init,
-			opt_in_capturing: vi.fn(),
-			opt_out_capturing: vi.fn(),
-			get_explicit_consent_status: vi.fn(() => 'pending'),
-			capture: vi.fn(),
-		};
-
 		const script = posthog({
 			id: 'phc_us',
 			region: 'us',
@@ -137,19 +132,18 @@ describe('posthog', () => {
 			'data-ui-host': 'https://us.posthog.com',
 		});
 
-		script.onLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: grantedMeasurementConsentState,
-			})
-		);
-
-		expect(init).toHaveBeenCalledWith('phc_us', {
-			api_host: 'https://us.i.posthog.com',
-			ui_host: 'https://us.posthog.com',
-			defaults: '2026-01-30',
-			cookieless_mode: 'on_reject',
-		});
+		expect(bootstrapPosthog(script)._i).toEqual([
+			[
+				'phc_us',
+				{
+					api_host: 'https://us.i.posthog.com',
+					ui_host: 'https://us.posthog.com',
+					defaults: '2026-01-30',
+					cookieless_mode: 'on_reject',
+				},
+				'posthog',
+			],
+		]);
 	});
 
 	it('derives the bootstrap script URL from an explicit API host', () => {
@@ -167,16 +161,6 @@ describe('posthog', () => {
 	});
 
 	it('allows explicit host and script URL overrides', () => {
-		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		globalRef.posthog = {
-			init,
-			opt_in_capturing: vi.fn(),
-			opt_out_capturing: vi.fn(),
-			get_explicit_consent_status: vi.fn(() => 'pending'),
-			capture: vi.fn(),
-		};
-
 		const script = posthog({
 			id: 'phc_custom',
 			region: 'us',
@@ -192,19 +176,18 @@ describe('posthog', () => {
 			'data-ui-host': 'https://app.example.com/posthog',
 		});
 
-		script.onLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: grantedMeasurementConsentState,
-			})
-		);
-
-		expect(init).toHaveBeenCalledWith('phc_custom', {
-			api_host: 'https://events.example.com/posthog',
-			ui_host: 'https://app.example.com/posthog',
-			defaults: '2026-01-30',
-			cookieless_mode: 'on_reject',
-		});
+		expect(bootstrapPosthog(script)._i).toEqual([
+			[
+				'phc_custom',
+				{
+					api_host: 'https://events.example.com/posthog',
+					ui_host: 'https://app.example.com/posthog',
+					defaults: '2026-01-30',
+					cookieless_mode: 'on_reject',
+				},
+				'posthog',
+			],
+		]);
 	});
 
 	it('uses explicit region UI host for custom API hosts', () => {
@@ -249,16 +232,6 @@ describe('posthog', () => {
 	});
 
 	it('allows init options to override non-host helper defaults', () => {
-		const globalRef = getTestGlobal();
-		const init = vi.fn();
-		globalRef.posthog = {
-			init,
-			opt_in_capturing: vi.fn(),
-			opt_out_capturing: vi.fn(),
-			get_explicit_consent_status: vi.fn(() => 'pending'),
-			capture: vi.fn(),
-		};
-
 		const script = posthog({
 			id: 'phc_overrides',
 			apiHost: 'https://eu.i.posthog.com',
@@ -270,18 +243,17 @@ describe('posthog', () => {
 			},
 		});
 
-		script.onLoad?.(
-			createCallbackInfo({
-				id: script.id,
-				consents: deniedConsentState,
-			})
-		);
-
-		expect(init).toHaveBeenCalledWith('phc_overrides', {
-			api_host: 'https://eu.i.posthog.com',
-			ui_host: 'https://eu.posthog.com',
-			defaults: '2025-05-24',
-			cookieless_mode: 'always',
-		});
+		expect(bootstrapPosthog(script)._i).toEqual([
+			[
+				'phc_overrides',
+				{
+					api_host: 'https://eu.i.posthog.com',
+					ui_host: 'https://eu.posthog.com',
+					defaults: '2025-05-24',
+					cookieless_mode: 'always',
+				},
+				'posthog',
+			],
+		]);
 	});
 });

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -20,9 +20,9 @@ declare global {
 			get_explicit_consent_status: () => string;
 			capture: (event: string, properties?: Record<string, unknown>) => void;
 			/**
-			 * Pending `init(...)` argument tuples, as seeded by the official
-			 * PostHog snippet. `array.js` only installs its runtime over an
-			 * existing `window.posthog` when this is an array.
+			 * Pending `[token, config, instanceName]` init tuples, as seeded by
+			 * the official PostHog snippet. `array.js` only installs its runtime
+			 * over an existing `window.posthog` when this is an array.
 			 */
 			_i?: unknown[][];
 		};
@@ -158,23 +158,39 @@ export const posthogManifest = {
 	alwaysLoad: true,
 	bootstrap: [
 		{
-			// `_i` must be an array: since posthog-js 1.410.2, `array.js` skips
-			// installing its runtime entirely when `window.posthog` already
-			// exists without a snippet-shaped pending-init queue, which would
-			// leave the stub methods below in place and drop every event.
 			type: 'setGlobal',
 			name: 'posthog',
-			value: { _i: [] },
+			value: [],
 			ifUndefined: true,
+		},
+		{
+			// Since posthog-js 1.410.2, array.js installs over an existing
+			// global only when `_i` is an array. Seeding the full tuple also lets
+			// the loader initialize before replaying calls captured on this queue.
+			type: 'setGlobalPath',
+			path: ['posthog', '_i'],
+			value: [['{{id}}', '{{initOptions}}', 'posthog']],
+			ifGlobalIsQueue: true,
+		},
+		{
+			// PostHog's loader reads the people sub-queue during installation.
+			// Keep the required shape without exposing or emulating its API.
+			type: 'setGlobalPath',
+			path: ['posthog', 'people'],
+			value: [],
+			ifGlobalIsQueue: true,
+		},
+		{
+			type: 'defineQueueMethods',
+			target: 'posthog',
+			methods: ['capture', 'opt_in_capturing', 'opt_out_capturing'],
 		},
 		{
 			type: 'defineGlobalMethods',
 			target: 'posthog',
+			ifGlobalIsQueue: true,
 			methods: [
 				{ name: 'init', behavior: 'noop' },
-				{ name: 'capture', behavior: 'noop' },
-				{ name: 'opt_in_capturing', behavior: 'noop' },
-				{ name: 'opt_out_capturing', behavior: 'noop' },
 				{
 					name: 'get_explicit_consent_status',
 					behavior: 'return',
@@ -195,12 +211,18 @@ export const posthogManifest = {
 			},
 		},
 	],
-	afterLoad: [
+	onBeforeLoadGranted: [
 		{
-			type: 'callGlobal',
-			global: 'posthog',
-			method: 'init',
-			args: ['{{id}}', '{{initOptions}}'],
+			type: 'pushToQueue',
+			queue: 'posthog',
+			value: ['opt_in_capturing', { captureEventName: null }],
+		},
+	],
+	onBeforeLoadDenied: [
+		{
+			type: 'pushToQueue',
+			queue: 'posthog',
+			value: ['opt_out_capturing'],
 		},
 	],
 	onLoadGranted: [


### PR DESCRIPTION
Stacked on #982. Review order: #982, then this PR.

## Why this follow-up exists

#982 restores the PostHog runtime with the smallest safe hotfix, but the old noop `capture` stub still drops calls made while the CDN script is in flight.

## Narrow fix

- use PostHog root array queue with a complete `[token, config, instanceName]` tuple in `_i`
- queue only `capture`, `opt_in_capturing`, and `opt_out_capturing`
- queue the current consent decision before pre-load captures replay
- let `array.js` run init from `_i`, avoiding a second post-load init
- guard snippet-only path and method setup so a revoke/re-grant cycle cannot overwrite an installed SDK

Compatibility is preserved: `window.posthog.init` remains required in the public type and remains a pre-load noop. This PR does not add a `people` API, nested queue DSL, method remapping, exported queue constants, or any other PostHog surface.

## Verification

- `@c15t/scripts`: 67 test files, 306 tests passing
- `@c15t/scripts` type-check passes
- docs lint and generated package docs pass
- real PostHog CDN probe confirms SDK 1.410.10 initialized and replayed the queued callback
- regression coverage includes capture ordering and installed-SDK preservation

Includes a patch changeset and updates the PostHog integration guide.
