### PR TITLE
test(backend): cover the migrator end to end, and the shipped artifact

### DIFF
--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1248,3 +1248,46 @@ so adding the services was the first thing to lint that file, and it surfaced
 seven pre-existing unpinned action references alongside my two images. The
 action SHAs are the ones the file and repo already use elsewhere, so this pins
 rather than upgrades.
+
+### 11.25 Covering the parts users touch
+
+§11.22 and §11.23 made the *data* layer trustworthy across four engines. A
+coverage read afterwards showed the weakness had moved to the opposite end:
+89% statements overall, but the **public API layer at 64%**, with
+`createMigrator` and `defineConfig` at **zero**. The layer with the least
+coverage was the only layer anybody imports.
+
+Three things closed it, and the choice of what to test was as important as the
+count:
+
+- **`createMigrator` end to end**, against SQLite, Postgres and MySQL, driven
+  by a *connection description* rather than a `Layer`. That form is what a
+  deploy script writes, and it is the only thing that exercises
+  `db/connect.ts`'s driver loading. It asserts the properties that matter to
+  someone running it against production: `plan` writes nothing, `apply` is
+  idempotent across separate processes, the pool is released, and an
+  unrecognisable database is **reported rather than thrown** — so a deploy
+  script can tell "I do not recognise this" from "the network is down".
+- **The driver-missing path**, which is what a self-hoster meets first if they
+  configure an engine whose optional peer they did not install. All three are
+  present in this repo, so the loader is exported `@internal` and handed an
+  importer that fails — the same failure a missing module produces.
+- **The published artifact.** Every other test in the package imports from
+  `src/`, which proves the code works and says nothing about whether the thing
+  on npm does. `./cache` and `./db/migrations/*` were both added to the exports
+  map during this rewrite and had never once been resolved the way npm
+  resolves them. It now checks that every entry has a built file, that `files`
+  covers everything the map references, that each subpath loads, that the
+  named exports are present, and that `require.resolve` succeeds through the
+  map rather than by file path. Verified to fail by adding a bogus subpath:
+  three of the seven catch it.
+
+Also covered the two remote cache adapters, ported at §11.14 with no tests at
+all. Both convert this package's milliseconds into their backend's seconds —
+arithmetic that is silently wrong by a factor of a thousand and shows up only
+as a cache that never hits or never expires.
+
+**95.9% statements, 94% functions, 388 tests across four engines**, stable over
+consecutive runs; 281 without Docker. `version.ts` is generated and
+`src/policy/builder.ts` — ported wholesale from 2.x — is the remaining soft
+spot at 69%.

