### PR TITLE
feat(backend): add consent write integrity foundations

### DIFF
--- a/.changeset/strong-lemons-write.md
+++ b/.changeset/strong-lemons-write.md
@@ -1,0 +1,6 @@
+---
+'@c15t/backend': minor
+'@c15t/schema': minor
+---
+
+Add backwards-compatible consent-write integrity configuration, signed subject capability and identity assertion helpers, write provenance fields, canonical domain keys, and replay storage foundations.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -93,6 +93,11 @@
 			"import": "./dist/types/index.js",
 			"require": "./dist/types/index.cjs"
 		},
+		"./write-integrity": {
+			"types": "./dist-types/write-integrity.d.ts",
+			"import": "./dist/write-integrity.js",
+			"require": "./dist/write-integrity.cjs"
+		},
 		"./cache": {
 			"types": "./dist-types/cache/index.d.ts",
 			"import": "./dist/cache.js",

--- a/packages/backend/rslib.config.ts
+++ b/packages/backend/rslib.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
 			'db/migrator': ['./src/db/migrator/index.ts'],
 			'define-config': ['./src/define-config.ts'],
 			'types/index': ['./src/types/index.ts'],
+			'write-integrity': ['./src/write-integrity/index.ts'],
 			cache: ['./src/cache/index.ts'],
 			edge: ['./src/edge/index.ts'],
 		},

--- a/packages/backend/src/db/registry/utils/generate-id.ts
+++ b/packages/backend/src/db/registry/utils/generate-id.ts
@@ -14,6 +14,7 @@ const prefixes: Record<keyof Tables, string> = {
 	domain: 'dom',
 	runtimePolicyDecision: 'rpd',
 	subject: 'sub',
+	writeReplay: 'wrp',
 } as const;
 
 const b58 = baseX('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz');

--- a/packages/backend/src/db/schema/2.1.0/audit-log.ts
+++ b/packages/backend/src/db/schema/2.1.0/audit-log.ts
@@ -1,0 +1,6 @@
+import { type AuditLog, auditLogSchema } from '@c15t/schema';
+import { auditLogTable as previousAuditLogTable } from '../2.0.0/audit-log';
+
+export const auditLogTable = previousAuditLogTable.clone();
+
+export { type AuditLog, auditLogSchema };

--- a/packages/backend/src/db/schema/2.1.0/consent-policy.ts
+++ b/packages/backend/src/db/schema/2.1.0/consent-policy.ts
@@ -1,0 +1,27 @@
+import {
+	type ConsentPolicy,
+	type ConsentPolicyType,
+	consentPolicySchema,
+	consentPolicyTypeSchema,
+	type LegalDocumentPolicyType,
+	legalDocumentPolicyTypeSchema,
+	type PolicyType,
+	policyTypeSchema,
+} from '@c15t/schema';
+import { consentPolicyTable as previousConsentPolicyTable } from '../2.0.0/consent-policy';
+
+export const consentPolicyTable = previousConsentPolicyTable.clone();
+
+export {
+	type ConsentPolicy,
+	type ConsentPolicyType,
+	consentPolicySchema,
+	consentPolicyTypeSchema,
+	type LegalDocumentPolicyType,
+	legalDocumentPolicyTypeSchema,
+	type PolicyType,
+	policyTypeSchema,
+};
+
+// Backward compatible alias
+export const PolicyTypeSchema = policyTypeSchema;

--- a/packages/backend/src/db/schema/2.1.0/consent-purpose.ts
+++ b/packages/backend/src/db/schema/2.1.0/consent-purpose.ts
@@ -1,0 +1,6 @@
+import { type ConsentPurpose, consentPurposeSchema } from '@c15t/schema';
+import { consentPurposeTable as previousConsentPurposeTable } from '../2.0.0/consent-purpose';
+
+export const consentPurposeTable = previousConsentPurposeTable.clone();
+
+export { type ConsentPurpose, consentPurposeSchema };

--- a/packages/backend/src/db/schema/2.1.0/consent.ts
+++ b/packages/backend/src/db/schema/2.1.0/consent.ts
@@ -1,0 +1,53 @@
+import {
+	type Consent,
+	type ConsentWriteSource,
+	consentSchema,
+	consentWriteSourceSchema,
+} from '@c15t/schema';
+import { column, idColumn, table } from 'fumadb/schema';
+
+export const consentTable = table('consent', {
+	id: idColumn('id', 'varchar(255)'),
+	subjectId: column('subjectId', 'string'),
+	domainId: column('domainId', 'string'),
+	policyId: column('policyId', 'string').nullable(),
+	purposeIds: column('purposeIds', 'json'),
+	metadata: column('metadata', 'json').nullable(),
+	ipAddress: column('ipAddress', 'string').nullable(),
+	userAgent: column('userAgent', 'string').nullable(),
+	givenAt: column('givenAt', 'timestamp').defaultTo$('now'),
+	validUntil: column('validUntil', 'timestamp').nullable(),
+	/** Jurisdiction code (e.g., 'GDPR', 'UK_GDPR', 'CCPA') */
+	jurisdiction: column('jurisdiction', 'string').nullable(),
+	/** Consent model used (e.g., 'opt-in', 'opt-out', 'iab') */
+	jurisdictionModel: column('jurisdictionModel', 'string').nullable(),
+	/** IAB TCF TC String (only for IAB consents) */
+	tcString: column('tcString', 'string').nullable(),
+	/** Which UI component collected this consent (e.g., 'banner', 'dialog', 'widget') */
+	uiSource: column('uiSource', 'string').nullable(),
+	/** Derived consent action (e.g., 'accept_all', 'reject_all', 'opt_out', 'custom') */
+	consentAction: column('consentAction', 'string').nullable(),
+	/** Runtime policy decision reference used for this consent record. */
+	runtimePolicyDecisionId: column(
+		'runtimePolicyDecisionId',
+		'string'
+	).nullable(),
+	/** Source of runtime policy decision evidence. */
+	runtimePolicySource: column('runtimePolicySource', 'string').nullable(),
+	/** Authority used to accept this write, independent of policy provenance. */
+	writeSource: column('writeSource', 'string').nullable(),
+	/** Credential or replay identifier associated with the accepted write. */
+	writeCredentialId: column('writeCredentialId', 'string').nullable(),
+	/** Issuer that authorized the accepted write. */
+	writeIssuer: column('writeIssuer', 'string').nullable(),
+	/** Request origin associated with the accepted write. */
+	writeOrigin: column('writeOrigin', 'string').nullable(),
+	tenantId: column('tenantId', 'string').nullable(),
+});
+
+export {
+	type Consent,
+	type ConsentWriteSource,
+	consentSchema,
+	consentWriteSourceSchema,
+};

--- a/packages/backend/src/db/schema/2.1.0/domain.ts
+++ b/packages/backend/src/db/schema/2.1.0/domain.ts
@@ -1,0 +1,14 @@
+import { type Domain, domainSchema } from '@c15t/schema';
+import { column, idColumn, table } from 'fumadb/schema';
+
+export const domainTable = table('domain', {
+	id: idColumn('id', 'varchar(255)'),
+	name: column('name', 'string'),
+	createdAt: column('createdAt', 'timestamp').defaultTo$('now'),
+	updatedAt: column('updatedAt', 'timestamp').defaultTo$('now'),
+	tenantId: column('tenantId', 'string').nullable(),
+	/** Canonical tenant/domain lookup key. Legacy rows may not have one. */
+	scopeKey: column('scopeKey', 'string').nullable().unique(),
+});
+
+export { type Domain, domainSchema };

--- a/packages/backend/src/db/schema/2.1.0/index.ts
+++ b/packages/backend/src/db/schema/2.1.0/index.ts
@@ -1,0 +1,61 @@
+import { schema } from 'fumadb/schema';
+import { auditLogTable } from './audit-log';
+import { consentTable } from './consent';
+import { consentPolicyTable } from './consent-policy';
+import { consentPurposeTable } from './consent-purpose';
+import { domainTable } from './domain';
+import { runtimePolicyDecisionTable } from './runtime-policy-decision';
+import { subjectTable } from './subject';
+import { writeReplayTable } from './write-replay';
+
+export const v2_1 = schema({
+	version: '2.1.0',
+	tables: {
+		subject: subjectTable,
+		domain: domainTable,
+		consentPolicy: consentPolicyTable,
+		runtimePolicyDecision: runtimePolicyDecisionTable,
+		consentPurpose: consentPurposeTable,
+		consent: consentTable,
+		auditLog: auditLogTable,
+		writeReplay: writeReplayTable,
+	},
+	relations: {
+		subject: ({ many }) => ({
+			consents: many('consent'),
+			auditLogs: many('auditLog'),
+		}),
+		domain: ({ many }) => ({
+			consents: many('consent'),
+		}),
+		consentPolicy: ({ many }) => ({
+			consents: many('consent'),
+		}),
+		runtimePolicyDecision: ({ many }) => ({
+			consents: many('consent'),
+		}),
+		consentPurpose: () => ({}),
+		consent: ({ one }) => ({
+			subject: one('subject', ['subjectId', 'id']).foreignKey(),
+			domain: one('domain', ['domainId', 'id']).foreignKey(),
+			policy: one('consentPolicy', ['policyId', 'id']).foreignKey(),
+			runtimePolicyDecision: one('runtimePolicyDecision', [
+				'runtimePolicyDecisionId',
+				'id',
+			]).foreignKey(),
+		}),
+		auditLog: ({ one }) => ({
+			subject: one('subject', ['subjectId', 'id']).foreignKey(),
+		}),
+		writeReplay: () => ({}),
+	},
+});
+
+export * from './audit-log';
+export * from './consent';
+export * from './consent-policy';
+export * from './consent-purpose';
+export * from './domain';
+export * from './runtime-policy-decision';
+export * from './subject';
+export * from './write-replay';

