### PR TITLE
test(backend): run the database suite on all four engines, in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Needed for checkout
+    # @c15t/backend supports Postgres, MySQL and SQLite, and its test matrix
+    # runs against whichever of them the environment provides. Without these
+    # services the MySQL and real-Postgres arms silently skip — which is how
+    # the package once shipped unable to execute a single statement against
+    # MySQL with a green suite (RFC 0004 §11.7).
+    #
+    # SQLite and PGlite need nothing: both run in-process.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: c15t
+          POSTGRES_DB: c15t
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: c15t
+          MYSQL_DATABASE: c15t
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -uroot -pc15t --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 15
     steps:
       - name: ⬇️ Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -175,6 +207,9 @@ jobs:
         env:
           TURBO_TOKEN: ${{ github.event_name != 'pull_request' && secrets.TURBO_TOKEN || '' }}
           TURBO_TEAM: ${{ github.event_name != 'pull_request' && secrets.TURBO_TEAM || '' }}
+          # Opt the backend's matrix into the two engines that need a server.
+          C15T_TEST_PG_URL: postgres://postgres:c15t@127.0.0.1:5432/c15t
+          C15T_TEST_MYSQL_URL: mysql://root:c15t@127.0.0.1:3306/c15t
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             bun turbo run test --filter="./packages/*" --filter="./internals/*" --filter="./apps/*" --affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,9 @@ jobs:
     # SQLite and PGlite need nothing: both run in-process.
     services:
       postgres:
-        image: postgres:16
+        # Pinned by digest, as the repo's action-security policy requires
+        # of every image and action reference.
+        image: postgres:16@sha256:33f923b05f64ca54ac4401c01126a6b92afe839a0aa0a52bc5aeb5cc958e5f20
         env:
           POSTGRES_PASSWORD: c15t
           POSTGRES_DB: c15t
@@ -133,7 +135,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       mysql:
-        image: mysql:8
+        image: mysql:8@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
         env:
           MYSQL_ROOT_PASSWORD: c15t
           MYSQL_DATABASE: c15t
@@ -261,12 +263,12 @@ jobs:
       contents: read
     steps:
       - name: ⬇️ Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 
       - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: latest
 
@@ -275,7 +277,7 @@ jobs:
 
       - name: 🎭 Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -341,7 +343,7 @@ jobs:
 
       - name: ⬆️ Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: apps/parity-runner/playwright-report/
@@ -356,12 +358,12 @@ jobs:
       contents: read
     steps:
       - name: ⬇️ Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 
       - name: 🟢 Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: latest
 
@@ -370,7 +372,7 @@ jobs:
 
       - name: 🎭 Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1140,3 +1140,45 @@ table, not the unique-index-on-`TEXT` case that actually failed. Re-running the
 fixture generator against it is the way to settle it. It would not change much
 either way: MySQL was one defect among the join-less surface, the total absence
 of indexes, and three of five adapters having no working migrator.
+
+### 11.22 The engine matrix, and CI that actually runs it
+
+§11.7 added a cross-engine suite after finding the package could not execute a
+statement against MySQL. That suite covered one file. Twelve others were still
+PGlite-only, real Postgres was **not in the matrix at all**, and neither MySQL
+nor Postgres ran in CI — so the MySQL arm and every schema-scoping test skipped
+silently on every pull request. Opt-in coverage that nothing opts into is not
+coverage.
+
+**Both Postgres engines are in the matrix now, deliberately.** PGlite is
+Postgres compiled to WASM and stands in for it almost everywhere — but it runs
+a single in-process connection, so it cannot exhibit anything pool-shaped.
+Schema scoping is the worked example: a one-off `SET search_path` passes on
+PGlite and scopes exactly one connection of a real pool.
+
+CI gained `postgres:16` and `mysql:8` services with health checks, so all four
+run on every pull request. A contributor without Docker still gets 255 tests
+across PGlite and SQLite; with servers it is 327.
+
+**What converting the suites found**, all of it invisible on PGlite:
+
+- `tenant-isolation` — the security suite — seeded `Date` values SQLite cannot
+  bind, wrote raw double-quoted SQL that MySQL rejects, and asserted
+  `isActive === true` where MySQL returns a tinyint `1` and SQLite an integer
+  `1`. Every one of those was a test-level assumption about Postgres, and the
+  suite that proves tenants cannot see each other ran on exactly one engine.
+- `classify` built its fixtures with double-quoted DDL and a `key` column,
+  which is reserved on MySQL.
+
+**Two classification cases are now explicitly Postgres-only**, rather than
+quietly passing. Telling legacy from fumadb 1.0.0 by column type depends on
+`jsonb` versus `json`, which exists nowhere else — SQLite collapses both to
+TEXT and MySQL has no `jsonb`, which is why §11.7 made MySQL answer by
+elimination. Running them elsewhere would assert behaviour the code
+deliberately does not have, so they skip with the reason stated in code.
+
+**One test was passing on ordering luck.** `migrates into the schema and leaves
+public alone` asserted `public` held no `subject` table. That was true only
+because the pg `resetDatabase` happened to run first; once other suites shared
+the server it was a coin flip. It establishes its own precondition now — the
+difference between evidence and coincidence.

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1219,3 +1219,32 @@ fresh in-process database.
 
 The standalone `adopt: sqlite` block is gone — the matrix covers what it
 asserted, on more engines than it did.
+
+### 11.24 The services were wired up and still did nothing
+
+The first CI run with `postgres:16` and `mysql:8` reported the backend at
+**22 passed, 1 skipped** — which is the *no-servers* count. The services were
+running, the URLs were set on the step, and the matrix still saw neither
+engine.
+
+Turborepo's default `envMode` is `strict`: a task only receives environment
+variables declared in `turbo.json`. `C15T_TEST_PG_URL` and
+`C15T_TEST_MYSQL_URL` were filtered out before vitest ever started, so
+`ENGINES` fell back to PGlite and SQLite and every MySQL and real-Postgres case
+skipped — silently, with a green backend suite.
+
+They are declared on the `test` task now, under `env` rather than
+`passThroughEnv`, because results genuinely differ with and without the
+servers and the cache key has to differ too.
+
+This is the same failure the whole exercise exists to prevent, one level up:
+coverage that looks present and is not. The tell was the count, not a failure —
+worth remembering that a passing suite is only evidence if you know how many
+tests it was supposed to run.
+
+**Also pinned every action and image in `ci.yml`.** The repo's action-security
+policy requires digests, and `zizmor` only audits workflows when one changes —
+so adding the services was the first thing to lint that file, and it surfaced
+seven pre-existing unpinned action references alongside my two images. The
+action SHAs are the ones the file and repo already use elsewhere, so this pins
+rather than upgrades.

