### PR TITLE
feat(backend): secure consent write submissions

### DIFF
--- a/.changeset/clean-lions-consent.md
+++ b/.changeset/clean-lions-consent.md
@@ -1,0 +1,6 @@
+---
+'@c15t/backend': minor
+'@c15t/schema': minor
+---
+
+Harden consent submissions with configured domain resolution, optional subject capabilities, atomic replay protection, abuse-control hooks, write provenance, and optional policy snapshot request bindings while preserving the legacy path by default.

--- a/packages/backend/src/core.ts
+++ b/packages/backend/src/core.ts
@@ -6,7 +6,7 @@ import { cors } from 'hono/cors';
 import { HTTPException } from 'hono/http-exception';
 import { openAPIRouteHandler } from 'hono-openapi';
 import { validateRequestAuth } from '~/middleware/auth';
-import { createCORSOptions } from '~/middleware/cors';
+import { createCORSOptions, processCors } from '~/middleware/cors';
 import { createOpenAPIConfig } from '~/middleware/openapi';
 import { getIpAddress } from '~/middleware/process-ip';
 import type { C15TContext, C15TOptions } from '~/types';
@@ -134,15 +134,19 @@ export const c15tInstance = (options: C15TOptions): C15TInstance => {
 			options.apiKeys
 		);
 
-		const enrichedContext: C15TContext = {
-			...context,
-			ipAddress: getIpAddress(request, options),
-			userAgent: request.headers.get('user-agent') || undefined,
-			apiKeyAuthenticated,
-			path: c.req.path,
-			method: c.req.method,
-			headers: request.headers,
-		};
+		const enrichedContext = processCors(
+			request,
+			{
+				...context,
+				ipAddress: getIpAddress(request, options),
+				userAgent: request.headers.get('user-agent') || undefined,
+				apiKeyAuthenticated,
+				path: c.req.path,
+				method: c.req.method,
+				headers: request.headers,
+			},
+			options.trustedOrigins
+		);
 
 		c.set('c15tContext', enrichedContext);
 

--- a/packages/backend/src/db/registry/domain.test.ts
+++ b/packages/backend/src/db/registry/domain.test.ts
@@ -442,4 +442,80 @@ describe('domainRegistry', () => {
 			expect(result.name).toBe(upperCaseDomain);
 		});
 	});
+
+	describe('findOrCreateScopedDomain', () => {
+		it('finds an existing domain by canonical scope key', async () => {
+			const existing = createMockDomain({
+				name: 'example.com',
+				scopeKey: 'default:example.com',
+			});
+			const db = {
+				findFirst: vi.fn().mockResolvedValue(existing),
+				create: vi.fn(),
+			};
+			const registry = domainRegistry({
+				db,
+				ctx: { logger: mockLogger },
+			} as unknown as Registry);
+
+			await expect(
+				registry.findOrCreateScopedDomain({
+					name: 'example.com',
+					scopeKey: 'default:example.com',
+				})
+			).resolves.toEqual(existing);
+			expect(db.create).not.toHaveBeenCalled();
+		});
+
+		it('creates a domain with its canonical scope key', async () => {
+			const created = createMockDomain({
+				name: 'example.com',
+				scopeKey: 'tenant_1:example.com',
+			});
+			const db = {
+				findFirst: vi.fn().mockResolvedValue(null),
+				create: vi.fn().mockResolvedValue(created),
+			};
+			const registry = domainRegistry({
+				db,
+				ctx: { logger: mockLogger, tenantId: 'tenant_1' },
+			} as unknown as Registry);
+
+			await registry.findOrCreateScopedDomain({
+				name: 'example.com',
+				scopeKey: 'tenant_1:example.com',
+			});
+
+			expect(db.create).toHaveBeenCalledWith('domain', {
+				id: 'dom_test',
+				name: 'example.com',
+				scopeKey: 'tenant_1:example.com',
+			});
+		});
+
+		it('returns the concurrent winner after a scope-key conflict', async () => {
+			const concurrent = createMockDomain({
+				name: 'example.com',
+				scopeKey: 'default:example.com',
+			});
+			const db = {
+				findFirst: vi
+					.fn()
+					.mockResolvedValueOnce(null)
+					.mockResolvedValueOnce(concurrent),
+				create: vi.fn().mockRejectedValue(new Error('unique conflict')),
+			};
+			const registry = domainRegistry({
+				db,
+				ctx: { logger: mockLogger },
+			} as unknown as Registry);
+
+			await expect(
+				registry.findOrCreateScopedDomain({
+					name: 'example.com',
+					scopeKey: 'default:example.com',
+				})
+			).resolves.toEqual(concurrent);
+		});
+	});
 });