--- a/packages/backend/src/db/schema/2.1.0/migration.test.ts
+++ b/packages/backend/src/db/schema/2.1.0/migration.test.ts
@@ -1,0 +1,145 @@
+import { Kysely } from 'kysely';
+import { KyselyPGlite } from 'kysely-pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { kyselyAdapter } from '~/db/adapters/kysely';
+import { DB } from '~/db/schema';
+
+describe('database schema 2.1.0 migration', () => {
+	let database: Kysely<Record<string, never>>;
+	let client: ReturnType<(typeof DB)['client']>;
+	let destructiveOperations: string[];
+	let addedScopeKeyConstraint: boolean;
+	let createdReplayTable: boolean;
+
+	beforeAll(async () => {
+		const pglite = await KyselyPGlite.create();
+		database = new Kysely({ dialect: pglite.dialect });
+		client = DB.client(
+			kyselyAdapter({
+				db: database,
+				provider: 'postgresql',
+			})
+		);
+
+		const initialMigration = await client
+			.createMigrator()
+			.migrateTo('2.0.0', { mode: 'from-database' });
+		await initialMigration.execute();
+
+		const oldOrm = client.orm('2.0.0');
+		await oldOrm.create('subject', {
+			id: 'sub_legacy',
+			externalId: null,
+			identityProvider: 'anonymous',
+		});
+		await oldOrm.create('domain', {
+			id: 'dom_legacy',
+			name: 'legacy.example',
+		});
+		await oldOrm.create('consent', {
+			id: 'cns_legacy',
+			subjectId: 'sub_legacy',
+			domainId: 'dom_legacy',
+			policyId: null,
+			purposeIds: { json: [] },
+		});
+
+		const migration = await client
+			.createMigrator()
+			.migrateTo('2.1.0', { mode: 'from-schema' });
+		destructiveOperations = migration.operations.flatMap((operation) => {
+			if (operation.type === 'update-table') {
+				return operation.value
+					.filter((column) => column.type !== 'create-column')
+					.map((column) => `${operation.type}:${column.type}`);
+			}
+
+			return [
+				'create-table',
+				'add-foreign-key',
+				'add-unique-constraint',
+				// FumaDB emits custom operations for its version metadata.
+				'custom',
+			].includes(operation.type)
+				? []
+				: [operation.type];
+		});
+		addedScopeKeyConstraint = migration.operations.some(
+			(operation) =>
+				operation.type === 'add-unique-constraint' &&
+				operation.table === 'domain' &&
+				operation.columns.includes('scopeKey')
+		);
+		createdReplayTable = migration.operations.some(
+			(operation) =>
+				operation.type === 'create-table' &&
+				operation.value.ormName === 'writeReplay'
+		);
+		await migration.execute();
+	}, 30_000);
+
+	afterAll(async () => {
+		await database.destroy();
+	});
+
+	it('uses an additive-only migration', () => {
+		expect(destructiveOperations).toEqual([]);
+		expect(addedScopeKeyConstraint).toBe(true);
+		expect(createdReplayTable).toBe(true);
+	});
+
+	it('preserves legacy records with nullable integrity fields', async () => {
+		const orm = client.orm('2.1.0');
+		const consent = await orm.findFirst('consent', {
+			where: (builder) => builder('id', '=', 'cns_legacy'),
+		});
+		const domain = await orm.findFirst('domain', {
+			where: (builder) => builder('id', '=', 'dom_legacy'),
+		});
+
+		expect(consent).toMatchObject({
+			writeSource: null,
+			writeCredentialId: null,
+			writeIssuer: null,
+			writeOrigin: null,
+		});
+		expect(domain?.scopeKey).toBeNull();
+	});
+
+	it('allows legacy null scope keys but rejects duplicate canonical keys', async () => {
+		const orm = client.orm('2.1.0');
+		await orm.create('domain', {
+			id: 'dom_null_scope',
+			name: 'another-legacy.example',
+			scopeKey: null,
+		});
+		await orm.create('domain', {
+			id: 'dom_canonical',
+			name: 'canonical.example',
+			scopeKey: 'tenant_1:canonical.example',
+		});
+
+		await expect(
+			orm.create('domain', {
+				id: 'dom_duplicate',
+				name: 'CANONICAL.example',
+				scopeKey: 'tenant_1:canonical.example',
+			})
+		).rejects.toBeDefined();
+	});
+
+	it('atomically rejects a consumed replay key', async () => {
+		const orm = client.orm('2.1.0');
+		const replay = {
+			id: 'replay_credential_1',
+			tenantId: 'tenant_1',
+			audience: 'subject_1',
+			tokenId: 'credential_1',
+			requestFingerprint: 'sha256:fingerprint',
+			expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+		};
+
+		await orm.create('writeReplay', replay);
+		await expect(orm.create('writeReplay', replay)).rejects.toBeDefined();
+	});
+});

--- a/packages/backend/src/db/schema/2.1.0/runtime-policy-decision.ts
+++ b/packages/backend/src/db/schema/2.1.0/runtime-policy-decision.ts
@@ -1,0 +1,10 @@
+import {
+	type RuntimePolicyDecision,
+	runtimePolicyDecisionSchema,
+} from '@c15t/schema';
+import { runtimePolicyDecisionTable as previousRuntimePolicyDecisionTable } from '../2.0.0/runtime-policy-decision';
+
+export const runtimePolicyDecisionTable =
+	previousRuntimePolicyDecisionTable.clone();
+
+export { type RuntimePolicyDecision, runtimePolicyDecisionSchema };

--- a/packages/backend/src/db/schema/2.1.0/subject.ts
+++ b/packages/backend/src/db/schema/2.1.0/subject.ts
@@ -1,0 +1,6 @@
+import { type Subject, subjectSchema } from '@c15t/schema';
+import { subjectTable as previousSubjectTable } from '../2.0.0/subject';
+
+export const subjectTable = previousSubjectTable.clone();
+
+export { type Subject, subjectSchema };

--- a/packages/backend/src/db/schema/2.1.0/write-replay.ts
+++ b/packages/backend/src/db/schema/2.1.0/write-replay.ts
@@ -1,0 +1,15 @@
+import { type WriteReplay, writeReplaySchema } from '@c15t/schema';
+import { column, idColumn, table } from 'fumadb/schema';
+
+export const writeReplayTable = table('writeReplay', {
+	/** Deterministic replay key used for atomic consumption. */
+	id: idColumn('id', 'varchar(255)'),
+	tenantId: column('tenantId', 'string').nullable(),
+	audience: column('audience', 'string'),
+	tokenId: column('tokenId', 'string'),
+	requestFingerprint: column('requestFingerprint', 'string'),
+	expiresAt: column('expiresAt', 'timestamp'),
+	createdAt: column('createdAt', 'timestamp').defaultTo$('now'),
+});
+
+export { type WriteReplay, writeReplaySchema };

--- a/packages/backend/src/db/schema/index.ts
+++ b/packages/backend/src/db/schema/index.ts
@@ -1,15 +1,16 @@
 import { fumadb } from 'fumadb';
 import { v1 } from './1.0.0';
 import { v2 } from './2.0.0';
+import { v2_1 } from './2.1.0';
 
-export * from './2.0.0';
+export * from './2.1.0';
 
 export const DB = fumadb({
 	namespace: 'c15t',
-	schemas: [v1, v2],
+	schemas: [v1, v2, v2_1],
 });
 
 export const LatestDB = fumadb({
 	namespace: 'c15t',
-	schemas: [v2],
+	schemas: [v2_1],
 });