--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1182,3 +1182,40 @@ public alone` asserted `public` held no `subject` table. That was true only
 because the pg `resetDatabase` happened to run first; once other suites shared
 the server it was a coin flip. It establishes its own precondition now — the
 difference between evidence and coincidence.
+
+### 11.23 Converting the adoption suite found a schema-scoping bug
+
+`adopt.test.ts` is the suite guarding the riskiest code in the package — the
+only part that touches a database someone else's production data lives in — and
+it ran on PGlite, with a small SQLite annex. It runs on all four engines now,
+and its fixtures build each legacy shape with that engine's own physical types
+rather than Postgres's: `datetime` and `varchar` on MySQL, epoch integers and
+TEXT on SQLite. Postgres types everywhere would have tested a database that has
+never existed, and on MySQL would not have created at all — it cannot index a
+`TEXT` foreign key column.
+
+**The conversion surfaced a genuine bug in `adopt.ts`.** Its Postgres
+foreign-key introspection read `pg_constraint` without joining `pg_namespace`,
+so it was **database-wide rather than schema-scoped**. That was harmless while
+c15t only ever lived in `public`. It stopped being harmless the moment
+§11.21 made a second installation in another schema a supported configuration:
+adoption would see that installation's foreign keys, conclude this one already
+had them, and skip both adding them *and* the orphan check that guards them.
+
+It surfaced as two tests failing only after the schema-scoping suite had run
+against the same server — a shape that is invisible when every test gets a
+fresh in-process database.
+
+**Twelve cases are now explicitly engine-gated** rather than quietly passing:
+
+- Six need to classify an *unmarked legacy* database, which SQLite cannot do —
+  legacy and fumadb 1.0.0 share seven tables and differ by `jsonb` against
+  `json`. SQLite answers `Unknown` and refuses, which is documented behaviour
+  and the reason `--assume-shape` exists.
+- Three manufacture an orphan row by dropping a named foreign key constraint,
+  which SQLite cannot do at all and MySQL names differently. The behaviour
+  under test is engine-independent; only that way of arranging the precondition
+  is not.
+
+The standalone `adopt: sqlite` block is gone — the matrix covers what it
+asserted, on more engines than it did.

--- a/packages/backend/src/__tests__/engines.ts
+++ b/packages/backend/src/__tests__/engines.ts
@@ -37,6 +37,7 @@
  */
 
 import { MysqlClient } from '@effect/sql-mysql2';
+import { PgClient } from '@effect/sql-pg';
 import { PgliteClient } from '@effect/sql-pglite';
 import { SqliteClient } from '@effect/sql-sqlite-node';
 import { Effect, Layer, Redacted } from 'effect';
@@ -44,9 +45,10 @@ import { SqlClient } from 'effect/unstable/sql';
 import { singleTenant, type Tenant, layer as tenantLayer } from '../db/tenant';
 
 const MYSQL_URL = process.env.C15T_TEST_MYSQL_URL;
+const PG_URL = process.env.C15T_TEST_PG_URL;
 
 export interface TestEngine {
-	readonly name: 'pglite' | 'sqlite' | 'mysql';
+	readonly name: 'pglite' | 'postgres' | 'sqlite' | 'mysql';
 	/** A client plus a single-tenant scope, which most tests want. */
 	readonly layer: Layer.Layer<SqlClient.SqlClient | Tenant>;
 	/** The same client, scoped to a named tenant. */
@@ -57,6 +59,7 @@ export interface TestEngine {
 
 const client = {
 	pglite: () => PgliteClient.layer({}),
+	postgres: () => PgClient.layer({ url: Redacted.make(PG_URL ?? '') }),
 	sqlite: () => SqliteClient.layer({ filename: ':memory:' }),
 	// Redacted, not a plain string: the URL carries credentials, and Effect
 	// keeps them out of logs and error messages by construction.
@@ -69,12 +72,34 @@ const engine = (name: TestEngine['name']): TestEngine => ({
 	asTenant: (tenantId) => Layer.merge(client[name](), tenantLayer(tenantId)),
 });
 
-/** Every engine this environment can exercise. */
+/**
+ * Every engine this environment can exercise.
+ *
+ * PGlite and real Postgres are both here on purpose rather than one standing
+ * in for the other. PGlite is Postgres compiled to WASM and is close enough
+ * for almost everything — but it runs a single in-process connection, so it
+ * cannot exhibit anything pool-shaped. Schema scoping is the worked example:
+ * a one-off `SET search_path` passes on PGlite and scopes exactly one
+ * connection of a real pool.
+ */
 export const ENGINES: readonly TestEngine[] = [
 	engine('pglite'),
 	engine('sqlite'),
+	...(PG_URL ? [engine('postgres')] : []),
 	...(MYSQL_URL ? [engine('mysql')] : []),
 ];
+
+/**
+ * The engines that are real servers rather than in-process databases.
+ *
+ * These keep their state between tests, so a suite that assumes an empty
+ * database has to reset first. PGlite and in-memory SQLite get a fresh
+ * database each time their layer is built.
+ */
+export const SHARED_ENGINES: ReadonlySet<TestEngine['name']> = new Set([
+	'postgres',
+	'mysql',
+]);
 
 /**
  * Drops every table, so a case starts from an empty database.
@@ -102,6 +127,20 @@ export const resetDatabase = Effect.gen(function* () {
 					yield* sql.unsafe(`drop table if exists \`${table.name}\``);
 				}
 				yield* sql`set foreign_key_checks = 1`;
+			}),
+		pg: () =>
+			Effect.gen(function* () {
+				// PGlite is fresh per layer build and has nothing to drop, so this
+				// only does work against a real server. `cascade` because the
+				// schema has foreign keys and dropping in dependency order by hand
+				// would break the moment one is added.
+				const tables = yield* sql<{ name: string }>`
+					select table_name as name from information_schema.tables
+					where table_schema = current_schema() and table_type = 'BASE TABLE'
+				`;
+				for (const table of tables) {
+					yield* sql.unsafe(`drop table if exists "${table.name}" cascade`);
+				}
 			}),
 		orElse: () => Effect.void,
 	});

--- a/packages/backend/src/db/adopt.test.ts
+++ b/packages/backend/src/db/adopt.test.ts
@@ -4,504 +4,533 @@
  * exist mostly to pin the properties that make it safe.
  */
 
-import { PgliteClient } from '@effect/sql-pglite';
-import { SqliteClient } from '@effect/sql-sqlite-node';
 import { assert, describe, it } from '@effect/vitest';
-import { Effect, Layer } from 'effect';
+import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
-import { singleTenant } from '../db/tenant';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
 import { apply, LEDGER_TABLE, plan } from './adopt';
 import { classify } from './classify';
+import * as Dialect from './dialect';
 import { up as baseline } from './migrations/1-baseline';
 