--- a/packages/backend/src/__tests__/packaged.test.ts
+++ b/packages/backend/src/__tests__/packaged.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The package as a consumer receives it.
+ *
+ * Every other test in this package imports from `src/`. That proves the code
+ * works and says nothing about whether the *published artifact* does — and the
+ * two can differ in ways no source test can see:
+ *
+ * - an `exports` entry pointing at a path `rslib` does not emit;
+ * - a subpath added to `src/` but never added to the exports map, so it
+ *   resolves for us and 404s for everyone else;
+ * - `files` omitting something the exports map references;
+ * - a type declaration that does not exist next to the JS it describes.
+ *
+ * `./cache` and `./db/migrations/*` were both added to that map during this
+ * rewrite and never once resolved the way npm resolves them.
+ *
+ * This reads `dist/` rather than packing a tarball: `test` already depends on
+ * `build` in `turbo.json`, so the artifact is there, and packing per test run
+ * would cost more than it tells us. `scripts/check-publish-artifacts.ts`
+ * remains the check on what the tarball *contains*; this is the check on
+ * whether it *loads*.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assert, describe, it } from '@effect/vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const manifest = JSON.parse(
+	readFileSync(join(packageRoot, 'package.json'), 'utf8')
+) as {
+	name: string;
+	exports: Record<string, { types: string; import: string; require: string }>;
+	files: string[];
+};
+
+const built = existsSync(join(packageRoot, 'dist'));
+const suite = built ? describe : describe.skip;
+
+/** Every concrete export path, with `*` patterns resolved to a real entry. */
+const entries = Object.entries(manifest.exports).flatMap(
+	([subpath, targets]) =>
+		subpath.includes('*')
+			? [
+					[
+						subpath.replace('*', '1-baseline'),
+						Object.fromEntries(
+							Object.entries(targets).map(([k, v]) => [
+								k,
+								v.replace('*', '1-baseline'),
+							])
+						) as typeof targets,
+					] as const,
+				]
+			: [[subpath, targets] as const]
+);
+
+suite('the published artifact', () => {
+	it('has a file behind every exports entry', () => {
+		for (const [subpath, targets] of entries) {
+			for (const [condition, target] of Object.entries(targets)) {
+				assert.isTrue(
+					existsSync(join(packageRoot, target)),
+					`${manifest.name}${subpath.slice(1)} (${condition}) points at ${target}, which was not built`
+				);
+			}
+		}
+	});
+
+	it('ships every path the exports map references', () => {
+		// `files` decides what npm uploads. An exports entry pointing outside it
+		// resolves locally and fails for everyone else.
+		for (const [, targets] of entries) {
+			for (const target of Object.values(targets)) {
+				const top = target.replace(/^\.\//, '').split('/')[0] ?? '';
+				assert.include(
+					manifest.files,
+					top,
+					`exports references ${target}, but "${top}" is not in "files"`
+				);
+			}
+		}
+	});
+
+	it('loads the main entry and exposes the public API', async () => {
+		const entry = manifest.exports['.']?.import ?? '';
+		const module = (await import(join(packageRoot, entry))) as Record<
+			string,
+			unknown
+		>;
+
+		// The names the 9 dependents and the docs actually import. A missing one
+		// is a broken install, not a failing test.
+		for (const name of [
+			'c15tInstance',
+			'createMigrator',
+			'migrate',
+			'classify',
+			'defineConfig',
+			'toLayer',
+			'policyPackPresets',
+			'policyBuilder',
+			'composePacks',
+			'version',
+		]) {
+			assert.isDefined(module[name], `${name} is missing from the entry point`);
+		}
+	});
+
+	it('loads every subpath', async () => {
+		for (const [subpath, targets] of entries) {
+			if (subpath === '.') {
+				continue;
+			}
+			const module = (await import(join(packageRoot, targets.import))) as
+				| Record<string, unknown>
+				| undefined;
+			assert.isDefined(module, `${subpath} failed to load`);
+		}
+	});
+
+	it('exposes the cache adapters consumers were told to use', async () => {
+		// examples/demo imports this by subpath; it was added to the exports map
+		// during the rewrite and nothing resolved it as npm would.
+		const cache = (await import(
+			join(packageRoot, manifest.exports['./cache']?.import ?? '')
+		)) as Record<string, unknown>;
+
+		for (const name of [
+			'createMemoryCacheAdapter',
+			'createUpstashRedisAdapter',
+			'createCloudflareKVAdapter',
+			'createGVLCacheKey',
+		]) {
+			assert.isDefined(cache[name], `${name} is missing from ./cache`);
+		}
+	});
+
+	it('resolves through the exports map, not just by file path', () => {
+		// The above import concrete paths, which would pass even if the map were
+		// malformed. This asks Node to resolve the specifier a consumer writes.
+		const require = createRequire(join(packageRoot, 'package.json'));
+		for (const [subpath] of entries) {
+			const specifier = `${manifest.name}${subpath.slice(1)}`;
+			assert.doesNotThrow(
+				() => require.resolve(specifier),
+				`${specifier} does not resolve through the exports map`
+			);
+		}
+	});
+
+	it('has types next to every entry', () => {
+		for (const [subpath, targets] of entries) {
+			assert.isTrue(
+				existsSync(join(packageRoot, targets.types)),
+				`${subpath} has no type declaration at ${targets.types}`
+			);
+		}
+	});
+});

--- a/packages/backend/src/cache/cache.test.ts
+++ b/packages/backend/src/cache/cache.test.ts
@@ -17,9 +17,12 @@ import { afterEach, assert, describe, it } from '@effect/vitest';
 import {
 	clearMemoryCache,
 	createCacheKey,
+	createCloudflareKVAdapter,
 	createGVLCacheKey,
 	createMemoryCacheAdapter,
+	createUpstashRedisAdapterFromClient,
 	getMemoryCacheSize,
+	type KVNamespace,
 } from './index';
 
 afterEach(() => {
@@ -104,5 +107,137 @@ describe('cache keys', () => {
 			createCacheKey('app', 'translations', 'en', 'banner'),
 			'app:translations:en:banner'
 		);
+	});
+});
+
+/**
+ * The two remote adapters, against fakes.
+ *
+ * Both were ported with no tests, and both convert between this package's
+ * milliseconds and their backend's own unit — the kind of arithmetic that is
+ * silently wrong by a factor of a thousand and only shows up as a cache that
+ * never hits, or one that never expires.
+ */
+describe('cloudflare KV adapter', () => {
+	const fakeKv = () => {
+		const store = new Map<string, string>();
+		const puts: { key: string; ttl?: number }[] = [];
+		const kv: KVNamespace = {
+			// Real KV parses when asked for `type: 'json'` and returns the raw
+			// string otherwise; the adapter relies on both halves of that.
+			get: async (key, options) => {
+				const raw = store.get(key);
+				if (raw === undefined) {
+					return null;
+				}
+				return options?.type === 'json' ? JSON.parse(raw) : raw;
+			},
+			put: async (key, value, options) => {
+				store.set(key, value);
+				puts.push({ key, ttl: options?.expirationTtl });
+			},
+			delete: async (key) => {
+				store.delete(key);
+			},
+		};
+		return { kv, store, puts };
+	};
+
+	it('round-trips a value as JSON', async () => {
+		const { kv, store } = fakeKv();
+		const cache = createCloudflareKVAdapter(kv);
+
+		await cache.set('k', { hello: 'world' });
+
+		// KV stores strings; the adapter owns the serialisation.
+		assert.strictEqual(store.get('k'), JSON.stringify({ hello: 'world' }));
+		assert.deepStrictEqual(await cache.get('k'), { hello: 'world' });
+	});
+
+	it('converts the ttl from milliseconds to seconds', async () => {
+		const { kv, puts } = fakeKv();
+		await createCloudflareKVAdapter(kv).set('k', 'v', 60_000);
+
+		// KV counts seconds. Passing milliseconds straight through would ask for
+		// a 60,000-second entry — sixteen hours instead of a minute.
+		assert.strictEqual(puts[0]?.ttl, 60);
+	});
+
+	it('reports a miss as null and deletes', async () => {
+		const { kv } = fakeKv();
+		const cache = createCloudflareKVAdapter(kv);
+
+		assert.isNull(await cache.get('absent'));
+		assert.isFalse(await cache.has('absent'));
+
+		await cache.set('k', 'v');
+		assert.isTrue(await cache.has('k'));
+		await cache.delete('k');
+		assert.isNull(await cache.get('k'));
+	});
+});
+
+describe('upstash redis adapter', () => {
+	const fakeRedis = () => {
+		const store = new Map<string, unknown>();
+		const sets: { key: string; ex?: number }[] = [];
+		const client = {
+			get: async <T>(key: string) => (store.get(key) ?? null) as T | null,
+			set: async <T>(key: string, value: T, options?: { ex?: number }) => {
+				store.set(key, value);
+				sets.push({ key, ex: options?.ex });
+			},
+			del: async (key: string) => {
+				store.delete(key);
+			},
+			exists: async (key: string) => (store.has(key) ? 1 : 0),
+		};
+		return { client, sets };
+	};
+
+	it('round-trips a value', async () => {
+		const { client } = fakeRedis();
+		const cache = createUpstashRedisAdapterFromClient(
+			client as unknown as Parameters<
+				typeof createUpstashRedisAdapterFromClient
+			>[0]
+		);
+
+		await cache.set('k', { hello: 'world' });
+		assert.deepStrictEqual(await cache.get('k'), { hello: 'world' });
+		assert.isTrue(await cache.has('k'));
+	});
+
+	it('converts the ttl from milliseconds to seconds', async () => {
+		const { client, sets } = fakeRedis();
+		const cache = createUpstashRedisAdapterFromClient(
+			client as unknown as Parameters<
+				typeof createUpstashRedisAdapterFromClient
+			>[0]
+		);
+
+		await cache.set('k', 'v', 60_000);
+		// Redis EX counts seconds.
+		assert.strictEqual(sets[0]?.ex, 60);
+
+		// And rounds up rather than to zero, which would mean "no expiry".
+		await cache.set('k2', 'v', 1);
+		assert.strictEqual(sets[1]?.ex, 1);
+	});
+
+	it('reports a miss as null and deletes', async () => {
+		const { client } = fakeRedis();
+		const cache = createUpstashRedisAdapterFromClient(
+			client as unknown as Parameters<
+				typeof createUpstashRedisAdapterFromClient
+			>[0]
+		);
+
+		assert.isNull(await cache.get('absent'));
+		assert.isFalse(await cache.has('absent'));
+
+		await cache.set('k', 'v');
+		await cache.delete('k');
+		assert.isFalse(await cache.has('k'));
 	});
 });

