### PR TITLE
fix(build): cache generated package versions

### DIFF
--- a/packages/iab/package.json
+++ b/packages/iab/package.json
@@ -48,7 +48,7 @@
 	"scripts": {
 		"prebuild": "genversion --esm --semi src/version.ts",
 		"build": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs",
-		"check-types": "tsc --noEmit",
+		"check-types": "bun prebuild && tsc --noEmit",
 		"dev": "sh -c 'bun prebuild && rslib build --no-dts --no-clean && rslib build --watch --no-dts --no-clean'",
 		"fmt": "bun biome format --write . && bun biome check --formatter-enabled=false --linter-enabled=false --write",
 		"lint": "bun biome lint ./src",

--- a/turbo.json
+++ b/turbo.json
@@ -12,32 +12,57 @@
 				"dist/**",
 				"dist-types/**",
 				"AGENTS.md",
-				"docs/**"
+				"docs/**",
+				"src/version.ts"
 			],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"c15t#build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", "dist-types/**", "AGENTS.md", "docs/**"],
+			"outputs": [
+				"dist/**",
+				"dist-types/**",
+				"AGENTS.md",
+				"docs/**",
+				"src/version.ts"
+			],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/react#build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", "dist-types/**", "AGENTS.md", "docs/**"],
+			"outputs": [
+				"dist/**",
+				"dist-types/**",
+				"AGENTS.md",
+				"docs/**",
+				"src/version.ts"
+			],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/nextjs#build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", "dist-types/**", "AGENTS.md", "docs/**"],
+			"outputs": [
+				"dist/**",
+				"dist-types/**",
+				"AGENTS.md",
+				"docs/**",
+				"src/version.ts"
+			],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/backend#build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
-			"outputs": ["dist/**", "dist-types/**", "AGENTS.md", "docs/**"],
+			"outputs": [
+				"dist/**",
+				"dist-types/**",
+				"AGENTS.md",
+				"docs/**",
+				"src/version.ts"
+			],
 			"env": ["WITH_RSDOCTOR"]
 		},
 		"@c15t/benchmarking#build": {


### PR DESCRIPTION
## Summary

- cache generated `src/version.ts` files with package build outputs
- run the IAB prebuild before type-checking, matching the other versioned packages
- keep this unrelated build fix out of the PostHog hotfix stack

A Turbo cache hit previously restored `dist/` without the generated source file, so a dependent `check-types` task could fail on a missing version import.

## Merge ordering

Land this PR before #982, #983, and #984. Their full repository type-check currently exposes this existing IAB failure; the build fix is intentionally kept here instead of being hidden inside a PostHog diff.

## Verification

- `bun run check-types --filter=@c15t/iab`

No changeset: this only changes repository build and type-check behavior.