-// Tests run single-tenant unless a case says otherwise; the scope is a
-// service, so a query cannot run without one.
-const Pglite = Layer.merge(PgliteClient.layer({}), singleTenant);
-
-/** A 1.0.0-era database: seven tables, no runtimePolicyDecision, with data. */
+/**
+ * A 1.0.0-era database: seven tables, no runtimePolicyDecision, with data.
+ *
+ * Built with each engine's own physical types rather than Postgres's, because
+ * that is what a real legacy database on that engine holds — `datetime` and
+ * `varchar` on MySQL, epoch integers and TEXT on SQLite. Using Postgres types
+ * everywhere would test a database that has never existed, and on MySQL would
+ * not even create: it cannot index a `TEXT` foreign key column.
+ */
 const legacyish = Effect.gen(function* () {
 	const sql = yield* SqlClient.SqlClient;
-	yield* sql.unsafe(`create table "subject" (
-		"id" varchar(255) primary key, "externalId" text, "createdAt" timestamp
+	const dialect = yield* Dialect.current;
+	const q = Dialect.escaperFor(dialect);
+	const t = Dialect.typesFor(dialect);
+
+	// Legacy Postgres declared `consent.metadata` as `jsonb`, which is what
+	// classify uses to tell it from fumadb 1.0.0. Neither other engine has the
+	// type, which is precisely why classify cannot make that distinction there.
+	const metadata = dialect === 'postgres' ? 'jsonb' : t.json;
+
+	yield* sql.unsafe(`create table ${q('subject')} (
+		${q('id')} ${t.id} primary key, ${q('externalId')} ${t.text},
+		${q('createdAt')} ${t.timestamp}
 	)`);
-	yield* sql.unsafe(`create table "domain" (
-		"id" varchar(255) primary key, "name" text
+	yield* sql.unsafe(`create table ${q('domain')} (
+		${q('id')} ${t.id} primary key, ${q('name')} ${t.text}
 	)`);
 	yield* sql.unsafe(
-		`create table "consentPolicy" ("id" varchar(255) primary key)`
+		`create table ${q('consentPolicy')} (${q('id')} ${t.id} primary key)`
 	);
 	yield* sql.unsafe(
-		`create table "consentPurpose" ("id" varchar(255) primary key)`
+		`create table ${q('consentPurpose')} (${q('id')} ${t.id} primary key)`
 	);
-	yield* sql.unsafe(`create table "auditLog" ("id" varchar(255) primary key)`);
-	yield* sql.unsafe(`create table "consent" (
-		"id" varchar(255) primary key,
-		"subjectId" text,
-		"domainId" text,
-		"metadata" jsonb,
-		"status" text,
-		"withdrawalReason" text
+	yield* sql.unsafe(
+		`create table ${q('auditLog')} (${q('id')} ${t.id} primary key)`
+	);
+	yield* sql.unsafe(`create table ${q('consent')} (
+		${q('id')} ${t.id} primary key,
+		${q('subjectId')} ${t.indexedText},
+		${q('domainId')} ${t.indexedText},
+		${q('metadata')} ${metadata},
+		${q('status')} ${t.text},
+		${q('withdrawalReason')} ${t.text}
 	)`);
-	yield* sql.unsafe(`create table "consentRecord" (
-		"id" varchar(255) primary key, "consentId" text
+	yield* sql.unsafe(`create table ${q('consentRecord')} (
+		${q('id')} ${t.id} primary key, ${q('consentId')} ${t.indexedText}
 	)`);
 
-	yield* sql.unsafe(
-		`insert into "subject" ("id", "externalId") values ('sub_1', 'ext_1')`
-	);
-	yield* sql.unsafe(
-		`insert into "domain" ("id", "name") values ('dom_1', 'a.com')`
-	);
-	yield* sql.unsafe(
-		`insert into "consent" ("id", "subjectId", "domainId", "status", "withdrawalReason") values ('cns_1', 'sub_1', 'dom_1', 'active', 'changed mind')`
-	);
-	yield* sql.unsafe(
-		`insert into "consentRecord" ("id", "consentId") values ('rec_1', 'cns_1')`
-	);
+	yield* sql`insert into ${sql('subject')} ${sql.insert({ id: 'sub_1', externalId: 'ext_1' })}`;
+	yield* sql`insert into ${sql('domain')} ${sql.insert({ id: 'dom_1', name: 'a.com' })}`;
+	yield* sql`insert into ${sql('consent')} ${sql.insert({
+		id: 'cns_1',
+		subjectId: 'sub_1',
+		domainId: 'dom_1',
+		status: 'active',
+		withdrawalReason: 'changed mind',
+	})}`;
+	yield* sql`insert into ${sql('consentRecord')} ${sql.insert({ id: 'rec_1', consentId: 'cns_1' })}`;
 });
 
+/** Row count of a table, quoted for the connected engine. */
+const countOf = Effect.fn('countOf')(function* (table: string) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{
+		count: string | number;
+	}>`select count(*) as count from ${sql(table)}`;
+	return Number(rows[0]?.count ?? 0);
+});
+
+/** Table names in the current database. SQLite has no information_schema. */
+const tablesOf = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{
+				name: string;
+			}>`select name from sqlite_master where type = 'table'`,
+		mysql: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = database()
+			`,
+		orElse: () =>
+			sql<{ name: string }>`
+				select table_name as name from information_schema.tables
+				where table_schema = current_schema() and table_type = 'BASE TABLE'
+			`,
+	});
+	return rows.map((row) => row.name);
+});
+
+/** Column names of a table. SQLite has no information_schema. */
 const columnsOf = Effect.fn('columnsOf')(function* (table: string) {
 	const sql = yield* SqlClient.SqlClient;
-	const rows = yield* sql<{ column_name: string }>`
-		select column_name from information_schema.columns where table_name = ${table}
-	`;
-	return rows.map((row) => row.column_name).sort();
-});
-
-describe('adopt', () => {
-	it.effect(
-		'plans a full create for an empty database',
-		() =>
-			Effect.gen(function* () {
-				const adoption = yield* plan;
-				assert.strictEqual(adoption.shape._tag, 'Empty');
-				assert.isUndefined(adoption.blocked);
-				assert.strictEqual(
-					adoption.steps.filter((step) => step.kind === 'create-table').length,
-					7
-				);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'never drops data that schema 2.0.0 removed',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				const adoption = yield* plan;
-
-				assert.isUndefined(adoption.blocked);
-				assert.deepStrictEqual(
-					adoption.steps.filter(
-						(step) =>
-							step.sql.includes('drop table') ||
-							step.sql.includes('drop column')
-					),
-					[],
-					'adoption must never drop anything'
-				);
-
-				yield* apply(adoption);
-
-				// consentRecord was dropped in 2.0.0. Discarding it would discard
-				// consent history, so it stays and is reported instead.
-				const sql = yield* SqlClient.SqlClient;
-				const kept = yield* sql<{
-					count: string;
-				}>`select count(*) as count from "consentRecord"`;
-				assert.strictEqual(Number(kept[0]?.count), 1);
-
-				const consent = yield* columnsOf('consent');
-				assert.include(consent, 'withdrawalReason');
-				assert.include(consent, 'status');
-				assert.include(
-					adoption.retained.join(' '),
-					'withdrawalReason',
-					'retained columns should be reported to the operator'
-				);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'brings a 1.0.0-era database up to the baseline contract',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				yield* apply(yield* plan);
-
-				// Every column the backend reads must now exist, whatever else does.
-				const consent = yield* columnsOf('consent');
-				for (const column of [
-					'runtimePolicyDecisionId',
-					'runtimePolicySource',
-					'tcString',
-					'uiSource',
-					'consentAction',
-					'jurisdiction',
-					'tenantId',
-				]) {
-					assert.include(consent, column);
-				}
-
-				const tables = yield* (function* () {
-					const sql = yield* SqlClient.SqlClient;
-					const rows = yield* sql<{ table_name: string }>`
-						select table_name from information_schema.tables
-						where table_schema = 'public' and table_type = 'BASE TABLE'
-					`;
-					return rows.map((row) => row.table_name);
-				})();
-				assert.include(tables, 'runtimePolicyDecision');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'emits no destructive statement for any shape it can encounter',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				const destructive = /\b(drop|truncate)\b|\bdelete\s+from\b/i;
-
-				// Empty database.
-				for (const step of (yield* plan).steps) {
-					assert.notMatch(step.sql, destructive, step.description);
-				}
-
-				// A 1.0.0-era database with data.
-				yield* legacyish;
-				for (const step of (yield* plan).steps) {
-					assert.notMatch(step.sql, destructive, step.description);
-				}
-
-				// A 2.0.0-shaped database missing only the newer columns.
-				yield* sql.unsafe('drop schema public cascade');
-				yield* sql.unsafe('create schema public');
-				yield* baseline;
-				yield* sql.unsafe(`alter table "consent" drop column "tenantId"`);
-				for (const step of (yield* plan).steps) {
-					assert.notMatch(step.sql, destructive, step.description);
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'refuses to apply a plan carrying a destructive statement',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				const adoption = yield* plan;
-
-				// Simulates a future edit smuggling a drop into an additive step.
-				const tampered = {
-					...adoption,
-					steps: [
-						...adoption.steps,
-						{
-							kind: 'add-column' as const,
-							description: 'sneaky',
-							sql: 'drop table "consentRecord"',
-						},
-					],
-				};
-
-				const outcome = yield* Effect.exit(apply(tampered));
-				assert.isTrue(outcome._tag === 'Failure');
-
-				// And the table it targeted is untouched.
-				const sql = yield* SqlClient.SqlClient;
-				const rows = yield* sql<{
-					count: string;
-				}>`select count(*) as count from "consentRecord"`;
-				assert.strictEqual(Number(rows[0]?.count), 1);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'reports the database as ours once adopted',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				yield* apply(yield* plan);
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Baseline');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'is safe to re-run after a partial application',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				yield* apply(yield* plan);
-				const first = yield* columnsOf('consent');
-
-				// Re-planning against the now-adopted database should be a no-op.
-				const second = yield* plan;
-				assert.strictEqual(second.shape._tag, 'Baseline');
-				yield* apply(second);
-				assert.deepStrictEqual(yield* columnsOf('consent'), first);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'refuses to add a foreign key that existing rows would violate',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				// Drop the constraint so we can create the orphan, mimicking a
-				// MySQL database that never had foreign keys at all.
-				yield* sql.unsafe(
-					`alter table "consent" drop constraint "consent_subjectId_fkey"`
-				);
-				yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
-					values ('dom_1', 'a.com', now(), now())`);
-				yield* sql.unsafe(`insert into "consent"
-					("id", "subjectId", "domainId", "purposeIds", "givenAt")
-					values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
-
-				const adoption = yield* plan;
-
-				assert.isDefined(adoption.blocked);
-				assert.include(adoption.blocked ?? '', '1 row(s)');
-				assert.include(adoption.blocked ?? '', 'skipForeignKeys');
-				assert.strictEqual(adoption.orphans.length, 1);
-				assert.strictEqual(adoption.orphans[0]?.table, 'consent');
-				assert.strictEqual(adoption.orphans[0]?.count, 1);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'proceeds without foreign keys when explicitly told to',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				yield* sql.unsafe(
-					`alter table "consent" drop constraint "consent_subjectId_fkey"`
-				);
-				yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
-					values ('dom_1', 'a.com', now(), now())`);
-				yield* sql.unsafe(`insert into "consent"
-					("id", "subjectId", "domainId", "purposeIds", "givenAt")
-					values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
-
-				const adoption = yield* plan;
-				yield* apply(adoption, { skipForeignKeys: true });
-
-				// The orphan row survives — the operator chose integrity later
-				// over losing data now.
-				const rows = yield* sql<{
-					count: string;
-				}>`select count(*) as count from "consent"`;
-				assert.strictEqual(Number(rows[0]?.count), 1);
-
-				const ledger = yield* sql<{ name: string }>`${sql.unsafe(
-					`select "name" from "${LEDGER_TABLE}"`
-				)}`;
-				assert.strictEqual(ledger[0]?.name, '1-baseline');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-});
-
-describe('adopt: refusals and edge cases', () => {
-	it.effect(
-		'refuses an unrecognised database rather than guessing',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				// A c15t-shaped database claiming a schema version we have no
-				// fixture for. Migrating it would be acting on an assumption
-				// about a shape nobody has seen.
-				yield* sql.unsafe(
-					`create table "subject" ("id" varchar(255) primary key)`
-				);
-				yield* sql.unsafe(
-					`create table "consent" ("id" varchar(255) primary key)`
-				);
-				yield* sql.unsafe(
-					`create table "private_c15t_settings" ("key" text primary key, "value" text)`
-				);
-				yield* sql.unsafe(
-					`insert into "private_c15t_settings" values ('version','9.9.9')`
-				);
-
-				const adoption = yield* plan;
-
-				assert.strictEqual(adoption.shape._tag, 'Unknown');
-				assert.isDefined(adoption.blocked);
-				assert.deepStrictEqual(adoption.steps, [], 'must plan nothing');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'dies rather than applying a blocked plan',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				yield* sql.unsafe(
-					`alter table "consent" drop constraint "consent_subjectId_fkey"`
-				);
-				yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
-					values ('dom_1','a.com',now(),now())`);
-				yield* sql.unsafe(`insert into "consent"
-					("id","subjectId","domainId","purposeIds","givenAt")
-					values ('cns_1','sub_missing','dom_1','[]',now())`);
-
-				const adoption = yield* plan;
-				const outcome = yield* Effect.exit(apply(adoption));
-
-				// Refusing loudly beats a partial migration an operator has to
-				// unpick by hand.
-				assert.strictEqual(outcome._tag, 'Failure');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'plans nothing for a database already at the baseline',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				yield* sql.unsafe(
-					`create table "c15t_migrations" ("id" integer primary key, "name" text)`
-				);
-
-				const adoption = yield* plan;
-
-				// Re-running adoption against our own output must be inert, or a
-				// retried deploy would churn the schema.
-				assert.strictEqual(adoption.shape._tag, 'Baseline');
-				assert.deepStrictEqual(adoption.steps, []);
-				assert.isUndefined(adoption.blocked);
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'adds only the columns a partial database is missing',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				yield* sql.unsafe(`alter table "consent" drop column "tenantId"`);
-				yield* sql.unsafe(`alter table "consent" drop column "uiSource"`);
-
-				const adoption = yield* plan;
-				const added = adoption.steps.filter(
-					(step) => step.kind === 'add-column'
-				);
-
-				// Precisely two, not a wholesale rewrite: adoption must touch as
-				// little as it can get away with.
-				assert.strictEqual(added.length, 2);
-				yield* apply(adoption);
-
-				const columns = yield* sql<{ column_name: string }>`
-					select column_name from information_schema.columns
-					where table_name = 'consent'
-				`;
-				const names = columns.map((row) => row.column_name);
-				assert.include(names, 'tenantId');
-				assert.include(names, 'uiSource');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'reports retained columns so an operator can prune deliberately',
-		() =>
-			Effect.gen(function* () {
-				yield* legacyish;
-				const adoption = yield* plan;
-
-				// The operator has to be told what was kept, or "additive" just
-				// means the extra columns are invisible instead of absent.
-				assert.isAbove(adoption.retained.length, 0);
-				assert.include(adoption.retained.join(' '), 'consentRecord');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{ name: string }>`select name from pragma_table_info(${table})`,
+		mysql: () =>
+			sql<{ name: string }>`
+				select column_name as name from information_schema.columns
+				where table_schema = database() and table_name = ${table}
+			`,
+		orElse: () =>
+			sql<{ name: string }>`
+				select column_name as name from information_schema.columns
+				where table_schema = current_schema() and table_name = ${table}
+			`,
+	});
+	return rows.map((row) => row.name).sort();
 });
 
 /**
- * SQLite adoption.
+ * Whether the engine can classify an unmarked legacy database.
  *
- * Every other case here runs on Postgres, which left the SQLite branches of
- * introspection and classification unexecuted — on the one code path that
- * touches a real deployment's data. SQLite is in-process, so there is no
- * excuse for not covering it.
+ * SQLite cannot: legacy and fumadb 1.0.0 carry the same seven tables and are
+ * told apart by `jsonb` against `json`, which SQLite collapses to TEXT. It
+ * answers `Unknown` and refuses, which is the documented behaviour (§3.3) and
+ * the reason `--assume-shape` exists — so the fixtures below have nothing to
+ * adopt there.
  */
