### PR TITLE
feat(backend): scope c15t to a Postgres schema

### DIFF
--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1075,3 +1075,68 @@ prefix-aware resolver threaded through the query layer — the same shape as
 `Tenant`, and roughly the same reach. The alternative is a documented break
 with a rename step in the upgrade guide, which is what the refusal message
 currently tells operators to do.
+
+### 11.21 Schema scoping, and why only Postgres gets an option
+
+Raised on #980: a self-hoster running c15t in the same process as their app
+wants it scoped rather than "cannibalising `public`". Two related asks came
+with it — bring-your-own-database with renameable columns, and not bundling a
+second copy of the user's ORM.
+
+**The ORM one is already answered by the rewrite**, and is worth stating
+plainly because it is the clearest external validation of it. The package's
+runtime dependencies are `@c15t/schema`, `effect`, `evlog`, `hono`,
+`hono-openapi`, `jose` and `valibot`. No Kysely, Drizzle, fumadb, Prisma,
+TypeORM or MongoDB — the drivers are optional peers. Two copies of the same
+ORM drifting out of sync is structurally impossible. The trade, already noted
+in §2, is that c15t opens its own pool rather than borrowing the caller's.
+
+**Schema scoping is implemented, and it turned out to be small.** The
+mechanism is `search_path` on the connection, not qualified table names:
+
+- a pool hands out many connections, so a one-off `SET search_path` would
+  scope exactly one of them — and would pass a PGlite test, which has a single
+  connection, while failing in production;
+- put on the connection string instead, it applies to every checkout.
+  Verified against a real pooled Postgres: `current_schema()` reports the
+  configured schema on all of them and an unqualified `create table` lands
+  there.
+
+The consequence is that **no query in the package had to change**. All 24
+unqualified table references resolve into the schema by themselves. Only the
+three introspection queries needed touching, and they now ask
+`current_schema()` rather than assuming `public` — which also means a caller
+who sets `search_path` their own way is handled without knowing about our
+option. `migrate` creates the schema when it is missing, as migration tools
+do, because a `search_path` pointing at a schema that does not exist fails
+with an error that never mentions schemas.
+
+**No equivalent option for MySQL or SQLite, deliberately.** Each already has
+an isolation primitive that the connection names:
+
+| Engine | Unit of isolation | How you scope c15t |
+| --- | --- | --- |
+| Postgres | schema, within one database | `schema: 'c15t'` |
+| MySQL | the database itself | point `url` at a different database |
+| SQLite | the file | point `filename` at a different file |
+
+Offering one `schema` option that meant three different things — a namespace,
+a database, an `ATTACH`-ed file — would be worse than not offering it, so it
+lives on the Postgres member of the config union and is a type error elsewhere.
+
+**Column renaming is not implemented and should not be.** fumadb supports it;
+`@c15t/backend` never exposed it, so nothing depends on it. Adding it means a
+name resolver at all 80 column references plus every `sql.insert` key —
+reintroducing exactly the indirection layer §2 argues produced the join-less
+query surface. The stated motivations behind the ask — adding indexes,
+timestamps and triggers — need no such thing: those are changes to the
+operator's own database, and adoption is add-only with a runtime guard against
+destructive DDL, so it will not fight them.
+
+**On the upstream fumadb MySQL fix.** 0.4.0 and 0.5.x have published since the
+0.3.0 that §3.5 tested. Unpacking 0.5.1 was inconclusive — the only
+`varchar(255)` is a type-prediction fallback for primary keys and the settings
+table, not the unique-index-on-`TEXT` case that actually failed. Re-running the
+fixture generator against it is the way to settle it. It would not change much
+either way: MySQL was one defect among the join-less surface, the total absence
+of indexes, and three of five adapters having no working migrator.

--- a/packages/backend/src/db/adopt.ts
+++ b/packages/backend/src/db/adopt.ts
@@ -114,7 +114,7 @@ const observeExisting = Effect.fn('adopt.observe')(function* () {
 		orElse: () =>
 			sql<{ table_name: string; column_name: string }>`
 				select table_name, column_name from information_schema.columns
-				where table_schema = 'public'
+				where table_schema = current_schema()
 			`,
 	});
 

--- a/packages/backend/src/db/classify.ts
+++ b/packages/backend/src/db/classify.ts
@@ -134,7 +134,7 @@ const observe = Effect.fn('classify.observe')(function* () {
 		orElse: () =>
 			sql<{
 				name: string;
-			}>`select table_name as name from information_schema.tables where table_schema = 'public' and table_type = 'BASE TABLE'`,
+			}>`select table_name as name from information_schema.tables where table_schema = current_schema() and table_type = 'BASE TABLE'`,
 	});
 
 	const all = rows.map((row) => row.name);