--- a/packages/backend/src/db/registry/domain.ts
+++ b/packages/backend/src/db/registry/domain.ts
@@ -40,6 +40,57 @@ export function domainRegistry({ db, ctx }: Registry) {
 
 	return {
 		findDomainByName,
+		findOrCreateScopedDomain: async (input: {
+			name: string;
+			scopeKey: string;
+		}) => {
+			const start = Date.now();
+			try {
+				const result = await withDatabaseSpan(
+					{ operation: 'findOrCreate', entity: 'domain' },
+					async () => {
+						const findByScopeKey = () =>
+							db.findFirst('domain', {
+								where: (b) => b('scopeKey', '=', input.scopeKey),
+							});
+						const existingDomain = await findByScopeKey();
+
+						if (existingDomain) {
+							logger.debug('Found existing scoped domain', input);
+							return existingDomain;
+						}
+
+						logger.debug('Creating scoped domain', input);
+						try {
+							return await db.create('domain', {
+								id: await generateUniqueId(db, 'domain', ctx),
+								name: input.name,
+								scopeKey: input.scopeKey,
+							});
+						} catch (error) {
+							// The unique scope key is the concurrency boundary. If another
+							// request inserted the same canonical domain first, return it.
+							const concurrentDomain = await findByScopeKey();
+							if (concurrentDomain) {
+								return concurrentDomain;
+							}
+							throw error;
+						}
+					}
+				);
+				getMetrics()?.recordDbQuery(
+					{ operation: 'findOrCreate', entity: 'domain' },
+					Date.now() - start
+				);
+				return result;
+			} catch (error) {
+				getMetrics()?.recordDbError({
+					operation: 'findOrCreate',
+					entity: 'domain',
+				});
+				throw error;
+			}
+		},
 		findOrCreateDomain: async (name: string) => {
 			const start = Date.now();
 			try {

--- a/packages/backend/src/handlers/policy/snapshot.test.ts
+++ b/packages/backend/src/handlers/policy/snapshot.test.ts
@@ -218,4 +218,65 @@ describe('policy snapshot token', () => {
 		expect(verified.payload.iss).toBe('consent.example.com');
 		expect(verified.payload.aud).toBe('policy-snapshot-api');
 	});
+
+	it('binds optional write fields and emits a replay identifier', async () => {
+		const writeBindings = {
+			domain: 'example.com',
+			subjectId: 'sub_123',
+			consentType: 'other' as const,
+			consentAction: 'custom',
+		};
+		const tokenResult = await createPolicySnapshotToken({
+			options: { signingKey: 'test-signing-key', ttlSeconds: 60 },
+			policyId: 'policy_default',
+			fingerprint: 'abc123',
+			matchedBy: 'default',
+			country: null,
+			region: null,
+			jurisdiction: 'GDPR',
+			model: 'opt-in',
+			writeBindings,
+		});
+
+		const verified = await verifyPolicySnapshotToken({
+			token: tokenResult?.token,
+			options: { signingKey: 'test-signing-key' },
+			expectedWriteBindings: writeBindings,
+		});
+
+		expect(verified.valid).toBe(true);
+		if (!verified.valid) {
+			throw new Error('Expected valid snapshot payload');
+		}
+		expect(verified.payload.writeBindings).toEqual(writeBindings);
+		expect(verified.payload.jti).toMatch(/^[0-9a-f-]{36}$/);
+	});
+
+	it('rejects a write binding mismatch without changing legacy verification', async () => {
+		const tokenResult = await createPolicySnapshotToken({
+			options: { signingKey: 'test-signing-key', ttlSeconds: 60 },
+			policyId: 'policy_default',
+			fingerprint: 'abc123',
+			matchedBy: 'default',
+			country: null,
+			region: null,
+			jurisdiction: 'GDPR',
+			model: 'opt-in',
+			writeBindings: { domain: 'example.com' },
+		});
+
+		await expect(
+			verifyPolicySnapshotToken({
+				token: tokenResult?.token,
+				options: { signingKey: 'test-signing-key' },
+				expectedWriteBindings: { domain: 'other.example' },
+			})
+		).resolves.toEqual({ valid: false, reason: 'invalid' });
+		await expect(
+			verifyPolicySnapshotToken({
+				token: tokenResult?.token,
+				options: { signingKey: 'test-signing-key' },
+			})
+		).resolves.toMatchObject({ valid: true });
+	});
 });

--- a/packages/backend/src/handlers/policy/snapshot.ts
+++ b/packages/backend/src/handlers/policy/snapshot.ts
@@ -1,3 +1,4 @@
+import type { PolicyType } from '@c15t/schema/types';
 import {
 	type JWTHeaderParameters,
 	type JWTPayload,
@@ -41,6 +42,20 @@ export interface PolicySnapshotUiSurface {
 }
 
 /**
+ * Optional request fields a snapshot issuer may bind into a policy snapshot.
+ *
+ * @remarks
+ * These claims only make the signed policy snapshot specific to the supplied
+ * values. They do not prove that a user performed an action or owns a subject.
+ */
+export interface PolicySnapshotWriteBindings {
+	domain?: string;
+	subjectId?: string;
+	consentType?: PolicyType;
+	consentAction?: string;
+}
+
+/**
  * JWT payload for a policy snapshot token.
  *
  * @remarks
@@ -80,6 +95,10 @@ export interface PolicySnapshotPayload extends JWTPayload {
 		storeUserAgent?: boolean;
 		storeLanguage?: boolean;
 	};
+	/** Request bindings supplied by the trusted snapshot issuer, when any. */
+	writeBindings?: PolicySnapshotWriteBindings;
+	/** Replay/audit identifier. Optional while rolling forward older v2 tokens. */
+	jti?: string;
 	iat: number;
 	exp: number;
 }
@@ -130,8 +149,44 @@ function isPolicySnapshotPayload(
 		typeof payload.iss === 'string' &&
 		typeof payload.aud === 'string' &&
 		typeof payload.sub === 'string' &&
+		(payload.jti === undefined ||
+			(typeof payload.jti === 'string' && payload.jti.length > 0)) &&
+		(payload.writeBindings === undefined ||
+			isPolicySnapshotWriteBindings(payload.writeBindings)) &&
 		typeof payload.iat === 'number' &&
 		typeof payload.exp === 'number'
+	);
+}
+
+function isPolicySnapshotWriteBindings(
+	value: unknown
+): value is PolicySnapshotWriteBindings {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const bindings = value as Record<string, unknown>;
+	return (
+		(bindings.domain === undefined || typeof bindings.domain === 'string') &&
+		(bindings.subjectId === undefined ||
+			typeof bindings.subjectId === 'string') &&
+		(bindings.consentType === undefined ||
+			typeof bindings.consentType === 'string') &&
+		(bindings.consentAction === undefined ||
+			typeof bindings.consentAction === 'string')
+	);
+}
+
+function matchesExpectedWriteBindings(
+	payload: PolicySnapshotPayload,
+	expected: PolicySnapshotWriteBindings | undefined
+): boolean {
+	if (!expected) {
+		return true;
+	}
+
+	return (Object.keys(expected) as (keyof PolicySnapshotWriteBindings)[]).every(
+		(key) => payload.writeBindings?.[key] === expected[key]
 	);
 }
 
@@ -163,6 +218,7 @@ export async function createPolicySnapshotToken(params: {
 		storeUserAgent?: boolean;
 		storeLanguage?: boolean;
 	};
+	writeBindings?: PolicySnapshotWriteBindings;
 }): Promise<{ token: string; payload: PolicySnapshotPayload } | undefined> {
 	const { options } = params;
 	if (!options?.signingKey) {
@@ -172,6 +228,7 @@ export async function createPolicySnapshotToken(params: {
 	const iat = Math.floor(Date.now() / 1000);
 	const ttlSeconds = options.ttlSeconds ?? 1800;
 	const exp = iat + ttlSeconds;
+	const jti = crypto.randomUUID();
 	const iss = resolveSnapshotIssuer(options);
 	const aud = resolveSnapshotAudience({
 		options,
@@ -200,6 +257,8 @@ export async function createPolicySnapshotToken(params: {
 		preselectedCategories: params.preselectedCategories,
 		gpc: params.gpc,
 		proofConfig: params.proofConfig,
+		writeBindings: params.writeBindings,
+		jti,
 		iat,
 		exp,
 	};
@@ -208,6 +267,7 @@ export async function createPolicySnapshotToken(params: {
 		.setProtectedHeader(POLICY_SNAPSHOT_JWT_HEADER)
 		.setIssuedAt(iat)
 		.setExpirationTime(exp)
+		.setJti(jti)
 		.sign(getSigningKey(options.signingKey));
 
 	return {
@@ -220,8 +280,9 @@ export async function verifyPolicySnapshotToken(params: {
 	token?: string;
 	options?: PolicySnapshotOptions;
 	tenantId?: string;
+	expectedWriteBindings?: PolicySnapshotWriteBindings;
 }): Promise<PolicySnapshotVerificationResult> {
-	const { token, options, tenantId } = params;
+	const { token, options, tenantId, expectedWriteBindings } = params;
 	if (!options?.signingKey) {
 		return {
 			valid: false,
@@ -272,6 +333,12 @@ export async function verifyPolicySnapshotToken(params: {
 			};
 		}
 		if ((tenantId ?? undefined) !== (payload.tenantId ?? undefined)) {
+			return {
+				valid: false,
+				reason: 'invalid',
+			};
+		}
+		if (!matchesExpectedWriteBindings(payload, expectedWriteBindings)) {
 			return {
 				valid: false,
 				reason: 'invalid',

--- a/packages/backend/src/handlers/subject/post.handler.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolvePolicyDecision } from '~/handlers/init/policy';
 import { verifyLegalDocumentSnapshotToken } from '~/handlers/legal-document/snapshot';
 import { verifyPolicySnapshotToken } from '~/handlers/policy/snapshot';
+import type { WriteIntegrityOptions } from '~/types';
+import { createSubjectCapability } from '~/write-integrity/subject-capability';
 import { buildConsentId } from './consent-idempotency';
 import {
 	buildRuntimeDecisionDedupeKey,
@@ -53,6 +55,7 @@ function createMockRegistry() {
 	return {
 		findOrCreateSubject: vi.fn().mockResolvedValue(mockSubject),
 		findOrCreateDomain: vi.fn().mockResolvedValue(mockDomain),
+		findOrCreateScopedDomain: vi.fn().mockResolvedValue(mockDomain),
 		findOrCreatePolicy: vi.fn().mockResolvedValue(mockPolicy),
 		findOrCreateLegalDocumentPolicy: vi
 			.fn()
@@ -103,6 +106,8 @@ function createMockContext(db: unknown, registry: unknown) {
 		},
 		legalDocumentSnapshot: undefined,
 		tenantId: undefined as string | undefined,
+		origin: undefined as string | undefined,
+		writeIntegrity: undefined as WriteIntegrityOptions | undefined,
 	};
 
 	let jsonData: unknown;
@@ -174,6 +179,302 @@ describe('buildRuntimeDecisionDedupeKey', () => {
 		});
 
 		expect(first).toBe(second);
+	});
+});
+
+describe('postSubjectHandler write integrity', () => {
+	const capabilitySecret = 'capability-secret-for-write-integrity-tests';
+
+	beforeEach(() => {
+		vi.mocked(resolvePolicyDecision).mockResolvedValue(undefined);
+		vi.mocked(verifyPolicySnapshotToken).mockResolvedValue({
+			valid: false,
+			reason: 'missing',
+		});
+		vi.mocked(verifyLegalDocumentSnapshotToken).mockResolvedValue({
+			valid: false,
+			reason: 'missing',
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		vi.useRealTimers();
+		vi.mocked(resolvePolicyDecision).mockResolvedValue(undefined);
+		vi.mocked(verifyPolicySnapshotToken).mockResolvedValue({
+			valid: false,
+			reason: 'missing',
+		});
+		vi.mocked(verifyLegalDocumentSnapshotToken).mockResolvedValue({
+			valid: false,
+			reason: 'missing',
+		});
+	});
+
+	function secureOptions(
+		overrides: Partial<WriteIntegrityOptions> = {}
+	): WriteIntegrityOptions {
+		return {
+			anonymousConsent: { mode: 'public' },
+			identityLinking: { mode: 'disabled' },
+			domains: { allowlist: ['example.com'] },
+			...overrides,
+		};
+	}
+
+	function consentPayload(db: ReturnType<typeof createMockDb>) {
+		return db.__tx.create.mock.calls.find(
+			(call) => call[0] === 'consent'
+		)?.[1] as Record<string, unknown> | undefined;
+	}
+
+	it('keeps the omitted configuration on the legacy path', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+
+		expect(registry.findOrCreateDomain).toHaveBeenCalledWith('example.com');
+		expect(registry.findOrCreateScopedDomain).not.toHaveBeenCalled();
+		expect(consentPayload(db)).toEqual(
+			expect.objectContaining({ writeSource: 'legacy' })
+		);
+	});
+
+	it('canonicalizes allowlisted public writes and records provenance', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.writeIntegrity = secureOptions();
+		mockCtx._ctx.origin = 'https://app.example.com';
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			domain: 'EXAMPLE.COM.',
+		});
+
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+
+		expect(registry.findOrCreateScopedDomain).toHaveBeenCalledWith({
+			name: 'example.com',
+			scopeKey: expect.stringMatching(/^domain:[a-f0-9]{64}$/),
+		});
+		expect(consentPayload(db)).toEqual(
+			expect.objectContaining({
+				writeSource: 'anonymous',
+				writeCredentialId: undefined,
+				writeOrigin: 'https://app.example.com',
+			})
+		);
+	});
+
+	it('rejects an unconfigured domain before database work', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.writeIntegrity = secureOptions();
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			domain: 'attacker.example',
+		});
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 403,
+			cause: { code: 'WRITE_DOMAIN_NOT_ALLOWED' },
+		});
+		expect(registry.findOrCreateSubject).not.toHaveBeenCalled();
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
+	it('supports a server-derived domain without an Origin header', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		const resolve = vi.fn(() => 'example.com');
+		mockCtx._ctx.writeIntegrity = secureOptions({
+			domains: { allowlist: ['example.com'], resolve },
+		});
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			domain: 'ignored.example',
+		});
+
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+
+		expect(resolve).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestedDomain: 'ignored.example',
+				origin: undefined,
+			})
+		);
+		expect(registry.findOrCreateScopedDomain).toHaveBeenCalledWith(
+			expect.objectContaining({ name: 'example.com' })
+		);
+	});
+
+	it('fails closed when abuse controls deny the write', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		const abuseControl = vi.fn(() => ({
+			allowed: false,
+			retryAfterSeconds: 30,
+		}));
+		mockCtx._ctx.writeIntegrity = secureOptions({ abuseControl });
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 429,
+			cause: { code: 'WRITE_ABUSE_CONTROL_DENIED' },
+		});
+		expect(registry.findOrCreateSubject).not.toHaveBeenCalled();
+		expect(db.transaction).not.toHaveBeenCalled();
+	});
+
+	it('requires a capability in capability mode', async () => {
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.writeIntegrity = secureOptions({
+			anonymousConsent: { mode: 'capability' },
+			subjectCapability: { signingKey: capabilitySecret },
+		});
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 401,
+			cause: { code: 'SUBJECT_CAPABILITY_REQUIRED' },
+		});
+		expect(registry.findOrCreateSubject).not.toHaveBeenCalled();
+	});
+
+	it('records capability provenance and allows an exact retry only', async () => {
+		const replayClaims = new Map<string, string>();
+		const replayStore = {
+			consume: vi.fn(
+				async (claim: { tokenId: string; requestFingerprint: string }) => {
+					const existing = replayClaims.get(claim.tokenId);
+					if (!existing) {
+						replayClaims.set(claim.tokenId, claim.requestFingerprint);
+						return { status: 'consumed' as const };
+					}
+					return existing === claim.requestFingerprint
+						? { status: 'idempotent' as const }
+						: { status: 'replayed' as const };
+				}
+			),
+		};
+		const capability = await createSubjectCapability({
+			options: { signingKey: capabilitySecret },
+			subjectId: 'sub_user1',
+			action: 'consent:create',
+			domain: 'example.com',
+		});
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.origin = 'https://app.example.com';
+		mockCtx._ctx.writeIntegrity = secureOptions({
+			anonymousConsent: { mode: 'capability' },
+			subjectCapability: { signingKey: capabilitySecret },
+			replayStore,
+		});
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			subjectCapability: capability.token,
+		});
+
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+		// @ts-expect-error - simplified test context
+		await postSubjectHandler(mockCtx);
+
+		expect(consentPayload(db)).toEqual(
+			expect.objectContaining({
+				writeSource: 'subject_capability',
+				writeCredentialId: capability.payload.jti,
+				writeIssuer: capability.payload.iss,
+				writeOrigin: 'https://app.example.com',
+			})
+		);
+		expect(replayStore.consume).toHaveBeenCalledTimes(2);
+
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			metadata: { changed: true },
+			subjectCapability: capability.token,
+		});
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 409,
+			cause: { code: 'SUBJECT_CAPABILITY_REPLAYED' },
+		});
+	});
+
+	it('rejects expired capabilities', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+		const capability = await createSubjectCapability({
+			options: { signingKey: capabilitySecret, ttlSeconds: 1 },
+			subjectId: 'sub_user1',
+			action: 'consent:create',
+			domain: 'example.com',
+		});
+		vi.setSystemTime(new Date('2026-01-01T00:00:02.000Z'));
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.writeIntegrity = secureOptions({
+			anonymousConsent: { mode: 'capability' },
+			subjectCapability: { signingKey: capabilitySecret },
+		});
+		mockCtx.req.json = vi.fn().mockResolvedValue({
+			...baseInput,
+			subjectCapability: capability.token,
+		});
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 401,
+			cause: { code: 'SUBJECT_CAPABILITY_EXPIRED' },
+		});
+		expect(registry.findOrCreateSubject).not.toHaveBeenCalled();
+	});
+
+	it('rejects a mismatched snapshot write binding', async () => {
+		vi.mocked(verifyPolicySnapshotToken).mockResolvedValue({
+			valid: true,
+			payload: {
+				iss: 'c15t',
+				aud: 'c15t-policy-snapshot',
+				sub: 'policy_default',
+				policyId: 'policy_default',
+				fingerprint: 'abc123',
+				matchedBy: 'default',
+				country: null,
+				region: null,
+				jurisdiction: 'GDPR',
+				model: 'opt-in',
+				writeBindings: { domain: 'other.example' },
+				iat: 1,
+				exp: 9_999_999_999,
+			},
+		});
+		const db = createMockDb(null);
+		const registry = createMockRegistry();
+		const mockCtx = createMockContext(db, registry);
+		mockCtx._ctx.writeIntegrity = secureOptions();
+
+		// @ts-expect-error - simplified test context
+		await expect(postSubjectHandler(mockCtx)).rejects.toMatchObject({
+			status: 409,
+			cause: { code: 'POLICY_SNAPSHOT_INVALID' },
+		});
+		expect(registry.findOrCreateSubject).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -21,9 +21,18 @@ import {
 	type PolicySnapshotVerificationFailureReason,
 	verifyPolicySnapshotToken,
 } from '~/handlers/policy/snapshot';
-import type { C15TContext } from '~/types';
+import type { C15TContext, WriteProvenance } from '~/types';
 import { extractErrorMessage } from '~/utils/extract-error-message';
 import { getMetrics } from '~/utils/metrics';
+import { enforceWriteAbuseControl } from '~/write-integrity/abuse-control';
+import { resolveWriteIntegrityOptions } from '~/write-integrity/configuration';
+import { resolveWriteDomain } from '~/write-integrity/domain';
+import {
+	buildWriteRequestFingerprint,
+	consumeWriteReplay,
+} from '~/write-integrity/replay';
+import { verifySubjectCapability } from '~/write-integrity/subject-capability';
+import type { WriteIntegrityVerificationFailureReason } from '~/write-integrity/token';
 import { resolvePolicyDecision } from '../init/policy';
 import {
 	buildConsentId,
@@ -239,6 +248,60 @@ function buildLegalDocumentProofHttpException(message: string): HTTPException {
 	});
 }
 
+function buildCapabilityHttpException(
+	reason: WriteIntegrityVerificationFailureReason
+): HTTPException {
+	switch (reason) {
+		case 'missing':
+			return new HTTPException(401, {
+				message: 'Subject capability is required',
+				cause: { code: 'SUBJECT_CAPABILITY_REQUIRED' },
+			});
+		case 'expired':
+			return new HTTPException(401, {
+				message: 'Subject capability has expired',
+				cause: { code: 'SUBJECT_CAPABILITY_EXPIRED' },
+			});
+		case 'malformed':
+		case 'invalid':
+			return new HTTPException(403, {
+				message: 'Subject capability is invalid',
+				cause: { code: 'SUBJECT_CAPABILITY_INVALID' },
+			});
+		default: {
+			const _exhaustive: never = reason;
+			throw new Error(
+				`Unhandled subject capability verification failure reason: ${_exhaustive}`
+			);
+		}
+	}
+}
+
+function snapshotBindingsMatch(
+	bindings: {
+		domain?: string;
+		subjectId?: string;
+		consentType?: string;
+		consentAction?: string;
+	},
+	request: {
+		domain: string;
+		subjectId: string;
+		consentType: string;
+		consentAction?: string;
+	}
+): boolean {
+	return (
+		(bindings.domain === undefined || bindings.domain === request.domain) &&
+		(bindings.subjectId === undefined ||
+			bindings.subjectId === request.subjectId) &&
+		(bindings.consentType === undefined ||
+			bindings.consentType === request.consentType) &&
+		(bindings.consentAction === undefined ||
+			bindings.consentAction === request.consentAction)
+	);
+}
+
 /**
  * Handles the creation of a new consent record for a subject.
  *
@@ -306,6 +369,100 @@ export const postSubjectHandler = async (c: Context) => {
 		}
 
 		const request = c.req.raw ?? new Request('https://c15t.local/subjects');
+		const writeIntegrity = resolveWriteIntegrityOptions(
+			ctx.writeIntegrity
+		).config;
+		const anonymousConsentMode = writeIntegrity.anonymousConsent.mode;
+		if (anonymousConsentMode === 'disabled') {
+			throw new HTTPException(403, {
+				message: 'Consent writes are disabled',
+				cause: { code: 'CONSENT_WRITE_DISABLED' },
+			});
+		}
+
+		const writeOrigin =
+			ctx.origin ?? request.headers.get('origin') ?? undefined;
+		const resolvedDomain = await resolveWriteDomain({
+			options: writeIntegrity.domains,
+			context: {
+				action: 'consent:create',
+				requestedDomain: domain,
+				origin: writeOrigin,
+				subjectId,
+				tenantId: ctx.tenantId,
+				request,
+			},
+		});
+
+		await enforceWriteAbuseControl(writeIntegrity.abuseControl, {
+			action: 'consent:create',
+			subjectId,
+			domain: resolvedDomain.domain,
+			origin: writeOrigin,
+			ipAddress: ctx.ipAddress,
+			tenantId: ctx.tenantId,
+			request,
+		});
+
+		let writeProvenance: WriteProvenance = {
+			source: anonymousConsentMode === 'legacy' ? 'legacy' : 'anonymous',
+			origin: writeOrigin,
+		};
+		if (anonymousConsentMode === 'capability') {
+			const capabilityOptions = writeIntegrity.subjectCapability;
+			if (!capabilityOptions) {
+				throw new HTTPException(500, {
+					message: 'Subject capability verification is not configured',
+					cause: { code: 'SUBJECT_CAPABILITY_NOT_CONFIGURED' },
+				});
+			}
+
+			const capability = await verifySubjectCapability({
+				token: input.subjectCapability,
+				options: capabilityOptions,
+				tenantId: ctx.tenantId,
+				subjectId,
+				action: 'consent:create',
+				domain: resolvedDomain.domain,
+			});
+			if (!capability.valid) {
+				throw buildCapabilityHttpException(capability.reason);
+			}
+
+			const { subjectCapability: _proof, ...requestInput } = input;
+			const requestFingerprint = await buildWriteRequestFingerprint({
+				action: 'consent:create',
+				tenantId: ctx.tenantId ?? null,
+				subjectId,
+				domain: resolvedDomain.domain,
+				input: { ...requestInput, domain: resolvedDomain.domain },
+			});
+			const replay = await consumeWriteReplay({
+				claim: {
+					tokenId: capability.payload.jti,
+					tenantId: ctx.tenantId,
+					audience: capability.payload.aud,
+					requestFingerprint,
+					expiresAt: new Date(capability.payload.exp * 1000),
+				},
+				database: db,
+				replayStore: writeIntegrity.replayStore,
+			});
+			if (replay.status === 'replayed') {
+				throw new HTTPException(409, {
+					message: 'Subject capability has already been used',
+					cause: { code: 'SUBJECT_CAPABILITY_REPLAYED' },
+				});
+			}
+
+			writeProvenance = {
+				source: 'subject_capability',
+				credentialId: capability.payload.jti,
+				issuer: capability.payload.iss,
+				origin: writeOrigin,
+			};
+		}
+
 		const acceptLanguage = request.headers.get('accept-language');
 		const requestLanguage = parseLanguageFromHeader(acceptLanguage);
 		const location = await getLocation(request, ctx);
@@ -335,6 +492,17 @@ export const postSubjectHandler = async (c: Context) => {
 		const snapshotPayload = runtimeSnapshotVerification.valid
 			? runtimeSnapshotVerification.payload
 			: null;
+		if (
+			snapshotPayload?.writeBindings &&
+			!snapshotBindingsMatch(snapshotPayload.writeBindings, {
+				domain: resolvedDomain.domain,
+				subjectId,
+				consentType: type,
+				consentAction: rawConsentAction,
+			})
+		) {
+			throw buildSnapshotHttpException('invalid');
+		}
 		const shouldRequireSnapshot =
 			!legalDocumentConsent &&
 			!!ctx.policySnapshot?.signingKey &&
@@ -419,12 +587,21 @@ export const postSubjectHandler = async (c: Context) => {
 
 		logger.debug('Subject found/created', { subjectId: subject.id });
 
-		const domainRecord = await registry.findOrCreateDomain(domain);
+		const domainRecord =
+			resolvedDomain.mode === 'configured'
+				? await registry.findOrCreateScopedDomain({
+						name: resolvedDomain.domain,
+						scopeKey: resolvedDomain.scopeKey,
+					})
+				: await registry.findOrCreateDomain(resolvedDomain.domain);
 
 		if (!domainRecord) {
 			throw new HTTPException(500, {
 				message: 'Failed to create domain',
-				cause: { code: 'DOMAIN_CREATION_FAILED', domain },
+				cause: {
+					code: 'DOMAIN_CREATION_FAILED',
+					domain: resolvedDomain.domain,
+				},
 			});
 		}
 
@@ -774,6 +951,10 @@ export const postSubjectHandler = async (c: Context) => {
 					validUntil,
 					runtimePolicyDecisionId: runtimePolicyDecision?.id,
 					runtimePolicySource: decisionPayload?.source,
+					writeSource: writeProvenance.source,
+					writeCredentialId: writeProvenance.credentialId,
+					writeIssuer: writeProvenance.issuer,
+					writeOrigin: writeProvenance.origin,
 				});
 
 				if (!consentRecord) {
@@ -782,7 +963,7 @@ export const postSubjectHandler = async (c: Context) => {
 						cause: {
 							code: 'CONSENT_CREATION_FAILED',
 							subjectId: subject.id,
-							domain,
+							domain: resolvedDomain.domain,
 						},
 					});
 				}
@@ -840,7 +1021,7 @@ export const postSubjectHandler = async (c: Context) => {
 				cause: {
 					code: 'CONSENT_CREATION_FAILED',
 					subjectId: subject.id,
-					domain,
+					domain: resolvedDomain.domain,
 				},
 			});
 		}

--- a/packages/backend/src/handlers/subject/post.handler.write-integrity.integration.test.ts
+++ b/packages/backend/src/handlers/subject/post.handler.write-integrity.integration.test.ts
@@ -1,0 +1,120 @@
+import { Kysely } from 'kysely';
+import { KyselyPGlite } from 'kysely-pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type C15TInstance, c15tInstance } from '~/core';
+import { kyselyAdapter } from '~/db/adapters/kysely';
+import { DB } from '~/db/schema';
+import { createSubjectCapability } from '~/write-integrity/subject-capability';
+
+const SUBJECT_ID = 'sub_2jv6z8n4q9';
+const DOMAIN = 'example.com';
+const GIVEN_AT = 1_775_000_000_000;
+const CAPABILITY_SECRET = 'integration-capability-secret-for-consent-writes';
+
+describe('POST /subjects write integrity (Postgres integration)', () => {
+	let database: Kysely<Record<string, never>>;
+	let instance: C15TInstance;
+	let orm: ReturnType<ReturnType<(typeof DB)['client']>['orm']>;
+	let capabilityToken: string;
+
+	beforeAll(async () => {
+		const pglite = await KyselyPGlite.create();
+		database = new Kysely({ dialect: pglite.dialect });
+		const adapter = kyselyAdapter({
+			db: database,
+			provider: 'postgresql',
+		});
+		const client = DB.client(adapter);
+		const migration = await client
+			.createMigrator()
+			.migrateToLatest({ mode: 'from-database' });
+		await migration.execute();
+		orm = client.orm('2.1.0');
+
+		instance = c15tInstance({
+			adapter,
+			disableGeoLocation: true,
+			trustedOrigins: ['app.example.com'],
+			writeIntegrity: {
+				anonymousConsent: { mode: 'capability' },
+				identityLinking: { mode: 'disabled' },
+				domains: { allowlist: [DOMAIN] },
+				subjectCapability: { signingKey: CAPABILITY_SECRET },
+			},
+		});
+
+		const capability = await createSubjectCapability({
+			options: { signingKey: CAPABILITY_SECRET },
+			subjectId: SUBJECT_ID,
+			action: 'consent:create',
+			domain: DOMAIN,
+		});
+		capabilityToken = capability.token;
+	}, 30_000);
+
+	afterAll(async () => {
+		await database.destroy();
+	});
+
+	const submit = (body: Record<string, unknown>) =>
+		instance.handler(
+			new Request('https://backend.example/subjects', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					origin: 'https://app.example.com',
+				},
+				body: JSON.stringify(body),
+			})
+		);
+
+	it('persists scoped domain, replay state, and capability provenance', async () => {
+		const body = {
+			type: 'other',
+			subjectId: SUBJECT_ID,
+			domain: 'EXAMPLE.COM.',
+			givenAt: GIVEN_AT,
+			subjectCapability: capabilityToken,
+		};
+
+		const first = await submit(body);
+		expect(first.status, await first.clone().text()).toBe(200);
+		const retry = await submit(body);
+		expect(retry.status, await retry.clone().text()).toBe(200);
+
+		expect(await orm.count('consent')).toBe(1);
+		expect(await orm.count('writeReplay')).toBe(1);
+		expect(await orm.count('domain')).toBe(1);
+		const consent = await orm.findFirst('consent', {
+			where: (builder) => builder('subjectId', '=', SUBJECT_ID),
+		});
+		const domain = await orm.findFirst('domain', {
+			where: (builder) => builder('name', '=', DOMAIN),
+		});
+
+		expect(consent).toMatchObject({
+			writeSource: 'subject_capability',
+			writeOrigin: 'https://app.example.com',
+		});
+		expect(consent?.writeCredentialId).toBeTruthy();
+		expect(consent?.writeIssuer).toBe('c15t');
+		expect(domain?.scopeKey).toMatch(/^domain:[a-f0-9]{64}$/);
+	});
+
+	it('rejects altered reuse of the consumed capability', async () => {
+		const response = await submit({
+			type: 'other',
+			subjectId: SUBJECT_ID,
+			domain: DOMAIN,
+			givenAt: GIVEN_AT,
+			metadata: { altered: true },
+			subjectCapability: capabilityToken,
+		});
+
+		expect(response.status).toBe(409);
+		await expect(response.json()).resolves.toMatchObject({
+			code: 'SUBJECT_CAPABILITY_REPLAYED',
+		});
+		expect(await orm.count('consent')).toBe(1);
+	});
+});

--- a/packages/backend/src/types/index.ts
+++ b/packages/backend/src/types/index.ts
@@ -515,6 +515,11 @@ export interface WriteReplayClaim {
 	expiresAt: Date;
 }
 
+/** Result returned by an atomic custom replay store. */
+export type WriteReplayStoreResult =
+	| boolean
+	| { status: 'consumed' | 'idempotent' | 'replayed' };
+
 /**
  * Atomic storage used to reject replayed write credentials.
  */
@@ -523,13 +528,14 @@ export interface WriteReplayStore {
 	 * Atomically records a replay claim if its token identifier is unused.
 	 *
 	 * Implementations must perform the existence check and insert as one atomic
-	 * operation. Return `true` only for the first accepted claim and `false` when
-	 * the token identifier was already consumed.
+	 * operation. Rich results can preserve exact-retry idempotency. Boolean
+	 * results remain supported: `true` means consumed and `false` is treated as
+	 * a replay.
 	 *
 	 * @param claim - Credential and request details to claim
-	 * @returns Whether the claim was recorded for the first time
+	 * @returns The consumption outcome, or a backwards-compatible boolean
 	 */
-	consume(claim: WriteReplayClaim): Promise<boolean>;
+	consume(claim: WriteReplayClaim): Promise<WriteReplayStoreResult>;
 }
 
 /**

--- a/packages/backend/src/write-integrity/abuse-control.test.ts
+++ b/packages/backend/src/write-integrity/abuse-control.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WriteAbuseControlContext } from '~/types';
+import {
+	enforceWriteAbuseControl,
+	runWriteAbuseControl,
+} from './abuse-control';
+
+const context: WriteAbuseControlContext = {
+	action: 'consent:create',
+	domain: 'example.com',
+	request: new Request('https://api.example.test/subjects'),
+};
+
+describe('runWriteAbuseControl', () => {
+	it('allows writes when no hook is configured', async () => {
+		await expect(runWriteAbuseControl(undefined, context)).resolves.toEqual({
+			status: 'allowed',
+		});
+	});
+
+	it('normalizes allow and deny decisions', async () => {
+		await expect(
+			runWriteAbuseControl(() => ({ allowed: true }), context)
+		).resolves.toEqual({ status: 'allowed' });
+
+		await expect(
+			runWriteAbuseControl(
+				() => ({
+					allowed: false,
+					reason: 'subject-rate-limit',
+					retryAfterSeconds: 30,
+				}),
+				context
+			)
+		).resolves.toEqual({
+			status: 'denied',
+			reason: 'subject-rate-limit',
+			retryAfterSeconds: 30,
+		});
+	});
+
+	it('returns a stable error when the hook throws', async () => {
+		const providerError = new Error('provider failed');
+
+		await expect(
+			runWriteAbuseControl(() => {
+				throw providerError;
+			}, context)
+		).resolves.toEqual({ status: 'error', error: providerError });
+	});
+
+	it('rejects malformed runtime decisions', async () => {
+		const invalidHook = vi.fn(() => ({
+			allowed: false,
+			retryAfterSeconds: -1,
+		}));
+
+		const result = await runWriteAbuseControl(invalidHook, context);
+		expect(result.status).toBe('error');
+	});
+});
+
+describe('enforceWriteAbuseControl', () => {
+	it('throws a retry-aware 429 for denied writes', async () => {
+		await expect(
+			enforceWriteAbuseControl(
+				() => ({ allowed: false, retryAfterSeconds: 15 }),
+				context
+			)
+		).rejects.toMatchObject({
+			status: 429,
+			code: 'WRITE_ABUSE_CONTROL_DENIED',
+			retryAfterSeconds: 15,
+		});
+	});
+
+	it('fails closed with a stable 503 when the hook fails', async () => {
+		await expect(
+			enforceWriteAbuseControl(() => {
+				throw new Error('provider failed');
+			}, context)
+		).rejects.toMatchObject({
+			status: 503,
+			code: 'WRITE_ABUSE_CONTROL_UNAVAILABLE',
+		});
+	});
+});

--- a/packages/backend/src/write-integrity/abuse-control.ts
+++ b/packages/backend/src/write-integrity/abuse-control.ts
@@ -1,0 +1,138 @@
+import { HTTPException } from 'hono/http-exception';
+import type { WriteAbuseControl, WriteAbuseControlContext } from '~/types';
+
+/** Stable outcomes from an application-provided abuse-control hook. */
+export type WriteAbuseControlResult =
+	| { status: 'allowed' }
+	| {
+			status: 'denied';
+			reason?: string;
+			retryAfterSeconds?: number;
+	  }
+	| { status: 'error'; error: unknown };
+
+/** Stable error codes exposed by {@link enforceWriteAbuseControl}. */
+export type WriteAbuseControlErrorCode =
+	| 'WRITE_ABUSE_CONTROL_DENIED'
+	| 'WRITE_ABUSE_CONTROL_UNAVAILABLE';
+
+/** HTTP-compatible failure from write abuse controls. */
+export class WriteAbuseControlError extends HTTPException {
+	readonly code: WriteAbuseControlErrorCode;
+	readonly retryAfterSeconds?: number;
+
+	constructor(
+		status: 429 | 503,
+		code: WriteAbuseControlErrorCode,
+		message: string,
+		options: {
+			reason?: string;
+			retryAfterSeconds?: number;
+			error?: unknown;
+		} = {}
+	) {
+		super(status, {
+			message,
+			cause: {
+				code,
+				reason: options.reason,
+				retryAfterSeconds: options.retryAfterSeconds,
+				error: options.error,
+			},
+		});
+		this.name = 'WriteAbuseControlError';
+		this.code = code;
+		this.retryAfterSeconds = options.retryAfterSeconds;
+	}
+}
+
+function isValidRetryDelay(value: number | undefined): boolean {
+	return (
+		value === undefined ||
+		(Number.isInteger(value) && Number.isFinite(value) && value >= 0)
+	);
+}
+
+/**
+ * Executes an abuse-control hook without leaking provider-specific errors into
+ * control flow.
+ *
+ * Missing hooks allow the write, preserving legacy behavior. Thrown errors and
+ * malformed decisions produce the stable `error` result so callers can fail
+ * closed and emit consistent HTTP responses.
+ *
+ * @param control - Optional application-provided control
+ * @param context - Trusted request context for the write
+ * @returns Stable allow, deny, or error result
+ */
+export async function runWriteAbuseControl(
+	control: WriteAbuseControl | undefined,
+	context: WriteAbuseControlContext
+): Promise<WriteAbuseControlResult> {
+	if (!control) {
+		return { status: 'allowed' };
+	}
+
+	try {
+		const decision = await control(context);
+		if (
+			typeof decision !== 'object' ||
+			decision === null ||
+			typeof decision.allowed !== 'boolean' ||
+			!isValidRetryDelay(decision.retryAfterSeconds)
+		) {
+			return {
+				status: 'error',
+				error: new TypeError('Abuse-control hook returned an invalid decision'),
+			};
+		}
+
+		if (decision.allowed) {
+			return { status: 'allowed' };
+		}
+
+		return {
+			status: 'denied',
+			reason: decision.reason,
+			retryAfterSeconds: decision.retryAfterSeconds,
+		};
+	} catch (error) {
+		return { status: 'error', error };
+	}
+}
+
+/**
+ * Runs configured abuse controls and throws an HTTP-compatible error unless
+ * the write is allowed.
+ *
+ * @param control - Optional application-provided control
+ * @param context - Trusted request context for the write
+ * @returns The stable allowed result
+ * @throws {WriteAbuseControlError} With 429 on denial or 503 on hook failure
+ */
+export async function enforceWriteAbuseControl(
+	control: WriteAbuseControl | undefined,
+	context: WriteAbuseControlContext
+): Promise<{ status: 'allowed' }> {
+	const result = await runWriteAbuseControl(control, context);
+
+	if (result.status === 'denied') {
+		throw new WriteAbuseControlError(
+			429,
+			'WRITE_ABUSE_CONTROL_DENIED',
+			'Write rejected by abuse controls',
+			result
+		);
+	}
+
+	if (result.status === 'error') {
+		throw new WriteAbuseControlError(
+			503,
+			'WRITE_ABUSE_CONTROL_UNAVAILABLE',
+			'Write abuse controls are unavailable',
+			{ error: result.error }
+		);
+	}
+
+	return result;
+}

--- a/packages/backend/src/write-integrity/domain.test.ts
+++ b/packages/backend/src/write-integrity/domain.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WriteDomainResolverContext } from '~/types';
+import type { ResolvedWriteDomainOptions } from './configuration';
+import {
+	buildDomainScopeKey,
+	normalizeWriteDomain,
+	resolveWriteDomain,
+	WriteDomainResolutionError,
+} from './domain';
+
+function resolverContext(
+	overrides: Partial<WriteDomainResolverContext> = {}
+): WriteDomainResolverContext {
+	return {
+		action: 'consent:create',
+		request: new Request('https://api.example.test/subjects'),
+		...overrides,
+	};
+}
+
+function configuredDomains(
+	overrides: Partial<ResolvedWriteDomainOptions> = {}
+): ResolvedWriteDomainOptions {
+	return {
+		mode: 'configured',
+		allowlist: ['example.com'],
+		...overrides,
+	};
+}
+
+describe('normalizeWriteDomain', () => {
+	it('normalizes case, international names, and a final DNS dot', () => {
+		expect(normalizeWriteDomain(' EXAMPLE.COM. ')).toBe('example.com');
+		expect(normalizeWriteDomain('münich.example')).toBe(
+			'xn--mnich-kva.example'
+		);
+	});
+
+	it.each([
+		'https://example.com',
+		'example.com:443',
+		'example.com/path',
+		'user@example.com',
+		'*.example.com',
+		'',
+	])('rejects non-hostname value %j', (value) => {
+		expect(() => normalizeWriteDomain(value)).toThrow(
+			WriteDomainResolutionError
+		);
+	});
+});
+
+describe('buildDomainScopeKey', () => {
+	it('is stable and tenant-aware', async () => {
+		const first = await buildDomainScopeKey('example.com', 'tenant-a');
+		const retry = await buildDomainScopeKey('example.com', 'tenant-a');
+		const otherTenant = await buildDomainScopeKey('example.com', 'tenant-b');
+		const unscoped = await buildDomainScopeKey('example.com');
+
+		expect(first).toBe(retry);
+		expect(first).toMatch(/^domain:[a-f0-9]{64}$/);
+		expect(otherTenant).not.toBe(first);
+		expect(unscoped).not.toBe(first);
+	});
+});
+
+describe('resolveWriteDomain', () => {
+	it('preserves the request value unchanged in legacy mode', async () => {
+		await expect(
+			resolveWriteDomain({
+				options: { mode: 'legacy', allowlist: [] },
+				context: resolverContext({ requestedDomain: ' EXAMPLE.COM. ' }),
+			})
+		).resolves.toEqual({
+			mode: 'legacy',
+			domain: ' EXAMPLE.COM. ',
+			source: 'request',
+		});
+	});
+
+	it('canonicalizes an allowlisted request and creates its scope key', async () => {
+		const result = await resolveWriteDomain({
+			options: configuredDomains({ allowlist: ['EXAMPLE.COM.'] }),
+			context: resolverContext({
+				requestedDomain: 'example.com',
+				tenantId: 'tenant-a',
+			}),
+		});
+
+		expect(result).toEqual({
+			mode: 'configured',
+			domain: 'example.com',
+			source: 'request',
+			scopeKey: await buildDomainScopeKey('example.com', 'tenant-a'),
+		});
+	});
+
+	it('uses the resolver output as authoritative', async () => {
+		const resolve = vi.fn(() => 'resolved.example');
+		const result = await resolveWriteDomain({
+			options: configuredDomains({
+				allowlist: ['resolved.example'],
+				resolve,
+			}),
+			context: resolverContext({ requestedDomain: 'attacker.example' }),
+		});
+
+		expect(resolve).toHaveBeenCalledOnce();
+		expect(result.domain).toBe('resolved.example');
+		expect(result.source).toBe('resolver');
+	});
+
+	it('checks resolver output against the allowlist', async () => {
+		const promise = resolveWriteDomain({
+			options: configuredDomains({
+				resolve: () => 'outside.example',
+			}),
+			context: resolverContext({ requestedDomain: 'example.com' }),
+		});
+
+		await expect(promise).rejects.toMatchObject({
+			status: 403,
+			code: 'WRITE_DOMAIN_NOT_ALLOWED',
+		});
+	});
+
+	it('maps resolver rejection and failure to stable errors', async () => {
+		await expect(
+			resolveWriteDomain({
+				options: configuredDomains({ resolve: () => null }),
+				context: resolverContext(),
+			})
+		).rejects.toMatchObject({
+			status: 403,
+			code: 'WRITE_DOMAIN_RESOLUTION_REJECTED',
+		});
+
+		await expect(
+			resolveWriteDomain({
+				options: configuredDomains({
+					resolve: () => {
+						throw new Error('provider failed');
+					},
+				}),
+				context: resolverContext(),
+			})
+		).rejects.toMatchObject({
+			status: 503,
+			code: 'WRITE_DOMAIN_RESOLUTION_FAILED',
+		});
+	});
+});