--- a/packages/backend/src/init.test.ts
+++ b/packages/backend/src/init.test.ts
@@ -72,6 +72,54 @@ describe('init', () => {
 
 		expect(context.appName).toBe('c15t');
 		expect(mockClient).toHaveBeenCalledTimes(1);
+		expect(mockClient().orm).toHaveBeenCalledWith('2.1.0');
+	});
+
+	it('preserves legacy write behavior and warns when configuration is omitted', () => {
+		const context = init(createOptions());
+
+		expect(context.writeIntegrity).toMatchObject({
+			anonymousConsent: { mode: 'legacy' },
+			identityLinking: { mode: 'legacy', reassignment: 'legacy' },
+			domains: { mode: 'legacy', allowlist: [] },
+		});
+		expect(mockLogger.warn).toHaveBeenCalledWith(
+			expect.stringMatching(/^writeIntegrity: .*deprecated legacy behavior/)
+		);
+	});
+
+	it('stores validated secure write configuration on the context', () => {
+		const context = init(
+			createOptions({
+				writeIntegrity: {
+					anonymousConsent: { mode: 'public' },
+					identityLinking: { mode: 'disabled' },
+					domains: { allowlist: ['example.com'] },
+				},
+			})
+		);
+
+		expect(context.writeIntegrity).toMatchObject({
+			anonymousConsent: { mode: 'public' },
+			identityLinking: { mode: 'disabled', reassignment: 'disabled' },
+			domains: { mode: 'configured', allowlist: ['example.com'] },
+		});
+		expect(mockLogger.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining('writeIntegrity:')
+		);
+	});
+
+	it('rejects incomplete secure write configuration', () => {
+		expect(() =>
+			init(
+				createOptions({
+					writeIntegrity: {
+						anonymousConsent: { mode: 'capability' },
+						identityLinking: { mode: 'disabled' },
+					},
+				})
+			)
+		).toThrow('Invalid write-integrity configuration');
 	});
 
 	it('uses the provided appName', () => {

--- a/packages/backend/src/init.ts
+++ b/packages/backend/src/init.ts
@@ -9,6 +9,7 @@ import {
 	isTelemetryEnabled,
 } from './utils/create-telemetry-options';
 import { initLogger } from './utils/logger';
+import { resolveWriteIntegrityOptions } from './write-integrity/configuration';
 
 /**
  * Initializes the c15t backend context.
@@ -42,6 +43,21 @@ export const init = (options: C15TOptions): C15TContext => {
 		...options.logger,
 		appName: String(appName),
 	});
+	const writeIntegrityValidation = resolveWriteIntegrityOptions(
+		options.writeIntegrity
+	);
+
+	for (const warning of writeIntegrityValidation.warnings) {
+		logger.warn(`writeIntegrity: ${warning}`);
+	}
+
+	if (writeIntegrityValidation.errors.length > 0) {
+		throw new Error(
+			`Invalid write-integrity configuration:\n${writeIntegrityValidation.errors
+				.map((error) => `- ${error}`)
+				.join('\n')}`
+		);
+	}
 
 	// Create telemetry options (validates and merges with defaults)
 	const telemetryOptions = createTelemetryOptions(
@@ -65,7 +81,7 @@ export const init = (options: C15TOptions): C15TContext => {
 	const db = options.tablePrefix ? DB.names.prefix(options.tablePrefix) : DB;
 	const client = db.client(options.adapter);
 
-	const rawOrm = client.orm('2.0.0');
+	const rawOrm = client.orm('2.1.0');
 	const orm = options.tenantId
 		? withTenantScope(rawOrm, options.tenantId)
 		: rawOrm;
@@ -106,6 +122,7 @@ export const init = (options: C15TOptions): C15TContext => {
 	const context: C15TContext = {
 		...baseOptions,
 		appName,
+		writeIntegrity: writeIntegrityValidation.config,
 		logger,
 		db: orm,
 		registry: createRegistry({

--- a/packages/backend/src/types/index.ts
+++ b/packages/backend/src/types/index.ts
@@ -2,6 +2,7 @@ import type { createLogger, LoggerOptions } from '@c15t/logger';
 import {
 	type Branding,
 	brandingValues,
+	type ConsentWriteSource,
 	type GlobalVendorList,
 	type NonIABVendor,
 	type PolicyConfig,
@@ -345,6 +346,273 @@ export interface BackgroundOptions {
 	run: (task: () => Promise<void>) => void;
 }
 
+/**
+ * A write operation protected by the write-integrity configuration.
+ */
+export type WriteIntegrityAction =
+	| 'consent:create'
+	| 'identity:link'
+	| 'identity:reassign';
+
+/**
+ * How anonymous consent submissions are accepted.
+ *
+ * `legacy` preserves the v2 behavior and is deprecated. `public` keeps consent
+ * submission anonymous while requiring configured domain resolution.
+ */
+export type AnonymousConsentSubmissionMode =
+	| 'legacy'
+	| 'public'
+	| 'capability'
+	| 'disabled';
+
+/**
+ * Anonymous consent submission configuration.
+ */
+export interface AnonymousConsentSubmissionOptions {
+	/**
+	 * Proof required to submit consent.
+	 */
+	mode: AnonymousConsentSubmissionMode;
+}
+
+/**
+ * How external identities may be linked to a subject.
+ */
+export type IdentityLinkingMode =
+	| 'legacy'
+	| 'capability'
+	| 'assertion'
+	| 'capability-and-assertion'
+	| 'disabled';
+
+/**
+ * Proof required to replace an external identity after its initial link.
+ */
+export type IdentityReassignmentMode =
+	| 'legacy'
+	| 'disabled'
+	| 'capability-and-assertion';
+
+/**
+ * External identity linking configuration.
+ */
+export interface IdentityLinkingOptions {
+	/**
+	 * Proof required for the initial, set-once identity link.
+	 */
+	mode: IdentityLinkingMode;
+
+	/**
+	 * Whether an existing external identity may be replaced.
+	 *
+	 * Secure modes default to `disabled`. Legacy mode continues to allow the
+	 * existing public replacement behavior for v2 compatibility.
+	 *
+	 * @default "disabled" for secure modes, "legacy" behavior otherwise
+	 */
+	reassignment?: IdentityReassignmentMode;
+}
+
+/**
+ * Context supplied to a trusted server-side domain resolver.
+ */
+export interface WriteDomainResolverContext {
+	/** Write operation being authorized. */
+	action: WriteIntegrityAction;
+	/** Domain supplied by the write request, when present. */
+	requestedDomain?: string;
+	/** Request origin after backend request enrichment. */
+	origin?: string;
+	/** Subject targeted by the write, when known. */
+	subjectId?: string;
+	/** Active tenant identifier. */
+	tenantId?: string;
+	/** Raw request for server-specific routing or authentication context. */
+	request: Request;
+}
+
+/**
+ * Resolves the authoritative domain for a write on the server.
+ *
+ * Returning `null` or `undefined` rejects domain resolution. When an allowlist
+ * is also configured, the resolved domain must be present in that allowlist.
+ */
+export type WriteDomainResolver = (
+	context: WriteDomainResolverContext
+) => Promise<string | null | undefined> | string | null | undefined;
+
+/**
+ * Domain controls for consent and identity writes.
+ */
+export interface WriteDomainOptions {
+	/**
+	 * Domains that may be associated with writes.
+	 *
+	 * When `resolve` is also provided, its output is checked against this list.
+	 */
+	allowlist?: readonly string[];
+
+	/**
+	 * Trusted server-side resolver for deriving a write's authoritative domain.
+	 */
+	resolve?: WriteDomainResolver;
+}
+
+/**
+ * Signing and verification configuration for short-lived subject capabilities.
+ */
+export interface SubjectCapabilityOptions {
+	/** Shared secret used to issue HS256 subject capabilities. */
+	signingKey: string;
+	/**
+	 * Verification secret when it differs from `signingKey`.
+	 *
+	 * Omit this for symmetric signing algorithms.
+	 */
+	verificationKey?: string;
+	/** Expected issuer and issuer claim for capabilities. */
+	issuer?: string;
+	/** Expected audience and audience claim for capabilities. */
+	audience?: string;
+	/**
+	 * Capability lifetime in seconds.
+	 * @default 300
+	 */
+	ttlSeconds?: number;
+}
+
+/**
+ * Verification configuration for assertions signed by an application server.
+ */
+export interface IdentityAssertionOptions {
+	/** Shared secret used to verify HS256 application-server assertions. */
+	verificationKey: string;
+	/** Expected assertion issuer. */
+	issuer?: string;
+	/** Expected assertion audience. */
+	audience?: string;
+	/**
+	 * Maximum accepted assertion age in seconds.
+	 * @default 300
+	 */
+	maxAgeSeconds?: number;
+}
+
+/**
+ * A replay identifier to claim before applying a credential-authorized write.
+ */
+export interface WriteReplayClaim {
+	/** Unique token identifier from the verified credential. */
+	tokenId: string;
+	/** Tenant associated with the credential. */
+	tenantId?: string;
+	/** Audience associated with the credential. */
+	audience: string;
+	/** Stable fingerprint of the action and request fields being authorized. */
+	requestFingerprint: string;
+	/** Time after which the replay claim may be discarded. */
+	expiresAt: Date;
+}
+
+/**
+ * Atomic storage used to reject replayed write credentials.
+ */
+export interface WriteReplayStore {
+	/**
+	 * Atomically records a replay claim if its token identifier is unused.
+	 *
+	 * Implementations must perform the existence check and insert as one atomic
+	 * operation. Return `true` only for the first accepted claim and `false` when
+	 * the token identifier was already consumed.
+	 *
+	 * @param claim - Credential and request details to claim
+	 * @returns Whether the claim was recorded for the first time
+	 */
+	consume(claim: WriteReplayClaim): Promise<boolean>;
+}
+
+/**
+ * Input supplied to the write abuse-control hook.
+ */
+export interface WriteAbuseControlContext {
+	/** Write operation being attempted. */
+	action: WriteIntegrityAction;
+	/** Subject targeted by the write, when known. */
+	subjectId?: string;
+	/** Authoritative domain resolved for the write, when known. */
+	domain?: string;
+	/** Request origin after backend request enrichment. */
+	origin?: string;
+	/** Request IP after the configured masking behavior. */
+	ipAddress?: string | null;
+	/** Active tenant identifier. */
+	tenantId?: string;
+	/** Raw request for adapter-specific rate-limit keys or metadata. */
+	request: Request;
+}
+
+/**
+ * Decision returned by a write abuse-control hook.
+ */
+export interface WriteAbuseControlDecision {
+	/** Whether the write may proceed. */
+	allowed: boolean;
+	/** Optional retry delay for rejected requests. */
+	retryAfterSeconds?: number;
+	/** Optional stable, non-sensitive reason for logs and telemetry. */
+	reason?: string;
+}
+
+/**
+ * Application-provided rate-limit or abuse-control integration.
+ */
+export type WriteAbuseControl = (
+	context: WriteAbuseControlContext
+) => Promise<WriteAbuseControlDecision> | WriteAbuseControlDecision;
+
+/**
+ * Authority used to accept a consent or identity write.
+ */
+export type WriteProvenanceSource = ConsentWriteSource;
+
+/**
+ * Audit provenance for a consent or identity write.
+ *
+ * This describes write authorization and is separate from runtime policy
+ * provenance, which describes how the consent experience was selected.
+ */
+export interface WriteProvenance {
+	/** Authority used to accept the write. */
+	source: WriteProvenanceSource;
+	/** Credential identifier, such as a capability or assertion token ID. */
+	credentialId?: string | null;
+	/** Issuer recorded from the verified credential. */
+	issuer?: string | null;
+	/** Request origin associated with the write. */
+	origin?: string | null;
+}
+
+/**
+ * Consent-write integrity and compatibility configuration.
+ */
+export interface WriteIntegrityOptions {
+	/** Anonymous consent submission behavior. */
+	anonymousConsent?: AnonymousConsentSubmissionOptions;
+	/** External identity linking and reassignment behavior. */
+	identityLinking?: IdentityLinkingOptions;
+	/** Domain allowlist and/or trusted server-side domain resolver. */
+	domains?: WriteDomainOptions;
+	/** Subject capability issuance and verification settings. */
+	subjectCapability?: SubjectCapabilityOptions;
+	/** Application-server identity assertion verification settings. */
+	identityAssertion?: IdentityAssertionOptions;
+	/** Optional custom atomic replay store. */
+	replayStore?: WriteReplayStore;
+	/** Optional rate-limit or abuse-control integration. */
+	abuseControl?: WriteAbuseControl;
+}
+
 export interface C15TOptions {
 	/**
 	 * The database adapter to use.
@@ -512,6 +780,14 @@ export interface C15TOptions {
 	 * Optional background task runner for non-critical side effects.
 	 */
 	background?: BackgroundOptions;
+
+	/**
+	 * Consent-write authorization, domain, replay, and abuse controls.
+	 *
+	 * Omit this field to preserve legacy v2 behavior. The legacy modes are
+	 * deprecated; configure explicit secure modes to prepare for v3.
+	 */
+	writeIntegrity?: WriteIntegrityOptions;
 }
 
 export interface C15TContext
@@ -546,3 +822,10 @@ export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
 	: T extends object
 		? { [K in keyof T]?: DeepPartial<T[K]> }
 		: T;
+
+export {
+	type ResolvedWriteDomainOptions,
+	type ResolvedWriteIntegrityOptions,
+	resolveWriteIntegrityOptions,
+	type WriteIntegrityConfigurationResult,
+} from '../write-integrity/configuration';

--- a/packages/backend/src/write-integrity/configuration.test.ts
+++ b/packages/backend/src/write-integrity/configuration.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveWriteIntegrityOptions } from './configuration';
+
+describe('resolveWriteIntegrityOptions', () => {
+	it('preserves legacy v2 behavior when configuration is omitted', () => {
+		const result = resolveWriteIntegrityOptions(undefined);
+
+		expect(result.config).toMatchObject({
+			anonymousConsent: { mode: 'legacy' },
+			identityLinking: {
+				mode: 'legacy',
+				reassignment: 'legacy',
+			},
+			domains: {
+				mode: 'legacy',
+				allowlist: [],
+			},
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.warnings).toEqual([
+			'`writeIntegrity.anonymousConsent` is using deprecated legacy behavior. Configure `public`, `capability`, or `disabled` before upgrading to v3.',
+			'`writeIntegrity.identityLinking` is using deprecated legacy behavior. Configure an explicit proof mode or `disabled` before upgrading to v3.',
+			'`writeIntegrity.domains` is not configured, so request-provided domains use deprecated legacy behavior. Configure an allowlist, a server resolver, or both before upgrading to v3.',
+		]);
+	});
+
+	it('resolves a public anonymous mode without changing identity defaults', () => {
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'public' },
+			domains: { allowlist: ['example.com'] },
+		});
+
+		expect(result.config.anonymousConsent.mode).toBe('public');
+		expect(result.config.identityLinking).toEqual({
+			mode: 'legacy',
+			reassignment: 'legacy',
+		});
+		expect(result.config.domains).toMatchObject({
+			mode: 'configured',
+			allowlist: ['example.com'],
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.warnings).toEqual([
+			'`writeIntegrity.identityLinking` is using deprecated legacy behavior. Configure an explicit proof mode or `disabled` before upgrading to v3.',
+		]);
+	});
+
+	it('accepts a resolver and allowlist together', () => {
+		const resolve = vi.fn(() => 'example.com');
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'public' },
+			identityLinking: { mode: 'disabled' },
+			domains: {
+				allowlist: ['example.com'],
+				resolve,
+			},
+		});
+
+		expect(result.config.domains).toEqual({
+			mode: 'configured',
+			allowlist: ['example.com'],
+			resolve,
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.warnings).toEqual([]);
+	});
+
+	it('requires domain controls for enabled secure writes', () => {
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'public' },
+			identityLinking: { mode: 'disabled' },
+		});
+
+		expect(result.errors).toEqual([
+			'Enabled secure write modes require `writeIntegrity.domains.allowlist`, `writeIntegrity.domains.resolve`, or both.',
+		]);
+	});
+
+	it('honors secure reassignment controls during a legacy linking migration', () => {
+		const result = resolveWriteIntegrityOptions({
+			identityLinking: {
+				mode: 'legacy',
+				reassignment: 'capability-and-assertion',
+			},
+			subjectCapability: { signingKey: 'capability-secret' },
+			identityAssertion: { verificationKey: 'assertion-secret' },
+		});
+
+		expect(result.config.identityLinking.reassignment).toBe(
+			'capability-and-assertion'
+		);
+		expect(result.errors).toEqual([
+			'Enabled secure write modes require `writeIntegrity.domains.allowlist`, `writeIntegrity.domains.resolve`, or both.',
+		]);
+	});
+
+	it('requires capability and assertion configuration for combined proof', () => {
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'disabled' },
+			identityLinking: { mode: 'capability-and-assertion' },
+			domains: { allowlist: ['example.com'] },
+		});
+
+		expect(result.errors).toEqual([
+			'Capability modes require `writeIntegrity.subjectCapability` configuration.',
+			'Assertion modes require `writeIntegrity.identityAssertion` configuration.',
+		]);
+	});
+
+	it('applies credential lifetime defaults for secure configuration', () => {
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'capability' },
+			identityLinking: {
+				mode: 'assertion',
+				reassignment: 'capability-and-assertion',
+			},
+			domains: { allowlist: ['example.com'] },
+			subjectCapability: { signingKey: 'capability-secret' },
+			identityAssertion: { verificationKey: 'assertion-public-key' },
+		});
+
+		expect(result.config.subjectCapability?.ttlSeconds).toBe(300);
+		expect(result.config.subjectCapability?.verificationKey).toBe(
+			'capability-secret'
+		);
+		expect(result.config.identityAssertion?.maxAgeSeconds).toBe(300);
+		expect(result.config.identityLinking.reassignment).toBe(
+			'capability-and-assertion'
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.warnings).toEqual([]);
+	});
+
+	it('rejects invalid credential lifetimes, keys, and allowlist entries', () => {
+		const result = resolveWriteIntegrityOptions({
+			anonymousConsent: { mode: 'capability' },
+			identityLinking: { mode: 'assertion' },
+			domains: { allowlist: [''] },
+			subjectCapability: { signingKey: '', ttlSeconds: 0 },
+			identityAssertion: { verificationKey: '', maxAgeSeconds: -1 },
+		});
+
+		expect(result.errors).toEqual([
+			'Enabled secure write modes require `writeIntegrity.domains.allowlist`, `writeIntegrity.domains.resolve`, or both.',
+			'`writeIntegrity.domains.allowlist` cannot contain empty domains.',
+			'`writeIntegrity.subjectCapability.signingKey` cannot be empty.',
+			'`writeIntegrity.subjectCapability.ttlSeconds` must be a positive integer.',
+			'`writeIntegrity.identityAssertion.verificationKey` cannot be empty.',
+			'`writeIntegrity.identityAssertion.maxAgeSeconds` must be a positive integer.',
+		]);
+	});
+
+	it('does not mutate caller-owned arrays or option objects', () => {
+		const allowlist = ['example.com'];
+		const options = {
+			anonymousConsent: { mode: 'public' as const },
+			identityLinking: { mode: 'disabled' as const },
+			domains: { allowlist },
+		};
+
+		const result = resolveWriteIntegrityOptions(options);
+		allowlist.push('later.example.com');
+
+		expect(result.config.domains.allowlist).toEqual(['example.com']);
+		expect(options).not.toHaveProperty('subjectCapability');
+	});
+});

