### PR TITLE
docs: add consent write integrity migration guidance

### DIFF
--- a/docs/frameworks/javascript/api/location-info.mdx
+++ b/docs/frameworks/javascript/api/location-info.mdx
@@ -90,3 +90,8 @@ The `identityProvider` field indicates which auth system provided the ID (e.g., 
 <Callout type="warn">
   `identifyUser()` sends the user ID to the c15t backend. Only call this after the user has authenticated and consented to being identified.
 </Callout>
+
+Self-hosted backends keep this proofless call for v2 compatibility. For secure
+identity-linking modes, issue credentials on a trusted server and use the
+low-level hosted client request with `domain`, `subjectCapability`, and
+`identityAssertion`. See [Consent Write Integrity](/docs/self-host/api/configuration#consent-write-integrity).

--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -123,7 +123,14 @@ export function ClerkConsentSync() {
 }
 ```
 
-`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, stop supplying the former visitor ID. The example clears its client-readable cookie only after `identifyUser()` succeeds so a later render cannot change the subject back to the anonymous ID.
+With the v2 compatibility configuration, `identifyUser()` replaces the
+subject's current `externalId`; it does not retain the anonymous ID as an alias.
+Secure self-hosted identity linking is set-once by default and requires
+server-issued proof. See [Consent Write Integrity](/docs/self-host/api/configuration#consent-write-integrity)
+before enabling a secure mode. When using the compatibility mode, stop
+supplying the former visitor ID. The example clears its client-readable cookie
+only after `identifyUser()` succeeds so a later render cannot change the
+subject back to the anonymous ID.
 
 <Callout type="info">
   Backend subject identification requires hosted mode (`mode: 'hosted'`). In

--- a/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
@@ -104,7 +104,13 @@ function ClerkConsentSync() {
 }
 ```
 
-`identifyUser()` replaces the subject's current `externalId`; it does not retain the anonymous ID as an alias. Once a visitor is linked to Clerk, clear the previous visitor ID from the application state or storage used by `getVisitorId()` so it cannot replace the Clerk ID later.
+With the v2 compatibility configuration, `identifyUser()` replaces the
+subject's current `externalId`; it does not retain the anonymous ID as an alias.
+Secure self-hosted identity linking is set-once by default and requires
+server-issued proof. See [Consent Write Integrity](/docs/self-host/api/configuration#consent-write-integrity)
+before enabling a secure mode. When using the compatibility mode, clear the
+previous visitor ID from the application state or storage used by
+`getVisitorId()` so it cannot replace the Clerk ID later.
 
 <Callout type="info">
   Backend subject identification requires hosted mode (`mode: 'hosted'`). In

--- a/docs/self-host/api/configuration.mdx
+++ b/docs/self-host/api/configuration.mdx
@@ -20,6 +20,192 @@ All options are passed to `c15tInstance()`. Only `adapter` and `trustedOrigins` 
 
 <AutoTypeTable path="./packages/backend/src/types/index.ts" name="IABOptions" />
 
+<AutoTypeTable path="./packages/backend/src/types/index.ts" name="WriteIntegrityOptions" />
+
+## Consent Write Integrity
+
+`writeIntegrity` separates anonymous consent submission from external identity
+linking. All of its controls are optional in v2. When it is omitted, c15t keeps
+the existing public consent and identity-write behavior and logs deprecation
+warnings. Set the legacy modes explicitly if you need a temporary compatibility
+configuration:
+
+```ts title="c15t.config.ts"
+export default defineConfig({
+  adapter,
+  trustedOrigins: ['https://app.example.com'],
+  writeIntegrity: {
+    anonymousConsent: { mode: 'legacy' },
+    identityLinking: {
+      mode: 'legacy',
+      reassignment: 'legacy',
+    },
+  },
+});
+```
+
+Legacy identity writes remain public overwrites. This compatibility path is
+deprecated and is planned to be removed in v3.
+
+### Recommended Secure Baseline
+
+Start by making the consent domain authoritative on the server and disabling
+browser identity linking:
+
+```ts title="c15t.config.ts"
+export default defineConfig({
+  adapter,
+  trustedOrigins: ['https://app.example.com'],
+  writeIntegrity: {
+    anonymousConsent: { mode: 'public' },
+    identityLinking: { mode: 'disabled' },
+    domains: {
+      allowlist: ['example.com', 'app.example.com'],
+    },
+  },
+});
+```
+
+`public` still accepts anonymous consent, but only for a configured domain. A
+trusted resolver can derive the domain from gateway routing, authenticated
+tenant context, or another server-owned signal:
+
+```ts
+domains: {
+  allowlist: ['example.com'],
+  resolve: ({ request }) => {
+    const project = getProjectFromGatewayRequest(request);
+    return project?.consentDomain;
+  },
+},
+```
+
+When both `resolve` and `allowlist` are present, the resolved value must be in
+the allowlist. Domain values are normalized before comparison and storage.
+
+### Subject Capabilities and Identity Assertions
+
+Use `capability` when the gateway can authorize a write for one subject. Use
+`assertion` when the application server can attest the exact authenticated
+external identity. `capability-and-assertion` requires both:
+
+```ts title="c15t.config.ts"
+export default defineConfig({
+  adapter,
+  trustedOrigins: ['https://app.example.com'],
+  writeIntegrity: {
+    anonymousConsent: { mode: 'capability' },
+    identityLinking: {
+      mode: 'capability-and-assertion',
+      reassignment: 'disabled',
+    },
+    domains: { allowlist: ['example.com'] },
+    subjectCapability: {
+      signingKey: env.C15T_CAPABILITY_SECRET,
+      issuer: 'project-gateway',
+    },
+    identityAssertion: {
+      verificationKey: env.APP_IDENTITY_SECRET,
+      issuer: 'example-app',
+    },
+  },
+});
+```
+
+Initial secure links are set once. An exact retry is idempotent. A different
+external identity returns `409` unless `reassignment` is
+`capability-and-assertion`, in which case both credentials must authorize the
+`identity:reassign` action. Credentials are short-lived, bound to their exact
+tenant, subject, action, and domain claims, and consumed through replay
+storage.
+
+Issue credentials only from trusted server code. The helpers are public so a
+hosted Project Gateway can use the controls without changing backend internals:
+
+```ts title="gateway.ts"
+import {
+  createIdentityAssertion,
+  createSubjectCapability,
+} from '@c15t/backend/write-integrity';
+
+const capability = await createSubjectCapability({
+  options: {
+    signingKey: env.C15T_CAPABILITY_SECRET,
+    issuer: 'project-gateway',
+  },
+  tenantId: project.id,
+  subjectId,
+  action: 'identity:link',
+  domain: project.consentDomain,
+});
+
+const assertion = await createIdentityAssertion({
+  options: {
+    signingKey: env.APP_IDENTITY_SECRET,
+    issuer: 'example-app',
+  },
+  tenantId: project.id,
+  subjectId,
+  action: 'identity:link',
+  domain: project.consentDomain,
+  externalId: authenticatedUser.id,
+  identityProvider: 'custom',
+});
+```
+
+Send the capability as `subjectCapability` and the assertion as
+`identityAssertion` to `PATCH /subjects/:id`. For an identity included in
+`POST /subjects`, use `identitySubjectCapability` to keep it separate from the
+consent-write capability.
+
+Never place signing keys in browser code. Proof-bound hosted-client requests do
+not fall back to optimistic offline success or persist short-lived proofs for a
+later retry.
+
+### Abuse Controls
+
+Use `abuseControl` to connect a rate limiter, bot check, or gateway quota. The
+hook receives trusted request context and runs before a write mutation:
+
+```ts
+writeIntegrity: {
+  // Other write-integrity options...
+  abuseControl: async ({ tenantId, subjectId, action, ipAddress }) => {
+    const decision = await limiter.check({
+      key: `${tenantId}:${subjectId}:${action}:${ipAddress}`,
+    });
+
+    return decision.allowed
+      ? { allowed: true }
+      : {
+          allowed: false,
+          reason: 'rate_limit',
+          retryAfterSeconds: decision.retryAfterSeconds,
+        };
+  },
+},
+```
+
+A denial returns `429`; hook failure returns `503` and fails closed. In
+production, rate limit at the gateway as well, expire replay records after the
+credential expiry time, and avoid logging credential strings or raw external
+identifiers.
+
+### What Each Check Attests
+
+- Trusted-origin checks decide which browser origins may call the backend. They
+  do not prove the requested domain, subject ownership, or authenticated user.
+- Domain controls decide the canonical domain stored with the write. They do
+  not authenticate a user.
+- Policy snapshot signatures attest the policy decision rendered by c15t. The
+  optional write bindings can bind domain, subject, consent type, and action,
+  but the snapshot is not an identity assertion or a substitute for replay
+  protection.
+- Subject capabilities authorize one subject action. Identity assertions also
+  bind the exact external ID and provider.
+- Write provenance records why the backend accepted a write. Runtime policy
+  provenance separately records how c15t selected the consent experience.
+
 ## Return Value
 
 `c15tInstance()` returns:

--- a/docs/self-host/api/endpoints.mdx
+++ b/docs/self-host/api/endpoints.mdx
@@ -91,6 +91,9 @@ Records a consent event. This is an append-only operation — every call creates
 | `metadata` | object | No | Arbitrary metadata |
 | `externalSubjectId` | string | No | External user ID for cross-device linking |
 | `identityProvider` | string | No | Identity provider name |
+| `subjectCapability` | string | No | Short-lived capability for the consent write when `anonymousConsent.mode` is `capability` |
+| `identitySubjectCapability` | string | No | Separate subject capability for an initial external identity link |
+| `identityAssertion` | string | No | App-server assertion for an initial external identity link |
 
 **Response:**
 
@@ -138,9 +141,24 @@ Links a subject to an external user ID for cross-device consent resolution.
 ```json
 {
   "externalId": "user_12345",
-  "identityProvider": "auth0"
+  "identityProvider": "auth0",
+  "domain": "example.com",
+  "subjectCapability": "eyJ...",
+  "identityAssertion": "eyJ..."
 }
 ```
+
+`domain`, `subjectCapability`, and `identityAssertion` are required according to
+the configured identity-linking mode. A trusted domain resolver can supply the
+domain instead of the request. Secure initial links are set-once and exact
+retries are idempotent. Replacing a different identity is disabled by default
+for secure modes and returns `409`.
+
+<Callout type="warn">
+  With omitted or explicit `legacy` configuration, this endpoint preserves the
+  v2 public overwrite behavior. Migrate to a proof mode or disable identity
+  linking before v3. See the [configuration reference](/docs/self-host/api/configuration#consent-write-integrity).
+</Callout>
 
 **Response:**
 


### PR DESCRIPTION
## Summary

- document the explicit v2 compatibility path and recommended secure baseline
- document Gateway issuance through public write-integrity exports
- cover domain authority, identity proofs, reassignment, replay, provenance, and abuse controls
- clarify what origin checks and policy snapshots do and do not attest
- update endpoint and framework identity-linking guidance

Stack 4 of 4 for [ENG-300](https://linear.app/inth/issue/ENG-300/ship-c15t-v2-consent-write-integrity-hardening). Depends on #988.

## Verification

- documentation lint and formatting
- package-doc bundle generation
- full repository typecheck/build graph: 47 tasks
- affected test graph: 45 tasks