--- a/packages/backend/src/write-integrity/domain.ts
+++ b/packages/backend/src/write-integrity/domain.ts
@@ -1,0 +1,219 @@
+import { hashSha256Hex } from '@c15t/schema/types';
+import { HTTPException } from 'hono/http-exception';
+import type { WriteDomainResolverContext } from '~/types';
+import type { ResolvedWriteDomainOptions } from './configuration';
+
+/** Stable failure codes emitted while resolving a write domain. */
+export type WriteDomainResolutionErrorCode =
+	| 'WRITE_DOMAIN_REQUIRED'
+	| 'WRITE_DOMAIN_INVALID'
+	| 'WRITE_DOMAIN_NOT_ALLOWED'
+	| 'WRITE_DOMAIN_RESOLUTION_REJECTED'
+	| 'WRITE_DOMAIN_RESOLUTION_FAILED';
+
+/** HTTP-compatible error raised when a secure write domain cannot be resolved. */
+export class WriteDomainResolutionError extends HTTPException {
+	readonly code: WriteDomainResolutionErrorCode;
+
+	constructor(
+		status: 403 | 422 | 503,
+		code: WriteDomainResolutionErrorCode,
+		message: string,
+		cause?: unknown
+	) {
+		super(status, {
+			message,
+			cause: { code, error: cause },
+		});
+		this.name = 'WriteDomainResolutionError';
+		this.code = code;
+	}
+}
+
+/** Result of resolving the authoritative domain for a write. */
+export type ResolvedWriteDomain =
+	| {
+			/** Legacy behavior leaves the request value unchanged. */
+			mode: 'legacy';
+			domain: string;
+			source: 'request';
+			scopeKey?: never;
+	  }
+	| {
+			/** Configured behavior produces a canonical, tenant-scoped domain. */
+			mode: 'configured';
+			domain: string;
+			source: 'request' | 'resolver';
+			scopeKey: string;
+	  };
+
+/** Parameters used to resolve an authoritative write domain. */
+export interface ResolveWriteDomainOptions {
+	/** Resolved write-integrity domain configuration. */
+	options: ResolvedWriteDomainOptions;
+	/** Request details supplied to the optional trusted resolver. */
+	context: WriteDomainResolverContext;
+}
+
+function invalidDomain(message: string): WriteDomainResolutionError {
+	return new WriteDomainResolutionError(422, 'WRITE_DOMAIN_INVALID', message);
+}
+
+/**
+ * Converts a domain name to its stable storage and comparison form.
+ *
+ * The accepted value is a hostname, not an origin or URL. Case, a final DNS
+ * dot, and internationalized names are normalized by the URL parser. Ports,
+ * paths, credentials, query strings, fragments, and wildcard labels are
+ * rejected so two syntactically different values cannot name the same scope.
+ *
+ * @param value - Domain name to normalize
+ * @returns Lowercase ASCII hostname without a trailing DNS dot
+ * @throws {WriteDomainResolutionError} When the value is not a hostname
+ */
+export function normalizeWriteDomain(value: string): string {
+	const input = value.trim();
+	if (input === '') {
+		throw invalidDomain('Write domain cannot be empty');
+	}
+
+	if (input.includes('://')) {
+		throw invalidDomain('Write domain must be a hostname, not a URL');
+	}
+
+	const bracketedIpv6 = input.startsWith('[') && input.endsWith(']');
+	if ((!bracketedIpv6 && input.includes(':')) || input.includes(']:')) {
+		throw invalidDomain('Write domain cannot include a port');
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(`https://${input}`);
+	} catch {
+		throw invalidDomain('Write domain is not a valid hostname');
+	}
+
+	if (
+		parsed.username !== '' ||
+		parsed.password !== '' ||
+		parsed.port !== '' ||
+		parsed.pathname !== '/' ||
+		parsed.search !== '' ||
+		parsed.hash !== ''
+	) {
+		throw invalidDomain(
+			'Write domain cannot include credentials, a port, path, query, or fragment'
+		);
+	}
+
+	const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '');
+	if (hostname === '' || hostname.includes('*')) {
+		throw invalidDomain('Write domain is not a valid hostname');
+	}
+
+	return hostname;
+}
+
+/**
+ * Builds a fixed-width lookup key for a canonical domain and tenant.
+ *
+ * JSON tuple encoding keeps a missing tenant distinct from tenant strings,
+ * while SHA-256 keeps the key within adapter column limits even for long IDs.
+ *
+ * @param domain - Canonical domain returned by {@link normalizeWriteDomain}
+ * @param tenantId - Active tenant, or `undefined` for the unscoped namespace
+ * @returns Stable `domain:`-prefixed scope key
+ */
+export async function buildDomainScopeKey(
+	domain: string,
+	tenantId?: string
+): Promise<string> {
+	const digest = await hashSha256Hex(
+		JSON.stringify([tenantId ?? null, domain])
+	);
+	return `domain:${digest}`;
+}
+
+/**
+ * Resolves and authorizes the domain associated with a consent write.
+ *
+ * A configured server resolver is authoritative. Its output is still checked
+ * against the configured allowlist, preventing a buggy resolver from bypassing
+ * the deployment's explicit domain boundary. Without a resolver, the request
+ * value is checked directly. Legacy mode deliberately returns the request value
+ * unchanged to keep this minor release backwards compatible.
+ *
+ * @param input - Resolved configuration and request context
+ * @returns Authoritative domain and its tenant-aware lookup key
+ * @throws {WriteDomainResolutionError} When resolution or authorization fails
+ */
+export async function resolveWriteDomain(
+	input: ResolveWriteDomainOptions
+): Promise<ResolvedWriteDomain> {
+	const { options, context } = input;
+
+	if (options.mode === 'legacy') {
+		if (context.requestedDomain === undefined) {
+			throw new WriteDomainResolutionError(
+				422,
+				'WRITE_DOMAIN_REQUIRED',
+				'Write domain is required'
+			);
+		}
+
+		return {
+			mode: 'legacy',
+			domain: context.requestedDomain,
+			source: 'request',
+		};
+	}
+
+	let resolvedValue: string | null | undefined;
+	if (options.resolve) {
+		try {
+			resolvedValue = await options.resolve(context);
+		} catch (error) {
+			throw new WriteDomainResolutionError(
+				503,
+				'WRITE_DOMAIN_RESOLUTION_FAILED',
+				'Write domain resolver failed',
+				error
+			);
+		}
+
+		if (resolvedValue === null || resolvedValue === undefined) {
+			throw new WriteDomainResolutionError(
+				403,
+				'WRITE_DOMAIN_RESOLUTION_REJECTED',
+				'Write domain resolver rejected the request'
+			);
+		}
+	} else {
+		resolvedValue = context.requestedDomain;
+	}
+
+	if (resolvedValue === undefined) {
+		throw new WriteDomainResolutionError(
+			422,
+			'WRITE_DOMAIN_REQUIRED',
+			'Write domain is required'
+		);
+	}
+
+	const domain = normalizeWriteDomain(resolvedValue);
+	const allowedDomains = options.allowlist.map(normalizeWriteDomain);
+	if (allowedDomains.length > 0 && !allowedDomains.includes(domain)) {
+		throw new WriteDomainResolutionError(
+			403,
+			'WRITE_DOMAIN_NOT_ALLOWED',
+			'Write domain is not allowed'
+		);
+	}
+
+	return {
+		mode: 'configured',
+		domain,
+		source: options.resolve ? 'resolver' : 'request',
+		scopeKey: await buildDomainScopeKey(domain, context.tenantId),
+	};
+}