--- a/packages/backend/src/db/connect.ts
+++ b/packages/backend/src/db/connect.ts
@@ -37,6 +37,25 @@ export type DatabaseConfig =
 			readonly dialect: 'postgres';
 			/** e.g. `postgres://user:pass@host:5432/db` */
 			readonly url: string;
+			/**
+			 * A Postgres schema to keep c15t's tables in.
+			 *
+			 * For sharing a database with another application: c15t's tables
+			 * land in this schema rather than `public`, which gives real
+			 * isolation — separate grants, `pg_dump -n c15t`, and
+			 * `DROP SCHEMA c15t CASCADE` to uninstall — rather than just a
+			 * naming convention.
+			 *
+			 * Created if it does not exist when you migrate.
+			 *
+			 * **Postgres only, and deliberately.** MySQL has no schemas: a
+			 * database *is* the unit of isolation, so point `url` at a
+			 * different one. SQLite's unit is the file, so use a different
+			 * `filename`. Both already scope c15t without a new option, and
+			 * offering one that meant three different things would be worse
+			 * than not offering it.
+			 */
+			readonly schema?: string;
 	  }
 	| {
 			readonly dialect: 'mysql';
@@ -123,6 +142,43 @@ const load = <A>(
 		Effect.orDie
 	);
 
+/**
+ * Puts a schema on the connection's `search_path`.
+ *
+ * Done on the connection rather than by qualifying every table name, because
+ * a pool hands out many connections and a one-off `SET search_path` would
+ * scope exactly one of them. Verified against a real pool: `current_schema()`
+ * reports the configured schema on every checkout, and an unqualified
+ * `create table` lands there rather than in `public`.
+ *
+ * The upshot is that no query in this package has to know about schemas —
+ * every unqualified name resolves into it — and the introspection queries ask
+ * `current_schema()` rather than assuming `public`.
+ */
+export function withSearchPath(
+	url: string,
+	schema: string | undefined
+): string {
+	if (schema === undefined || schema.trim() === '') {
+		return url;
+	}
+
+	// Rejected rather than escaped: this ends up in a startup parameter, not a
+	// bound value, and a schema name is a short identifier in every legitimate
+	// use. Anything else is a mistake worth surfacing loudly.
+	if (!/^[A-Za-z_][A-Za-z0-9_$]*$/.test(schema)) {
+		throw new Error(
+			`Invalid Postgres schema name "${schema}". Expected an unquoted ` +
+				'identifier: a letter or underscore followed by letters, digits, ' +
+				'underscores or dollar signs.'
+		);
+	}
+
+	const parsed = new URL(url);
+	parsed.searchParams.set('options', `-c search_path=${schema}`);
+	return parsed.toString();
+}
+
 const fromConfig = (
 	config: DatabaseConfig
 	// The three drivers do not agree on an error channel — MySQL's adds
@@ -138,7 +194,10 @@ const fromConfig = (
 					load('postgres', () => import('@effect/sql-pg')),
 					// Redacted because the URL carries credentials, and Effect keeps
 					// them out of logs and error messages by construction.
-					({ PgClient }) => PgClient.layer({ url: Redacted.make(config.url) })
+					({ PgClient }) =>
+						PgClient.layer({
+							url: Redacted.make(withSearchPath(config.url, config.schema)),
+						})
 				)
 			);
 		case 'mysql':

--- a/packages/backend/src/db/migrate.ts
+++ b/packages/backend/src/db/migrate.ts
@@ -121,7 +121,7 @@ const ledgerExists = Effect.gen(function* () {
 		orElse: () =>
 			sql<{ name: string }>`
 				select table_name as name from information_schema.tables
-				where table_schema = 'public' and table_name = ${LEDGER_TABLE}
+				where table_schema = current_schema() and table_name = ${LEDGER_TABLE}
 			`,
 	});
 	return rows.length > 0;
@@ -155,6 +155,48 @@ const stamp = Effect.fn('migrate.stamp')(function* (migration: Migration) {
 });
 
 /**
+ * Creates the configured Postgres schema if it is missing.
+ *
+ * A `search_path` naming a schema that does not exist leaves
+ * `current_schema()` null, and every `create table` then fails with something
+ * that does not mention schemas at all. Creating it is what a migration tool
+ * is for — Flyway, Liquibase and Prisma all do the same — and it is a no-op
+ * once it exists.
+ *
+ * Postgres only: MySQL scopes by database and SQLite by file, neither of
+ * which a migrator should be creating behind the operator's back.
+ */
+const ensureSchema = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+
+	yield* sql.onDialectOrElse({
+		pg: () =>
+			Effect.gen(function* () {
+				const rows = yield* sql<{ schema: string | null }>`
+					select current_schema() as ${sql('schema')}
+				`;
+				if (rows[0]?.schema !== null && rows[0]?.schema !== undefined) {
+					return;
+				}
+
+				// `search_path` points somewhere that does not exist yet. Its head
+				// is the name to create.
+				const path = yield* sql<{ search_path: string }>`show search_path`;
+				const head = (path[0]?.search_path ?? '')
+					.split(',')[0]
+					?.trim()
+					.replace(/^"|"$/g, '');
+
+				if (!head || head === '$user') {
+					return;
+				}
+				yield* sql.unsafe(`create schema if not exists "${head}"`);
+			}),
+		orElse: () => Effect.void,
+	});
+});
+
+/**
  * Migrates a database to the current schema.
  *
  * Safe to re-run: a database already up to date does nothing and reports an
@@ -172,6 +214,8 @@ const stamp = Effect.fn('migrate.stamp')(function* (migration: Migration) {
 export const migrate = Effect.fn('db.migrate')(function* (
 	options: MigrateOptions = {}
 ) {
+	yield* ensureSchema;
+
 	const shape = yield* classify;
 	const adoption = yield* plan;
 

--- a/packages/backend/src/db/schema-scoping.test.ts
+++ b/packages/backend/src/db/schema-scoping.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Keeping c15t's tables in a Postgres schema.
+ *
+ * Opt-in, because this needs a real Postgres rather than PGlite: the whole
+ * point is that the scoping survives a **connection pool**, and PGlite has one
+ * connection. A one-off `SET search_path` would scope exactly one checkout and
+ * pass a PGlite test while failing in production.
+ *
+ * ```
+ * docker run --rm -d -p 5455:5432 -e POSTGRES_PASSWORD=c15t \
+ *   -e POSTGRES_DB=c15t --name c15t-pg postgres:16
+ * C15T_TEST_PG_URL=postgres://postgres:c15t@127.0.0.1:5455/c15t bun run test
+ * ```
+ *
+ * The unit-level half — that the URL is built correctly — runs everywhere.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { Effect, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { toLayer, withSearchPath } from './connect';
+import { migrate } from './migrate';
+
+const PG_URL = process.env.C15T_TEST_PG_URL;
+const suite = PG_URL ? describe : describe.skip;
+
+describe('withSearchPath', () => {
+	it('leaves the url alone when no schema is set', () => {
+		const url = 'postgres://u:p@host:5432/db';
+		assert.strictEqual(withSearchPath(url, undefined), url);
+		assert.strictEqual(withSearchPath(url, ''), url);
+	});
+
+	it('adds the search_path option', () => {
+		const out = new URL(withSearchPath('postgres://u:p@host:5432/db', 'c15t'));
+		assert.strictEqual(out.searchParams.get('options'), '-c search_path=c15t');
+	});
+
+	it('keeps other connection parameters', () => {
+		const out = new URL(
+			withSearchPath('postgres://u:p@host:5432/db?sslmode=require', 'c15t')
+		);
+		// Dropping sslmode while adding a schema would silently downgrade the
+		// connection's security.
+		assert.strictEqual(out.searchParams.get('sslmode'), 'require');
+		assert.strictEqual(out.searchParams.get('options'), '-c search_path=c15t');
+	});
+
+	it('rejects a name that is not a plain identifier', () => {
+		// This lands in a startup parameter rather than a bound value, so it is
+		// refused rather than escaped.
+		assert.throws(() => withSearchPath('postgres://h/db', 'c15t; drop schema'));
+		assert.throws(() => withSearchPath('postgres://h/db', '1bad'));
+		assert.throws(() => withSearchPath('postgres://h/db', 'has space'));
+	});
+});
+
+suite('schema scoping against real Postgres', () => {
+	const withSchema = async <A>(
+		schema: string,
+		use: (
+			runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>
+		) => Promise<A>
+	): Promise<A> => {
+		const runtime = ManagedRuntime.make(
+			toLayer({ dialect: 'postgres', url: PG_URL ?? '', schema })
+		);
+		try {
+			return await use(runtime);
+		} finally {
+			await runtime.dispose();
+		}
+	};
+
+	it('migrates into the schema and leaves public alone', async () => {
+		const schema = 'c15t_scope_a';
+
+		await withSchema(schema, async (runtime) => {
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql.unsafe(`drop schema if exists ${schema} cascade`);
+				})
+			);
+		});
+
+		await withSchema(schema, async (runtime) => {
+			// The schema does not exist yet — creating it is the migrator's job,
+			// or every `create table` fails with an error that never mentions
+			// schemas.
+			const report = await runtime.runPromise(migrate());
+			assert.isTrue(report.applied);
+
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+
+					const mine = yield* sql<{ n: string }>`
+							select count(*) as n from information_schema.tables
+							where table_schema = ${schema}
+						`;
+					const inPublic = yield* sql<{ n: string }>`
+							select count(*) as n from information_schema.tables
+							where table_schema = 'public' and table_name = 'subject'
+						`;
+
+					assert.isAbove(Number(mine[0]?.n), 5);
+					// The entire point: sharing a database must not mean
+					// cannibalising public.
+					assert.strictEqual(Number(inPublic[0]?.n), 0);
+				})
+			);
+		});
+	}, 120_000);
+
+	it('keeps two schemas independent on one database', async () => {
+		for (const schema of ['c15t_scope_b', 'c15t_scope_c']) {
+			await withSchema(schema, async (runtime) => {
+				await runtime.runPromise(
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient;
+						yield* sql.unsafe(`drop schema if exists ${schema} cascade`);
+					})
+				);
+			});
+			await withSchema(schema, (runtime) => runtime.runPromise(migrate()));
+		}
+
+		await withSchema('c15t_scope_b', async (runtime) => {
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql`
+							insert into ${sql('subject')} ${sql.insert({
+								id: 'sub_in_b',
+								createdAt: new Date(),
+								updatedAt: new Date(),
+							})}
+						`;
+				})
+			);
+		});
+
+		await withSchema('c15t_scope_c', async (runtime) => {
+			const rows = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{
+						id: string;
+					}>`select ${sql('id')} from ${sql('subject')}`;
+				})
+			);
+			// Two tenants of the same server, isolated by schema rather than by
+			// a naming convention — which is what makes grants and
+			// `DROP SCHEMA` meaningful.
+			assert.strictEqual(rows.length, 0);
+		});
+	}, 120_000);
+
+	it('is idempotent when the schema already exists', async () => {
+		const schema = 'c15t_scope_d';
+		await withSchema(schema, async (runtime) => {
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql.unsafe(`drop schema if exists ${schema} cascade`);
+				})
+			);
+		});
+
+		await withSchema(schema, async (runtime) => {
+			await runtime.runPromise(migrate());
+			const again = await runtime.runPromise(migrate());
+
+			assert.deepStrictEqual(again.adoption, []);
+			assert.deepStrictEqual(again.pending, []);
+		});
+	}, 120_000);
+});

--- a/packages/cli/src/commands/self-host/migrate/ensure-backend-config.ts
+++ b/packages/cli/src/commands/self-host/migrate/ensure-backend-config.ts
@@ -73,13 +73,22 @@ export async function pathExists(filePath: string): Promise<boolean> {
 export function buildConfig(dialect: Dialect): string {
 	const { envVar, placeholder, field } = DIALECTS[dialect];
 
+	// Postgres is the only engine that needs an isolation option: MySQL scopes
+	// by database and SQLite by file, both of which the connection already
+	// names. Commented rather than omitted so it is discoverable by whoever
+	// shares a database with another application.
+	const scoping =
+		dialect === 'postgres'
+			? "\n\t\t// Keep c15t's tables out of `public`, if you share this database:\n\t\t// schema: 'c15t',"
+			: '';
+
 	return `import { defineConfig } from '@c15t/backend';
 
 export default defineConfig({
 	database: {
 		dialect: '${dialect}',
 		// e.g. ${placeholder}
-		${field}: process.env.${envVar} ?? '',
+		${field}: process.env.${envVar} ?? '',${scoping}
 	},
 });
 `;


### PR DESCRIPTION
Raised on #980: running c15t in the same process as your app and wanting it out of `public`.

## The mechanism is `search_path`, not qualified table names

A pool hands out many connections, so a one-off `SET search_path` scopes **exactly one** — and would pass a PGlite test, which has a single connection, while failing in production. This sets it on the connection string.

Verified against a real pooled Postgres: `current_schema()` reports the configured schema on every checkout, and an unqualified `create table` lands there.

So **no query in the package changed**. All 24 unqualified table references resolve into the schema by themselves; only the three introspection queries needed touching, and they now ask `current_schema()` rather than assuming `public` — which also handles a caller who sets `search_path` their own way.

`migrate` creates the schema when missing, because a `search_path` pointing at one that does not exist fails with an error that never mentions schemas.

## No equivalent for MySQL or SQLite, deliberately

MySQL's unit of isolation is the database and SQLite's is the file, both of which the connection already names. One option meaning three different things would be worse than none — so `schema` lives on the **postgres member** of the config union and is a type error elsewhere.

## Validation

The schema name is rejected rather than escaped if it is not a plain identifier: it lands in a startup parameter, not a bound value.