--- a/packages/backend/src/write-integrity/configuration.ts
+++ b/packages/backend/src/write-integrity/configuration.ts
@@ -1,0 +1,255 @@
+import type {
+	AnonymousConsentSubmissionOptions,
+	IdentityAssertionOptions,
+	IdentityLinkingOptions,
+	SubjectCapabilityOptions,
+	WriteDomainOptions,
+	WriteIntegrityOptions,
+} from '../types';
+
+const DEFAULT_CAPABILITY_TTL_SECONDS = 300;
+const DEFAULT_ASSERTION_MAX_AGE_SECONDS = 300;
+
+const LEGACY_ANONYMOUS_CONSENT_WARNING =
+	'`writeIntegrity.anonymousConsent` is using deprecated legacy behavior. Configure `public`, `capability`, or `disabled` before upgrading to v3.';
+const LEGACY_IDENTITY_LINKING_WARNING =
+	'`writeIntegrity.identityLinking` is using deprecated legacy behavior. Configure an explicit proof mode or `disabled` before upgrading to v3.';
+const LEGACY_DOMAIN_WARNING =
+	'`writeIntegrity.domains` is not configured, so request-provided domains use deprecated legacy behavior. Configure an allowlist, a server resolver, or both before upgrading to v3.';
+
+/**
+ * Fully resolved domain controls.
+ */
+export interface ResolvedWriteDomainOptions extends WriteDomainOptions {
+	/** Whether legacy request-provided domain behavior remains active. */
+	mode: 'legacy' | 'configured';
+	/** Copied configured allowlist. */
+	allowlist: readonly string[];
+}
+
+/**
+ * Write-integrity options with compatibility defaults applied.
+ */
+export interface ResolvedWriteIntegrityOptions
+	extends Omit<
+		WriteIntegrityOptions,
+		'anonymousConsent' | 'identityLinking' | 'domains'
+	> {
+	anonymousConsent: AnonymousConsentSubmissionOptions;
+	identityLinking: Omit<IdentityLinkingOptions, 'reassignment'> & {
+		reassignment: 'legacy' | 'disabled' | 'capability-and-assertion';
+	};
+	domains: ResolvedWriteDomainOptions;
+	subjectCapability?: Omit<
+		SubjectCapabilityOptions,
+		'ttlSeconds' | 'verificationKey'
+	> & {
+		ttlSeconds: number;
+		verificationKey: string;
+	};
+	identityAssertion?: Omit<IdentityAssertionOptions, 'maxAgeSeconds'> & {
+		maxAgeSeconds: number;
+	};
+}
+
+/**
+ * Result of resolving and validating write-integrity configuration.
+ */
+export interface WriteIntegrityConfigurationResult {
+	/** Configuration with backwards-compatible defaults applied. */
+	config: ResolvedWriteIntegrityOptions;
+	/** Fatal configuration problems in deterministic validation order. */
+	errors: string[];
+	/** Compatibility and migration warnings in deterministic order. */
+	warnings: string[];
+}
+
+function hasDomainControl(options: WriteDomainOptions | undefined): boolean {
+	return Boolean(
+		options?.resolve ||
+			options?.allowlist?.some((domain) => domain.trim() !== '')
+	);
+}
+
+function isPositiveInteger(value: number | undefined): boolean {
+	return value === undefined || (Number.isInteger(value) && value > 0);
+}
+
+function requiresCapability(options: WriteIntegrityOptions): boolean {
+	const anonymousMode = options.anonymousConsent?.mode;
+	const identityMode = options.identityLinking?.mode;
+	const reassignment = options.identityLinking?.reassignment;
+
+	return (
+		anonymousMode === 'capability' ||
+		identityMode === 'capability' ||
+		identityMode === 'capability-and-assertion' ||
+		reassignment === 'capability-and-assertion'
+	);
+}
+
+function requiresAssertion(options: WriteIntegrityOptions): boolean {
+	const identityMode = options.identityLinking?.mode;
+	const reassignment = options.identityLinking?.reassignment;
+
+	return (
+		identityMode === 'assertion' ||
+		identityMode === 'capability-and-assertion' ||
+		reassignment === 'capability-and-assertion'
+	);
+}
+
+function hasEnabledSecureWrite(options: WriteIntegrityOptions): boolean {
+	const anonymousMode = options.anonymousConsent?.mode ?? 'legacy';
+	const identityMode = options.identityLinking?.mode ?? 'legacy';
+	const reassignment = options.identityLinking?.reassignment;
+
+	return (
+		(anonymousMode !== 'legacy' && anonymousMode !== 'disabled') ||
+		(identityMode !== 'legacy' && identityMode !== 'disabled') ||
+		reassignment === 'capability-and-assertion'
+	);
+}
+
+/**
+ * Resolves write-integrity defaults and validates dependencies between modes.
+ *
+ * This function is pure: it returns warnings for the caller to log and never
+ * mutates the supplied options. Omitted configuration deliberately resolves to
+ * the legacy v2 behavior so adopting this minor release is non-breaking.
+ *
+ * @param options - Optional write-integrity configuration
+ * @returns Resolved configuration, validation errors, and migration warnings
+ */
+export function resolveWriteIntegrityOptions(
+	options: WriteIntegrityOptions | undefined
+): WriteIntegrityConfigurationResult {
+	const source = options ?? {};
+	const anonymousConsent = source.anonymousConsent ?? { mode: 'legacy' };
+	const identityLinking = source.identityLinking ?? { mode: 'legacy' };
+	const domainsConfigured = hasDomainControl(source.domains);
+	const warnings: string[] = [];
+	const errors: string[] = [];
+
+	if (anonymousConsent.mode === 'legacy') {
+		warnings.push(LEGACY_ANONYMOUS_CONSENT_WARNING);
+	}
+
+	if (identityLinking.mode === 'legacy') {
+		warnings.push(LEGACY_IDENTITY_LINKING_WARNING);
+	}
+
+	if (!domainsConfigured) {
+		warnings.push(LEGACY_DOMAIN_WARNING);
+	}
+
+	if (hasEnabledSecureWrite(source) && !domainsConfigured) {
+		errors.push(
+			'Enabled secure write modes require `writeIntegrity.domains.allowlist`, `writeIntegrity.domains.resolve`, or both.'
+		);
+	}
+
+	if (source.domains?.allowlist?.some((domain) => domain.trim() === '')) {
+		errors.push(
+			'`writeIntegrity.domains.allowlist` cannot contain empty domains.'
+		);
+	}
+
+	if (requiresCapability(source) && !source.subjectCapability) {
+		errors.push(
+			'Capability modes require `writeIntegrity.subjectCapability` configuration.'
+		);
+	}
+
+	if (
+		source.subjectCapability &&
+		source.subjectCapability.signingKey.trim() === ''
+	) {
+		errors.push(
+			'`writeIntegrity.subjectCapability.signingKey` cannot be empty.'
+		);
+	}
+
+	if (
+		source.subjectCapability?.verificationKey !== undefined &&
+		source.subjectCapability.verificationKey.trim() === ''
+	) {
+		errors.push(
+			'`writeIntegrity.subjectCapability.verificationKey` cannot be empty.'
+		);
+	}
+
+	if (
+		source.subjectCapability &&
+		!isPositiveInteger(source.subjectCapability.ttlSeconds)
+	) {
+		errors.push(
+			'`writeIntegrity.subjectCapability.ttlSeconds` must be a positive integer.'
+		);
+	}
+
+	if (requiresAssertion(source) && !source.identityAssertion) {
+		errors.push(
+			'Assertion modes require `writeIntegrity.identityAssertion` configuration.'
+		);
+	}
+
+	if (
+		source.identityAssertion &&
+		source.identityAssertion.verificationKey.trim() === ''
+	) {
+		errors.push(
+			'`writeIntegrity.identityAssertion.verificationKey` cannot be empty.'
+		);
+	}
+
+	if (
+		source.identityAssertion &&
+		!isPositiveInteger(source.identityAssertion.maxAgeSeconds)
+	) {
+		errors.push(
+			'`writeIntegrity.identityAssertion.maxAgeSeconds` must be a positive integer.'
+		);
+	}
+
+	const resolvedIdentityReassignment =
+		identityLinking.reassignment ??
+		(identityLinking.mode === 'legacy' ? 'legacy' : 'disabled');
+
+	return {
+		config: {
+			...source,
+			anonymousConsent: { ...anonymousConsent },
+			identityLinking: {
+				...identityLinking,
+				reassignment: resolvedIdentityReassignment,
+			},
+			domains: {
+				...source.domains,
+				mode: domainsConfigured ? 'configured' : 'legacy',
+				allowlist: [...(source.domains?.allowlist ?? [])],
+			},
+			subjectCapability: source.subjectCapability
+				? {
+						...source.subjectCapability,
+						ttlSeconds:
+							source.subjectCapability.ttlSeconds ??
+							DEFAULT_CAPABILITY_TTL_SECONDS,
+						verificationKey:
+							source.subjectCapability.verificationKey ??
+							source.subjectCapability.signingKey,
+					}
+				: undefined,
+			identityAssertion: source.identityAssertion
+				? {
+						...source.identityAssertion,
+						maxAgeSeconds:
+							source.identityAssertion.maxAgeSeconds ??
+							DEFAULT_ASSERTION_MAX_AGE_SECONDS,
+					}
+				: undefined,
+		},
+		errors,
+		warnings,
+	};
+}