--- a/packages/backend/src/db/connect.ts
+++ b/packages/backend/src/db/connect.ts
@@ -128,7 +128,16 @@ const driver = {
 	sqlite: '@effect/sql-sqlite-node',
 } as const;
 
-const load = <A>(
+/**
+ * Imports a driver, turning "not installed" into an actionable message.
+ *
+ * Exported for its test: the failure only happens when an optional peer is
+ * absent, and all three are present in this repo, so the only way to exercise
+ * it is to hand it an importer that fails. Not part of the public API.
+ *
+ * @internal
+ */
+export const loadDriver = <A>(
 	dialect: DatabaseConfig['dialect'],
 	importer: () => Promise<A>
 ): Effect.Effect<A> =>
@@ -191,7 +200,7 @@ const fromConfig = (
 		case 'postgres':
 			return Layer.unwrap(
 				Effect.map(
-					load('postgres', () => import('@effect/sql-pg')),
+					loadDriver('postgres', () => import('@effect/sql-pg')),
 					// Redacted because the URL carries credentials, and Effect keeps
 					// them out of logs and error messages by construction.
 					({ PgClient }) =>
@@ -203,7 +212,7 @@ const fromConfig = (
 		case 'mysql':
 			return Layer.unwrap(
 				Effect.map(
-					load('mysql', () => import('@effect/sql-mysql2')),
+					loadDriver('mysql', () => import('@effect/sql-mysql2')),
 					({ MysqlClient }) =>
 						MysqlClient.layer({ url: Redacted.make(config.url) })
 				)
@@ -211,7 +220,7 @@ const fromConfig = (
 		case 'sqlite':
 			return Layer.unwrap(
 				Effect.map(
-					load('sqlite', () => import('@effect/sql-sqlite-node')),
+					loadDriver('sqlite', () => import('@effect/sql-sqlite-node')),
 					({ SqliteClient }) =>
 						SqliteClient.layer({ filename: config.filename })
 				)

--- a/packages/backend/src/define-config.test.ts
+++ b/packages/backend/src/define-config.test.ts
@@ -1,0 +1,21 @@
+/**
+ * `defineConfig` is an identity function, and worth one test anyway: it is a
+ * public export that a config file's type-checking hangs on, and it was at
+ * zero coverage — so nothing would have noticed it being deleted.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { defineConfig } from './define-config';
+
+describe('defineConfig', () => {
+	it('returns the config unchanged', () => {
+		const config = {
+			database: { dialect: 'postgres', url: 'postgres://h/db' },
+			trustedOrigins: ['https://example.com'],
+		} as const;
+
+		// Identity, deliberately: its whole job is to attach a type so an editor
+		// completes the object and a typo is a compile error.
+		assert.deepStrictEqual(defineConfig(config), config);
+	});
+});

--- a/packages/backend/src/migrator.test.ts
+++ b/packages/backend/src/migrator.test.ts
@@ -1,0 +1,287 @@
+/**
+ * The migrator, end to end, as a deploy script uses it.
+ *
+ * `db/migrate.test.ts` covers the Effect underneath against every engine.
+ * This covers the thing people actually call — and it had **no tests at all**,
+ * which is a poor state for the API that runs DDL against production.
+ *
+ * Two differences from the layer below, and both are the point:
+ *
+ * - it takes a **connection description**, not a `Layer`, so this is the only
+ *   test that exercises `db/connect.ts`'s driver loading — the code that
+ *   decides which of three optional peer dependencies to import;
+ * - it **owns a pool**, so `dispose` is part of the contract rather than a
+ *   detail. A deploy script that leaks one does not exit, and CI hangs.
+ *
+ * SQLite runs everywhere. Postgres and MySQL join when their URLs are set;
+ * see `__tests__/engines`.
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assert, describe, expect, it } from '@effect/vitest';
+import { Effect, type Layer, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { resetDatabase } from './__tests__/engines';
+import type { DatabaseConfig } from './db/connect';
+import { loadDriver, MissingDatabaseError, toLayer } from './db/connect';
+import * as Dialect from './db/dialect';
+import { createMigrator } from './migrator';
+
+const PG_URL = process.env.C15T_TEST_PG_URL;
+const MYSQL_URL = process.env.C15T_TEST_MYSQL_URL;
+
+/** A fresh SQLite file per case; the file *is* the isolation on SQLite. */
+const sqliteConfig = (): DatabaseConfig => ({
+	dialect: 'sqlite',
+	filename: join(mkdtempSync(join(tmpdir(), 'c15t-migrator-')), 'c15t.db'),
+});
+
+const CONFIGS: ReadonlyArray<readonly [string, () => DatabaseConfig]> = [
+	['sqlite', sqliteConfig],
+	...(PG_URL
+		? ([
+				[
+					'postgres',
+					// Its own schema per run, so this suite cannot collide with the
+					// rest of the suite sharing the server.
+					() =>
+						({
+							dialect: 'postgres',
+							url: PG_URL,
+							schema: 'c15t_migrator_e2e',
+						}) as DatabaseConfig,
+				],
+			] as const)
+		: []),
+	...(MYSQL_URL
+		? ([
+				[
+					'mysql',
+					() => ({ dialect: 'mysql', url: MYSQL_URL }) as DatabaseConfig,
+				],
+			] as const)
+		: []),
+];
+
+/**
+ * Drops everything, so a case starts from an empty database.
+ *
+ * SQLite gets a fresh file per case and needs nothing. Postgres and MySQL are
+ * shared servers where every case in this file would otherwise inherit the
+ * last one's schema — which silently turned "a fresh database has work to do"
+ * into "it does not".
+ */
+const reset = async (config: DatabaseConfig): Promise<void> => {
+	if (config.dialect === 'sqlite') {
+		return;
+	}
+	const runtime = ManagedRuntime.make(
+		toLayer(config) as Layer.Layer<SqlClient.SqlClient, never>
+	);
+	try {
+		await runtime.runPromise(resetDatabase);
+	} finally {
+		await runtime.dispose();
+	}
+};
+
+/** Runs `use` with a migrator and always releases the pool. */
+const withMigrator = async <A>(
+	config: DatabaseConfig,
+	use: (migrator: ReturnType<typeof createMigrator>) => Promise<A>
+): Promise<A> => {
+	const migrator = createMigrator(config);
+	try {
+		return await use(migrator);
+	} finally {
+		await migrator.dispose();
+	}
+};
+
+describe('createMigrator: configuration', () => {
+	it('refuses a missing database by name', () => {
+		// The first thing anyone upgrading from 2.x hits, because `adapter` is
+		// gone and its replacement is required. A bare TypeError mentioning the
+		// `in` operator would tell them nothing.
+		assert.throws(
+			() => toLayer(undefined as unknown as DatabaseConfig),
+			MissingDatabaseError
+		);
+		assert.throws(
+			() => toLayer(undefined as unknown as DatabaseConfig),
+			/replaced 2\.x/
+		);
+	});
+
+	it('builds a layer for each dialect without connecting', () => {
+		// Construction is lazy: nothing dials a database until the layer is
+		// built, which is what lets a config file be imported safely.
+		assert.isDefined(toLayer({ dialect: 'postgres', url: 'postgres://h/db' }));
+		assert.isDefined(toLayer({ dialect: 'mysql', url: 'mysql://h/db' }));
+		assert.isDefined(toLayer({ dialect: 'sqlite', filename: ':memory:' }));
+	});
+});
+
+for (const [name, makeConfig] of CONFIGS) {
+	describe(`createMigrator: ${name}`, () => {
+		it('takes a fresh database to the current schema', async () => {
+			const config = makeConfig();
+			await reset(config);
+			await withMigrator(config, async (migrator) => {
+				const planned = await migrator.plan();
+				assert.isUndefined(planned.blocked);
+				assert.isFalse(planned.applied, 'plan must not write');
+				assert.isAbove(planned.adoption.length, 0);
+				assert.deepStrictEqual(planned.pending, ['2-hot-path-indexes']);
+
+				const applied = await migrator.apply();
+				assert.isTrue(applied.applied);
+
+				// The database is up to date, so a fresh plan has nothing left.
+				const after = await migrator.plan();
+				assert.strictEqual(after.shape._tag, 'Baseline');
+				assert.deepStrictEqual(after.adoption, []);
+				assert.deepStrictEqual(after.pending, []);
+			});
+		}, 120_000);
+
+		it('is idempotent across separate migrator instances', async () => {
+			// A deploy runs this per release, in a new process each time.
+			const config = makeConfig();
+			await reset(config);
+			await withMigrator(config, (migrator) => migrator.apply());
+			const second = await withMigrator(config, (migrator) => migrator.apply());
+
+			assert.deepStrictEqual(second.adoption, []);
+			assert.deepStrictEqual(second.pending, []);
+		}, 120_000);
+
+		it('plan writes nothing', async () => {
+			const config = makeConfig();
+			await reset(config);
+			await withMigrator(config, async (migrator) => {
+				await migrator.plan();
+				await migrator.plan();
+			});
+
+			// A second migrator sees an untouched database: if `plan` had
+			// applied anything, this would report nothing left to do.
+			await withMigrator(config, async (migrator) => {
+				const planned = await migrator.plan();
+				assert.isAbove(
+					planned.adoption.length,
+					0,
+					'plan appears to have written'
+				);
+			});
+		}, 120_000);
+
+		it('releases the pool', async () => {
+			const config = makeConfig();
+			await reset(config);
+			const migrator = createMigrator(config);
+			await migrator.apply();
+			await migrator.dispose();
+
+			// Nothing to assert beyond "this returned" — a pool that cannot be
+			// released hangs the process that opened it, which for a CLI or a
+			// deploy step means a job that never finishes.
+			assert.isTrue(true);
+		}, 120_000);
+
+		it('reports a refusal rather than throwing', async () => {
+			const config = makeConfig();
+			await reset(config);
+
+			// An unrecognisable database: c15t-shaped, no ledger, and a fumadb
+			// marker naming a schema version nothing has a fixture for.
+			const runtime = ManagedRuntime.make(
+				toLayer(config) as Layer.Layer<SqlClient.SqlClient, never>
+			);
+			try {
+				await runtime.runPromise(
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient;
+						const q = Dialect.escaperFor(yield* Dialect.current);
+						yield* sql.unsafe(
+							`create table ${q('subject')} (${q('id')} varchar(255) primary key)`
+						);
+						yield* sql.unsafe(
+							`create table ${q('consent')} (${q('id')} varchar(255) primary key)`
+						);
+						yield* sql.unsafe(
+							`create table ${q('private_c15t_settings')} (${q('key')} varchar(255) primary key, ${q('value')} text)`
+						);
+						yield* sql`
+							insert into ${sql('private_c15t_settings')} ${sql.insert({
+								key: 'version',
+								value: '9.9.9',
+							})}
+						`;
+					})
+				);
+			} finally {
+				await runtime.dispose();
+			}
+
+			await withMigrator(config, async (migrator) => {
+				const planned = await migrator.plan();
+
+				// Reported, not thrown: refusing is a normal outcome the caller
+				// decides about, and the CLI prints it. Throwing would make a
+				// deploy script treat "I do not recognise this database" the same
+				// as "the network is down".
+				assert.isDefined(planned.blocked);
+				assert.include(planned.blocked ?? '', '9.9.9');
+				assert.isFalse(planned.applied);
+
+				// And applying it changes nothing rather than guessing.
+				const applied = await migrator.apply();
+				assert.isDefined(applied.blocked);
+				assert.isFalse(applied.applied);
+			});
+		}, 120_000);
+	});
+}
+
+describe('createMigrator: driver resolution', () => {
+	it('names the package to install when a driver is missing', async () => {
+		// The error a self-hoster meets first if they configure an engine whose
+		// optional peer they did not install. All three are present in this
+		// repo, so the only way to exercise it is to hand the loader an importer
+		// that fails — which is exactly what a missing module does.
+		const missing = loadDriver('mysql', () =>
+			Promise.reject(new Error('Cannot find module'))
+		);
+
+		// A defect rather than a typed failure: a missing driver is a
+		// configuration mistake the operator must fix, not something the backend
+		// can recover from, so every caller is spared threading it through.
+		await expect(Effect.runPromise(missing)).rejects.toThrow(
+			/@effect\/sql-mysql2 is not installed/
+		);
+	});
+
+	it('names the right package per dialect', async () => {
+		for (const [dialect, pkg] of [
+			['postgres', '@effect/sql-pg'],
+			['mysql', '@effect/sql-mysql2'],
+			['sqlite', '@effect/sql-sqlite-node'],
+		] as const) {
+			await expect(
+				Effect.runPromise(
+					loadDriver(dialect, () => Promise.reject(new Error('nope')))
+				)
+			).rejects.toThrow(pkg);
+		}
+	});
+
+	it('passes a working import straight through', async () => {
+		const loaded = await Effect.runPromise(
+			loadDriver('sqlite', () => Promise.resolve({ marker: true }))
+		);
+		assert.deepStrictEqual(loaded, { marker: true });
+	});
+});

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -30,6 +30,13 @@ export default mergeConfig(
 			// timeouts on individual tests and finding the next one under load.
 			testTimeout: 60_000,
 			hookTimeout: 60_000,
+			coverage: {
+				// `__tests__/packaged.test.ts` imports the built artifact on
+				// purpose, which would otherwise drag `dist/` into the coverage
+				// report and halve every number for no reason — it is the same
+				// code, compiled.
+				exclude: ['dist/**', 'dist-types/**'],
+			},
 			// No coverage thresholds yet: the package has no behaviour to cover.
 			// RFC 0004 §6 sets the floor at the old package's 55% once the first
 			// handlers land, and it ratchets up from there — it never ships below


### PR DESCRIPTION
A coverage read after the engine-matrix work showed the weakness had moved to the opposite end: **89% overall, but the public API layer at 64%**, with `createMigrator` and `defineConfig` at zero. The layer with the least coverage was the only layer anybody imports.

## `createMigrator`, end to end

Tested against SQLite, Postgres and MySQL, driven by a **connection description rather than a Layer** — the form a deploy script writes, and the only thing that exercises `connect.ts`'s driver loading.

It asserts what matters when pointed at production:

- `plan` writes nothing;
- `apply` is idempotent **across separate processes**, not just across calls;
- the pool is released — a deploy script that leaks one does not exit, and CI hangs;
- an unrecognisable database is **reported rather than thrown**, so a caller can tell "I do not recognise this" from "the network is down".

The driver-missing path is covered by exporting the loader `@internal` and handing it an importer that fails. All three drivers are installed here, so that is the only way to reach the error a self-hoster meets first.

## The published artifact

Every other test imports from `src/`, which proves the code works and says nothing about whether **what npm serves** does. `./cache` and `./db/migrations/*` were both added to the exports map during this rewrite and never once resolved the way npm resolves them.

Now checked: a built file behind every entry, `files` covering the map, each subpath loading, the named exports being present, and `require.resolve` succeeding **through the map** rather than by file path.

Verified it can fail: a bogus `./ghost` subpath trips three of the seven.

## Cache adapters

Also covers the Cloudflare KV and Upstash adapters, ported with no tests. Both convert milliseconds to their backend's seconds — wrong by a factor of a thousand is invisible except as a cache that never hits.

## Coverage

95.9% statements, 94% functions, 388 tests on four engines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading configured database drivers with clearer handling when a driver is unavailable.
  - Improved availability and validation of published package entry points, cache adapters, and type declarations.

- **Bug Fixes**
  - Improved reliability across SQLite, PostgreSQL, and MySQL migration workflows.
  - Added coverage for cache expiration, missing values, deletion, and connectivity scenarios.

- **Documentation**
  - Documented expanded public API, migration workflows, cache adapters, and package coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->