--- a/packages/backend/src/write-integrity/index.ts
+++ b/packages/backend/src/write-integrity/index.ts
@@ -1,3 +1,11 @@
+export {
+	createPolicySnapshotToken,
+	type PolicySnapshotPayload,
+	type PolicySnapshotVerificationFailureReason,
+	type PolicySnapshotVerificationResult,
+	type PolicySnapshotWriteBindings,
+	verifyPolicySnapshotToken,
+} from '~/handlers/policy/snapshot';
 export type {
 	AnonymousConsentSubmissionMode,
 	AnonymousConsentSubmissionOptions,
@@ -17,13 +25,30 @@ export type {
 	WriteProvenanceSource,
 	WriteReplayClaim,
 	WriteReplayStore,
+	WriteReplayStoreResult,
 } from '~/types';
+export {
+	enforceWriteAbuseControl,
+	runWriteAbuseControl,
+	WriteAbuseControlError,
+	type WriteAbuseControlErrorCode,
+	type WriteAbuseControlResult,
+} from './abuse-control';
 export {
 	type ResolvedWriteDomainOptions,
 	type ResolvedWriteIntegrityOptions,
 	resolveWriteIntegrityOptions,
 	type WriteIntegrityConfigurationResult,
 } from './configuration';
+export {
+	buildDomainScopeKey,
+	normalizeWriteDomain,
+	type ResolvedWriteDomain,
+	type ResolveWriteDomainOptions,
+	resolveWriteDomain,
+	WriteDomainResolutionError,
+	type WriteDomainResolutionErrorCode,
+} from './domain';
 export {
 	type CreateIdentityAssertionOptions,
 	createIdentityAssertion,
@@ -33,6 +58,13 @@ export {
 	type VerifyIdentityAssertionOptions,
 	verifyIdentityAssertion,
 } from './identity-assertion';
+export {
+	buildWriteReplayId,
+	buildWriteRequestFingerprint,
+	type ConsumeWriteReplayOptions,
+	consumeWriteReplay,
+	type WriteReplayConsumptionResult,
+} from './replay';
 export {
 	type CreateSubjectCapabilityOptions,
 	createSubjectCapability,

--- a/packages/backend/src/write-integrity/replay.test.ts
+++ b/packages/backend/src/write-integrity/replay.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WriteReplayClaim } from '~/types';
+import {
+	buildWriteReplayId,
+	buildWriteRequestFingerprint,
+	type ConsumeWriteReplayOptions,
+	consumeWriteReplay,
+} from './replay';
+
+type ReplayDatabase = ConsumeWriteReplayOptions['database'];
+type ReplayRecord = {
+	id: string;
+	tenantId: string | null;
+	audience: string;
+	tokenId: string;
+	requestFingerprint: string;
+	expiresAt: Date;
+};
+
+const claim: WriteReplayClaim = {
+	tokenId: 'credential-1',
+	tenantId: 'tenant-a',
+	audience: 'subject-1',
+	requestFingerprint: 'sha256:request-a',
+	expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+};
+
+function createDatabase() {
+	const records = new Map<string, ReplayRecord>();
+	const create = vi.fn(async (_table: string, value: ReplayRecord) => {
+		if (records.has(value.id)) {
+			throw Object.assign(new Error('duplicate key'), { code: '23505' });
+		}
+		records.set(value.id, value);
+		return value;
+	});
+	const findFirst = vi.fn(async () => records.values().next().value ?? null);
+
+	return {
+		database: { create, findFirst } as unknown as ReplayDatabase,
+		create,
+		findFirst,
+		records,
+	};
+}
+
+describe('buildWriteReplayId', () => {
+	it('is stable across fingerprints but scoped by credential identity', async () => {
+		const first = await buildWriteReplayId(claim);
+		const alteredRequest = await buildWriteReplayId({
+			...claim,
+			requestFingerprint: 'sha256:request-b',
+		});
+		const otherTenant = await buildWriteReplayId({
+			...claim,
+			tenantId: 'tenant-b',
+		});
+
+		expect(first).toBe(alteredRequest);
+		expect(first).toMatch(/^wrp_/);
+		expect(otherTenant).not.toBe(first);
+	});
+});
+
+describe('buildWriteRequestFingerprint', () => {
+	it('recursively sorts object keys while preserving array order', async () => {
+		const first = await buildWriteRequestFingerprint({
+			action: 'consent:create',
+			body: {
+				preferences: { analytics: true, marketing: false },
+				domain: 'example.com',
+				purposes: ['analytics', 'marketing'],
+			},
+		});
+		const reordered = await buildWriteRequestFingerprint({
+			body: {
+				purposes: ['analytics', 'marketing'],
+				domain: 'example.com',
+				preferences: { marketing: false, analytics: true },
+			},
+			action: 'consent:create',
+		});
+		const altered = await buildWriteRequestFingerprint({
+			action: 'consent:create',
+			body: {
+				preferences: { analytics: false, marketing: false },
+				domain: 'example.com',
+				purposes: ['analytics', 'marketing'],
+			},
+		});
+
+		expect(first).toBe(reordered);
+		expect(first).toMatch(/^sha256:[a-f0-9]{64}$/);
+		expect(altered).not.toBe(first);
+	});
+
+	it('lets exact semantic retries pass while altered requests are rejected', async () => {
+		const { database } = createDatabase();
+		const firstFingerprint = await buildWriteRequestFingerprint({
+			domain: 'example.com',
+			preferences: { analytics: true, marketing: false },
+		});
+		const reorderedFingerprint = await buildWriteRequestFingerprint({
+			preferences: { marketing: false, analytics: true },
+			domain: 'example.com',
+		});
+		const alteredFingerprint = await buildWriteRequestFingerprint({
+			domain: 'example.com',
+			preferences: { analytics: false, marketing: false },
+		});
+
+		await consumeWriteReplay({
+			claim: { ...claim, requestFingerprint: firstFingerprint },
+			database,
+		});
+		await expect(
+			consumeWriteReplay({
+				claim: { ...claim, requestFingerprint: reorderedFingerprint },
+				database,
+			})
+		).resolves.toEqual({ status: 'idempotent' });
+		await expect(
+			consumeWriteReplay({
+				claim: { ...claim, requestFingerprint: alteredFingerprint },
+				database,
+			})
+		).resolves.toEqual({ status: 'replayed' });
+	});
+});
+
+describe('consumeWriteReplay', () => {
+	it('atomically inserts before performing a read', async () => {
+		const { database, create, findFirst } = createDatabase();
+
+		await expect(consumeWriteReplay({ claim, database })).resolves.toEqual({
+			status: 'consumed',
+		});
+		expect(create).toHaveBeenCalledOnce();
+		expect(findFirst).not.toHaveBeenCalled();
+	});
+
+	it('treats an exact retry as idempotent', async () => {
+		const { database } = createDatabase();
+
+		await consumeWriteReplay({ claim, database });
+		await expect(consumeWriteReplay({ claim, database })).resolves.toEqual({
+			status: 'idempotent',
+		});
+	});
+
+	it('rejects the same credential with an altered fingerprint', async () => {
+		const { database } = createDatabase();
+
+		await consumeWriteReplay({ claim, database });
+		await expect(
+			consumeWriteReplay({
+				claim: { ...claim, requestFingerprint: 'sha256:request-b' },
+				database,
+			})
+		).resolves.toEqual({ status: 'replayed' });
+	});
+
+	it('allows only one concurrent consumer and makes its exact peer idempotent', async () => {
+		const { database } = createDatabase();
+		const results = await Promise.all([
+			consumeWriteReplay({ claim, database }),
+			consumeWriteReplay({ claim, database }),
+		]);
+
+		expect(results).toEqual([{ status: 'consumed' }, { status: 'idempotent' }]);
+	});
+
+	it('does not hide non-unique database errors', async () => {
+		const error = new Error('database unavailable');
+		const database = {
+			create: vi.fn(async () => {
+				throw error;
+			}),
+			findFirst: vi.fn(),
+		} as unknown as ReplayDatabase;
+
+		await expect(consumeWriteReplay({ claim, database })).rejects.toBe(error);
+	});
+
+	it('supports boolean and richer custom store results', async () => {
+		const { database } = createDatabase();
+
+		await expect(
+			consumeWriteReplay({
+				claim,
+				database,
+				replayStore: { consume: async () => true },
+			})
+		).resolves.toEqual({ status: 'consumed' });
+
+		await expect(
+			consumeWriteReplay({
+				claim,
+				database,
+				replayStore: {
+					consume: async () => ({ status: 'idempotent' }),
+				},
+			})
+		).resolves.toEqual({ status: 'idempotent' });
+
+		await expect(
+			consumeWriteReplay({
+				claim,
+				database,
+				replayStore: { consume: async () => false },
+			})
+		).resolves.toEqual({ status: 'replayed' });
+	});
+});

--- a/packages/backend/src/write-integrity/replay.ts
+++ b/packages/backend/src/write-integrity/replay.ts
@@ -1,0 +1,157 @@
+import { createDeterministicFingerprint } from '@c15t/schema/types';
+import { generateDeterministicId } from '~/db/registry/utils/generate-id';
+import type { C15TContext, WriteReplayClaim, WriteReplayStore } from '~/types';
+import { extractErrorMessage } from '~/utils/extract-error-message';
+
+type ReplayDatabase = Pick<C15TContext['db'], 'create' | 'findFirst'>;
+
+/** Stable result of consuming a credential replay claim. */
+export type WriteReplayConsumptionResult =
+	| { status: 'consumed' }
+	| { status: 'idempotent' }
+	| { status: 'replayed' };
+
+/** Inputs for the built-in or custom replay consumer. */
+export interface ConsumeWriteReplayOptions {
+	/** Replay claim derived from a verified credential. */
+	claim: WriteReplayClaim;
+	/** Database used by the built-in atomic consumer. */
+	database: ReplayDatabase;
+	/** Optional custom atomic store from write-integrity configuration. */
+	replayStore?: WriteReplayStore;
+}
+
+function isUniqueConstraintViolation(error: unknown): boolean {
+	const code =
+		typeof error === 'object' && error !== null && 'code' in error
+			? String((error as { code: unknown }).code)
+			: undefined;
+
+	if (
+		code === '23505' ||
+		code === 'ER_DUP_ENTRY' ||
+		code === '1062' ||
+		code === 'P2002' ||
+		code?.startsWith('SQLITE_CONSTRAINT')
+	) {
+		return true;
+	}
+
+	const message = extractErrorMessage(error).toLowerCase();
+	return (
+		message.includes('unique constraint') ||
+		message.includes('unique violation') ||
+		message.includes('duplicate key') ||
+		message.includes('duplicate entry') ||
+		message.includes('unique conflict')
+	);
+}
+
+/**
+ * Derives the primary key used to atomically consume a write credential.
+ *
+ * The ID intentionally excludes the request fingerprint. An altered retry of
+ * the same token therefore collides with the original row and is rejected.
+ *
+ * @param claim - Verified credential replay claim
+ * @returns Stable `wrp_` identifier scoped by tenant, audience, and token ID
+ */
+export function buildWriteReplayId(claim: WriteReplayClaim): Promise<string> {
+	return generateDeterministicId('writeReplay', 0, [
+		claim.tenantId ?? null,
+		claim.audience,
+		claim.tokenId,
+	]);
+}
+
+/**
+ * Builds a stable SHA-256 fingerprint for the request fields authorized by a
+ * credential.
+ *
+ * Object keys are recursively sorted, while array order remains significant.
+ * This helper intentionally does not guess which fields are proof material:
+ * callers must pass a payload that already excludes capability/assertion token
+ * strings and includes every action field that should be replay-bound.
+ *
+ * @param payload - Caller-selected request and action fields to bind
+ * @returns Stable, algorithm-prefixed request fingerprint
+ */
+export async function buildWriteRequestFingerprint(
+	payload: unknown
+): Promise<string> {
+	return `sha256:${await createDeterministicFingerprint(payload)}`;
+}
+
+/**
+ * Atomically consumes a verified write credential.
+ *
+ * The built-in implementation inserts a deterministic primary key before
+ * performing any read. A unique-key conflict proves that another request won
+ * the race; the stored fingerprint then distinguishes an exact idempotent
+ * retry from a modified replay. Custom stores use their atomic `consume`
+ * contract; because that contract returns only a boolean, an existing custom
+ * claim is conservatively reported as `replayed`.
+ *
+ * @param options - Claim, database, and optional custom store
+ * @returns Whether the credential was consumed, retried exactly, or replayed
+ * @throws The storage error when replay state cannot be determined safely
+ */
+export async function consumeWriteReplay(
+	options: ConsumeWriteReplayOptions
+): Promise<WriteReplayConsumptionResult> {
+	const { claim, database, replayStore } = options;
+
+	if (replayStore) {
+		const result = await replayStore.consume(claim);
+		if (typeof result === 'boolean') {
+			return result ? { status: 'consumed' } : { status: 'replayed' };
+		}
+
+		if (
+			result.status === 'consumed' ||
+			result.status === 'idempotent' ||
+			result.status === 'replayed'
+		) {
+			return result;
+		}
+
+		throw new TypeError('Replay store returned an invalid consumption result');
+	}
+
+	const id = await buildWriteReplayId(claim);
+	let insertError: unknown;
+	try {
+		await database.create('writeReplay', {
+			id,
+			tenantId: claim.tenantId ?? null,
+			audience: claim.audience,
+			tokenId: claim.tokenId,
+			requestFingerprint: claim.requestFingerprint,
+			expiresAt: claim.expiresAt,
+		});
+		return { status: 'consumed' };
+	} catch (error) {
+		if (!isUniqueConstraintViolation(error)) {
+			throw error;
+		}
+		insertError = error;
+	}
+
+	const existing = await database.findFirst('writeReplay', {
+		where: (builder) => builder('id', '=', id),
+	});
+
+	if (!existing) {
+		throw insertError;
+	}
+
+	const sameCredential =
+		existing.tokenId === claim.tokenId &&
+		existing.audience === claim.audience &&
+		(existing.tenantId ?? undefined) === claim.tenantId;
+
+	return sameCredential &&
+		existing.requestFingerprint === claim.requestFingerprint
+		? { status: 'idempotent' }
+		: { status: 'replayed' };
+}

--- a/packages/schema/src/api/subject/post.test.ts
+++ b/packages/schema/src/api/subject/post.test.ts
@@ -40,3 +40,16 @@ describe('postSubjectInputSchema givenAt', () => {
 		expect(parseGivenAt(1e18).success).toBe(false);
 	});
 });
