### PR TITLE
feat(backend): secure external identity linking

### DIFF
--- a/.changeset/calm-otters-link.md
+++ b/.changeset/calm-otters-link.md
@@ -1,0 +1,7 @@
+---
+'c15t': minor
+'@c15t/backend': minor
+'@c15t/schema': minor
+---
+
+Add opt-in proof-bound identity linking and reassignment with set-once semantics, atomic replay protection, audit provenance, and safe hosted-client handling while preserving legacy identity writes by default.

--- a/packages/backend/src/handlers/subject/patch.handler.ts
+++ b/packages/backend/src/handlers/subject/patch.handler.ts
@@ -6,10 +6,11 @@
 
 import type { Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { generateUniqueId } from '~/db/registry/utils';
 import type { C15TContext } from '~/types';
 import { extractErrorMessage } from '~/utils/extract-error-message';
 import { getMetrics } from '~/utils/metrics';
+import { resolveWriteIntegrityOptions } from '~/write-integrity/configuration';
+import { linkSubjectIdentity } from '~/write-integrity/identity-linking';
 
 /**
  * Handles linking an external ID to a subject.
@@ -23,15 +24,22 @@ export const patchSubjectHandler = async (c: Context) => {
 	const logger = ctx.logger;
 	logger.info('Handling PATCH /subjects/:id request');
 
-	const { db } = ctx;
-
 	// Get input from validated params and body
 	const subjectId = c.req.param('id');
 	const body = await c.req.json<{
 		externalId: string;
 		identityProvider?: string;
+		domain?: string;
+		subjectCapability?: string;
+		identityAssertion?: string;
 	}>();
-	const { externalId, identityProvider = 'external' } = body;
+	const {
+		externalId,
+		identityProvider = 'external',
+		domain,
+		subjectCapability,
+		identityAssertion,
+	} = body;
 
 	if (!subjectId) {
 		throw new HTTPException(400, {
@@ -47,56 +55,29 @@ export const patchSubjectHandler = async (c: Context) => {
 	});
 
 	try {
-		// Find the subject
-		const subject = await db.findFirst('subject', {
-			where: (b) => b('id', '=', subjectId),
-		});
-
-		if (!subject) {
-			throw new HTTPException(404, {
-				message: 'Subject not found',
-				cause: { code: 'SUBJECT_NOT_FOUND', subjectId },
-			});
-		}
-
-		// Update the subject with externalId (no merge logic)
-		await db.transaction(async (tx) => {
-			await tx.updateMany('subject', {
-				where: (b) => b('id', '=', subjectId),
-				set: {
-					externalId,
-					identityProvider,
-					updatedAt: new Date(),
-				},
-			});
-
-			// Create audit log
-			await tx.create('auditLog', {
-				id: await generateUniqueId(tx, 'auditLog', ctx),
+		const request = c.req.raw ?? new Request('https://c15t.local/subjects');
+		const writeIntegrity = resolveWriteIntegrityOptions(
+			ctx.writeIntegrity
+		).config;
+		const result = await linkSubjectIdentity({
+			ctx,
+			writeIntegrity,
+			input: {
 				subjectId,
-				entityType: 'subject',
-				entityId: subjectId,
-				actionType: 'identify_user',
-				ipAddress: ctx.ipAddress || null,
-				userAgent: ctx.userAgent || null,
-				changes: {
-					externalId: { from: subject.externalId, to: externalId },
-					identityProvider: {
-						from: subject.identityProvider,
-						to: identityProvider,
-					},
-				},
-				metadata: {
-					externalId,
-					identityProvider,
-				},
-			});
+				externalId,
+				identityProvider,
+				domain,
+				subjectCapability,
+				identityAssertion,
+				request,
+			},
 		});
 
 		logger.info('Subject linked to external ID', {
 			subjectId,
 			externalId,
 			identityProvider,
+			status: result.status,
 		});
 
 		getMetrics()?.recordSubjectLinked(identityProvider);

--- a/packages/backend/src/handlers/subject/patch.handler.write-integrity.integration.test.ts
+++ b/packages/backend/src/handlers/subject/patch.handler.write-integrity.integration.test.ts
@@ -1,0 +1,261 @@
+import { Kysely } from 'kysely';
+import { KyselyPGlite } from 'kysely-pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type C15TInstance, c15tInstance } from '~/core';
+import { kyselyAdapter } from '~/db/adapters/kysely';
+import { DB } from '~/db/schema';
+import { createIdentityAssertion } from '~/write-integrity/identity-assertion';
+import { createSubjectCapability } from '~/write-integrity/subject-capability';
+
+const DOMAIN = 'example.com';
+const CAPABILITY_SECRET = 'integration-capability-secret-for-identity-writes';
+const ASSERTION_SECRET = 'integration-assertion-secret-for-identity-writes';
+
+describe('PATCH /subjects/:id write integrity (Postgres integration)', () => {
+	let database: Kysely<Record<string, never>>;
+	let instance: C15TInstance;
+	let legacyInstance: C15TInstance;
+	let orm: ReturnType<ReturnType<(typeof DB)['client']>['orm']>;
+
+	beforeAll(async () => {
+		const pglite = await KyselyPGlite.create();
+		database = new Kysely({ dialect: pglite.dialect });
+		const adapter = kyselyAdapter({
+			db: database,
+			provider: 'postgresql',
+		});
+		const client = DB.client(adapter);
+		const migration = await client
+			.createMigrator()
+			.migrateToLatest({ mode: 'from-database' });
+		await migration.execute();
+		orm = client.orm('2.1.0');
+
+		instance = c15tInstance({
+			adapter,
+			disableGeoLocation: true,
+			trustedOrigins: ['app.example.com'],
+			writeIntegrity: {
+				anonymousConsent: { mode: 'public' },
+				identityLinking: {
+					mode: 'capability-and-assertion',
+					reassignment: 'disabled',
+				},
+				domains: { allowlist: [DOMAIN] },
+				subjectCapability: { signingKey: CAPABILITY_SECRET },
+				identityAssertion: { verificationKey: ASSERTION_SECRET },
+			},
+		});
+		legacyInstance = c15tInstance({
+			adapter,
+			disableGeoLocation: true,
+			trustedOrigins: ['app.example.com'],
+		});
+	}, 30_000);
+
+	afterAll(async () => {
+		await database.destroy();
+	});
+
+	const createSubject = (subjectId: string) =>
+		orm.create('subject', {
+			id: subjectId,
+			externalId: null,
+			identityProvider: 'anonymous',
+		});
+
+	const createProofs = async (params: {
+		subjectId: string;
+		externalId: string;
+		identityProvider?: string;
+	}) => {
+		const identityProvider = params.identityProvider ?? 'clerk';
+		const capability = await createSubjectCapability({
+			options: { signingKey: CAPABILITY_SECRET },
+			subjectId: params.subjectId,
+			action: 'identity:link',
+			domain: DOMAIN,
+		});
+		const assertion = await createIdentityAssertion({
+			options: { signingKey: ASSERTION_SECRET },
+			subjectId: params.subjectId,
+			action: 'identity:link',
+			domain: DOMAIN,
+			externalId: params.externalId,
+			identityProvider,
+		});
+
+		return {
+			domain: DOMAIN,
+			externalId: params.externalId,
+			identityProvider,
+			subjectCapability: capability.token,
+			identityAssertion: assertion.token,
+		};
+	};
+
+	const patch = (subjectId: string, body: Record<string, unknown>) =>
+		instance.handler(
+			new Request(`https://backend.example/subjects/${subjectId}`, {
+				method: 'PATCH',
+				headers: {
+					'content-type': 'application/json',
+					origin: 'https://app.example.com',
+				},
+				body: JSON.stringify(body),
+			})
+		);
+
+	it('preserves legacy public replacement when configuration is omitted', async () => {
+		const subjectId = 'sub_2jv6z8n4qE';
+		await orm.create('subject', {
+			id: subjectId,
+			externalId: 'user_before',
+			identityProvider: 'legacy',
+		});
+		const response = await legacyInstance.handler(
+			new Request(`https://backend.example/subjects/${subjectId}`, {
+				method: 'PATCH',
+				headers: {
+					'content-type': 'application/json',
+					origin: 'https://app.example.com',
+				},
+				body: JSON.stringify({
+					externalId: 'user_after',
+					identityProvider: 'legacy',
+				}),
+			})
+		);
+
+		expect(response.status, await response.clone().text()).toBe(200);
+		const subject = await orm.findFirst('subject', {
+			where: (builder) => builder('id', '=', subjectId),
+		});
+		expect(subject?.externalId).toBe('user_after');
+	});
+
+	it('requires both proofs, records provenance, and allows exact retries', async () => {
+		const subjectId = 'sub_2jv6z8n4qA';
+		await createSubject(subjectId);
+		const body = await createProofs({
+			subjectId,
+			externalId: 'user_123',
+		});
+
+		const missingProofs = await patch(subjectId, {
+			domain: DOMAIN,
+			externalId: 'user_123',
+			identityProvider: 'clerk',
+		});
+		expect(missingProofs.status).toBe(401);
+
+		const first = await patch(subjectId, body);
+		expect(first.status, await first.clone().text()).toBe(200);
+		const retry = await patch(subjectId, body);
+		expect(retry.status, await retry.clone().text()).toBe(200);
+
+		const subject = await orm.findFirst('subject', {
+			where: (builder) => builder('id', '=', subjectId),
+		});
+		const audit = await orm.findFirst('auditLog', {
+			where: (builder) => builder('subjectId', '=', subjectId),
+		});
+		expect(subject).toMatchObject({
+			externalId: 'user_123',
+			identityProvider: 'clerk',
+		});
+		expect(audit?.metadata).toMatchObject({
+			writeProvenance: {
+				source: 'identity_assertion',
+				domain: DOMAIN,
+				credentials: [
+					{ type: 'subject_capability' },
+					{ type: 'identity_assertion' },
+				],
+			},
+		});
+		expect(
+			await orm.count('auditLog', {
+				where: (builder) => builder('subjectId', '=', subjectId),
+			})
+		).toBe(1);
+		expect(await orm.count('writeReplay')).toBe(2);
+	});
+
+	it('rejects reassignment when it is disabled', async () => {
+		const subjectId = 'sub_2jv6z8n4qB';
+		await createSubject(subjectId);
+		const body = await createProofs({
+			subjectId,
+			externalId: 'user_original',
+		});
+		expect((await patch(subjectId, body)).status).toBe(200);
+
+		const response = await patch(subjectId, {
+			domain: DOMAIN,
+			externalId: 'user_replacement',
+			identityProvider: 'clerk',
+		});
+		expect(response.status).toBe(409);
+		await expect(response.json()).resolves.toMatchObject({
+			code: 'IDENTITY_REASSIGNMENT_DISABLED',
+		});
+	});
+
+	it('applies the same proof rules to identity supplied during consent creation', async () => {
+		const subjectId = 'sub_2jv6z8n4qD';
+		const proofs = await createProofs({
+			subjectId,
+			externalId: 'user_from_consent',
+		});
+		const response = await instance.handler(
+			new Request('https://backend.example/subjects', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					origin: 'https://app.example.com',
+				},
+				body: JSON.stringify({
+					type: 'other',
+					subjectId,
+					domain: DOMAIN,
+					givenAt: 1_775_000_000_100,
+					externalSubjectId: proofs.externalId,
+					identityProvider: proofs.identityProvider,
+					identitySubjectCapability: proofs.subjectCapability,
+					identityAssertion: proofs.identityAssertion,
+				}),
+			})
+		);
+
+		expect(response.status, await response.clone().text()).toBe(200);
+		const subject = await orm.findFirst('subject', {
+			where: (builder) => builder('id', '=', subjectId),
+		});
+		expect(subject).toMatchObject({
+			externalId: 'user_from_consent',
+			identityProvider: 'clerk',
+		});
+	});
+
+	it('allows only one concurrent initial assignment', async () => {
+		const subjectId = 'sub_2jv6z8n4qC';
+		await createSubject(subjectId);
+		const [firstBody, secondBody] = await Promise.all([
+			createProofs({ subjectId, externalId: 'user_a' }),
+			createProofs({ subjectId, externalId: 'user_b' }),
+		]);
+
+		const responses = await Promise.all([
+			patch(subjectId, firstBody),
+			patch(subjectId, secondBody),
+		]);
+		expect(responses.map((response) => response.status).sort()).toEqual([
+			200, 409,
+		]);
+		const subject = await orm.findFirst('subject', {
+			where: (builder) => builder('id', '=', subjectId),
+		});
+		expect(['user_a', 'user_b']).toContain(subject?.externalId);
+	});
+});

--- a/packages/backend/src/handlers/subject/post.handler.ts
+++ b/packages/backend/src/handlers/subject/post.handler.ts
@@ -27,6 +27,7 @@ import { getMetrics } from '~/utils/metrics';
 import { enforceWriteAbuseControl } from '~/write-integrity/abuse-control';
 import { resolveWriteIntegrityOptions } from '~/write-integrity/configuration';
 import { resolveWriteDomain } from '~/write-integrity/domain';
+import { linkSubjectIdentity } from '~/write-integrity/identity-linking';
 import {
 	buildWriteRequestFingerprint,
 	consumeWriteReplay,
@@ -429,7 +430,12 @@ export const postSubjectHandler = async (c: Context) => {
 				throw buildCapabilityHttpException(capability.reason);
 			}
 
-			const { subjectCapability: _proof, ...requestInput } = input;
+			const {
+				subjectCapability: _proof,
+				identitySubjectCapability: _identityCapability,
+				identityAssertion: _identityAssertion,
+				...requestInput
+			} = input;
 			const requestFingerprint = await buildWriteRequestFingerprint({
 				action: 'consent:create',
 				tenantId: ctx.tenantId ?? null,
@@ -573,8 +579,14 @@ export const postSubjectHandler = async (c: Context) => {
 		// Find or create subject with the client-provided ID
 		const subject = await registry.findOrCreateSubject({
 			subjectId,
-			externalSubjectId,
-			identityProvider,
+			externalSubjectId:
+				writeIntegrity.identityLinking.mode === 'legacy'
+					? externalSubjectId
+					: undefined,
+			identityProvider:
+				writeIntegrity.identityLinking.mode === 'legacy'
+					? identityProvider
+					: undefined,
 			ipAddress: ctx.ipAddress,
 		});
 
@@ -586,6 +598,22 @@ export const postSubjectHandler = async (c: Context) => {
 		}
 
 		logger.debug('Subject found/created', { subjectId: subject.id });
+
+		if (externalSubjectId && writeIntegrity.identityLinking.mode !== 'legacy') {
+			await linkSubjectIdentity({
+				ctx,
+				writeIntegrity,
+				input: {
+					subjectId,
+					externalId: externalSubjectId,
+					identityProvider: identityProvider ?? 'external',
+					domain: resolvedDomain.domain,
+					subjectCapability: input.identitySubjectCapability,
+					identityAssertion: input.identityAssertion,
+					request,
+				},
+			});
+		}
 
 		const domainRecord =
 			resolvedDomain.mode === 'configured'

--- a/packages/backend/src/write-integrity/identity-linking.ts
+++ b/packages/backend/src/write-integrity/identity-linking.ts
@@ -1,0 +1,410 @@
+import { HTTPException } from 'hono/http-exception';
+import { generateUniqueId } from '~/db/registry/utils';
+import type { C15TContext, WriteProvenance } from '~/types';
+import { enforceWriteAbuseControl } from './abuse-control';
+import type { ResolvedWriteIntegrityOptions } from './configuration';
+import { resolveWriteDomain } from './domain';
+import {
+	type IdentityAssertionAction,
+	verifyIdentityAssertion,
+} from './identity-assertion';
+import { buildWriteRequestFingerprint, consumeWriteReplay } from './replay';
+import { verifySubjectCapability } from './subject-capability';
+import type { WriteIntegrityVerificationFailureReason } from './token';
+
+interface IdentityCredentialProvenance {
+	type: 'subject_capability' | 'identity_assertion';
+	credentialId: string;
+	issuer: string;
+}
+
+/** Input for an external-identity link or reassignment. */
+export interface LinkSubjectIdentityInput {
+	subjectId: string;
+	externalId: string;
+	identityProvider: string;
+	domain?: string;
+	subjectCapability?: string;
+	identityAssertion?: string;
+	request: Request;
+}
+
+/** Result of applying an identity link. */
+export interface LinkSubjectIdentityResult {
+	status: 'linked' | 'reassigned' | 'idempotent';
+	provenance: WriteProvenance;
+}
+
+function buildCredentialHttpException(
+	type: 'Subject capability' | 'Identity assertion',
+	codePrefix: 'SUBJECT_CAPABILITY' | 'IDENTITY_ASSERTION',
+	reason: WriteIntegrityVerificationFailureReason
+): HTTPException {
+	if (reason === 'missing') {
+		return new HTTPException(401, {
+			message: `${type} is required`,
+			cause: { code: `${codePrefix}_REQUIRED` },
+		});
+	}
+
+	if (reason === 'expired') {
+		return new HTTPException(401, {
+			message: `${type} has expired`,
+			cause: { code: `${codePrefix}_EXPIRED` },
+		});
+	}
+
+	return new HTTPException(403, {
+		message: `${type} is invalid`,
+		cause: { code: `${codePrefix}_INVALID` },
+	});
+}
+
+function buildIdentityConflictException(): HTTPException {
+	return new HTTPException(409, {
+		message: 'Subject is already linked to a different external identity',
+		cause: { code: 'IDENTITY_ALREADY_LINKED' },
+	});
+}
+
+function resolveOperation(params: {
+	currentExternalId: string | null;
+	currentIdentityProvider: string | null;
+	externalId: string;
+	identityProvider: string;
+}): { action: IdentityAssertionAction; exactMatch: boolean } {
+	const exactMatch =
+		params.currentExternalId === params.externalId &&
+		params.currentIdentityProvider === params.identityProvider;
+
+	return {
+		action:
+			params.currentExternalId === null || exactMatch
+				? 'identity:link'
+				: 'identity:reassign',
+		exactMatch,
+	};
+}
+
+function resolveProofMode(
+	writeIntegrity: ResolvedWriteIntegrityOptions,
+	action: IdentityAssertionAction
+):
+	| 'legacy'
+	| 'capability'
+	| 'assertion'
+	| 'capability-and-assertion'
+	| 'disabled' {
+	if (action === 'identity:link') {
+		return writeIntegrity.identityLinking.mode;
+	}
+
+	return writeIntegrity.identityLinking.reassignment;
+}
+
+async function consumeCredential(params: {
+	ctx: C15TContext;
+	writeIntegrity: ResolvedWriteIntegrityOptions;
+	tokenId: string;
+	audience: string;
+	expiresAt: Date;
+	requestFingerprint: string;
+	errorCode: 'SUBJECT_CAPABILITY_REPLAYED' | 'IDENTITY_ASSERTION_REPLAYED';
+	errorMessage: string;
+}): Promise<void> {
+	const replay = await consumeWriteReplay({
+		claim: {
+			tokenId: params.tokenId,
+			tenantId: params.ctx.tenantId,
+			audience: params.audience,
+			requestFingerprint: params.requestFingerprint,
+			expiresAt: params.expiresAt,
+		},
+		database: params.ctx.db,
+		replayStore: params.writeIntegrity.replayStore,
+	});
+
+	if (replay.status === 'replayed') {
+		throw new HTTPException(409, {
+			message: params.errorMessage,
+			cause: { code: params.errorCode },
+		});
+	}
+}
+
+/**
+ * Links a subject to an external identity under the resolved write-integrity
+ * policy. Secure modes use compare-and-set semantics; legacy mode preserves
+ * the v2 public replacement behavior.
+ */
+export async function linkSubjectIdentity(params: {
+	ctx: C15TContext;
+	writeIntegrity: ResolvedWriteIntegrityOptions;
+	input: LinkSubjectIdentityInput;
+}): Promise<LinkSubjectIdentityResult> {
+	const { ctx, writeIntegrity, input } = params;
+	const subject = await ctx.db.findFirst('subject', {
+		where: (builder) => builder('id', '=', input.subjectId),
+	});
+
+	if (!subject) {
+		throw new HTTPException(404, {
+			message: 'Subject not found',
+			cause: { code: 'SUBJECT_NOT_FOUND', subjectId: input.subjectId },
+		});
+	}
+
+	const operation = resolveOperation({
+		currentExternalId: subject.externalId,
+		currentIdentityProvider: subject.identityProvider,
+		externalId: input.externalId,
+		identityProvider: input.identityProvider,
+	});
+	const proofMode = resolveProofMode(writeIntegrity, operation.action);
+	if (proofMode === 'disabled') {
+		if (operation.exactMatch) {
+			return {
+				status: 'idempotent',
+				provenance: { source: 'anonymous', origin: ctx.origin },
+			};
+		}
+
+		throw new HTTPException(operation.action === 'identity:link' ? 403 : 409, {
+			message:
+				operation.action === 'identity:link'
+					? 'Identity linking is disabled'
+					: 'Identity reassignment is disabled',
+			cause: {
+				code:
+					operation.action === 'identity:link'
+						? 'IDENTITY_LINKING_DISABLED'
+						: 'IDENTITY_REASSIGNMENT_DISABLED',
+			},
+		});
+	}
+
+	const writeOrigin =
+		ctx.origin ?? input.request.headers.get('origin') ?? undefined;
+	const resolvedDomain =
+		proofMode === 'legacy'
+			? undefined
+			: await resolveWriteDomain({
+					options: writeIntegrity.domains,
+					context: {
+						action: operation.action,
+						requestedDomain: input.domain,
+						origin: writeOrigin,
+						subjectId: input.subjectId,
+						tenantId: ctx.tenantId,
+						request: input.request,
+					},
+				});
+
+	await enforceWriteAbuseControl(writeIntegrity.abuseControl, {
+		action: operation.action,
+		subjectId: input.subjectId,
+		domain: resolvedDomain?.domain,
+		origin: writeOrigin,
+		ipAddress: ctx.ipAddress,
+		tenantId: ctx.tenantId,
+		request: input.request,
+	});
+
+	const requestFingerprint = await buildWriteRequestFingerprint({
+		action: operation.action,
+		tenantId: ctx.tenantId ?? null,
+		subjectId: input.subjectId,
+		domain: resolvedDomain?.domain ?? null,
+		externalId: input.externalId,
+		identityProvider: input.identityProvider,
+	});
+	const credentialProvenance: IdentityCredentialProvenance[] = [];
+
+	if (proofMode === 'capability' || proofMode === 'capability-and-assertion') {
+		const capabilityOptions = writeIntegrity.subjectCapability;
+		if (!capabilityOptions) {
+			throw new HTTPException(500, {
+				message: 'Subject capability verification is not configured',
+				cause: { code: 'SUBJECT_CAPABILITY_NOT_CONFIGURED' },
+			});
+		}
+
+		const capability = await verifySubjectCapability({
+			token: input.subjectCapability,
+			options: capabilityOptions,
+			tenantId: ctx.tenantId,
+			subjectId: input.subjectId,
+			action: operation.action,
+			domain: resolvedDomain?.domain,
+		});
+		if (!capability.valid) {
+			throw buildCredentialHttpException(
+				'Subject capability',
+				'SUBJECT_CAPABILITY',
+				capability.reason
+			);
+		}
+
+		await consumeCredential({
+			ctx,
+			writeIntegrity,
+			tokenId: capability.payload.jti,
+			audience: capability.payload.aud,
+			expiresAt: new Date(capability.payload.exp * 1000),
+			requestFingerprint,
+			errorCode: 'SUBJECT_CAPABILITY_REPLAYED',
+			errorMessage: 'Subject capability has already been used',
+		});
+		credentialProvenance.push({
+			type: 'subject_capability',
+			credentialId: capability.payload.jti,
+			issuer: capability.payload.iss,
+		});
+	}
+
+	if (proofMode === 'assertion' || proofMode === 'capability-and-assertion') {
+		const assertionOptions = writeIntegrity.identityAssertion;
+		if (!assertionOptions) {
+			throw new HTTPException(500, {
+				message: 'Identity assertion verification is not configured',
+				cause: { code: 'IDENTITY_ASSERTION_NOT_CONFIGURED' },
+			});
+		}
+
+		const assertion = await verifyIdentityAssertion({
+			token: input.identityAssertion,
+			options: assertionOptions,
+			tenantId: ctx.tenantId,
+			subjectId: input.subjectId,
+			action: operation.action,
+			domain: resolvedDomain?.domain,
+			externalId: input.externalId,
+			identityProvider: input.identityProvider,
+		});
+		if (!assertion.valid) {
+			throw buildCredentialHttpException(
+				'Identity assertion',
+				'IDENTITY_ASSERTION',
+				assertion.reason
+			);
+		}
+
+		await consumeCredential({
+			ctx,
+			writeIntegrity,
+			tokenId: assertion.payload.jti,
+			audience: assertion.payload.aud,
+			expiresAt: new Date(assertion.payload.exp * 1000),
+			requestFingerprint,
+			errorCode: 'IDENTITY_ASSERTION_REPLAYED',
+			errorMessage: 'Identity assertion has already been used',
+		});
+		credentialProvenance.push({
+			type: 'identity_assertion',
+			credentialId: assertion.payload.jti,
+			issuer: assertion.payload.iss,
+		});
+	}
+
+	const primaryCredential = credentialProvenance.at(-1);
+	const provenance: WriteProvenance = {
+		source: primaryCredential?.type ?? 'legacy',
+		credentialId: primaryCredential?.credentialId,
+		issuer: primaryCredential?.issuer,
+		origin: writeOrigin,
+	};
+
+	if (operation.exactMatch && proofMode !== 'legacy') {
+		return { status: 'idempotent', provenance };
+	}
+
+	return ctx.db.transaction(async (tx) => {
+		const current = await tx.findFirst('subject', {
+			where: (builder) => builder('id', '=', input.subjectId),
+		});
+		if (!current) {
+			throw new HTTPException(404, {
+				message: 'Subject not found',
+				cause: { code: 'SUBJECT_NOT_FOUND', subjectId: input.subjectId },
+			});
+		}
+
+		const currentOperation = resolveOperation({
+			currentExternalId: current.externalId,
+			currentIdentityProvider: current.identityProvider,
+			externalId: input.externalId,
+			identityProvider: input.identityProvider,
+		});
+		if (currentOperation.exactMatch && proofMode !== 'legacy') {
+			return { status: 'idempotent', provenance };
+		}
+		if (
+			proofMode !== 'legacy' &&
+			(current.externalId !== subject.externalId ||
+				current.identityProvider !== subject.identityProvider)
+		) {
+			throw buildIdentityConflictException();
+		}
+
+		await tx.updateMany('subject', {
+			where: (builder) =>
+				proofMode === 'legacy'
+					? builder('id', '=', input.subjectId)
+					: builder.and(
+							builder('id', '=', input.subjectId),
+							subject.externalId === null
+								? builder.isNull('externalId')
+								: builder('externalId', '=', subject.externalId),
+							builder('identityProvider', '=', subject.identityProvider)
+						),
+			set: {
+				externalId: input.externalId,
+				identityProvider: input.identityProvider,
+				updatedAt: new Date(),
+			},
+		});
+
+		const updated = await tx.findFirst('subject', {
+			where: (builder) => builder('id', '=', input.subjectId),
+		});
+		if (
+			!updated ||
+			updated.externalId !== input.externalId ||
+			updated.identityProvider !== input.identityProvider
+		) {
+			throw buildIdentityConflictException();
+		}
+
+		await tx.create('auditLog', {
+			id: await generateUniqueId(tx, 'auditLog', ctx),
+			subjectId: input.subjectId,
+			entityType: 'subject',
+			entityId: input.subjectId,
+			actionType: 'identify_user',
+			ipAddress: ctx.ipAddress || null,
+			userAgent: ctx.userAgent || null,
+			changes: {
+				externalId: { from: current.externalId, to: input.externalId },
+				identityProvider: {
+					from: current.identityProvider,
+					to: input.identityProvider,
+				},
+			},
+			metadata: {
+				externalId: input.externalId,
+				identityProvider: input.identityProvider,
+				writeProvenance: {
+					...provenance,
+					domain: resolvedDomain?.domain,
+					credentials: credentialProvenance,
+				},
+			},
+		});
+
+		return {
+			status:
+				operation.action === 'identity:reassign' ? 'reassigned' : 'linked',
+			provenance,
+		};
+	});
+}

--- a/packages/core/src/client/client-interface.ts
+++ b/packages/core/src/client/client-interface.ts
@@ -52,6 +52,15 @@ type IdentifyUserRequestBodyBase = {
 
 	/** Identity provider name (optional) */
 	identityProvider?: string;
+
+	/** Domain the identity link is authorized for */
+	domain?: string;
+
+	/** Short-lived capability authorizing this identity operation */
+	subjectCapability?: string;
+
+	/** App-server assertion binding the requested external identity */
+	identityAssertion?: string;
 };
 
 type IdentifyUserRequestBodyWithSubjectId = IdentifyUserRequestBodyBase & {

--- a/packages/core/src/client/hosted/__tests__/identify-user.test.ts
+++ b/packages/core/src/client/hosted/__tests__/identify-user.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchMock, mockLocalStorage } from '../../../../vitest.setup';
 import { setDebugEnabled } from '../../../libs/debug';
 import { STORAGE_KEY_V2 } from '../../../store/initial-state';
@@ -39,7 +39,7 @@ describe('Hosted Client identifyUser Tests', () => {
 		const response = await client.identifyUser({
 			body: {
 				subjectId: 'sub_test123abc',
-				externalId: 'user_123',
+				externalId: 'secure_rejected_user',
 				identityProvider: 'clerk',
 			},
 		});
@@ -230,6 +230,69 @@ describe('Hosted Client identifyUser Tests', () => {
 
 		// Assertions - 404 should use fallback (optimistic)
 		expect(response.ok).toBe(true);
+	});
+
+	it('does not turn secure identity rejection into offline success', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					message: 'Subject capability is required',
+					code: 'SUBJECT_CAPABILITY_REQUIRED',
+				}),
+				{
+					status: 401,
+					headers: { 'Content-Type': 'application/json' },
+				}
+			)
+		);
+		const client = configureConsentManager({
+			mode: 'hosted',
+			backendURL: '/api/c15t',
+		});
+
+		const response = await client.identifyUser({
+			body: {
+				subjectId: 'sub_test123abc',
+				externalId: 'user_123',
+			},
+		});
+
+		expect(response.ok).toBe(false);
+		expect(response.error?.code).toBe('SUBJECT_CAPABILITY_REQUIRED');
+		expect(
+			mockLocalStorage.getItem('c15t-pending-identify-submissions')
+		).toBeNull();
+		expect(mockLocalStorage.getItem(STORAGE_KEY_V2)).not.toContain(
+			'secure_rejected_user'
+		);
+	});
+
+	it('does not queue short-lived identity proofs after a network failure', async () => {
+		fetchMock.mockRejectedValueOnce(new Error('Network error'));
+		const client = configureConsentManager({
+			mode: 'hosted',
+			backendURL: '/api/c15t',
+			retryConfig: { maxRetries: 0, retryOnNetworkError: false },
+		});
+
+		const response = await client.identifyUser({
+			body: {
+				subjectId: 'sub_test123abc',
+				externalId: 'secure_network_user',
+				domain: 'example.com',
+				subjectCapability: 'short-lived-proof',
+				identityAssertion: 'short-lived-assertion',
+			},
+		});
+
+		expect(response.ok).toBe(false);
+		expect(response.error?.code).toBe('NETWORK_ERROR');
+		expect(
+			mockLocalStorage.getItem('c15t-pending-identify-submissions')
+		).toBeNull();
+		expect(mockLocalStorage.getItem(STORAGE_KEY_V2)).not.toContain(
+			'secure_network_user'
+		);
 	});
 
 	it('should still support the legacy id alias for subjectId', async () => {

--- a/packages/core/src/client/hosted/__tests__/offline-fallback.test.ts
+++ b/packages/core/src/client/hosted/__tests__/offline-fallback.test.ts
@@ -129,6 +129,45 @@ describe('Hosted Client Offline Fallback Tests', () => {
 		);
 	});
 
+	it('does not queue proof-bound consent after a secure rejection', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					message: 'Subject capability is invalid',
+					code: 'SUBJECT_CAPABILITY_INVALID',
+				}),
+				{
+					status: 403,
+					headers: { 'Content-Type': 'application/json' },
+				}
+			)
+		);
+		const client = configureConsentManager({
+			mode: 'hosted',
+			backendURL: '/api/c15t',
+		});
+
+		const response = await client.setConsent({
+			body: {
+				subjectId: 'sub_test123abc',
+				type: 'other',
+				domain: 'example.com',
+				givenAt: Date.now(),
+				subjectCapability: 'short-lived-proof',
+				preferences: { secureRejectedCategory: true },
+			},
+		});
+
+		expect(response.ok).toBe(false);
+		expect(response.error?.code).toBe('SUBJECT_CAPABILITY_INVALID');
+		expect(
+			mockLocalStorage.getItem('c15t-pending-consent-submissions')
+		).toBeNull();
+		expect(mockLocalStorage.getItem(STORAGE_KEY_V2)).not.toContain(
+			'secureRejectedCategory'
+		);
+	});
+
 	it('should store multiple pending submissions of different types', async () => {
 		// Mock multiple failed API responses
 		fetchMock.mockRejectedValue(new Error('Network error'));

--- a/packages/core/src/client/hosted/identify-user.ts
+++ b/packages/core/src/client/hosted/identify-user.ts
@@ -1,5 +1,9 @@
 import type { StorageConfig } from '../../libs/cookie';
-import { getConsentFromStorage, saveConsentToStorage } from '../../libs/cookie';
+import {
+	deleteConsentFromStorage,
+	getConsentFromStorage,
+	saveConsentToStorage,
+} from '../../libs/cookie';
 import { getDebugLogger } from '../../libs/debug';
 import type { ConsentState } from '../../types/compliance';
 import type { ConsentInfo } from '../../types/consent-types';
@@ -103,6 +107,9 @@ export async function identifyUser(
 ): Promise<ResponseContext<IdentifyUserResponse>> {
 	const { body, ...restOptions } = options;
 	const subjectId = getIdentifySubjectId(body);
+	const hasWriteProof = Boolean(
+		body?.subjectCapability || body?.identityAssertion
+	);
 
 	if (!body || !subjectId) {
 		return {
@@ -117,7 +124,9 @@ export async function identifyUser(
 		};
 	}
 
-	// 1. Save externalId to storage FIRST (optimistic update)
+	// 1. Preserve the legacy optimistic update for proofless requests. Proofs
+	// are short-lived and must never turn a rejected server write into local
+	// success.
 	// This ensures the externalId is persisted even if the API call fails
 	// Read existing data to preserve consents
 	const existingData = getConsentFromStorage<{
@@ -125,20 +134,38 @@ export async function identifyUser(
 		consentInfo?: ConsentInfo;
 	}>(storageConfig);
 
-	saveConsentToStorage(
-		{
-			consents: existingData?.consents || {},
-			consentInfo: {
-				...existingData?.consentInfo,
-				time: existingData?.consentInfo?.time || Date.now(),
-				subjectId,
-				externalId: body.externalId,
-				identityProvider: body.identityProvider,
+	const persistIdentity = () => {
+		saveConsentToStorage(
+			{
+				consents: existingData?.consents || {},
+				consentInfo: {
+					...existingData?.consentInfo,
+					time: existingData?.consentInfo?.time || Date.now(),
+					subjectId,
+					externalId: body.externalId,
+					identityProvider: body.identityProvider,
+				},
 			},
-		},
-		undefined,
-		storageConfig
-	);
+			undefined,
+			storageConfig
+		);
+	};
+	const restoreIdentity = () => {
+		deleteConsentFromStorage(undefined, storageConfig);
+		if (existingData?.consentInfo) {
+			saveConsentToStorage(
+				{
+					consents: existingData.consents || {},
+					consentInfo: existingData.consentInfo,
+				},
+				undefined,
+				storageConfig
+			);
+		}
+	};
+	if (!hasWriteProof) {
+		persistIdentity();
+	}
 
 	// 2. Build the path with the subject ID
 	const path = `${API_ENDPOINTS.PATCH_SUBJECT}/${subjectId}`;
@@ -147,7 +174,7 @@ export async function identifyUser(
 	const { subjectId: _subjectId, id: _legacySubjectId, ...patchBody } = body;
 
 	// 3. Make API call with fallback
-	return withFallback<IdentifyUserResponse, typeof patchBody>(
+	const response = await withFallback<IdentifyUserResponse, typeof patchBody>(
 		context,
 		path,
 		'PATCH',
@@ -162,6 +189,26 @@ export async function identifyUser(
 				...fallbackOptions,
 				body: fullBody as IdentifyUserRequestBody,
 			});
+		},
+		{
+			shouldFallback: (failedResponse) => {
+				const status = failedResponse.error?.status;
+				return (
+					!hasWriteProof && status !== 401 && status !== 403 && status !== 409
+				);
+			},
+			fallbackOnError: !hasWriteProof,
 		}
 	);
+
+	if (response.ok && hasWriteProof) {
+		persistIdentity();
+	} else if (
+		!response.ok &&
+		[401, 403, 409].includes(response.error?.status ?? 0)
+	) {
+		restoreIdentity();
+	}
+
+	return response;
 }

--- a/packages/core/src/client/hosted/set-consent.ts
+++ b/packages/core/src/client/hosted/set-consent.ts
@@ -1,4 +1,8 @@
-import { saveConsentToStorage } from '../../libs/cookie';
+import {
+	deleteConsentFromStorage,
+	getConsentFromStorage,
+	saveConsentToStorage,
+} from '../../libs/cookie';
 import { getDebugLogger } from '../../libs/debug';
 import type {
 	SetConsentRequestBody,
@@ -110,19 +114,45 @@ export async function setConsent(
 	storageConfig: import('../../libs/cookie').StorageConfig | undefined,
 	options?: FetchOptions<SetConsentResponse, SetConsentRequestBody>
 ): Promise<ResponseContext<SetConsentResponse>> {
-	saveConsentToStorage(
-		{
-			consents: options?.body?.preferences || {},
-			consentInfo: {
-				time: Date.now(),
-				subjectId: options?.body?.subjectId,
-				externalId: options?.body?.externalSubjectId,
-				identityProvider: options?.body?.identityProvider,
-			},
-		},
-		undefined,
-		storageConfig
+	const existingData = getConsentFromStorage<{
+		consents?: import('../../types/compliance').ConsentState;
+		consentInfo?: import('../../types/consent-types').ConsentInfo;
+	}>(storageConfig);
+	const hasWriteProof = Boolean(
+		options?.body?.subjectCapability ||
+			options?.body?.identitySubjectCapability ||
+			options?.body?.identityAssertion
 	);
+	const persistConsent = () =>
+		saveConsentToStorage(
+			{
+				consents: options?.body?.preferences || {},
+				consentInfo: {
+					time: Date.now(),
+					subjectId: options?.body?.subjectId,
+					externalId: options?.body?.externalSubjectId,
+					identityProvider: options?.body?.identityProvider,
+				},
+			},
+			undefined,
+			storageConfig
+		);
+	const restoreConsent = () => {
+		deleteConsentFromStorage(undefined, storageConfig);
+		if (existingData?.consentInfo) {
+			saveConsentToStorage(
+				{
+					consents: existingData.consents || {},
+					consentInfo: existingData.consentInfo,
+				},
+				undefined,
+				storageConfig
+			);
+		}
+	};
+	if (!hasWriteProof) {
+		persistConsent();
+	}
 
 	const response = await withFallback<
 		SetConsentResponse,
@@ -134,8 +164,25 @@ export async function setConsent(
 		options,
 		async (fallbackOptions) => {
 			return offlineFallbackForSetConsent(storageConfig, fallbackOptions);
+		},
+		{
+			shouldFallback: (failedResponse) => {
+				const status = failedResponse.error?.status;
+				return (
+					!hasWriteProof && status !== 401 && status !== 403 && status !== 409
+				);
+			},
+			fallbackOnError: !hasWriteProof,
 		}
 	);
+	if (response.ok && hasWriteProof) {
+		persistConsent();
+	} else if (
+		!response.ok &&
+		[401, 403, 409].includes(response.error?.status ?? 0)
+	) {
+		restoreConsent();
+	}
 
 	return response;
 }

--- a/packages/core/src/client/hosted/with-fallback.ts
+++ b/packages/core/src/client/hosted/with-fallback.ts
@@ -2,6 +2,13 @@ import type { FetchOptions, ResponseContext } from '../types';
 import type { FetcherContext } from './fetcher';
 import { fetcher } from './fetcher';
 
+interface FallbackPolicy<ResponseType> {
+	/** Whether a non-success response should be replaced by offline fallback. */
+	shouldFallback?: (response: ResponseContext<ResponseType>) => boolean;
+	/** Whether thrown request errors should use offline fallback. */
+	fallbackOnError?: boolean;
+}
+
 /**
  * Generic fallback/retry wrapper for API requests.
  * Attempts to call the API, and if it fails, calls the provided fallback function.
@@ -25,7 +32,8 @@ export async function withFallback<
 	options: FetchOptions<ResponseType, BodyType, QueryType> | undefined,
 	fallbackFn: (
 		options?: FetchOptions<ResponseType, BodyType, QueryType>
-	) => Promise<ResponseContext<ResponseType>>
+	) => Promise<ResponseContext<ResponseType>>,
+	policy: FallbackPolicy<ResponseType> = {}
 ): Promise<ResponseContext<ResponseType>> {
 	try {
 		// First try the actual API request
@@ -42,6 +50,9 @@ export async function withFallback<
 		if (response.ok) {
 			return response;
 		}
+		if (policy.shouldFallback && !policy.shouldFallback(response)) {
+			return response;
+		}
 
 		// If we got here, the request failed but didn't throw - fall back to offline mode
 		console.warn(
@@ -49,6 +60,9 @@ export async function withFallback<
 		);
 		return fallbackFn(options);
 	} catch (error) {
+		if (policy.fallbackOnError === false) {
+			throw error;
+		}
 		// If an error was thrown, fall back to offline mode
 		console.warn(
 			`Error calling ${endpoint}, falling back to offline mode:`,

--- a/packages/schema/src/api/subject/patch.ts
+++ b/packages/schema/src/api/subject/patch.ts
@@ -31,6 +31,34 @@ export const patchSubjectInputSchema = v.object({
 			v.examples(['auth0', 'clerk'])
 		)
 	),
+	/** Domain the identity link is authorized for */
+	domain: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Domain for identity-link authorization. May be omitted when the backend resolves it from trusted request context.'
+			),
+			v.examples(['example.com'])
+		)
+	),
+	/** Short-lived capability authorizing this identity operation */
+	subjectCapability: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Short-lived subject capability authorizing this identity operation.'
+			)
+		)
+	),
+	/** App-server assertion binding the requested external identity */
+	identityAssertion: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Application-server assertion binding this subject to the requested external identity.'
+			)
+		)
+	),
 });
 
 /**

--- a/packages/schema/src/api/subject/post.ts
+++ b/packages/schema/src/api/subject/post.ts
@@ -125,6 +125,24 @@ const baseSubjectConsentSchema = v.object({
 			)
 		)
 	),
+	/** Short-lived capability authorizing the optional identity link */
+	identitySubjectCapability: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Short-lived subject capability authorizing the optional identity link.'
+			)
+		)
+	),
+	/** App-server assertion binding the optional external identity */
+	identityAssertion: v.optional(
+		v.pipe(
+			v.string(),
+			v.description(
+				'Application-server assertion binding this subject to the optional external identity.'
+			)
+		)
+	),
 	/** Signed legal-document snapshot token from a rendered document view */
 	documentSnapshotToken: v.optional(
 		v.pipe(


### PR DESCRIPTION
## Summary

- make configured initial identity links set-once and exact retries idempotent
- require subject capabilities, app-server assertions, or both according to configuration
- disable reassignment by default for secure modes and support stronger dual-proof reassignment
- use compare-and-set updates, replay protection, abuse controls, and audit provenance
- prevent hosted clients from turning secure rejections into offline success or queueing short-lived proofs
- preserve public v2 overwrite behavior in legacy mode

Stack 3 of 4 for [ENG-300](https://linear.app/inth/issue/ENG-300/ship-c15t-v2-consent-write-integrity-hardening). Depends on #987.

## Verification

- backend full suite: 637 tests
- core full suite: 528 tests
- schema full suite: 105 tests
- Postgres concurrency, exact-retry, initial POST link, provenance, and legacy compatibility tests
- package type checks and changed-file Biome checks