--- a/packages/backend/src/write-integrity/identity-assertion.test.ts
+++ b/packages/backend/src/write-integrity/identity-assertion.test.ts
@@ -1,0 +1,164 @@
+import { SignJWT } from 'jose';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	createIdentityAssertion,
+	verifyIdentityAssertion,
+} from './identity-assertion';
+
+const SIGNING_KEY = 'identity-assertion-test-signing-key';
+
+function createAssertion(
+	overrides: Partial<Parameters<typeof createIdentityAssertion>[0]> = {}
+) {
+	return createIdentityAssertion({
+		options: { signingKey: SIGNING_KEY, ttlSeconds: 60 },
+		tenantId: 'tenant_123',
+		subjectId: 'subject_123',
+		action: 'identity:link',
+		domain: 'example.com',
+		externalId: 'user_123',
+		identityProvider: 'clerk',
+		...overrides,
+	});
+}
+
+function verifyAssertion(
+	token: string | undefined,
+	overrides: Partial<Parameters<typeof verifyIdentityAssertion>[0]> = {}
+) {
+	return verifyIdentityAssertion({
+		token,
+		options: { verificationKey: SIGNING_KEY },
+		tenantId: 'tenant_123',
+		subjectId: 'subject_123',
+		action: 'identity:link',
+		domain: 'example.com',
+		externalId: 'user_123',
+		identityProvider: 'clerk',
+		...overrides,
+	});
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('identity assertion', () => {
+	it('creates and verifies an assertion for one exact external identity', async () => {
+		const created = await createAssertion();
+		const verified = await verifyAssertion(created.token);
+
+		expect(verified).toEqual({ valid: true, payload: created.payload });
+		expect(created.payload).toMatchObject({
+			iss: 'c15t-app',
+			aud: 'c15t-identity-assertion',
+			sub: 'subject_123',
+			tenantId: 'tenant_123',
+			action: 'identity:link',
+			domain: 'example.com',
+			externalId: 'user_123',
+			identityProvider: 'clerk',
+		});
+		expect(created.payload.jti).toEqual(expect.any(String));
+	});
+
+	it.each([
+		['tenant', { tenantId: 'tenant_other' }],
+		['subject', { subjectId: 'subject_other' }],
+		['action', { action: 'identity:reassign' as const }],
+		['domain', { domain: 'other.example.com' }],
+		['external ID', { externalId: 'user_other' }],
+		['identity provider', { identityProvider: 'auth0' }],
+	])('rejects a mismatched %s binding', async (_name, overrides) => {
+		const created = await createAssertion();
+
+		await expect(verifyAssertion(created.token, overrides)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+	});
+
+	it('rejects a token signed with a different key', async () => {
+		const created = await createAssertion();
+
+		await expect(
+			verifyAssertion(created.token, {
+				options: { verificationKey: 'different-signing-key' },
+			})
+		).resolves.toEqual({ valid: false, reason: 'invalid' });
+	});
+
+	it('enforces the configured maximum assertion age', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-04T10:00:00Z'));
+		const created = await createAssertion({
+			options: { signingKey: SIGNING_KEY, ttlSeconds: 600 },
+		});
+		vi.setSystemTime(new Date('2026-08-04T10:05:01Z'));
+
+		await expect(verifyAssertion(created.token)).resolves.toEqual({
+			valid: false,
+			reason: 'expired',
+		});
+	});
+
+	it('classifies missing, malformed, expired, and tampered tokens', async () => {
+		await expect(verifyAssertion(undefined)).resolves.toEqual({
+			valid: false,
+			reason: 'missing',
+		});
+		await expect(verifyAssertion('not-a-jwt')).resolves.toEqual({
+			valid: false,
+			reason: 'malformed',
+		});
+
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-04T10:00:00Z'));
+		const created = await createAssertion({
+			options: { signingKey: SIGNING_KEY, ttlSeconds: 1 },
+		});
+		vi.setSystemTime(new Date('2026-08-04T10:00:02Z'));
+		await expect(verifyAssertion(created.token)).resolves.toEqual({
+			valid: false,
+			reason: 'expired',
+		});
+
+		const [header, payload, signature] = created.token.split('.');
+		await expect(
+			verifyAssertion(`${header}.${payload}x.${signature}`)
+		).resolves.toEqual({ valid: false, reason: 'invalid' });
+	});
+
+	it('rejects tokens with an unexpected algorithm or type', async () => {
+		const issuedAt = Math.floor(Date.now() / 1000);
+		const claims = {
+			iss: 'c15t-app',
+			aud: 'c15t-identity-assertion',
+			sub: 'subject_123',
+			tenantId: 'tenant_123',
+			action: 'identity:link',
+			domain: 'example.com',
+			externalId: 'user_123',
+			identityProvider: 'clerk',
+			iat: issuedAt,
+			exp: issuedAt + 60,
+			jti: crypto.randomUUID(),
+		};
+		const key = new TextEncoder().encode(SIGNING_KEY);
+		const wrongAlgorithm = await new SignJWT(claims)
+			.setProtectedHeader({ alg: 'HS384', typ: 'c15t-identity-assertion+jwt' })
+			.sign(key);
+		const wrongType = await new SignJWT(claims)
+			.setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+			.sign(key);
+
+		await expect(verifyAssertion(wrongAlgorithm)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+		await expect(verifyAssertion(wrongType)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+	});
+});

--- a/packages/backend/src/write-integrity/identity-assertion.ts
+++ b/packages/backend/src/write-integrity/identity-assertion.ts
@@ -1,0 +1,173 @@
+import { type JWTPayload, SignJWT } from 'jose';
+import {
+	assertNonEmpty,
+	getSigningKey,
+	isWriteIntegrityPayload,
+	resolveTtlSeconds,
+	verifyWriteIntegrityToken,
+	type WriteIntegrityPayload,
+	type WriteIntegrityVerificationResult,
+} from './token';
+
+const DEFAULT_ISSUER = 'c15t-app';
+const DEFAULT_AUDIENCE = 'c15t-identity-assertion';
+const DEFAULT_TTL_SECONDS = 300;
+const IDENTITY_ASSERTION_TYPE = 'c15t-identity-assertion+jwt';
+
+/**
+ * An action that can be authorized by an identity assertion.
+ */
+export type IdentityAssertionAction = 'identity:link' | 'identity:reassign';
+
+/**
+ * Options used by an application server to sign an identity assertion.
+ */
+export interface CreateIdentityAssertionOptions {
+	/** Shared secret used to sign the assertion with HS256. */
+	signingKey: string;
+	/** Token issuer. Defaults to `c15t-app`. */
+	issuer?: string;
+	/** Intended recipient. Defaults to `c15t-identity-assertion`. */
+	audience?: string;
+	/** Assertion lifetime in seconds. Defaults to 300 seconds. */
+	ttlSeconds?: number;
+}
+
+/**
+ * Options used by c15t to verify an identity assertion.
+ */
+export interface VerifyIdentityAssertionOptions {
+	/** Shared secret used to verify the HS256 signature. */
+	verificationKey: string;
+	/** Expected token issuer. Defaults to `c15t-app`. */
+	issuer?: string;
+	/** Expected recipient. Defaults to `c15t-identity-assertion`. */
+	audience?: string;
+	/** Maximum assertion age in seconds. Defaults to 300 seconds. */
+	maxAgeSeconds?: number;
+}
+
+/**
+ * Claims carried by an app-server-signed identity assertion.
+ */
+export interface IdentityAssertionPayload extends WriteIntegrityPayload {
+	action: IdentityAssertionAction;
+	externalId: string;
+	identityProvider: string;
+}
+
+/**
+ * Result returned after verifying an identity assertion.
+ */
+export type IdentityAssertionVerificationResult =
+	WriteIntegrityVerificationResult<IdentityAssertionPayload>;
+
+/**
+ * Creates an assertion that authorizes linking one exact external identity.
+ *
+ * The external ID and identity provider are signed without normalization.
+ * Callers must verify against the exact values received in the write request.
+ *
+ * @param params - Signing options and claims to bind to the assertion
+ * @returns The compact JWT and its signed claims
+ * @throws {TypeError} When a required string is empty
+ * @throws {RangeError} When `ttlSeconds` is not a positive integer
+ */
+export async function createIdentityAssertion(params: {
+	options: CreateIdentityAssertionOptions;
+	tenantId?: string;
+	subjectId: string;
+	action: IdentityAssertionAction;
+	domain?: string;
+	externalId: string;
+	identityProvider: string;
+}): Promise<{ token: string; payload: IdentityAssertionPayload }> {
+	const issuer = params.options.issuer?.trim() || DEFAULT_ISSUER;
+	const audience = params.options.audience?.trim() || DEFAULT_AUDIENCE;
+	const ttlSeconds = resolveTtlSeconds(
+		params.options.ttlSeconds,
+		DEFAULT_TTL_SECONDS
+	);
+
+	assertNonEmpty(params.options.signingKey, 'signingKey');
+	assertNonEmpty(params.subjectId, 'subjectId');
+	assertNonEmpty(params.externalId, 'externalId');
+	assertNonEmpty(params.identityProvider, 'identityProvider');
+	if (params.tenantId !== undefined) {
+		assertNonEmpty(params.tenantId, 'tenantId');
+	}
+	if (params.domain !== undefined) {
+		assertNonEmpty(params.domain, 'domain');
+	}
+
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = iat + ttlSeconds;
+	const jti = crypto.randomUUID();
+	const payload: IdentityAssertionPayload = {
+		iss: issuer,
+		aud: audience,
+		sub: params.subjectId,
+		tenantId: params.tenantId,
+		action: params.action,
+		domain: params.domain,
+		externalId: params.externalId,
+		identityProvider: params.identityProvider,
+		iat,
+		exp,
+		jti,
+	};
+	const token = await new SignJWT(payload)
+		.setProtectedHeader({ alg: 'HS256', typ: IDENTITY_ASSERTION_TYPE })
+		.sign(getSigningKey(params.options.signingKey));
+
+	return { token, payload };
+}
+
+/**
+ * Verifies an identity assertion and all request-specific bindings.
+ *
+ * @param params - Token, verification options, and exact expected claims
+ * @returns A discriminated result containing either verified claims or a
+ * stable failure reason
+ */
+export function verifyIdentityAssertion(params: {
+	token?: string;
+	options: VerifyIdentityAssertionOptions;
+	tenantId?: string;
+	subjectId: string;
+	action: IdentityAssertionAction;
+	domain?: string;
+	externalId: string;
+	identityProvider: string;
+}): Promise<IdentityAssertionVerificationResult> {
+	return verifyWriteIntegrityToken({
+		token: params.token,
+		verificationKey: params.options.verificationKey,
+		issuer: params.options.issuer?.trim() || DEFAULT_ISSUER,
+		audience: params.options.audience?.trim() || DEFAULT_AUDIENCE,
+		type: IDENTITY_ASSERTION_TYPE,
+		maxAgeSeconds: params.options.maxAgeSeconds ?? DEFAULT_TTL_SECONDS,
+		isPayload: isIdentityAssertionPayload,
+		matchesExpectedClaims: (payload) =>
+			payload.sub === params.subjectId &&
+			payload.action === params.action &&
+			(payload.tenantId ?? undefined) === (params.tenantId ?? undefined) &&
+			(payload.domain ?? undefined) === (params.domain ?? undefined) &&
+			payload.externalId === params.externalId &&
+			payload.identityProvider === params.identityProvider,
+	});
+}
+
+function isIdentityAssertionPayload(
+	payload: JWTPayload
+): payload is IdentityAssertionPayload {
+	return (
+		isWriteIntegrityPayload(payload) &&
+		(payload.action === 'identity:link' ||
+			payload.action === 'identity:reassign') &&
+		typeof payload.externalId === 'string' &&
+		payload.externalId.length > 0 &&
+		typeof payload.identityProvider === 'string' &&
+		payload.identityProvider.length > 0
+	);
+}

--- a/packages/backend/src/write-integrity/index.ts
+++ b/packages/backend/src/write-integrity/index.ts
@@ -1,0 +1,48 @@
+export type {
+	AnonymousConsentSubmissionMode,
+	AnonymousConsentSubmissionOptions,
+	IdentityAssertionOptions,
+	IdentityLinkingMode,
+	IdentityLinkingOptions,
+	IdentityReassignmentMode,
+	SubjectCapabilityOptions,
+	WriteAbuseControl,
+	WriteAbuseControlContext,
+	WriteAbuseControlDecision,
+	WriteDomainOptions,
+	WriteDomainResolver,
+	WriteDomainResolverContext,
+	WriteIntegrityOptions,
+	WriteProvenance,
+	WriteProvenanceSource,
+	WriteReplayClaim,
+	WriteReplayStore,
+} from '~/types';
+export {
+	type ResolvedWriteDomainOptions,
+	type ResolvedWriteIntegrityOptions,
+	resolveWriteIntegrityOptions,
+	type WriteIntegrityConfigurationResult,
+} from './configuration';
+export {
+	type CreateIdentityAssertionOptions,
+	createIdentityAssertion,
+	type IdentityAssertionAction,
+	type IdentityAssertionPayload,
+	type IdentityAssertionVerificationResult,
+	type VerifyIdentityAssertionOptions,
+	verifyIdentityAssertion,
+} from './identity-assertion';
+export {
+	type CreateSubjectCapabilityOptions,
+	createSubjectCapability,
+	type SubjectCapabilityPayload,
+	type SubjectCapabilityVerificationResult,
+	type VerifySubjectCapabilityOptions,
+	verifySubjectCapability,
+} from './subject-capability';
+export type {
+	WriteIntegrityAction,
+	WriteIntegrityVerificationFailureReason,
+	WriteIntegrityVerificationResult,
+} from './token';

--- a/packages/backend/src/write-integrity/subject-capability.test.ts
+++ b/packages/backend/src/write-integrity/subject-capability.test.ts
@@ -1,0 +1,162 @@
+import { SignJWT } from 'jose';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	createSubjectCapability,
+	verifySubjectCapability,
+} from './subject-capability';
+
+const SIGNING_KEY = 'subject-capability-test-signing-key';
+
+function createCapability(
+	overrides: Partial<Parameters<typeof createSubjectCapability>[0]> = {}
+) {
+	return createSubjectCapability({
+		options: { signingKey: SIGNING_KEY, ttlSeconds: 60 },
+		tenantId: 'tenant_123',
+		subjectId: 'subject_123',
+		action: 'consent:create',
+		domain: 'example.com',
+		...overrides,
+	});
+}
+
+function verifyCapability(
+	token: string | undefined,
+	overrides: Partial<Parameters<typeof verifySubjectCapability>[0]> = {}
+) {
+	return verifySubjectCapability({
+		token,
+		options: { signingKey: SIGNING_KEY },
+		tenantId: 'tenant_123',
+		subjectId: 'subject_123',
+		action: 'consent:create',
+		domain: 'example.com',
+		...overrides,
+	});
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('subject capability', () => {
+	it('creates and verifies an HS256 capability with bound claims', async () => {
+		const created = await createCapability();
+		const verified = await verifyCapability(created.token);
+
+		expect(created.token.split('.')).toHaveLength(3);
+		expect(verified).toEqual({ valid: true, payload: created.payload });
+		expect(created.payload).toMatchObject({
+			iss: 'c15t',
+			aud: 'c15t-subject-capability',
+			sub: 'subject_123',
+			tenantId: 'tenant_123',
+			action: 'consent:create',
+			domain: 'example.com',
+		});
+		expect(created.payload.exp - created.payload.iat).toBe(60);
+		expect(created.payload.jti).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+		);
+	});
+
+	it('supports custom issuer and audience values', async () => {
+		const created = await createCapability({
+			options: {
+				signingKey: SIGNING_KEY,
+				issuer: 'https://consent.example.com',
+				audience: 'consent-write-api',
+			},
+		});
+
+		const verified = await verifyCapability(created.token, {
+			options: {
+				signingKey: SIGNING_KEY,
+				issuer: 'https://consent.example.com',
+				audience: 'consent-write-api',
+			},
+		});
+
+		expect(verified.valid).toBe(true);
+	});
+
+	it.each([
+		['tenant', { tenantId: 'tenant_other' }],
+		['subject', { subjectId: 'subject_other' }],
+		['action', { action: 'identity:link' as const }],
+		['domain', { domain: 'other.example.com' }],
+	])('rejects a mismatched %s binding', async (_name, overrides) => {
+		const created = await createCapability();
+
+		await expect(verifyCapability(created.token, overrides)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+	});
+
+	it('treats presence and absence of an optional domain as distinct', async () => {
+		const created = await createCapability({ domain: undefined });
+
+		await expect(
+			verifyCapability(created.token, { domain: 'example.com' })
+		).resolves.toEqual({ valid: false, reason: 'invalid' });
+	});
+
+	it('classifies missing, malformed, expired, and tampered tokens', async () => {
+		await expect(verifyCapability(undefined)).resolves.toEqual({
+			valid: false,
+			reason: 'missing',
+		});
+		await expect(verifyCapability('not-a-jwt')).resolves.toEqual({
+			valid: false,
+			reason: 'malformed',
+		});
+
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-04T10:00:00Z'));
+		const created = await createCapability({
+			options: { signingKey: SIGNING_KEY, ttlSeconds: 1 },
+		});
+		vi.setSystemTime(new Date('2026-08-04T10:00:02Z'));
+		await expect(verifyCapability(created.token)).resolves.toEqual({
+			valid: false,
+			reason: 'expired',
+		});
+
+		const [header, payload, signature] = created.token.split('.');
+		await expect(
+			verifyCapability(`${header}.${payload}x.${signature}`)
+		).resolves.toEqual({ valid: false, reason: 'invalid' });
+	});
+
+	it('rejects tokens with an unexpected algorithm or type', async () => {
+		const issuedAt = Math.floor(Date.now() / 1000);
+		const claims = {
+			iss: 'c15t',
+			aud: 'c15t-subject-capability',
+			sub: 'subject_123',
+			tenantId: 'tenant_123',
+			action: 'consent:create',
+			domain: 'example.com',
+			iat: issuedAt,
+			exp: issuedAt + 60,
+			jti: crypto.randomUUID(),
+		};
+		const key = new TextEncoder().encode(SIGNING_KEY);
+		const wrongAlgorithm = await new SignJWT(claims)
+			.setProtectedHeader({ alg: 'HS384', typ: 'c15t-subject-capability+jwt' })
+			.sign(key);
+		const wrongType = await new SignJWT(claims)
+			.setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+			.sign(key);
+
+		await expect(verifyCapability(wrongAlgorithm)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+		await expect(verifyCapability(wrongType)).resolves.toEqual({
+			valid: false,
+			reason: 'invalid',
+		});
+	});
+});

--- a/packages/backend/src/write-integrity/subject-capability.ts
+++ b/packages/backend/src/write-integrity/subject-capability.ts
@@ -1,0 +1,147 @@
+import { type JWTPayload, SignJWT } from 'jose';
+import {
+	assertNonEmpty,
+	getSigningKey,
+	isWriteIntegrityPayload,
+	resolveTtlSeconds,
+	verifyWriteIntegrityToken,
+	type WriteIntegrityAction,
+	type WriteIntegrityPayload,
+	type WriteIntegrityVerificationResult,
+} from './token';
+
+const DEFAULT_ISSUER = 'c15t';
+const DEFAULT_AUDIENCE = 'c15t-subject-capability';
+const DEFAULT_TTL_SECONDS = 300;
+const SUBJECT_CAPABILITY_TYPE = 'c15t-subject-capability+jwt';
+
+/**
+ * Options used to sign a subject capability.
+ */
+export interface CreateSubjectCapabilityOptions {
+	/** Shared secret used to sign the capability with HS256. */
+	signingKey: string;
+	/** Token issuer. Defaults to `c15t`. */
+	issuer?: string;
+	/** Intended recipient. Defaults to `c15t-subject-capability`. */
+	audience?: string;
+	/** Capability lifetime in seconds. Defaults to 300 seconds. */
+	ttlSeconds?: number;
+}
+
+/**
+ * Options used to verify a subject capability.
+ */
+export interface VerifySubjectCapabilityOptions {
+	/** Secret used to issue capabilities and, by default, verify them. */
+	signingKey: string;
+	/** Optional separate secret used to verify the HS256 signature. */
+	verificationKey?: string;
+	/** Expected token issuer. Defaults to `c15t`. */
+	issuer?: string;
+	/** Expected recipient. Defaults to `c15t-subject-capability`. */
+	audience?: string;
+}
+
+/**
+ * Claims carried by a short-lived, subject-scoped write capability.
+ */
+export interface SubjectCapabilityPayload extends WriteIntegrityPayload {}
+
+/**
+ * Result returned after verifying a subject capability.
+ */
+export type SubjectCapabilityVerificationResult =
+	WriteIntegrityVerificationResult<SubjectCapabilityPayload>;
+
+/**
+ * Creates a short-lived capability for one subject write.
+ *
+ * The optional tenant and domain are exact bindings: a verifier expecting an
+ * omitted value will reject a token that contains one, and vice versa.
+ *
+ * @param params - Signing options and claims to bind to the capability
+ * @returns The compact JWT and its signed claims
+ * @throws {TypeError} When a required string is empty
+ * @throws {RangeError} When `ttlSeconds` is not a positive integer
+ */
+export async function createSubjectCapability(params: {
+	options: CreateSubjectCapabilityOptions;
+	tenantId?: string;
+	subjectId: string;
+	action: WriteIntegrityAction;
+	domain?: string;
+}): Promise<{ token: string; payload: SubjectCapabilityPayload }> {
+	const issuer = params.options.issuer?.trim() || DEFAULT_ISSUER;
+	const audience = params.options.audience?.trim() || DEFAULT_AUDIENCE;
+	const ttlSeconds = resolveTtlSeconds(
+		params.options.ttlSeconds,
+		DEFAULT_TTL_SECONDS
+	);
+
+	assertNonEmpty(params.options.signingKey, 'signingKey');
+	assertNonEmpty(params.subjectId, 'subjectId');
+	if (params.tenantId !== undefined) {
+		assertNonEmpty(params.tenantId, 'tenantId');
+	}
+	if (params.domain !== undefined) {
+		assertNonEmpty(params.domain, 'domain');
+	}
+
+	const iat = Math.floor(Date.now() / 1000);
+	const exp = iat + ttlSeconds;
+	const jti = crypto.randomUUID();
+	const payload: SubjectCapabilityPayload = {
+		iss: issuer,
+		aud: audience,
+		sub: params.subjectId,
+		tenantId: params.tenantId,
+		action: params.action,
+		domain: params.domain,
+		iat,
+		exp,
+		jti,
+	};
+	const token = await new SignJWT(payload)
+		.setProtectedHeader({ alg: 'HS256', typ: SUBJECT_CAPABILITY_TYPE })
+		.sign(getSigningKey(params.options.signingKey));
+
+	return { token, payload };
+}
+
+/**
+ * Verifies a subject capability and all request-specific bindings.
+ *
+ * @param params - Token, verification options, and exact expected claims
+ * @returns A discriminated result containing either verified claims or a
+ * stable failure reason
+ */
+export function verifySubjectCapability(params: {
+	token?: string;
+	options: VerifySubjectCapabilityOptions;
+	tenantId?: string;
+	subjectId: string;
+	action: WriteIntegrityAction;
+	domain?: string;
+}): Promise<SubjectCapabilityVerificationResult> {
+	return verifyWriteIntegrityToken({
+		token: params.token,
+		verificationKey:
+			params.options.verificationKey ?? params.options.signingKey,
+		issuer: params.options.issuer?.trim() || DEFAULT_ISSUER,
+		audience: params.options.audience?.trim() || DEFAULT_AUDIENCE,
+		type: SUBJECT_CAPABILITY_TYPE,
+		isPayload: isSubjectCapabilityPayload,
+		matchesExpectedClaims: (payload) =>
+			payload.sub === params.subjectId &&
+			payload.action === params.action &&
+			(payload.tenantId ?? undefined) === (params.tenantId ?? undefined) &&
+			(payload.domain ?? undefined) === (params.domain ?? undefined),
+	});
+}
+
+function isSubjectCapabilityPayload(
+	payload: JWTPayload
+): payload is SubjectCapabilityPayload {
+	return isWriteIntegrityPayload(payload);
+}

--- a/packages/backend/src/write-integrity/token.ts
+++ b/packages/backend/src/write-integrity/token.ts
@@ -1,0 +1,174 @@
+import { type JWTPayload, errors as joseErrors, jwtVerify } from 'jose';
+import type { WriteIntegrityAction } from '~/types';
+
+/**
+ * Actions that a write-integrity token can authorize.
+ */
+export type { WriteIntegrityAction } from '~/types';
+
+/**
+ * Stable failure classifications returned by write-integrity token verifiers.
+ */
+export type WriteIntegrityVerificationFailureReason =
+	| 'missing'
+	| 'malformed'
+	| 'expired'
+	| 'invalid';
+
+/**
+ * Claims shared by subject capabilities and identity assertions.
+ */
+export interface WriteIntegrityPayload extends JWTPayload {
+	iss: string;
+	aud: string;
+	sub: string;
+	tenantId?: string;
+	action: WriteIntegrityAction;
+	domain?: string;
+	iat: number;
+	exp: number;
+	jti: string;
+}
+
+/**
+ * A successful or failed write-integrity token verification.
+ *
+ * @typeParam Payload - The claims returned for a valid token
+ */
+export type WriteIntegrityVerificationResult<
+	Payload extends WriteIntegrityPayload,
+> =
+	| {
+			valid: true;
+			payload: Payload;
+	  }
+	| {
+			valid: false;
+			reason: WriteIntegrityVerificationFailureReason;
+	  };
+
+interface VerifyTokenParams<Payload extends WriteIntegrityPayload> {
+	token?: string;
+	verificationKey: string;
+	issuer: string;
+	audience: string;
+	type: string;
+	maxAgeSeconds?: number;
+	isPayload: (payload: JWTPayload) => payload is Payload;
+	matchesExpectedClaims: (payload: Payload) => boolean;
+}
+
+const WRITE_INTEGRITY_ACTIONS: ReadonlySet<string> = new Set([
+	'consent:create',
+	'identity:link',
+	'identity:reassign',
+]);
+
+/** @internal */
+export function getSigningKey(secret: string): Uint8Array {
+	return new TextEncoder().encode(secret);
+}
+
+/** @internal */
+export function isNonEmptyString(value: unknown): value is string {
+	return typeof value === 'string' && value.length > 0;
+}
+
+/** @internal */
+export function isWriteIntegrityAction(
+	value: unknown
+): value is WriteIntegrityAction {
+	return typeof value === 'string' && WRITE_INTEGRITY_ACTIONS.has(value);
+}
+
+/** @internal */
+export function isWriteIntegrityPayload(
+	payload: JWTPayload
+): payload is WriteIntegrityPayload {
+	return (
+		isNonEmptyString(payload.iss) &&
+		isNonEmptyString(payload.aud) &&
+		isNonEmptyString(payload.sub) &&
+		(payload.tenantId === undefined || isNonEmptyString(payload.tenantId)) &&
+		isWriteIntegrityAction(payload.action) &&
+		(payload.domain === undefined || isNonEmptyString(payload.domain)) &&
+		typeof payload.iat === 'number' &&
+		Number.isFinite(payload.iat) &&
+		typeof payload.exp === 'number' &&
+		Number.isFinite(payload.exp) &&
+		payload.exp > payload.iat &&
+		isNonEmptyString(payload.jti)
+	);
+}
+
+/** @internal */
+export function assertNonEmpty(value: string, name: string): void {
+	if (!isNonEmptyString(value)) {
+		throw new TypeError(`${name} must be a non-empty string`);
+	}
+}
+
+/** @internal */
+export function resolveTtlSeconds(
+	ttlSeconds: number | undefined,
+	defaultTtlSeconds: number
+): number {
+	const resolved = ttlSeconds ?? defaultTtlSeconds;
+	if (!Number.isSafeInteger(resolved) || resolved <= 0) {
+		throw new RangeError('ttlSeconds must be a positive integer');
+	}
+
+	return resolved;
+}
+
+/** @internal */
+export async function verifyWriteIntegrityToken<
+	Payload extends WriteIntegrityPayload,
+>(
+	params: VerifyTokenParams<Payload>
+): Promise<WriteIntegrityVerificationResult<Payload>> {
+	if (!params.token) {
+		return { valid: false, reason: 'missing' };
+	}
+
+	const segments = params.token.split('.');
+	if (segments.length !== 3 || segments.some((segment) => !segment)) {
+		return { valid: false, reason: 'malformed' };
+	}
+
+	try {
+		const { payload, protectedHeader } = await jwtVerify(
+			params.token,
+			getSigningKey(params.verificationKey),
+			{
+				algorithms: ['HS256'],
+				issuer: params.issuer,
+				audience: params.audience,
+				maxTokenAge: params.maxAgeSeconds,
+			}
+		);
+
+		if (
+			protectedHeader.alg !== 'HS256' ||
+			protectedHeader.typ !== params.type ||
+			!params.isPayload(payload) ||
+			!params.matchesExpectedClaims(payload)
+		) {
+			return { valid: false, reason: 'invalid' };
+		}
+
+		return { valid: true, payload };
+	} catch (error) {
+		if (error instanceof joseErrors.JWTExpired) {
+			return { valid: false, reason: 'expired' };
+		}
+		if (
+			error instanceof joseErrors.JWTInvalid ||
+			error instanceof joseErrors.JWSInvalid
+		) {
+			return { valid: false, reason: 'malformed' };
+		}
+
+		return { valid: false, reason: 'invalid' };
+	}
+}

--- a/packages/schema/src/domain/consent.ts
+++ b/packages/schema/src/domain/consent.ts
@@ -1,5 +1,16 @@
 import * as v from 'valibot';
 
+/** Authority used to accept a consent write. */
+export const consentWriteSourceSchema = v.picklist([
+	'legacy',
+	'anonymous',
+	'subject_capability',
+	'identity_assertion',
+	'api_key',
+]);
+
+export type ConsentWriteSource = v.InferOutput<typeof consentWriteSourceSchema>;
+
 export const consentSchema = v.object({
 	id: v.string(),
 	subjectId: v.string(),
@@ -27,6 +38,14 @@ export const consentSchema = v.object({
 	runtimePolicySource: v.nullish(
 		v.picklist(['snapshot_token', 'write_time_fallback'])
 	),
+	/** Authority used to accept this write, independent of policy provenance. */
+	writeSource: v.nullish(consentWriteSourceSchema),
+	/** Credential or replay identifier associated with the accepted write. */
+	writeCredentialId: v.nullish(v.string()),
+	/** Issuer that authorized the accepted write. */
+	writeIssuer: v.nullish(v.string()),
+	/** Request origin associated with the accepted write. */
+	writeOrigin: v.nullish(v.string()),
 	tenantId: v.nullish(v.string()),
 });
 

--- a/packages/schema/src/domain/domain.ts
+++ b/packages/schema/src/domain/domain.ts
@@ -6,6 +6,8 @@ export const domainSchema = v.object({
 	createdAt: v.optional(v.date(), () => new Date()),
 	updatedAt: v.optional(v.date(), () => new Date()),
 	tenantId: v.nullish(v.string()),
+	/** Canonical tenant/domain lookup key. Legacy rows may not have one. */
+	scopeKey: v.nullish(v.string()),
 });
 
 export type Domain = v.InferOutput<typeof domainSchema>;

--- a/packages/schema/src/domain/index.ts
+++ b/packages/schema/src/domain/index.ts
@@ -5,7 +5,9 @@ export {
 
 export {
 	type Consent,
+	type ConsentWriteSource,
 	consentSchema,
+	consentWriteSourceSchema,
 } from './consent';
 
 export {
@@ -39,3 +41,7 @@ export {
 	type Subject,
 	subjectSchema,
 } from './subject';
+export {
+	type WriteReplay,
+	writeReplaySchema,
+} from './write-replay';

--- a/packages/schema/src/domain/write-integrity.test.ts
+++ b/packages/schema/src/domain/write-integrity.test.ts
@@ -1,0 +1,78 @@
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { consentSchema, consentWriteSourceSchema } from './consent';
+import { domainSchema } from './domain';
+import { writeReplaySchema } from './write-replay';
+
+describe('consent write provenance schemas', () => {
+	it.each([
+		'legacy',
+		'anonymous',
+		'subject_capability',
+		'identity_assertion',
+		'api_key',
+	])('accepts the %s write source', (source) => {
+		expect(v.is(consentWriteSourceSchema, source)).toBe(true);
+	});
+
+	it('keeps provenance optional for legacy consent records', () => {
+		const result = v.safeParse(consentSchema, {
+			id: 'cns_legacy',
+			subjectId: 'sub_legacy',
+			domainId: 'dom_legacy',
+			purposeIds: [],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('validates stored provenance independently from runtime policy evidence', () => {
+		const result = v.safeParse(consentSchema, {
+			id: 'cns_secure',
+			subjectId: 'sub_secure',
+			domainId: 'dom_secure',
+			purposeIds: [],
+			runtimePolicySource: 'snapshot_token',
+			writeSource: 'subject_capability',
+			writeCredentialId: 'capability_1',
+			writeIssuer: 'https://issuer.example',
+			writeOrigin: 'https://app.example',
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('domain integrity schema', () => {
+	it('allows a missing scope key on legacy rows', () => {
+		expect(
+			v.is(domainSchema, {
+				id: 'dom_legacy',
+				name: 'legacy.example',
+			})
+		).toBe(true);
+	});
+});
+
+describe('write replay schema', () => {
+	it('requires the credential binding and expiry fields', () => {
+		expect(
+			v.is(writeReplaySchema, {
+				id: 'replay_1',
+				audience: 'subject_1',
+				tokenId: 'credential_1',
+				requestFingerprint: 'sha256:fingerprint',
+				expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+			})
+		).toBe(true);
+
+		expect(
+			v.is(writeReplaySchema, {
+				id: 'replay_1',
+				audience: 'subject_1',
+				tokenId: 'credential_1',
+				expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+			})
+		).toBe(false);
+	});
+});

--- a/packages/schema/src/domain/write-replay.ts
+++ b/packages/schema/src/domain/write-replay.ts
@@ -1,0 +1,14 @@
+import * as v from 'valibot';
+
+/** Persisted consumption of a single-use consent-write credential. */
+export const writeReplaySchema = v.object({
+	id: v.string(),
+	tenantId: v.nullish(v.string()),
+	audience: v.string(),
+	tokenId: v.string(),
+	requestFingerprint: v.string(),
+	expiresAt: v.date(),
+	createdAt: v.optional(v.date(), () => new Date()),
+});
+
+export type WriteReplay = v.InferOutput<typeof writeReplaySchema>;

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -54,12 +54,14 @@ export type {
 	ConsentPolicy,
 	ConsentPolicyType,
 	ConsentPurpose,
+	ConsentWriteSource,
 	Domain,
 	LegalDocumentPolicyType,
 	LegalDocumentTypePrefix,
 	PolicyType,
 	RuntimePolicyDecision,
 	Subject,
+	WriteReplay,
 } from './domain';
 export {
 	isLegalDocumentType,


### PR DESCRIPTION
## Summary

- add backwards-compatible write-integrity configuration with independent consent and identity modes
- add public subject-capability and identity-assertion helpers, replay storage, domain scoping, and write provenance fields
- retain omitted v2 configuration as the deprecated legacy path with startup warnings
- add additive minor changesets for the backend and schema packages

Stack 1 of 4 for [ENG-300](https://linear.app/inth/issue/ENG-300/ship-c15t-v2-consent-write-integrity-hardening).

## Verification

- backend and schema unit tests
- backend and schema type checks
- changed-file Biome checks