+
+describe('postSubjectInputSchema write integrity', () => {
+	it('accepts an optional subject capability without requiring it for legacy writes', () => {
+		expect(
+			v.safeParse(postSubjectInputSchema, {
+				...baseInput,
+				givenAt: 1_735_689_600_000,
+				subjectCapability: 'header.payload.signature',
+			}).success
+		).toBe(true);
+		expect(parseGivenAt(1_735_689_600_000).success).toBe(true);
+	});
+});

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -116,6 +116,15 @@ const baseSubjectConsentSchema = v.object({
 			v.description('Signed policy snapshot token returned by /init.')
 		)
 	),
+	/** Short-lived capability authorizing this subject consent write */
+	subjectCapability: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Short-lived subject capability authorizing this consent write.'
+			)
+		)
+	),
 	/** Signed legal-document snapshot token from a rendered document view */
 	documentSnapshotToken: v.optional(
 		v.pipe(


### PR DESCRIPTION
## Summary

- enforce configured domain allowlists and trusted server-side resolution for consent writes
- verify subject capabilities, reject altered replay, and preserve exact-retry idempotency
- record authorization provenance separately from runtime policy provenance
- bind optional policy snapshots to write fields and integrate fail-closed abuse controls
- retain the existing anonymous consent behavior when legacy configuration is used

Stack 2 of 4 for [ENG-300](https://linear.app/inth/issue/ENG-300/ship-c15t-v2-consent-write-integrity-hardening). Depends on #986.

## Verification

- backend full suite
- schema full suite
- Postgres endpoint integration tests for replay, domain scope, and provenance
- backend and schema type checks
- changed-file Biome checks