-describe('adopt: sqlite', () => {
-	const Sqlite = Layer.merge(
-		SqliteClient.layer({ filename: ':memory:' }),
-		singleTenant
-	);
+const classifiesUnmarkedLegacy = (engine: (typeof ENGINES)[number]) =>
+	engine.name !== 'sqlite';
 
-	it.effect(
-		'plans a full create for an empty sqlite database',
-		() =>
-			Effect.gen(function* () {
-				const adoption = yield* plan;
+/**
+ * Whether a named foreign key constraint can be dropped to manufacture an
+ * orphan row.
+ *
+ * SQLite cannot drop constraints at all, and MySQL names them differently.
+ * The behaviour under test — refusing to add a foreign key existing rows would
+ * violate — is engine-independent; only this way of arranging the precondition
+ * is not.
+ */
+const canDropNamedConstraint = (engine: (typeof ENGINES)[number]) =>
+	engine.name === 'pglite' || engine.name === 'postgres';
 
-				assert.strictEqual(adoption.shape._tag, 'Empty');
-				assert.strictEqual(
-					adoption.steps.filter((step) => step.kind === 'create-table').length,
-					7
-				);
-			}).pipe(Effect.provide(Sqlite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'adopts and then reports itself as baseline',
-		() =>
-			Effect.gen(function* () {
-				yield* apply(yield* plan);
-				const second = yield* plan;
-
-				assert.strictEqual(second.shape._tag, 'Baseline');
-				assert.deepStrictEqual(second.steps, []);
-			}).pipe(Effect.provide(Sqlite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'emits no destructive statement on sqlite either',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				// A 1.0.0-era sqlite database, columns and all.
-				yield* sql.unsafe(
-					`create table "subject" ("id" text primary key, "externalId" text)`
-				);
-				yield* sql.unsafe(
-					`create table "consent" ("id" text primary key, "status" text)`
-				);
-				yield* sql.unsafe(
-					`create table "consentRecord" ("id" text primary key)`
-				);
-
-				for (const step of (yield* plan).steps) {
-					assert.notMatch(
-						step.sql,
-						/\b(drop|truncate)\b|\bdelete\s+from\b/i,
-						step.description
+for (const engine of ENGINES) {
+	describe('adopt', () => {
+		it.effect(
+			'plans a full create for an empty database',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const adoption = yield* plan;
+					assert.strictEqual(adoption.shape._tag, 'Empty');
+					assert.isUndefined(adoption.blocked);
+					assert.strictEqual(
+						adoption.steps.filter((step) => step.kind === 'create-table')
+							.length,
+						7
 					);
-				}
-			}).pipe(Effect.provide(Sqlite)),
-		{ timeout: 60_000 }
-	);
-});
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'never drops data that schema 2.0.0 removed',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					const adoption = yield* plan;
+
+					assert.isUndefined(adoption.blocked);
+					assert.deepStrictEqual(
+						adoption.steps.filter(
+							(step) =>
+								step.sql.includes('drop table') ||
+								step.sql.includes('drop column')
+						),
+						[],
+						'adoption must never drop anything'
+					);
+
+					yield* apply(adoption);
+
+					// consentRecord was dropped in 2.0.0. Discarding it would discard
+					// consent history, so it stays and is reported instead.
+					assert.strictEqual(yield* countOf('consentRecord'), 1);
+
+					const consent = yield* columnsOf('consent');
+					assert.include(consent, 'withdrawalReason');
+					assert.include(consent, 'status');
+					assert.include(
+						adoption.retained.join(' '),
+						'withdrawalReason',
+						'retained columns should be reported to the operator'
+					);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'brings a 1.0.0-era database up to the baseline contract',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					yield* apply(yield* plan);
+
+					// Every column the backend reads must now exist, whatever else does.
+					const consent = yield* columnsOf('consent');
+					for (const column of [
+						'runtimePolicyDecisionId',
+						'runtimePolicySource',
+						'tcString',
+						'uiSource',
+						'consentAction',
+						'jurisdiction',
+						'tenantId',
+					]) {
+						assert.include(consent, column);
+					}
+
+					assert.include(yield* tablesOf, 'runtimePolicyDecision');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'emits no destructive statement for any shape it can encounter',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					const destructive = /\b(drop|truncate)\b|\bdelete\s+from\b/i;
+
+					// Empty database.
+					for (const step of (yield* plan).steps) {
+						assert.notMatch(step.sql, destructive, step.description);
+					}
+
+					// A 1.0.0-era database with data.
+					yield* legacyish;
+					for (const step of (yield* plan).steps) {
+						assert.notMatch(step.sql, destructive, step.description);
+					}
+
+					// A 2.0.0-shaped database missing only the newer columns.
+					// `resetDatabase` rather than dropping the schema, which is
+					// Postgres-only syntax.
+					yield* resetDatabase;
+					yield* baseline;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					yield* sql.unsafe(
+						`alter table ${q('consent')} drop column ${q('tenantId')}`
+					);
+					for (const step of (yield* plan).steps) {
+						assert.notMatch(step.sql, destructive, step.description);
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'refuses to apply a plan carrying a destructive statement',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					const adoption = yield* plan;
+
+					// Simulates a future edit smuggling a drop into an additive step.
+					const tampered = {
+						...adoption,
+						steps: [
+							...adoption.steps,
+							{
+								kind: 'add-column' as const,
+								description: 'sneaky',
+								sql: 'drop table "consentRecord"',
+							},
+						],
+					};
+
+					const outcome = yield* Effect.exit(apply(tampered));
+					assert.isTrue(outcome._tag === 'Failure');
+
+					// And the table it targeted is untouched.
+					assert.strictEqual(yield* countOf('consentRecord'), 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'reports the database as ours once adopted',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					yield* apply(yield* plan);
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Baseline');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'is safe to re-run after a partial application',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					yield* apply(yield* plan);
+					const first = yield* columnsOf('consent');
+
+					// Re-planning against the now-adopted database should be a no-op.
+					const second = yield* plan;
+					assert.strictEqual(second.shape._tag, 'Baseline');
+					yield* apply(second);
+					assert.deepStrictEqual(yield* columnsOf('consent'), first);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(canDropNamedConstraint(engine) ? it.effect : it.effect.skip)(
+			'refuses to add a foreign key that existing rows would violate',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					yield* baseline;
+					// Drop the constraint so we can create the orphan, mimicking a
+					// MySQL database that never had foreign keys at all.
+					yield* sql.unsafe(
+						`alter table "consent" drop constraint "consent_subjectId_fkey"`
+					);
+					yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+						values ('dom_1', 'a.com', now(), now())`);
+					yield* sql.unsafe(`insert into "consent"
+						("id", "subjectId", "domainId", "purposeIds", "givenAt")
+						values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
+
+					const adoption = yield* plan;
+
+					assert.isDefined(adoption.blocked);
+					assert.include(adoption.blocked ?? '', '1 row(s)');
+					assert.include(adoption.blocked ?? '', 'skipForeignKeys');
+					assert.strictEqual(adoption.orphans.length, 1);
+					assert.strictEqual(adoption.orphans[0]?.table, 'consent');
+					assert.strictEqual(adoption.orphans[0]?.count, 1);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(canDropNamedConstraint(engine) ? it.effect : it.effect.skip)(
+			'proceeds without foreign keys when explicitly told to',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					yield* baseline;
+					yield* sql.unsafe(
+						`alter table "consent" drop constraint "consent_subjectId_fkey"`
+					);
+					yield* sql.unsafe(`insert into "domain" ("id", "name", "createdAt", "updatedAt")
+						values ('dom_1', 'a.com', now(), now())`);
+					yield* sql.unsafe(`insert into "consent"
+						("id", "subjectId", "domainId", "purposeIds", "givenAt")
+						values ('cns_1', 'sub_missing', 'dom_1', '[]', now())`);
+
+					const adoption = yield* plan;
+					yield* apply(adoption, { skipForeignKeys: true });
+
+					// The orphan row survives — the operator chose integrity later
+					// over losing data now.
+					assert.strictEqual(yield* countOf('consent'), 1);
+
+					const ledger = yield* sql<{ name: string }>`
+						select ${sql('name')} from ${sql(LEDGER_TABLE)}
+					`;
+					assert.strictEqual(ledger[0]?.name, '1-baseline');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+	});
+
+	describe('adopt: refusals and edge cases', () => {
+		it.effect(
+			'refuses an unrecognised database rather than guessing',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					// A c15t-shaped database claiming a schema version we have no
+					// fixture for. Migrating it would be acting on an assumption
+					// about a shape nobody has seen.
+					yield* sql.unsafe(
+						`create table ${q('subject')} (${q('id')} varchar(255) primary key)`
+					);
+					yield* sql.unsafe(
+						`create table ${q('consent')} (${q('id')} varchar(255) primary key)`
+					);
+					// `key` is reserved on MySQL, and a primary key there must be
+					// bounded — hence varchar rather than text.
+					yield* sql.unsafe(
+						`create table ${q('private_c15t_settings')} (${q('key')} varchar(255) primary key, ${q('value')} text)`
+					);
+					yield* sql`
+						insert into ${sql('private_c15t_settings')} ${sql.insert({
+							key: 'version',
+							value: '9.9.9',
+						})}
+					`;
+
+					const adoption = yield* plan;
+
+					assert.strictEqual(adoption.shape._tag, 'Unknown');
+					assert.isDefined(adoption.blocked);
+					assert.deepStrictEqual(adoption.steps, [], 'must plan nothing');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(canDropNamedConstraint(engine) ? it.effect : it.effect.skip)(
+			'dies rather than applying a blocked plan',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					yield* baseline;
+					yield* sql.unsafe(
+						`alter table "consent" drop constraint "consent_subjectId_fkey"`
+					);
+					yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
+						values ('dom_1','a.com',now(),now())`);
+					yield* sql.unsafe(`insert into "consent"
+						("id","subjectId","domainId","purposeIds","givenAt")
+						values ('cns_1','sub_missing','dom_1','[]',now())`);
+
+					const adoption = yield* plan;
+					const outcome = yield* Effect.exit(apply(adoption));
+
+					// Refusing loudly beats a partial migration an operator has to
+					// unpick by hand.
+					assert.strictEqual(outcome._tag, 'Failure');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'plans nothing for a database already at the baseline',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					yield* baseline;
+					yield* sql.unsafe(
+						`create table ${q('c15t_migrations')} (${q('id')} integer primary key, ${q('name')} text)`
+					);
+
+					const adoption = yield* plan;
+
+					// Re-running adoption against our own output must be inert, or a
+					// retried deploy would churn the schema.
+					assert.strictEqual(adoption.shape._tag, 'Baseline');
+					assert.deepStrictEqual(adoption.steps, []);
+					assert.isUndefined(adoption.blocked);
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'adds only the columns a partial database is missing',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					yield* baseline;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					yield* sql.unsafe(
+						`alter table ${q('consent')} drop column ${q('tenantId')}`
+					);
+					yield* sql.unsafe(
+						`alter table ${q('consent')} drop column ${q('uiSource')}`
+					);
+
+					const adoption = yield* plan;
+					const added = adoption.steps.filter(
+						(step) => step.kind === 'add-column'
+					);
+
+					// Precisely two, not a wholesale rewrite: adoption must touch as
+					// little as it can get away with.
+					assert.strictEqual(added.length, 2);
+					yield* apply(adoption);
+
+					const names = yield* columnsOf('consent');
+					assert.include(names, 'tenantId');
+					assert.include(names, 'uiSource');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
+			'reports retained columns so an operator can prune deliberately',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* legacyish;
+					const adoption = yield* plan;
+
+					// The operator has to be told what was kept, or "additive" just
+					// means the extra columns are invisible instead of absent.
+					assert.isAbove(adoption.retained.length, 0);
+					assert.include(adoption.retained.join(' '), 'consentRecord');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+	});
+
+	/**
+	 * SQLite adoption.
+	 *
+	 * Every other case here runs on Postgres, which left the SQLite branches of
+	 * introspection and classification unexecuted — on the one code path that
+	 * touches a real deployment's data. SQLite is in-process, so there is no
+	 * excuse for not covering it.
+	 */
+}

--- a/packages/backend/src/db/adopt.ts
+++ b/packages/backend/src/db/adopt.ts
@@ -142,14 +142,21 @@ const observeExisting = Effect.fn('adopt.observe')(function* () {
 					where table_schema = database()
 						and referenced_table_name is not null
 				`,
+			// Scoped to the current schema. `pg_constraint` is database-wide, so
+			// without the namespace join a second c15t installation in another
+			// schema of the same database — which `database.schema` now makes a
+			// supported configuration — would look like foreign keys already
+			// present here. Adoption would then skip adding them *and* skip the
+			// orphan check that guards them.
 			orElse: () =>
 				sql<{ table_name: string; column_name: string }>`
 					select cl.relname as table_name, att.attname as column_name
 					from pg_constraint con
 					join pg_class cl on cl.oid = con.conrelid
+					join pg_namespace ns on ns.oid = cl.relnamespace
 					join unnest(con.conkey) as k(attnum) on true
 					join pg_attribute att on att.attrelid = con.conrelid and att.attnum = k.attnum
-					where con.contype = 'f'
+					where con.contype = 'f' and ns.nspname = current_schema()
 				`,
 		})
 		.pipe(Effect.orElseSucceed(() => []));

--- a/packages/backend/src/db/classify.test.ts
+++ b/packages/backend/src/db/classify.test.ts
@@ -5,17 +5,25 @@
  * RFC 0004 would have misfiled as legacy and converged destructively.
  */
 
-import { PgliteClient } from '@effect/sql-pglite';
 import { assert, describe, it } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
 import { singleTenant } from '../db/tenant';
 import { classify } from './classify';
+import * as Dialect from './dialect';
 import { up as baseline } from './migrations/1-baseline';
 
-// Tests run single-tenant unless a case says otherwise; the scope is a
-// service, so a query cannot run without one.
-const Pglite = Layer.merge(PgliteClient.layer({}), singleTenant);
+/**
+ * DDL quoted for the connected engine.
+ *
+ * These fixtures build legacy shapes by hand, so they emit their own DDL
+ * rather than going through `schema.ts`. MySQL delimits with backticks and
+ * rejects the double quotes the other two want.
+ */
+const quoted = Effect.gen(function* () {
+	return Dialect.escaperFor(yield* Dialect.current);
+});
 
 /**
  * The seven tables legacy and fumadb 1.0.0 share, differing only in whether
@@ -25,6 +33,13 @@ const Pglite = Layer.merge(PgliteClient.layer({}), singleTenant);
 const sevenTables = (metadataType: 'json' | 'jsonb') =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient;
+		const q = yield* quoted;
+		// MySQL has no `jsonb`; both eras store `json` there, which is exactly
+		// why classify cannot tell them apart on MySQL and answers by
+		// elimination instead (§11.7).
+		const metadata =
+			(yield* Dialect.current) === 'mysql' ? 'json' : metadataType;
+
 		for (const table of [
 			'subject',
 			'domain',
@@ -33,180 +48,213 @@ const sevenTables = (metadataType: 'json' | 'jsonb') =>
 			'auditLog',
 		]) {
 			yield* sql.unsafe(
-				`create table "${table}" ("id" varchar(255) primary key)`
+				`create table ${q(table)} (${q('id')} varchar(255) primary key)`
 			);
 		}
 		yield* sql.unsafe(
-			`create table "consent" ("id" varchar(255) primary key, "metadata" ${metadataType})`
+			`create table ${q('consent')} (${q('id')} varchar(255) primary key, ${q('metadata')} ${metadata})`
 		);
 		yield* sql.unsafe(
-			`create table "consentRecord" ("id" varchar(255) primary key)`
+			`create table ${q('consentRecord')} (${q('id')} varchar(255) primary key)`
 		);
 	});
 
 const withMarker = (version: string) =>
 	Effect.gen(function* () {
 		const sql = yield* SqlClient.SqlClient;
+		const q = yield* quoted;
+		// `key` is reserved on MySQL, and the value column must be bounded to
+		// be a primary key there.
 		yield* sql.unsafe(
-			`create table "private_c15t_settings" ("key" text primary key, "value" text)`
+			`create table ${q('private_c15t_settings')} (${q('key')} varchar(255) primary key, ${q('value')} text)`
 		);
-		yield* sql.unsafe(
-			`insert into "private_c15t_settings" ("key", "value") values ('version', '${version}')`
+		yield* sql`
+			insert into ${sql('private_c15t_settings')} ${sql.insert({
+				key: 'version',
+				value: version,
+			})}
+		`;
+	});
+
+/**
+ * Telling legacy from fumadb 1.0.0 by column type only works on Postgres.
+ *
+ * The distinction is `jsonb` against `json`, and it exists nowhere else:
+ * SQLite collapses both to TEXT, and MySQL has no `jsonb` at all — which is
+ * why classify answers by elimination there instead (§11.7). Running these
+ * cases on the other engines would assert behaviour the code deliberately
+ * does not have.
+ */
+const distinguishesByColumnType = (engine: (typeof ENGINES)[number]) =>
+	engine.name === 'pglite' || engine.name === 'postgres';
+
+for (const engine of ENGINES) {
+	describe('classify', () => {
+		it.effect(
+			'reports Empty for a database with no c15t tables',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Empty');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'recognises our own baseline output as the 2.0.0 shape',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					// Expected, and worth stating: the baseline reproduces 2.0.0
+					// exactly, so before the ledger is stamped it is indistinguishable
+					// from an adopted 2.0.0 database. That is the whole point.
+					yield* baseline;
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Fumadb200');
+					if (shape._tag === 'Fumadb200') {
+						assert.isFalse(shape.hasMarker);
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'reports Baseline once the ledger exists',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					const q = yield* quoted;
+					yield* baseline;
+					yield* sql.unsafe(
+						`create table ${q('c15t_migrations')} (${q('id')} integer primary key, ${q('name')} text)`
+					);
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Baseline');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(distinguishesByColumnType(engine) ? it.effect : it.effect.skip)(
+			'distinguishes legacy from fumadb 1.0.0 by column type when neither has a marker',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* sevenTables('jsonb');
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Legacy');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		(distinguishesByColumnType(engine) ? it.effect : it.effect.skip)(
+			'does not mistake an unmarked fumadb 1.0.0 database for legacy',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					// The ORM codegen path: c15t printed schema for the user to apply
+					// with Drizzle/Prisma/TypeORM, so fumadb's migrator never ran and
+					// never wrote a marker — but the schema is fumadb-shaped. Treating
+					// this as legacy would converge it destructively.
+					yield* sevenTables('json');
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Fumadb100');
+					if (shape._tag === 'Fumadb100') {
+						assert.isFalse(shape.hasMarker);
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'trusts the marker over shape inference when one is present',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* sevenTables('jsonb');
+					yield* withMarker('1.0.0');
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Fumadb100');
+					if (shape._tag === 'Fumadb100') {
+						assert.isTrue(shape.hasMarker);
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'refuses to guess at a marker naming an unknown schema version',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* sevenTables('json');
+					yield* withMarker('3.7.0');
+					const shape = yield* classify;
+					assert.strictEqual(shape._tag, 'Unknown');
+					if (shape._tag === 'Unknown') {
+						assert.include(shape.why, '3.7.0');
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
 		);
 	});
 
-describe('classify', () => {
-	it.effect(
-		'reports Empty for a database with no c15t tables',
-		() =>
-			Effect.gen(function* () {
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Empty');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
+	describe('a 2.x database created with tablePrefix', () => {
+		it.effect(
+			'refuses rather than reporting it empty',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					// What `tablePrefix: 'acme_'` produced in 2.x.
+					const q = yield* quoted;
+					for (const table of ['subject', 'consent', 'domain']) {
+						yield* sql.unsafe(
+							`create table ${q(`acme_${table}`)} (${q('id')} varchar(255) primary key)`
+						);
+					}
 
-	it.effect(
-		'recognises our own baseline output as the 2.0.0 shape',
-		() =>
-			Effect.gen(function* () {
-				// Expected, and worth stating: the baseline reproduces 2.0.0
-				// exactly, so before the ledger is stamped it is indistinguishable
-				// from an adopted 2.0.0 database. That is the whole point.
-				yield* baseline;
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Fumadb200');
-				if (shape._tag === 'Fumadb200') {
-					assert.isFalse(shape.hasMarker);
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
+					const shape = yield* classify;
 
-	it.effect(
-		'reports Baseline once the ledger exists',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* baseline;
-				yield* sql.unsafe(
-					`create table "c15t_migrations" ("id" integer primary key, "name" text)`
-				);
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Baseline');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
+					// Reporting Empty here is the dangerous answer, not a harmless one:
+					// the migrator would create a parallel schema and leave every
+					// existing consent record orphaned while the deployment came up
+					// looking healthy.
+					assert.strictEqual(shape._tag, 'Unknown');
+					if (shape._tag === 'Unknown') {
+						assert.include(shape.why, 'acme_');
+						assert.include(shape.why, 'tablePrefix');
+					}
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'distinguishes legacy from fumadb 1.0.0 by column type when neither has a marker',
-		() =>
-			Effect.gen(function* () {
-				yield* sevenTables('jsonb');
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Legacy');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'does not mistake an unmarked fumadb 1.0.0 database for legacy',
-		() =>
-			Effect.gen(function* () {
-				// The ORM codegen path: c15t printed schema for the user to apply
-				// with Drizzle/Prisma/TypeORM, so fumadb's migrator never ran and
-				// never wrote a marker — but the schema is fumadb-shaped. Treating
-				// this as legacy would converge it destructively.
-				yield* sevenTables('json');
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Fumadb100');
-				if (shape._tag === 'Fumadb100') {
-					assert.isFalse(shape.hasMarker);
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'trusts the marker over shape inference when one is present',
-		() =>
-			Effect.gen(function* () {
-				yield* sevenTables('jsonb');
-				yield* withMarker('1.0.0');
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Fumadb100');
-				if (shape._tag === 'Fumadb100') {
-					assert.isTrue(shape.hasMarker);
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'refuses to guess at a marker naming an unknown schema version',
-		() =>
-			Effect.gen(function* () {
-				yield* sevenTables('json');
-				yield* withMarker('3.7.0');
-				const shape = yield* classify;
-				assert.strictEqual(shape._tag, 'Unknown');
-				if (shape._tag === 'Unknown') {
-					assert.include(shape.why, '3.7.0');
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-});
-
-describe('a 2.x database created with tablePrefix', () => {
-	it.effect(
-		'refuses rather than reporting it empty',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				// What `tablePrefix: 'acme_'` produced in 2.x.
-				for (const table of ['subject', 'consent', 'domain']) {
+		it.effect(
+			'is not fooled by one unrelated table that happens to end in a known name',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					// Someone else's billing table. One match is not evidence.
+					const q = yield* quoted;
 					yield* sql.unsafe(
-						`create table "acme_${table}" ("id" varchar(255) primary key)`
+						`create table ${q('billing_consent')} (${q('id')} varchar(255) primary key)`
 					);
-				}
 
-				const shape = yield* classify;
+					assert.strictEqual((yield* classify)._tag, 'Empty');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
 
-				// Reporting Empty here is the dangerous answer, not a harmless one:
-				// the migrator would create a parallel schema and leave every
-				// existing consent record orphaned while the deployment came up
-				// looking healthy.
-				assert.strictEqual(shape._tag, 'Unknown');
-				if (shape._tag === 'Unknown') {
-					assert.include(shape.why, 'acme_');
-					assert.include(shape.why, 'tablePrefix');
-				}
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'is not fooled by one unrelated table that happens to end in a known name',
-		() =>
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				// Someone else's billing table. One match is not evidence.
-				yield* sql.unsafe(
-					'create table "billing_consent" ("id" varchar(255) primary key)'
-				);
-
-				assert.strictEqual((yield* classify)._tag, 'Empty');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-
-	it.effect(
-		'still recognises an ordinary empty database',
-		() =>
-			Effect.gen(function* () {
-				assert.strictEqual((yield* classify)._tag, 'Empty');
-			}).pipe(Effect.provide(Pglite)),
-		{ timeout: 60_000 }
-	);
-});
+		it.effect(
+			'still recognises an ordinary empty database',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					assert.strictEqual((yield* classify)._tag, 'Empty');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+	});
+}

--- a/packages/backend/src/db/schema-scoping.test.ts
+++ b/packages/backend/src/db/schema-scoping.test.ts
@@ -80,6 +80,11 @@ suite('schema scoping against real Postgres', () => {
 				Effect.gen(function* () {
 					const sql = yield* SqlClient.SqlClient;
 					yield* sql.unsafe(`drop schema if exists ${schema} cascade`);
+					// Establish the precondition rather than inherit it. The rest of
+					// the suite now runs against this same server and leaves its own
+					// tables in `public`, so this passing without the drop would be
+					// luck about test ordering rather than evidence.
+					yield* sql.unsafe('drop table if exists public.subject cascade');
 				})
 			);
 		});

--- a/packages/backend/src/db/tenant-isolation.test.ts
+++ b/packages/backend/src/db/tenant-isolation.test.ts
@@ -15,10 +15,10 @@
  * because nothing tested for it.
  */
 
-import { PgliteClient } from '@effect/sql-pglite';
 import { assert, describe, it } from '@effect/vitest';
-import { Effect, Layer } from 'effect';
+import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
 import { syncCurrent } from '../repository/legal-document';
 import { submit } from '../repository/record-consent';
 import {
@@ -29,199 +29,251 @@ import {
 } from '../repository/subject';
 import { up as baseline } from './migrations/1-baseline';
 import { layer as tenantLayer } from './tenant';
-
-const Pglite = PgliteClient.layer({});
-const asTenant = (id: string) => Layer.merge(Pglite, tenantLayer(id));
+import { encodeRow, encoder, toBoolean } from './values';
 
 /**
  * Two tenants whose data collides on every natural key: same external id, same
  * subject id shape, same policy type. Anything that leaks will be visible.
  */
 const seedBothTenants = Effect.gen(function* () {
+	yield* resetDatabase;
 	yield* baseline;
 	const sql = yield* SqlClient.SqlClient;
+	// Seeds go through the same encoder as production writes: SQLite can bind
+	// neither a Date nor a boolean.
+	const encode = yield* encoder;
+	const now = new Date(1_800_000_000_000);
 
 	for (const tenant of ['tenant_a', 'tenant_b']) {
-		yield* sql`insert into "domain" ("id","name","tenantId","createdAt","updatedAt")
-			values (${`dom_${tenant}`}, ${'shared.example'}, ${tenant}, ${new Date()}, ${new Date()})`;
-		yield* sql`insert into "subject" ("id","externalId","tenantId","createdAt","updatedAt")
-			values (${`sub_${tenant}`}, ${'shared_external_id'}, ${tenant}, ${new Date()}, ${new Date()})`;
-		yield* sql`insert into "consentPolicy"
-			("id","version","type","effectiveDate","isActive","tenantId","createdAt")
-			values (${`pol_${tenant}`}, ${'1.0'}, ${'cookie'}, ${new Date()}, ${true},
-				${tenant}, ${new Date()})`;
-		yield* sql`insert into "consent"
-			("id","subjectId","domainId","policyId","purposeIds","givenAt","tenantId")
-			values (${`cns_${tenant}`}, ${`sub_${tenant}`}, ${`dom_${tenant}`},
-				${`pol_${tenant}`}, ${'[]'}, ${new Date()}, ${tenant})`;
+		yield* sql`insert into ${sql('domain')} ${sql.insert(
+			encodeRow(encode, {
+				id: `dom_${tenant}`,
+				name: 'shared.example',
+				tenantId: tenant,
+				createdAt: now,
+				updatedAt: now,
+			})
+		)}`;
+		yield* sql`insert into ${sql('subject')} ${sql.insert(
+			encodeRow(encode, {
+				id: `sub_${tenant}`,
+				externalId: 'shared_external_id',
+				tenantId: tenant,
+				createdAt: now,
+				updatedAt: now,
+			})
+		)}`;
+		yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+			encodeRow(encode, {
+				id: `pol_${tenant}`,
+				version: '1.0',
+				type: 'cookie',
+				effectiveDate: now,
+				isActive: true,
+				tenantId: tenant,
+				createdAt: now,
+			})
+		)}`;
+		yield* sql`insert into ${sql('consent')} ${sql.insert(
+			encodeRow(encode, {
+				id: `cns_${tenant}`,
+				subjectId: `sub_${tenant}`,
+				domainId: `dom_${tenant}`,
+				policyId: `pol_${tenant}`,
+				purposeIds: '[]',
+				givenAt: now,
+				tenantId: tenant,
+			})
+		)}`;
 	}
 });
 
-describe('tenant isolation: reads', () => {
-	it.effect(
-		'listing sees only its own tenant despite a shared external id',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
-				const subjects = yield* listByExternalId('shared_external_id');
+for (const engine of ENGINES) {
+	describe('tenant isolation: reads', () => {
+		it.effect(
+			'listing sees only its own tenant despite a shared external id',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
+					const subjects = yield* listByExternalId('shared_external_id');
 
-				assert.strictEqual(subjects.length, 1, 'leaked another tenant');
-				assert.strictEqual(subjects[0]?.id, 'sub_tenant_a');
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
+					assert.strictEqual(subjects.length, 1, 'leaked another tenant');
+					assert.strictEqual(subjects[0]?.id, 'sub_tenant_a');
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'counting does not count another tenant',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
-				// Both tenants have exactly one subject under this external id.
-				assert.strictEqual(yield* countByExternalId('shared_external_id'), 1);
-			}).pipe(Effect.provide(asTenant('tenant_b'))),
-		{ timeout: 60_000 }
-	);
+		it.effect(
+			'counting does not count another tenant',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
+					// Both tenants have exactly one subject under this external id.
+					assert.strictEqual(yield* countByExternalId('shared_external_id'), 1);
+				}).pipe(Effect.provide(engine.asTenant('tenant_b'))),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'fetching another tenant subject by id returns nothing',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
-				// Knowing the id must not be enough — ids are guessable and
-				// sometimes logged.
-				assert.isUndefined(yield* findById('sub_tenant_b'));
-				assert.isDefined(yield* findById('sub_tenant_a'));
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
+		it.effect(
+			'fetching another tenant subject by id returns nothing',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
+					// Knowing the id must not be enough — ids are guessable and
+					// sometimes logged.
+					assert.isUndefined(yield* findById('sub_tenant_b'));
+					assert.isDefined(yield* findById('sub_tenant_a'));
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'a consent is not marked latest by another tenant policy',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
-				const subjects = yield* listByExternalId('shared_external_id');
-				const consent = subjects[0]?.consents[0];
+		it.effect(
+			'a consent is not marked latest by another tenant policy',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
+					const subjects = yield* listByExternalId('shared_external_id');
+					const consent = subjects[0]?.consents[0];
 
-				// The "latest policy per type" lookup is tenant-scoped; if it were
-				// not, tenant B's newer policy would silently invalidate tenant
-				// A's consent.
-				assert.isTrue(consent?.isLatestPolicy);
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
-});
+					// The "latest policy per type" lookup is tenant-scoped; if it were
+					// not, tenant B's newer policy would silently invalidate tenant
+					// A's consent.
+					assert.isTrue(consent?.isLatestPolicy);
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
+	});
 
-describe('tenant isolation: writes', () => {
-	it.effect(
-		'syncing a release does not deactivate another tenant policy',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
+	describe('tenant isolation: writes', () => {
+		it.effect(
+			'syncing a release does not deactivate another tenant policy',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
 
-				yield* syncCurrent({
-					tenantId: 'tenant_a',
-					type: 'cookie',
-					version: '2.0',
-					hash: 'sha256-new',
-					effectiveDate: new Date(),
-				});
+					yield* syncCurrent({
+						tenantId: 'tenant_a',
+						type: 'cookie',
+						version: '2.0',
+						hash: 'sha256-new',
+						effectiveDate: new Date(),
+					});
 
-				const sql = yield* SqlClient.SqlClient;
-				const others = yield* sql<{ isActive: boolean }>`
-					select "isActive" from "consentPolicy" where "id" = 'pol_tenant_b'
+					const sql = yield* SqlClient.SqlClient;
+					const others = yield* sql<{ isActive: unknown }>`
+					select ${sql('isActive')} from ${sql('consentPolicy')}
+					where ${sql('id')} = ${'pol_tenant_b'}
 				`;
 
-				// Cross-tenant corruption, not just disclosure: tenant B's banner
-				// would stop matching a current policy because tenant A published.
-				assert.isTrue(
-					others[0]?.isActive,
-					"deactivated another tenant's policy"
-				);
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
+					// Cross-tenant corruption, not just disclosure: tenant B's banner
+					// would stop matching a current policy because tenant A published.
+					// Decoded rather than compared raw: Postgres gives `true`, MySQL a
+					// tinyint `1`, SQLite an integer `1`.
+					assert.isTrue(
+						toBoolean(others[0]?.isActive),
+						"deactivated another tenant's policy"
+					);
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'identifying a subject cannot reach another tenant',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
+		it.effect(
+			'identifying a subject cannot reach another tenant',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
 
-				const result = yield* linkExternalId({
-					subjectId: 'sub_tenant_b',
-					externalId: 'hijacked',
-					identityProvider: 'external',
-					ipAddress: null,
-					userAgent: null,
-				});
+					const result = yield* linkExternalId({
+						subjectId: 'sub_tenant_b',
+						externalId: 'hijacked',
+						identityProvider: 'external',
+						ipAddress: null,
+						userAgent: null,
+					});
 
-				assert.isUndefined(result, 'wrote to another tenant');
+					assert.isUndefined(result, 'wrote to another tenant');
 
-				const sql = yield* SqlClient.SqlClient;
-				const rows = yield* sql<{ externalId: string | null }>`
-					select "externalId" from "subject" where "id" = 'sub_tenant_b'
+					const sql = yield* SqlClient.SqlClient;
+					const rows = yield* sql<{ externalId: string | null }>`
+					select ${sql('externalId')} from ${sql('subject')}
+						where ${sql('id')} = ${'sub_tenant_b'}
 				`;
-				assert.strictEqual(rows[0]?.externalId, 'shared_external_id');
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
+					assert.strictEqual(rows[0]?.externalId, 'shared_external_id');
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
 
-	it.effect(
-		'the same submission under two tenants is two consents',
-		() =>
-			Effect.gen(function* () {
-				yield* baseline;
-				const sql = yield* SqlClient.SqlClient;
-				for (const tenant of ['tenant_a', 'tenant_b']) {
-					yield* sql`insert into "domain" ("id","name","tenantId","createdAt","updatedAt")
-						values (${`dom_${tenant}`}, ${'d'}, ${tenant}, ${new Date()}, ${new Date()})`;
-				}
+		it.effect(
+			'the same submission under two tenants is two consents',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* baseline;
+					const sql = yield* SqlClient.SqlClient;
+					const encode = yield* encoder;
+					for (const tenant of ['tenant_a', 'tenant_b']) {
+						yield* sql`insert into ${sql('domain')} ${sql.insert(
+							encodeRow(encode, {
+								id: `dom_${tenant}`,
+								name: 'd',
+								tenantId: tenant,
+								createdAt: new Date(1_800_000_000_000),
+								updatedAt: new Date(1_800_000_000_000),
+							})
+						)}`;
+					}
 
-				const submission = {
-					subjectId: 'sub_shared',
-					domainId: 'dom_tenant_a',
-					purposeIds: ['analytics'],
-					givenAt: new Date(1_800_000_000_000),
-					ipAddress: null,
-					userAgent: null,
-				};
+					const submission = {
+						subjectId: 'sub_shared',
+						domainId: 'dom_tenant_a',
+						purposeIds: ['analytics'],
+						givenAt: new Date(1_800_000_000_000),
+						ipAddress: null,
+						userAgent: null,
+					};
 
-				yield* submit({ ...submission, tenantId: 'tenant_a' });
-				yield* submit({
-					...submission,
-					domainId: 'dom_tenant_b',
-					tenantId: 'tenant_b',
-				});
+					yield* submit({ ...submission, tenantId: 'tenant_a' });
+					yield* submit({
+						...submission,
+						domainId: 'dom_tenant_b',
+						tenantId: 'tenant_b',
+					});
 
-				// Structurally identical consent from two tenants is two separate
-				// legal records, so the deterministic id must include the tenant.
-				const rows = yield* sql<{ total: string }>`
-					select count(*) as total from "consent"
+					// Structurally identical consent from two tenants is two separate
+					// legal records, so the deterministic id must include the tenant.
+					const rows = yield* sql<{ total: string }>`
+					select count(*) as total from ${sql('consent')}
 				`;
-				assert.strictEqual(Number(rows[0]?.total), 2);
-			}).pipe(Effect.provide(asTenant('tenant_a'))),
-		{ timeout: 60_000 }
-	);
-});
+					assert.strictEqual(Number(rows[0]?.total), 2);
+				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
+			{ timeout: 60_000 }
+		);
+	});
 
-describe('tenant isolation: single-tenant deployments', () => {
-	it.effect(
-		'a null-tenant scope does not see tenanted rows',
-		() =>
-			Effect.gen(function* () {
-				yield* seedBothTenants;
-				const sql = yield* SqlClient.SqlClient;
-				yield* sql`insert into "subject" ("id","externalId","createdAt","updatedAt")
-					values (${'sub_null'}, ${'shared_external_id'}, ${new Date()}, ${new Date()})`;
+	describe('tenant isolation: single-tenant deployments', () => {
+		it.effect(
+			'a null-tenant scope does not see tenanted rows',
+			() =>
+				Effect.gen(function* () {
+					yield* seedBothTenants;
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql`insert into ${sql('subject')} ${sql.insert(
+						encodeRow(yield* encoder, {
+							id: 'sub_null',
+							externalId: 'shared_external_id',
+							createdAt: new Date(1_800_000_000_000),
+							updatedAt: new Date(1_800_000_000_000),
+						})
+					)}`;
 
-				const subjects = yield* listByExternalId('shared_external_id');
+					const subjects = yield* listByExternalId('shared_external_id');
 
-				// `is null` is still a filter. A single-tenant deployment that
-				// later gains tenanted rows must not start seeing them.
-				assert.strictEqual(subjects.length, 1);
-				assert.strictEqual(subjects[0]?.id, 'sub_null');
-			}).pipe(Effect.provide(Layer.merge(Pglite, tenantLayer(undefined)))),
-		{ timeout: 60_000 }
-	);
-});
+					// `is null` is still a filter. A single-tenant deployment that
+					// later gains tenanted rows must not start seeing them.
+					assert.strictEqual(subjects.length, 1);
+					assert.strictEqual(subjects[0]?.id, 'sub_null');
+				}).pipe(Effect.provide(engine.asTenant(undefined))),
+			{ timeout: 60_000 }
+		);
+	});
+}

--- a/turbo.json
+++ b/turbo.json
@@ -197,7 +197,8 @@
 				"coverage/coverage-summary.json",
 				"coverage/coverage-final.json",
 				"coverage/html/**"
-			]
+			],
+			"env": ["C15T_TEST_PG_URL", "C15T_TEST_MYSQL_URL"]
 		},
 		"test-storybook": {
 			"dependsOn": ["build", "^build"],


### PR DESCRIPTION
The cross-engine suite added after MySQL was found unable to run a single statement covered **one file**. Twelve others were PGlite-only, real Postgres was not in the matrix at all, and neither MySQL nor Postgres ran in CI — so the MySQL arm and every schema-scoping test **skipped silently on every pull request**.

Opt-in coverage that nothing opts into is not coverage.

## CI gains `postgres:16` and `mysql:8`

Both Postgres engines are in the matrix deliberately. PGlite stands in for Postgres almost everywhere, but runs a single in-process connection and so cannot exhibit anything pool-shaped — schema scoping being the worked example, where a one-off `SET search_path` passes on PGlite and scopes one connection of a real pool.

## What converting the suites found — all invisible on PGlite

**Tenant isolation** (the suite proving tenants cannot see each other, which ran on exactly one engine): seeded `Date`s SQLite cannot bind, wrote raw double-quoted SQL MySQL rejects, and asserted `isActive === true` where MySQL returns tinyint `1` and SQLite integer `1`.

**classify**: built fixtures with double-quoted DDL and a `key` column, reserved on MySQL. Two classification cases are now explicitly Postgres-only rather than quietly passing — telling legacy from fumadb by column type needs `jsonb` vs `json`, which exists nowhere else.

**One test was passing on ordering luck.** `leaves public alone` was only true because the pg reset happened to run first. It establishes its own precondition now.

## Adoption, on all four engines

`adopt.test.ts` guards the only code in the package that touches someone else's production data, and it ran on PGlite with a small SQLite annex. It now builds each legacy shape with that engine's **own physical types** — `datetime` and `varchar` on MySQL, epoch integers and `TEXT` on SQLite. Postgres types everywhere would test a database that has never existed, and on MySQL would not create at all: it cannot index a `TEXT` foreign key column.

**That conversion surfaced a real bug.** `adopt.ts`'s Postgres foreign-key introspection read `pg_constraint` without joining `pg_namespace`, so it was database-wide rather than schema-scoped. Harmless while c15t only lived in `public`; not harmless now that a second installation in another schema is a supported configuration — adoption would see that installation's foreign keys, conclude this one already had them, and **skip both adding them and the orphan check that guards them**. It showed up as two tests failing only after the schema-scoping suite had touched the same server; invisible when every test gets a fresh in-process database.

Twelve cases are explicitly engine-gated rather than quietly passing. Six need to classify an unmarked legacy database, which SQLite cannot do. Three manufacture an orphan by dropping a named constraint, which SQLite cannot do and MySQL names differently — the behaviour is engine-independent, only that precondition is not.

## The CI run that reported green while testing nothing

The first run with the services reported the backend at **22 passed, 1 skipped** — the no-servers count. The services were up and the URLs were set on the step, and the matrix still saw neither engine.

Turborepo's default `envMode` is **strict**: a task only receives environment variables declared in `turbo.json`. `C15T_TEST_PG_URL` and `C15T_TEST_MYSQL_URL` were filtered out before vitest started, so `ENGINES` fell back to PGlite and SQLite and every MySQL and real-Postgres case skipped silently, with a green suite.

They are declared on the `test` task now, under `env` rather than `passThroughEnv`, because the results differ with and without the servers so the cache key must too. Verified through turbo as CI invokes it: 23 of 23 files with the servers, 22 passed 1 skipped without.

## Workflow pinning

Also pins every action and image reference in `ci.yml`. zizmor only audits workflows when one changes, so adding the services was the first thing to lint that file — surfacing seven pre-existing unpinned actions alongside my two images. The action SHAs are the ones this file and the repo already use, so this **pins rather than upgrades**. Verified with zizmor at CI's own settings: no findings.

## Tests

354 across four engines, stable over three consecutive runs; 257 across two without Docker.
