### PR TITLE
test(backend): run the HTTP suites on every engine and cover the policy builder

### DIFF
--- a/internals/rfcs/0004-backend-effect-rewrite.md
+++ b/internals/rfcs/0004-backend-effect-rewrite.md
@@ -1291,3 +1291,32 @@ as a cache that never hits or never expires.
 consecutive runs; 281 without Docker. `version.ts` is generated and
 `src/policy/builder.ts` — ported wholesale from 2.x — is the remaining soft
 spot at 69%.
+
+### 11.26 The HTTP surface on every engine
+
+The last PGlite-only suites were the HTTP ones — including `app.test.ts`, 45
+tests of the actual route surface, and the conformance runner that enforces
+wire compatibility with 2.x. Both now run on all four engines, which is where
+that guarantee belongs: "the wire contract holds" meant "on Postgres" until
+now.
+
+Converting them turned up nothing new about the *backend* and a good deal about
+the tests, which had absorbed Postgres assumptions the way the earlier suites
+had: `now()`, `drop table … cascade`, double-quoted identifiers, `isActive =
+true` as a literal, and a JSON column read as an object — true on Postgres and
+MySQL, a string on SQLite, where the driver does not parse it.
+
+`src/policy/builder.ts` is covered too, at 100% statements. It arrived from 2.x
+untested, and the gap was `createPackWithDefault` — the function that guarantees
+**every visitor resolves to some policy**. A pack with no default leaves anyone
+who matches no country rule with no decision at all, which means either no
+banner where one is required or a blocked page.
+
+**576 tests across four engines, 96.8% statements, 94.8% functions.**
+
+One consequence worth flagging: the suite now takes long enough that a full
+four-engine run exceeds ten minutes locally. That is the cost of running the
+HTTP surface four times, and it will show up in CI wall-clock. If it becomes a
+problem, the lever is running the HTTP suites on one Postgres engine rather than
+both PGlite and real Postgres — but only once something has been paying that
+cost long enough to say it is not earning it.

--- a/packages/backend/src/__tests__/engines.ts
+++ b/packages/backend/src/__tests__/engines.ts
@@ -51,6 +51,13 @@ export interface TestEngine {
 	readonly name: 'pglite' | 'postgres' | 'sqlite' | 'mysql';
 	/** A client plus a single-tenant scope, which most tests want. */
 	readonly layer: Layer.Layer<SqlClient.SqlClient | Tenant>;
+	/**
+	 * The client alone.
+	 *
+	 * For the HTTP tests: `createApp` takes a runtime carrying only the SQL
+	 * client, because `makeRun` provides the tenant scope itself, per request.
+	 */
+	readonly client: Layer.Layer<SqlClient.SqlClient>;
 	/** The same client, scoped to a named tenant. */
 	readonly asTenant: (
 		tenantId: string | undefined
@@ -68,6 +75,7 @@ const client = {
 
 const engine = (name: TestEngine['name']): TestEngine => ({
 	name,
+	client: client[name]() as Layer.Layer<SqlClient.SqlClient>,
 	layer: Layer.merge(client[name](), singleTenant),
 	asTenant: (tenantId) => Layer.merge(client[name](), tenantLayer(tenantId)),
 });

--- a/packages/backend/src/http/app.test.ts
+++ b/packages/backend/src/http/app.test.ts
@@ -9,690 +9,774 @@
  */
 
 import { listSubjectsOutputSchema } from '@c15t/schema';
-import { PgliteClient } from '@effect/sql-pglite';
 import { Effect, ManagedRuntime } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import * as v from 'valibot';
 import { afterEach, assert, beforeEach, describe, it } from 'vitest';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import * as Dialect from '../db/dialect';
 import { up as baseline } from '../db/migrations/1-baseline';
 import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import { encodeRow, encoder } from '../db/values';
 import { createApp } from './app';
 
-let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
-let app: ReturnType<typeof createApp>;
+for (const engine of ENGINES) {
+	let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
+	let app: ReturnType<typeof createApp>;
 
-const API_KEY = 'sk_test_key';
-const authed = { headers: { Authorization: `Bearer ${API_KEY}` } };
+	const API_KEY = 'sk_test_key';
+	const authed = { headers: { Authorization: `Bearer ${API_KEY}` } };
 
-beforeEach(async () => {
-	runtime = ManagedRuntime.make(PgliteClient.layer({}));
-	await runtime.runPromise(
-		Effect.gen(function* () {
-			yield* baseline;
-			yield* indexes;
-		})
-	);
-	app = createApp(runtime, {
-		apiKeys: [API_KEY],
-		trustedOrigins: ['https://app.example.com'],
-	});
-});
-
-afterEach(async () => {
-	await runtime.dispose();
-});
-
-const seed = () =>
-	runtime.runPromise(
-		Effect.gen(function* () {
-			const sql = yield* SqlClient.SqlClient;
-			yield* sql.unsafe(`insert into "domain" ("id","name","createdAt","updatedAt")
-				values ('dom_1','example.com',now(),now())`);
-			yield* sql.unsafe(`insert into "consentPolicy"
-				("id","version","type","effectiveDate","isActive","createdAt")
-				values ('pol_1','1.0','cookie',now(),true,now())`);
-			yield* sql.unsafe(`insert into "subject"
-				("id","externalId","createdAt","updatedAt")
-				values ('sub_1','ext_1',now(),now())`);
-			yield* sql.unsafe(`insert into "consent"
-				("id","subjectId","domainId","policyId","purposeIds","givenAt")
-				values ('cns_1','sub_1','dom_1','pol_1','[]',now())`);
-		})
-	);
-
-describe('GET /subjects', () => {
-	it('returns a body satisfying the shared output schema', async () => {
-		await seed();
-
-		const response = await app.request('/subjects?externalId=ext_1', authed);
-		assert.strictEqual(response.status, 200);
-
-		const body = await response.json();
-
-		// Dates arrive as ISO strings over the wire; the schema expects Date,
-		// so revive before validating — as a 2.x client would. Done generically
-		// rather than field by field, because naming each one means a new date
-		// field silently fails the assertion for the wrong reason.
-		const ISO = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/;
-		const revive = (value: unknown): unknown => {
-			if (typeof value === 'string')
-				return ISO.test(value) ? new Date(value) : value;
-			if (Array.isArray(value)) return value.map(revive);
-			if (value !== null && typeof value === 'object') {
-				return Object.fromEntries(
-					Object.entries(value).map(([key, nested]) => [key, revive(nested)])
-				);
-			}
-			return value;
-		};
-		const revived = revive(body);
-
-		const parsed = v.safeParse(listSubjectsOutputSchema, revived);
-		assert.isTrue(
-			parsed.success,
-			parsed.success ? '' : JSON.stringify(v.flatten(parsed.issues))
-		);
-	});
-
-	it('reports a missing externalId the way 2.x does', async () => {
-		const response = await app.request('/subjects', authed);
-
-		assert.strictEqual(response.status, 400);
-		assert.deepStrictEqual(await response.json(), {
-			message: 'externalId query parameter is required',
-			cause: { code: 'EXTERNAL_ID_REQUIRED' },
-		});
-	});
-
-	it('treats an empty externalId as missing rather than matching nothing', async () => {
-		// A bare `?externalId=` is a client bug, and answering it with an empty
-		// list would hide that. 2.x rejects it, so this does too.
-		const response = await app.request('/subjects?externalId=', authed);
-		assert.strictEqual(response.status, 400);
-	});
-
-	it('returns an empty list for an externalId nobody has', async () => {
-		await seed();
-		const response = await app.request(
-			'/subjects?externalId=ext_absent',
-			authed
-		);
-
-		assert.strictEqual(response.status, 200);
-		assert.deepStrictEqual(await response.json(), { subjects: [] });
-	});
-
-	it('does not leak database detail when a query fails', async () => {
-		// Drop the table out from under the handler to force a SqlError.
+	beforeEach(async () => {
+		runtime = ManagedRuntime.make(engine.client);
 		await runtime.runPromise(
 			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* sql.unsafe('drop table "consent" cascade');
+				yield* resetDatabase;
+				yield* baseline;
+				yield* indexes;
 			})
 		);
-
-		const response = await app.request('/subjects?externalId=ext_1', authed);
-		const body = await response.json();
-
-		assert.strictEqual(response.status, 500);
-		// Table and column names in an error body are information disclosure,
-		// and more so on a consent platform. Detail belongs in the wide event.
-		assert.deepStrictEqual(body, {
-			message: 'Internal server error',
-			cause: { code: 'DATABASE_ERROR' },
-		});
-		assert.notInclude(JSON.stringify(body), 'consent');
-	});
-
-	it('refuses a request with no API key', async () => {
-		await seed();
-		const response = await app.request('/subjects?externalId=ext_1');
-
-		// Listing subjects exposes consent records for a named person, so an
-		// unauthenticated caller must get nothing — not an empty list, which
-		// would imply the person has no consents.
-		assert.strictEqual(response.status, 401);
-		assert.deepStrictEqual(await response.json(), {
-			message: 'Unauthorized',
-			cause: { code: 'UNAUTHORIZED' },
-		});
-	});
-
-	it('refuses a wrong API key', async () => {
-		const response = await app.request('/subjects?externalId=ext_1', {
-			headers: { Authorization: 'Bearer sk_test_wrong' },
-		});
-		assert.strictEqual(response.status, 401);
-	});
-
-	it('authenticates before validating input', async () => {
-		// A missing externalId must not leak that the endpoint exists in a
-		// usable state to an unauthenticated caller.
-		const response = await app.request('/subjects');
-		assert.strictEqual(response.status, 401);
-	});
-});
-
-describe('GET /status', () => {
-	it('reports version and client context', async () => {
-		const response = await app.request('/status', {
-			headers: {
-				'accept-language': 'de-DE',
-				'x-forwarded-for': '203.0.113.42',
-			},
-		});
-
-		assert.strictEqual(response.status, 200);
-		const body = await response.json();
-		assert.strictEqual(body.client.acceptLanguage, 'de-DE');
-		// The IP is masked on the way in, as it is everywhere else.
-		assert.strictEqual(body.client.ip, '203.0.113.0');
-		assert.isString(body.version);
-	});
-
-	it('needs no API key', async () => {
-		// A health check a load balancer cannot reach without credentials is
-		// not a health check.
-		const response = await app.request('/status');
-		assert.strictEqual(response.status, 200);
-	});
-
-	it('reports 503 rather than 500 when the database is unreachable', async () => {
-		await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* sql.unsafe('drop table "subject" cascade');
-			})
-		);
-
-		const response = await app.request('/status');
-
-		// Orchestrators read 503 as "retry me" and 500 as "I am broken". An
-		// unreachable database is the former.
-		assert.strictEqual(response.status, 503);
-		assert.deepStrictEqual(await response.json(), {
-			message: 'Database health check failed',
-			cause: { code: 'SERVICE_UNAVAILABLE' },
-		});
-	});
-});
-
-describe('GET /subjects/:id', () => {
-	it('returns a body satisfying the shared output schema', async () => {
-		await seed();
-		const response = await app.request('/subjects/sub_1');
-
-		assert.strictEqual(response.status, 200);
-		const body = await response.json();
-		assert.strictEqual(body.subject.id, 'sub_1');
-		assert.strictEqual(body.consents.length, 1);
-	});
-
-	it('404s for a subject that does not exist', async () => {
-		const response = await app.request('/subjects/sub_absent');
-
-		// Distinct from an empty consent list, which would wrongly assert the
-		// subject exists and has consented to nothing.
-		assert.strictEqual(response.status, 404);
-		assert.deepStrictEqual(await response.json(), {
-			message: 'Subject not found',
-			cause: { code: 'NOT_FOUND' },
-		});
-	});
-
-	it('narrows to the requested policy types', async () => {
-		await seed();
-		const matched = await (
-			await app.request('/subjects/sub_1?type=cookie')
-		).json();
-		assert.strictEqual(matched.consents.length, 1);
-
-		const unmatched = await (
-			await app.request('/subjects/sub_1?type=marketing')
-		).json();
-		assert.strictEqual(unmatched.consents.length, 0);
-	});
-
-	it('is valid only against the current policy', async () => {
-		await seed();
-
-		// With no filter there is nothing to be invalid about.
-		const unfiltered = await (await app.request('/subjects/sub_1')).json();
-		assert.isTrue(unfiltered.isValid);
-
-		const matched = await (
-			await app.request('/subjects/sub_1?type=cookie')
-		).json();
-		assert.isTrue(matched.isValid);
-
-		// A type the subject has never consented to cannot be valid.
-		const missing = await (
-			await app.request('/subjects/sub_1?type=marketing')
-		).json();
-		assert.isFalse(missing.isValid);
-	});
-
-	it('does not count consent given against a superseded policy', async () => {
-		await seed();
-		await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				// A newer active policy of the same type supersedes pol_1.
-				yield* sql.unsafe(`insert into "consentPolicy"
-					("id","version","type","effectiveDate","isActive","createdAt")
-					values ('pol_2','2.0','cookie',now() + interval '1 day',true,now())`);
-			})
-		);
-
-		const body = await (
-			await app.request('/subjects/sub_1?type=cookie')
-		).json();
-
-		// The consent still exists, but it is against an outdated policy — which
-		// is exactly the case a compliance check has to catch.
-		assert.strictEqual(body.consents.length, 1);
-		assert.isFalse(body.consents[0].isLatestPolicy);
-		assert.isFalse(body.isValid);
-	});
-});
-
-describe('GET /consents/check', () => {
-	it('reports every requested type, present or not', async () => {
-		await seed();
-		const body = await (
-			await app.request(
-				'/consents/check?externalId=ext_1&type=cookie,marketing'
-			)
-		).json();
-
-		// An absent type must appear as false rather than be omitted: a caller
-		// gating script execution has to tell "no consent" from "unknown type".
-		assert.deepStrictEqual(body.results, {
-			cookie: { hasConsent: true, isLatestPolicy: true },
-			marketing: { hasConsent: false, isLatestPolicy: false },
-		});
-	});
-
-	it('separates having consent from it being current', async () => {
-		await seed();
-		await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				yield* sql.unsafe(`insert into "consentPolicy"
-					("id","version","type","effectiveDate","isActive","createdAt")
-					values ('pol_2','2.0','cookie',now() + interval '1 day',true,now())`);
-			})
-		);
-
-		const body = await (
-			await app.request('/consents/check?externalId=ext_1&type=cookie')
-		).json();
-
-		// Consent exists but is against a superseded policy — the two flags
-		// exist precisely so a caller can act on that difference.
-		assert.deepStrictEqual(body.results.cookie, {
-			hasConsent: true,
-			isLatestPolicy: false,
-		});
-	});
-
-	it('requires both query parameters', async () => {
-		const noExternal = await app.request('/consents/check?type=cookie');
-		assert.strictEqual(noExternal.status, 400);
-		assert.strictEqual(
-			(await noExternal.json()).cause.code,
-			'EXTERNAL_ID_REQUIRED'
-		);
-
-		const noType = await app.request('/consents/check?externalId=ext_1');
-		assert.strictEqual(noType.status, 400);
-		assert.strictEqual((await noType.json()).cause.code, 'TYPE_REQUIRED');
-	});
-
-	it('reports all types false for an unknown subject', async () => {
-		const body = await (
-			await app.request('/consents/check?externalId=nobody&type=cookie')
-		).json();
-		assert.deepStrictEqual(body.results.cookie, {
-			hasConsent: false,
-			isLatestPolicy: false,
-		});
-	});
-});
-
-describe('CORS', () => {
-	it('allows a trusted origin', async () => {
-		const response = await app.request('/status', {
-			headers: { Origin: 'https://app.example.com' },
-		});
-		assert.strictEqual(
-			response.headers.get('Access-Control-Allow-Origin'),
-			'https://app.example.com'
-		);
-		// Without Vary, a shared cache could serve one origin's response to
-		// another.
-		assert.strictEqual(response.headers.get('Vary'), 'Origin');
-	});
-
-	it('sends no CORS headers for an untrusted origin', async () => {
-		const response = await app.request('/status', {
-			headers: { Origin: 'https://evil.example.com' },
-		});
-		// Absence is the rejection — the browser blocks it. Echoing the origin
-		// back would defeat the allowlist entirely.
-		assert.isNull(response.headers.get('Access-Control-Allow-Origin'));
-	});
-
-	it('rejects every origin when none are configured', async () => {
-		const closed = createApp(runtime, { apiKeys: [API_KEY] });
-		const response = await closed.request('/status', {
-			headers: { Origin: 'https://app.example.com' },
-		});
-		// A deployment that has not configured origins should reject rather
-		// than default open.
-		assert.isNull(response.headers.get('Access-Control-Allow-Origin'));
-	});
-
-	it('answers a preflight without reaching a route', async () => {
-		const response = await app.request('/subjects', {
-			method: 'OPTIONS',
-			headers: {
-				Origin: 'https://app.example.com',
-				'Access-Control-Request-Method': 'GET',
-			},
-		});
-
-		// 204 and not 401: the preflight carries no credentials by design, so
-		// requiring auth here would break every browser client.
-		assert.strictEqual(response.status, 204);
-		assert.include(
-			response.headers.get('Access-Control-Allow-Methods') ?? '',
-			'GET'
-		);
-	});
-});
-
-describe('PUT /legal-documents/:type/current', () => {
-	const release = {
-		version: '1.0',
-		hash: 'sha256-abc',
-		effectiveDate: new Date(1_800_000_000_000).toISOString(),
-	};
-	const put = (body: unknown, auth = true) =>
-		app.request('/legal-documents/privacy_policy/current', {
-			method: 'PUT',
-			headers: {
-				'Content-Type': 'application/json',
-				...(auth ? { Authorization: `Bearer ${API_KEY}` } : {}),
-			},
-			body: JSON.stringify(body),
-		});
-
-	it('requires an API key', async () => {
-		const response = await put(release, false);
-		// This decides which policy every later consent is measured against,
-		// so it is an administrative operation.
-		assert.strictEqual(response.status, 401);
-	});
-
-	it('creates and activates a release', async () => {
-		const body = await (await put(release)).json();
-		assert.strictEqual(body.policy.version, '1.0');
-		assert.isTrue(body.policy.isActive);
-	});
-
-	it('is idempotent', async () => {
-		const first = await (await put(release)).json();
-		const second = await (await put(release)).json();
-
-		assert.strictEqual(second.policy.id, first.policy.id);
-
-		const rows = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{
-					total: string;
-				}>`select count(*) as total from "consentPolicy"`;
-			})
-		);
-		assert.strictEqual(Number(rows[0]?.total), 1);
-	});
-
-	it('leaves exactly one active policy per type', async () => {
-		await put(release);
-		await put({ ...release, version: '2.0', hash: 'sha256-def' });
-
-		const active = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{ version: string }>`
-					select "version" from "consentPolicy"
-					where "type" = 'privacy_policy' and "isActive" = true
-				`;
-			})
-		);
-
-		// isLatestPolicy on every consent is derived from this invariant, so
-		// two actives would silently break validity checks system-wide.
-		assert.strictEqual(active.length, 1);
-		assert.strictEqual(active[0]?.version, '2.0');
-	});
-
-	it('rejects a hash reused under different metadata', async () => {
-		await put(release);
-		const response = await put({ ...release, version: '9.9' });
-
-		// The hash identifies the content; the same hash claiming a different
-		// version means the caller has two ideas about what the document says.
-		assert.strictEqual(response.status, 400);
-		assert.strictEqual((await response.json()).cause.code, 'CONFLICT');
-	});
-
-	it('rejects an unparseable effectiveDate', async () => {
-		const response = await put({ ...release, effectiveDate: 'not-a-date' });
-		assert.strictEqual(response.status, 422);
-	});
-});
-
-describe('PATCH /subjects/:id', () => {
-	const patch = (id: string, body: unknown) =>
-		app.request(`/subjects/${id}`, {
-			method: 'PATCH',
-			headers: {
-				'Content-Type': 'application/json',
-				'x-forwarded-for': '203.0.113.42',
-			},
-			body: JSON.stringify(body),
-		});
-
-	it('links a subject to an external identity', async () => {
-		await seed();
-		const body = await (await patch('sub_1', { externalId: 'ext_new' })).json();
-		assert.strictEqual(body.subject.externalId, 'ext_new');
-		assert.strictEqual(body.subject.identityProvider, 'external');
-	});
-
-	it('writes an audit entry recording what changed', async () => {
-		await seed();
-		await patch('sub_1', { externalId: 'ext_new', identityProvider: 'auth0' });
-
-		const entries = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{
-					actionType: string;
-					changes: unknown;
-					ipAddress: string | null;
-				}>`select "actionType","changes","ipAddress" from "auditLog"`;
-			})
-		);
-
-		assert.strictEqual(entries.length, 1);
-		assert.strictEqual(entries[0]?.actionType, 'identify_user');
-		// From-and-to, not just "changed": a trail that cannot answer "from
-		// what?" cannot support a subject access request.
-		const changes = entries[0]?.changes as {
-			externalId: { from: string | null; to: string };
-		};
-		assert.strictEqual(changes.externalId.from, 'ext_1');
-		assert.strictEqual(changes.externalId.to, 'ext_new');
-		// The recorded IP is masked, as everywhere else.
-		assert.strictEqual(entries[0]?.ipAddress, '203.0.113.0');
-	});
-
-	it('404s for a subject that does not exist', async () => {
-		const response = await patch('sub_absent', { externalId: 'ext_new' });
-		assert.strictEqual(response.status, 404);
-	});
-
-	it('requires an externalId', async () => {
-		await seed();
-		const response = await patch('sub_1', {});
-		assert.strictEqual(response.status, 400);
-	});
-
-	it('writes no audit entry when the subject is missing', async () => {
-		await patch('sub_absent', { externalId: 'ext_new' });
-		const entries = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{
-					total: string;
-				}>`select count(*) as total from "auditLog"`;
-			})
-		);
-		// An audit entry for a change that never happened is worse than none.
-		assert.strictEqual(Number(entries[0]?.total), 0);
-	});
-});
-
-describe('POST /subjects', () => {
-	const post = (body: unknown) =>
-		app.request('/subjects', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'x-forwarded-for': '203.0.113.42',
-			},
-			body: JSON.stringify(body),
-		});
-
-	const submission = {
-		subjectId: 'sub_client',
-		domainId: 'dom_1',
-		policyId: 'pol_1',
-		purposeIds: ['analytics'],
-		givenAt: new Date(1_800_000_000_000).toISOString(),
-	};
-
-	it('records a consent', async () => {
-		await seed();
-		const response = await post(submission);
-
-		assert.strictEqual(response.status, 200);
-		const body = await response.json();
-		assert.match(body.consentId, /^cns_/);
-		assert.strictEqual(body.subjectId, 'sub_client');
-	});
-
-	it('is unauthenticated', async () => {
-		// A visitor's own browser submits its own consent; requiring an API key
-		// would mean shipping one to every client.
-		await seed();
-		assert.strictEqual((await post(submission)).status, 200);
-	});
-
-	it('returns the same consent id on a replay', async () => {
-		await seed();
-		const first = await (await post(submission)).json();
-		const second = await (await post(submission)).json();
-
-		assert.strictEqual(second.consentId, first.consentId);
-
-		// Scoped to this submission: seed() already inserted an unrelated
-		// consent, so a bare count would measure the fixture, not the replay.
-		const rows = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{ total: string }>`
-					select count(*) as total from "consent" where "id" = ${first.consentId}
-				`;
-			})
-		);
-		assert.strictEqual(Number(rows[0]?.total), 1);
-	});
-
-	it('masks the recorded IP', async () => {
-		await seed();
-		const { consentId } = await (await post(submission)).json();
-
-		const rows = await runtime.runPromise(
-			Effect.gen(function* () {
-				const sql = yield* SqlClient.SqlClient;
-				return yield* sql<{ ipAddress: string | null }>`
-					select "ipAddress" from "consent" where "id" = ${consentId}
-				`;
-			})
-		);
-		assert.strictEqual(rows[0]?.ipAddress, '203.0.113.0');
-	});
-
-	it('rejects a submission missing its identifiers', async () => {
-		assert.strictEqual((await post({ domainId: 'dom_1' })).status, 400);
-		assert.strictEqual((await post({ subjectId: 'sub_1' })).status, 400);
-	});
-
-	it('rejects an unparseable givenAt rather than defaulting to now', async () => {
-		await seed();
-		// Defaulting would make a malformed retry a distinct consent, since
-		// givenAt is part of the deterministic id.
-		const response = await post({ ...submission, givenAt: 'not-a-date' });
-		assert.strictEqual(response.status, 400);
-	});
-});
-
-describe('OpenAPI spec', () => {
-	it('publishes a spec listing every route', async () => {
-		const response = await app.request('/spec.json');
-		assert.strictEqual(response.status, 200);
-
-		const spec = await response.json();
-		assert.strictEqual(spec.openapi, '3.1.0');
-
-		// Every endpoint the backend serves should be discoverable — a spec
-		// that silently omits routes is worse than none, because an integrator
-		// concludes they do not exist.
-		for (const path of [
-			'/subjects',
-			'/subjects/{id}',
-			'/consents/check',
-			'/legal-documents/{type}/current',
-			'/status',
-		]) {
-			assert.property(spec.paths, path, path);
-		}
-	});
-
-	it('declares the bearer scheme the authenticated routes use', async () => {
-		const spec = await (await app.request('/spec.json')).json();
-		assert.deepStrictEqual(spec.components.securitySchemes.bearerAuth, {
-			type: 'http',
-			scheme: 'bearer',
-		});
-	});
-
-	it('can be turned off', async () => {
-		const quiet = createApp(runtime, {
+		app = createApp(runtime, {
 			apiKeys: [API_KEY],
-			openapi: { enabled: false },
+			trustedOrigins: ['https://app.example.com'],
 		});
-		assert.strictEqual((await quiet.request('/spec.json')).status, 404);
 	});
 
-	it('is enabled by default', async () => {
-		// The spec documents a public API; an integrator should not have to opt
-		// in to discovering the endpoints.
-		const bare = createApp(runtime, {});
-		assert.strictEqual((await bare.request('/spec.json')).status, 200);
+	afterEach(async () => {
+		await runtime.dispose();
 	});
-});
+
+	const seed = () =>
+		runtime.runPromise(
+			Effect.gen(function* () {
+				const sql = yield* SqlClient.SqlClient;
+				// Through the encoder, quoted by the dialect: SQLite binds neither a
+				// Date nor a boolean, and MySQL rejects double-quoted identifiers.
+				const encode = yield* encoder;
+				const now = new Date(1_800_000_000_000);
+
+				yield* sql`insert into ${sql('domain')} ${sql.insert(
+					encodeRow(encode, {
+						id: 'dom_1',
+						name: 'example.com',
+						createdAt: now,
+						updatedAt: now,
+					})
+				)}`;
+				yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+					encodeRow(encode, {
+						id: 'pol_1',
+						version: '1.0',
+						type: 'cookie',
+						effectiveDate: now,
+						isActive: true,
+						createdAt: now,
+					})
+				)}`;
+				yield* sql`insert into ${sql('subject')} ${sql.insert(
+					encodeRow(encode, {
+						id: 'sub_1',
+						externalId: 'ext_1',
+						createdAt: now,
+						updatedAt: now,
+					})
+				)}`;
+				yield* sql`insert into ${sql('consent')} ${sql.insert(
+					encodeRow(encode, {
+						id: 'cns_1',
+						subjectId: 'sub_1',
+						domainId: 'dom_1',
+						policyId: 'pol_1',
+						purposeIds: '[]',
+						givenAt: now,
+					})
+				)}`;
+			})
+		);
+
+	describe('GET /subjects', () => {
+		it('returns a body satisfying the shared output schema', async () => {
+			await seed();
+
+			const response = await app.request('/subjects?externalId=ext_1', authed);
+			assert.strictEqual(response.status, 200);
+
+			const body = await response.json();
+
+			// Dates arrive as ISO strings over the wire; the schema expects Date,
+			// so revive before validating — as a 2.x client would. Done generically
+			// rather than field by field, because naming each one means a new date
+			// field silently fails the assertion for the wrong reason.
+			const ISO = /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/;
+			const revive = (value: unknown): unknown => {
+				if (typeof value === 'string')
+					return ISO.test(value) ? new Date(value) : value;
+				if (Array.isArray(value)) return value.map(revive);
+				if (value !== null && typeof value === 'object') {
+					return Object.fromEntries(
+						Object.entries(value).map(([key, nested]) => [key, revive(nested)])
+					);
+				}
+				return value;
+			};
+			const revived = revive(body);
+
+			const parsed = v.safeParse(listSubjectsOutputSchema, revived);
+			assert.isTrue(
+				parsed.success,
+				parsed.success ? '' : JSON.stringify(v.flatten(parsed.issues))
+			);
+		});
+
+		it('reports a missing externalId the way 2.x does', async () => {
+			const response = await app.request('/subjects', authed);
+
+			assert.strictEqual(response.status, 400);
+			assert.deepStrictEqual(await response.json(), {
+				message: 'externalId query parameter is required',
+				cause: { code: 'EXTERNAL_ID_REQUIRED' },
+			});
+		});
+
+		it('treats an empty externalId as missing rather than matching nothing', async () => {
+			// A bare `?externalId=` is a client bug, and answering it with an empty
+			// list would hide that. 2.x rejects it, so this does too.
+			const response = await app.request('/subjects?externalId=', authed);
+			assert.strictEqual(response.status, 400);
+		});
+
+		it('returns an empty list for an externalId nobody has', async () => {
+			await seed();
+			const response = await app.request(
+				'/subjects?externalId=ext_absent',
+				authed
+			);
+
+			assert.strictEqual(response.status, 200);
+			assert.deepStrictEqual(await response.json(), { subjects: [] });
+		});
+
+		it('does not leak database detail when a query fails', async () => {
+			// Drop the table out from under the handler to force a SqlError.
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					// Foreign keys point at this table, so they have to go first
+					// on the engines with no `cascade`.
+					yield* sql.onDialectOrElse({
+						pg: () => sql.unsafe(`drop table ${q('consent')} cascade`),
+						mysql: () =>
+							Effect.gen(function* () {
+								yield* sql`set foreign_key_checks = 0`;
+								yield* sql.unsafe(`drop table ${q('consent')}`);
+								yield* sql`set foreign_key_checks = 1`;
+							}),
+						orElse: () => sql.unsafe(`drop table ${q('consent')}`),
+					});
+				})
+			);
+
+			const response = await app.request('/subjects?externalId=ext_1', authed);
+			const body = await response.json();
+
+			assert.strictEqual(response.status, 500);
+			// Table and column names in an error body are information disclosure,
+			// and more so on a consent platform. Detail belongs in the wide event.
+			assert.deepStrictEqual(body, {
+				message: 'Internal server error',
+				cause: { code: 'DATABASE_ERROR' },
+			});
+			assert.notInclude(JSON.stringify(body), 'consent');
+		});
+
+		it('refuses a request with no API key', async () => {
+			await seed();
+			const response = await app.request('/subjects?externalId=ext_1');
+
+			// Listing subjects exposes consent records for a named person, so an
+			// unauthenticated caller must get nothing — not an empty list, which
+			// would imply the person has no consents.
+			assert.strictEqual(response.status, 401);
+			assert.deepStrictEqual(await response.json(), {
+				message: 'Unauthorized',
+				cause: { code: 'UNAUTHORIZED' },
+			});
+		});
+
+		it('refuses a wrong API key', async () => {
+			const response = await app.request('/subjects?externalId=ext_1', {
+				headers: { Authorization: 'Bearer sk_test_wrong' },
+			});
+			assert.strictEqual(response.status, 401);
+		});
+
+		it('authenticates before validating input', async () => {
+			// A missing externalId must not leak that the endpoint exists in a
+			// usable state to an unauthenticated caller.
+			const response = await app.request('/subjects');
+			assert.strictEqual(response.status, 401);
+		});
+	});
+
+	describe('GET /status', () => {
+		it('reports version and client context', async () => {
+			const response = await app.request('/status', {
+				headers: {
+					'accept-language': 'de-DE',
+					'x-forwarded-for': '203.0.113.42',
+				},
+			});
+
+			assert.strictEqual(response.status, 200);
+			const body = await response.json();
+			assert.strictEqual(body.client.acceptLanguage, 'de-DE');
+			// The IP is masked on the way in, as it is everywhere else.
+			assert.strictEqual(body.client.ip, '203.0.113.0');
+			assert.isString(body.version);
+		});
+
+		it('needs no API key', async () => {
+			// A health check a load balancer cannot reach without credentials is
+			// not a health check.
+			const response = await app.request('/status');
+			assert.strictEqual(response.status, 200);
+		});
+
+		it('reports 503 rather than 500 when the database is unreachable', async () => {
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const q = Dialect.escaperFor(yield* Dialect.current);
+					yield* sql.onDialectOrElse({
+						pg: () => sql.unsafe(`drop table ${q('subject')} cascade`),
+						mysql: () =>
+							Effect.gen(function* () {
+								yield* sql`set foreign_key_checks = 0`;
+								yield* sql.unsafe(`drop table ${q('subject')}`);
+								yield* sql`set foreign_key_checks = 1`;
+							}),
+						orElse: () => sql.unsafe(`drop table ${q('subject')}`),
+					});
+				})
+			);
+
+			const response = await app.request('/status');
+
+			// Orchestrators read 503 as "retry me" and 500 as "I am broken". An
+			// unreachable database is the former.
+			assert.strictEqual(response.status, 503);
+			assert.deepStrictEqual(await response.json(), {
+				message: 'Database health check failed',
+				cause: { code: 'SERVICE_UNAVAILABLE' },
+			});
+		});
+	});
+
+	describe('GET /subjects/:id', () => {
+		it('returns a body satisfying the shared output schema', async () => {
+			await seed();
+			const response = await app.request('/subjects/sub_1');
+
+			assert.strictEqual(response.status, 200);
+			const body = await response.json();
+			assert.strictEqual(body.subject.id, 'sub_1');
+			assert.strictEqual(body.consents.length, 1);
+		});
+
+		it('404s for a subject that does not exist', async () => {
+			const response = await app.request('/subjects/sub_absent');
+
+			// Distinct from an empty consent list, which would wrongly assert the
+			// subject exists and has consented to nothing.
+			assert.strictEqual(response.status, 404);
+			assert.deepStrictEqual(await response.json(), {
+				message: 'Subject not found',
+				cause: { code: 'NOT_FOUND' },
+			});
+		});
+
+		it('narrows to the requested policy types', async () => {
+			await seed();
+			const matched = await (
+				await app.request('/subjects/sub_1?type=cookie')
+			).json();
+			assert.strictEqual(matched.consents.length, 1);
+
+			const unmatched = await (
+				await app.request('/subjects/sub_1?type=marketing')
+			).json();
+			assert.strictEqual(unmatched.consents.length, 0);
+		});
+
+		it('is valid only against the current policy', async () => {
+			await seed();
+
+			// With no filter there is nothing to be invalid about.
+			const unfiltered = await (await app.request('/subjects/sub_1')).json();
+			assert.isTrue(unfiltered.isValid);
+
+			const matched = await (
+				await app.request('/subjects/sub_1?type=cookie')
+			).json();
+			assert.isTrue(matched.isValid);
+
+			// A type the subject has never consented to cannot be valid.
+			const missing = await (
+				await app.request('/subjects/sub_1?type=marketing')
+			).json();
+			assert.isFalse(missing.isValid);
+		});
+
+		it('does not count consent given against a superseded policy', async () => {
+			await seed();
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					// A newer active policy of the same type supersedes pol_1.
+					const encode = yield* encoder;
+					yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+						encodeRow(encode, {
+							id: 'pol_2',
+							version: '2.0',
+							type: 'cookie',
+							effectiveDate: new Date(1_800_086_400_000),
+							isActive: true,
+							createdAt: new Date(1_800_000_000_000),
+						})
+					)}`;
+				})
+			);
+
+			const body = await (
+				await app.request('/subjects/sub_1?type=cookie')
+			).json();
+
+			// The consent still exists, but it is against an outdated policy — which
+			// is exactly the case a compliance check has to catch.
+			assert.strictEqual(body.consents.length, 1);
+			assert.isFalse(body.consents[0].isLatestPolicy);
+			assert.isFalse(body.isValid);
+		});
+	});
+
+	describe('GET /consents/check', () => {
+		it('reports every requested type, present or not', async () => {
+			await seed();
+			const body = await (
+				await app.request(
+					'/consents/check?externalId=ext_1&type=cookie,marketing'
+				)
+			).json();
+
+			// An absent type must appear as false rather than be omitted: a caller
+			// gating script execution has to tell "no consent" from "unknown type".
+			assert.deepStrictEqual(body.results, {
+				cookie: { hasConsent: true, isLatestPolicy: true },
+				marketing: { hasConsent: false, isLatestPolicy: false },
+			});
+		});
+
+		it('separates having consent from it being current', async () => {
+			await seed();
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+						encodeRow(yield* encoder, {
+							id: 'pol_2',
+							version: '2.0',
+							type: 'cookie',
+							effectiveDate: new Date(1_800_086_400_000),
+							isActive: true,
+							createdAt: new Date(1_800_000_000_000),
+						})
+					)}`;
+				})
+			);
+
+			const body = await (
+				await app.request('/consents/check?externalId=ext_1&type=cookie')
+			).json();
+
+			// Consent exists but is against a superseded policy — the two flags
+			// exist precisely so a caller can act on that difference.
+			assert.deepStrictEqual(body.results.cookie, {
+				hasConsent: true,
+				isLatestPolicy: false,
+			});
+		});
+
+		it('requires both query parameters', async () => {
+			const noExternal = await app.request('/consents/check?type=cookie');
+			assert.strictEqual(noExternal.status, 400);
+			assert.strictEqual(
+				(await noExternal.json()).cause.code,
+				'EXTERNAL_ID_REQUIRED'
+			);
+
+			const noType = await app.request('/consents/check?externalId=ext_1');
+			assert.strictEqual(noType.status, 400);
+			assert.strictEqual((await noType.json()).cause.code, 'TYPE_REQUIRED');
+		});
+
+		it('reports all types false for an unknown subject', async () => {
+			const body = await (
+				await app.request('/consents/check?externalId=nobody&type=cookie')
+			).json();
+			assert.deepStrictEqual(body.results.cookie, {
+				hasConsent: false,
+				isLatestPolicy: false,
+			});
+		});
+	});
+
+	describe('CORS', () => {
+		it('allows a trusted origin', async () => {
+			const response = await app.request('/status', {
+				headers: { Origin: 'https://app.example.com' },
+			});
+			assert.strictEqual(
+				response.headers.get('Access-Control-Allow-Origin'),
+				'https://app.example.com'
+			);
+			// Without Vary, a shared cache could serve one origin's response to
+			// another.
+			assert.strictEqual(response.headers.get('Vary'), 'Origin');
+		});
+
+		it('sends no CORS headers for an untrusted origin', async () => {
+			const response = await app.request('/status', {
+				headers: { Origin: 'https://evil.example.com' },
+			});
+			// Absence is the rejection — the browser blocks it. Echoing the origin
+			// back would defeat the allowlist entirely.
+			assert.isNull(response.headers.get('Access-Control-Allow-Origin'));
+		});
+
+		it('rejects every origin when none are configured', async () => {
+			const closed = createApp(runtime, { apiKeys: [API_KEY] });
+			const response = await closed.request('/status', {
+				headers: { Origin: 'https://app.example.com' },
+			});
+			// A deployment that has not configured origins should reject rather
+			// than default open.
+			assert.isNull(response.headers.get('Access-Control-Allow-Origin'));
+		});
+
+		it('answers a preflight without reaching a route', async () => {
+			const response = await app.request('/subjects', {
+				method: 'OPTIONS',
+				headers: {
+					Origin: 'https://app.example.com',
+					'Access-Control-Request-Method': 'GET',
+				},
+			});
+
+			// 204 and not 401: the preflight carries no credentials by design, so
+			// requiring auth here would break every browser client.
+			assert.strictEqual(response.status, 204);
+			assert.include(
+				response.headers.get('Access-Control-Allow-Methods') ?? '',
+				'GET'
+			);
+		});
+	});
+
+	describe('PUT /legal-documents/:type/current', () => {
+		const release = {
+			version: '1.0',
+			hash: 'sha256-abc',
+			effectiveDate: new Date(1_800_000_000_000).toISOString(),
+		};
+		const put = (body: unknown, auth = true) =>
+			app.request('/legal-documents/privacy_policy/current', {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json',
+					...(auth ? { Authorization: `Bearer ${API_KEY}` } : {}),
+				},
+				body: JSON.stringify(body),
+			});
+
+		it('requires an API key', async () => {
+			const response = await put(release, false);
+			// This decides which policy every later consent is measured against,
+			// so it is an administrative operation.
+			assert.strictEqual(response.status, 401);
+		});
+
+		it('creates and activates a release', async () => {
+			const body = await (await put(release)).json();
+			assert.strictEqual(body.policy.version, '1.0');
+			assert.isTrue(body.policy.isActive);
+		});
+
+		it('is idempotent', async () => {
+			const first = await (await put(release)).json();
+			const second = await (await put(release)).json();
+
+			assert.strictEqual(second.policy.id, first.policy.id);
+
+			const rows = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{
+						total: string;
+					}>`select count(*) as total from ${sql('consentPolicy')}`;
+				})
+			);
+			assert.strictEqual(Number(rows[0]?.total), 1);
+		});
+
+		it('leaves exactly one active policy per type', async () => {
+			await put(release);
+			await put({ ...release, version: '2.0', hash: 'sha256-def' });
+
+			const active = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{ version: string }>`
+						select ${sql('version')} from ${sql('consentPolicy')}
+						where ${sql('type')} = ${'privacy_policy'}
+							and ${sql('isActive')} = ${(yield* encoder)(true)}
+					`;
+				})
+			);
+
+			// isLatestPolicy on every consent is derived from this invariant, so
+			// two actives would silently break validity checks system-wide.
+			assert.strictEqual(active.length, 1);
+			assert.strictEqual(active[0]?.version, '2.0');
+		});
+
+		it('rejects a hash reused under different metadata', async () => {
+			await put(release);
+			const response = await put({ ...release, version: '9.9' });
+
+			// The hash identifies the content; the same hash claiming a different
+			// version means the caller has two ideas about what the document says.
+			assert.strictEqual(response.status, 400);
+			assert.strictEqual((await response.json()).cause.code, 'CONFLICT');
+		});
+
+		it('rejects an unparseable effectiveDate', async () => {
+			const response = await put({ ...release, effectiveDate: 'not-a-date' });
+			assert.strictEqual(response.status, 422);
+		});
+	});
+
+	describe('PATCH /subjects/:id', () => {
+		const patch = (id: string, body: unknown) =>
+			app.request(`/subjects/${id}`, {
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-forwarded-for': '203.0.113.42',
+				},
+				body: JSON.stringify(body),
+			});
+
+		it('links a subject to an external identity', async () => {
+			await seed();
+			const body = await (
+				await patch('sub_1', { externalId: 'ext_new' })
+			).json();
+			assert.strictEqual(body.subject.externalId, 'ext_new');
+			assert.strictEqual(body.subject.identityProvider, 'external');
+		});
+
+		it('writes an audit entry recording what changed', async () => {
+			await seed();
+			await patch('sub_1', {
+				externalId: 'ext_new',
+				identityProvider: 'auth0',
+			});
+
+			const entries = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{
+						actionType: string;
+						changes: unknown;
+						ipAddress: string | null;
+					}>`select ${sql('actionType')}, ${sql('changes')}, ${sql('ipAddress')}
+						from ${sql('auditLog')}`;
+				})
+			);
+
+			assert.strictEqual(entries.length, 1);
+			assert.strictEqual(entries[0]?.actionType, 'identify_user');
+			// From-and-to, not just "changed": a trail that cannot answer "from
+			// what?" cannot support a subject access request.
+			// Postgres and MySQL hand back parsed JSON; SQLite stores the column
+			// as TEXT and returns the string.
+			const raw = entries[0]?.changes;
+			const changes = (typeof raw === 'string' ? JSON.parse(raw) : raw) as {
+				externalId: { from: string | null; to: string };
+			};
+			assert.strictEqual(changes.externalId.from, 'ext_1');
+			assert.strictEqual(changes.externalId.to, 'ext_new');
+			// The recorded IP is masked, as everywhere else.
+			assert.strictEqual(entries[0]?.ipAddress, '203.0.113.0');
+		});
+
+		it('404s for a subject that does not exist', async () => {
+			const response = await patch('sub_absent', { externalId: 'ext_new' });
+			assert.strictEqual(response.status, 404);
+		});
+
+		it('requires an externalId', async () => {
+			await seed();
+			const response = await patch('sub_1', {});
+			assert.strictEqual(response.status, 400);
+		});
+
+		it('writes no audit entry when the subject is missing', async () => {
+			await patch('sub_absent', { externalId: 'ext_new' });
+			const entries = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{
+						total: string;
+					}>`select count(*) as total from ${sql('auditLog')}`;
+				})
+			);
+			// An audit entry for a change that never happened is worse than none.
+			assert.strictEqual(Number(entries[0]?.total), 0);
+		});
+	});
+
+	describe('POST /subjects', () => {
+		const post = (body: unknown) =>
+			app.request('/subjects', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'x-forwarded-for': '203.0.113.42',
+				},
+				body: JSON.stringify(body),
+			});
+
+		const submission = {
+			subjectId: 'sub_client',
+			domainId: 'dom_1',
+			policyId: 'pol_1',
+			purposeIds: ['analytics'],
+			givenAt: new Date(1_800_000_000_000).toISOString(),
+		};
+
+		it('records a consent', async () => {
+			await seed();
+			const response = await post(submission);
+
+			assert.strictEqual(response.status, 200);
+			const body = await response.json();
+			assert.match(body.consentId, /^cns_/);
+			assert.strictEqual(body.subjectId, 'sub_client');
+		});
+
+		it('is unauthenticated', async () => {
+			// A visitor's own browser submits its own consent; requiring an API key
+			// would mean shipping one to every client.
+			await seed();
+			assert.strictEqual((await post(submission)).status, 200);
+		});
+
+		it('returns the same consent id on a replay', async () => {
+			await seed();
+			const first = await (await post(submission)).json();
+			const second = await (await post(submission)).json();
+
+			assert.strictEqual(second.consentId, first.consentId);
+
+			// Scoped to this submission: seed() already inserted an unrelated
+			// consent, so a bare count would measure the fixture, not the replay.
+			const rows = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{ total: string }>`
+						select count(*) as total from ${sql('consent')}
+						where ${sql('id')} = ${first.consentId}
+					`;
+				})
+			);
+			assert.strictEqual(Number(rows[0]?.total), 1);
+		});
+
+		it('masks the recorded IP', async () => {
+			await seed();
+			const { consentId } = await (await post(submission)).json();
+
+			const rows = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{ ipAddress: string | null }>`
+						select ${sql('ipAddress')} from ${sql('consent')}
+						where ${sql('id')} = ${consentId}
+					`;
+				})
+			);
+			assert.strictEqual(rows[0]?.ipAddress, '203.0.113.0');
+		});
+
+		it('rejects a submission missing its identifiers', async () => {
+			assert.strictEqual((await post({ domainId: 'dom_1' })).status, 400);
+			assert.strictEqual((await post({ subjectId: 'sub_1' })).status, 400);
+		});
+
+		it('rejects an unparseable givenAt rather than defaulting to now', async () => {
+			await seed();
+			// Defaulting would make a malformed retry a distinct consent, since
+			// givenAt is part of the deterministic id.
+			const response = await post({ ...submission, givenAt: 'not-a-date' });
+			assert.strictEqual(response.status, 400);
+		});
+	});
+
+	describe('OpenAPI spec', () => {
+		it('publishes a spec listing every route', async () => {
+			const response = await app.request('/spec.json');
+			assert.strictEqual(response.status, 200);
+
+			const spec = await response.json();
+			assert.strictEqual(spec.openapi, '3.1.0');
+
+			// Every endpoint the backend serves should be discoverable — a spec
+			// that silently omits routes is worse than none, because an integrator
+			// concludes they do not exist.
+			for (const path of [
+				'/subjects',
+				'/subjects/{id}',
+				'/consents/check',
+				'/legal-documents/{type}/current',
+				'/status',
+			]) {
+				assert.property(spec.paths, path, path);
+			}
+		});
+
+		it('declares the bearer scheme the authenticated routes use', async () => {
+			const spec = await (await app.request('/spec.json')).json();
+			assert.deepStrictEqual(spec.components.securitySchemes.bearerAuth, {
+				type: 'http',
+				scheme: 'bearer',
+			});
+		});
+
+		it('can be turned off', async () => {
+			const quiet = createApp(runtime, {
+				apiKeys: [API_KEY],
+				openapi: { enabled: false },
+			});
+			assert.strictEqual((await quiet.request('/spec.json')).status, 404);
+		});
+
+		it('is enabled by default', async () => {
+			// The spec documents a public API; an integrator should not have to opt
+			// in to discovering the endpoints.
+			const bare = createApp(runtime, {});
+			assert.strictEqual((await bare.request('/spec.json')).status, 200);
+		});
+	});
+}

--- a/packages/backend/src/http/conformance.test.ts
+++ b/packages/backend/src/http/conformance.test.ts
@@ -12,110 +12,144 @@ import {
 	CASES,
 	type SeedFixture,
 } from '@c15t/backend-conformance';
-import { PgliteClient } from '@effect/sql-pglite';
 import { Effect, ManagedRuntime } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import { afterEach, assert, beforeEach, describe, it } from 'vitest';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
 import { up as baseline } from '../db/migrations/1-baseline';
 import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import { encodeRow, encoder } from '../db/values';
 import { createApp } from './app';
 
 const API_KEY = 'sk_conformance';
 
-let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
-let backend: Backend;
+for (const engine of ENGINES) {
+	let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
+	let backend: Backend;
 
-beforeEach(async () => {
-	runtime = ManagedRuntime.make(PgliteClient.layer({}));
-	await runtime.runPromise(
-		Effect.gen(function* () {
-			yield* baseline;
-			yield* indexes;
-		})
-	);
+	beforeEach(async () => {
+		runtime = ManagedRuntime.make(engine.client);
+		await runtime.runPromise(
+			Effect.gen(function* () {
+				yield* resetDatabase;
+				yield* baseline;
+				yield* indexes;
+			})
+		);
 
-	const app = createApp(runtime, {
-		apiKeys: [API_KEY],
-		trustedOrigins: ['https://app.example.com'],
-		version: '3.0.0-conformance',
+		const app = createApp(runtime, {
+			apiKeys: [API_KEY],
+			trustedOrigins: ['https://app.example.com'],
+			version: '3.0.0-conformance',
+		});
+
+		backend = {
+			name: 'backend',
+			apiKey: API_KEY,
+			reset: async () => {},
+			seed: (fixture: SeedFixture) =>
+				runtime.runPromise(
+					Effect.gen(function* () {
+						const sql = yield* SqlClient.SqlClient;
+						// Through the encoder and the dialect's own quoting: the same
+						// fixture has to load on all four engines or the wire contract
+						// is only proven on one.
+						const encode = yield* encoder;
+						const now = new Date(1_800_000_000_000);
+
+						for (const subject of fixture.subjects) {
+							yield* sql`insert into ${sql('subject')} ${sql.insert(
+								encodeRow(encode, {
+									id: subject.id,
+									externalId: subject.externalId ?? null,
+									identityProvider: subject.identityProvider ?? null,
+									createdAt: now,
+									updatedAt: now,
+								})
+							)}`;
+						}
+						for (const domain of fixture.domains) {
+							yield* sql`insert into ${sql('domain')} ${sql.insert(
+								encodeRow(encode, {
+									id: domain.id,
+									name: domain.name,
+									createdAt: now,
+									updatedAt: now,
+								})
+							)}`;
+						}
+						for (const policy of fixture.policies) {
+							yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+								encodeRow(encode, {
+									id: policy.id,
+									version: policy.version,
+									type: policy.type,
+									effectiveDate: policy.effectiveDate,
+									isActive: policy.isActive,
+									createdAt: now,
+								})
+							)}`;
+						}
+						for (const consent of fixture.consents) {
+							yield* sql`insert into ${sql('consent')} ${sql.insert(
+								encodeRow(encode, {
+									id: consent.id,
+									subjectId: consent.subjectId,
+									domainId: consent.domainId,
+									policyId: consent.policyId,
+									purposeIds: '[]',
+									givenAt: consent.givenAt,
+								})
+							)}`;
+						}
+					})
+				),
+			request: (request) => app.request(request),
+		};
 	});
 
-	backend = {
-		name: 'backend',
-		apiKey: API_KEY,
-		reset: async () => {},
-		seed: (fixture: SeedFixture) =>
-			runtime.runPromise(
-				Effect.gen(function* () {
-					const sql = yield* SqlClient.SqlClient;
-					for (const subject of fixture.subjects) {
-						yield* sql`insert into "subject" ("id","externalId","identityProvider","createdAt","updatedAt")
-							values (${subject.id}, ${subject.externalId ?? null},
-								${subject.identityProvider ?? null}, ${new Date()}, ${new Date()})`;
-					}
-					for (const domain of fixture.domains) {
-						yield* sql`insert into "domain" ("id","name","createdAt","updatedAt")
-							values (${domain.id}, ${domain.name}, ${new Date()}, ${new Date()})`;
-					}
-					for (const policy of fixture.policies) {
-						yield* sql`insert into "consentPolicy"
-							("id","version","type","effectiveDate","isActive","createdAt")
-							values (${policy.id}, ${policy.version}, ${policy.type},
-								${policy.effectiveDate}, ${policy.isActive}, ${new Date()})`;
-					}
-					for (const consent of fixture.consents) {
-						yield* sql`insert into "consent"
-							("id","subjectId","domainId","policyId","purposeIds","givenAt")
-							values (${consent.id}, ${consent.subjectId}, ${consent.domainId},
-								${consent.policyId}, ${'[]'}, ${consent.givenAt})`;
-					}
-				})
-			),
-		request: (request) => app.request(request),
-	};
-});
+	afterEach(async () => {
+		await runtime.dispose();
+	});
 
-afterEach(async () => {
-	await runtime.dispose();
-});
+	describe('conformance: backend', () => {
+		for (const testCase of CASES) {
+			const known = testCase.knownGap?.backend === 'backend';
+			// A recorded gap still runs — if it starts passing, the record is stale
+			// and should be removed rather than left to rot.
+			it(testCase.name, async () => {
+				if (testCase.seed) {
+					await backend.seed(testCase.seed);
+				}
 
-describe('conformance: backend', () => {
-	for (const testCase of CASES) {
-		const known = testCase.knownGap?.backend === 'backend';
-		// A recorded gap still runs — if it starts passing, the record is stale
-		// and should be removed rather than left to rot.
-		it(testCase.name, async () => {
-			if (testCase.seed) {
-				await backend.seed(testCase.seed);
-			}
+				const response = await backend.request(
+					testCase.request({ apiKey: backend.apiKey })
+				);
+				const body = await response
+					.clone()
+					.json()
+					.catch(() => undefined);
 
-			const response = await backend.request(
-				testCase.request({ apiKey: backend.apiKey })
-			);
-			const body = await response
-				.clone()
-				.json()
-				.catch(() => undefined);
-
-			try {
-				await testCase.expect(response, body);
-				if (known) {
+				try {
+					await testCase.expect(response, body);
+					if (known) {
+						assert.fail(
+							`${testCase.name} now passes — remove its knownGap entry`
+						);
+					}
+				} catch (error) {
+					if (known) {
+						return;
+					}
+					// Surface the rationale on failure: a conformance break should
+					// say what behaviour was lost, not just which assertion tripped.
 					assert.fail(
-						`${testCase.name} now passes — remove its knownGap entry`
+						`${testCase.name}\n  why it matters: ${testCase.rationale}\n  ${
+							error instanceof Error ? error.message : String(error)
+						}`
 					);
 				}
-			} catch (error) {
-				if (known) {
-					return;
-				}
-				// Surface the rationale on failure: a conformance break should
-				// say what behaviour was lost, not just which assertion tripped.
-				assert.fail(
-					`${testCase.name}\n  why it matters: ${testCase.rationale}\n  ${
-						error instanceof Error ? error.message : String(error)
-					}`
-				);
-			}
-		});
-	}
-});
+			});
+		}
+	});
+}

--- a/packages/backend/src/policy/builder.test.ts
+++ b/packages/backend/src/policy/builder.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Policy pack authoring.
+ *
+ * Ported wholesale from `@c15t/backend` at the rewrite, and it arrived with no
+ * tests of its own — `instance.test.ts` exercised `createPack` and
+ * `composePacks` in passing and left the rest at 69%.
+ *
+ * What is worth pinning is the part with consequences: **every visitor must
+ * resolve to some policy**. A pack with no default leaves whoever does not
+ * match a country rule with no decision at all, which on a consent platform
+ * means either no banner where one is required, or a blocked page.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { composePacks, policyBuilder } from './builder';
+
+describe('createPackWithDefault', () => {
+	it('appends a world fallback when the pack has none', () => {
+		const pack = policyBuilder.createPackWithDefault([
+			{ id: 'eu', countries: ['DE'], model: 'opt-in' },
+		]);
+
+		// Without this a visitor from anywhere but Germany resolves nothing.
+		const fallback = pack.at(-1);
+		assert.strictEqual(pack.length, 2);
+		assert.strictEqual(fallback?.id, 'world_no_banner');
+		assert.isTrue(fallback?.match.isDefault);
+	});
+
+	it('leaves a pack that already has a default alone', () => {
+		const pack = policyBuilder.createPackWithDefault([
+			{ id: 'eu', countries: ['DE'] },
+			{ id: 'catch_all', isDefault: true, model: 'none' },
+		]);
+
+		// Appending a second default would make which one wins depend on order.
+		assert.strictEqual(pack.length, 2);
+		assert.strictEqual(
+			pack.filter((policy) => policy.match.isDefault).length,
+			1
+		);
+	});
+
+	it('uses a supplied fallback, stripped of any geography', () => {
+		const pack = policyBuilder.createPackWithDefault(
+			[{ id: 'eu', countries: ['DE'] }],
+			{ id: 'house_rules', countries: ['US'], regions: [], model: 'opt-out' }
+		);
+
+		const fallback = pack.at(-1);
+		assert.strictEqual(fallback?.id, 'house_rules');
+		assert.isTrue(fallback?.match.isDefault);
+		// A default that also matched on country would not be a default: it
+		// would be another rule that happens to be last.
+		assert.isUndefined(fallback?.match.countries);
+		assert.isUndefined(fallback?.match.regions);
+	});
+});
+
+describe('createPack', () => {
+	it('normalises UI surface config', () => {
+		const [policy] = policyBuilder.createPack([
+			{
+				id: 'eu',
+				countries: ['DE'],
+				banner: {
+					allowedActions: ['accept', 'accept', ' reject ', ''],
+				},
+			},
+		]);
+
+		// Duplicates and whitespace come from hand-written config files. A
+		// duplicated action would render twice.
+		assert.deepStrictEqual(policy?.ui?.banner?.allowedActions, [
+			'accept',
+			'reject',
+		]);
+	});
+
+	it('omits a surface that was not configured', () => {
+		const [policy] = policyBuilder.createPack([
+			{ id: 'eu', countries: ['DE'] },
+		]);
+
+		// Absent rather than an empty object: the manifest is fingerprinted, and
+		// an empty surface is not the same document as no surface.
+		assert.isUndefined(policy?.ui?.banner);
+		assert.isUndefined(policy?.ui?.dialog);
+	});
+});
+
+describe('composePacks', () => {
+	it('keeps the first policy to claim an id', () => {
+		const composed = composePacks(
+			policyBuilder.createPack([{ id: 'eu', countries: ['DE'] }]),
+			policyBuilder.createPack([{ id: 'eu', countries: ['FR'] }])
+		);
+
+		assert.strictEqual(composed.length, 1);
+		assert.deepStrictEqual(composed[0]?.match?.countries, ['DE']);
+	});
+
+	it('preserves order across packs', () => {
+		const composed = composePacks(
+			policyBuilder.createPack([{ id: 'a', countries: ['DE'] }]),
+			policyBuilder.createPack([{ id: 'b', countries: ['US'] }]),
+			policyBuilder.createPack([{ id: 'c', isDefault: true }])
+		);
+
+		// Resolution walks the list in order, so composition order is the
+		// precedence the author wrote.
+		assert.deepStrictEqual(
+			composed.map((policy) => policy.id),
+			['a', 'b', 'c']
+		);
+	});
+
+	it('returns an empty pack unchanged', () => {
+		assert.deepStrictEqual(composePacks(), []);
+		assert.deepStrictEqual(composePacks([]), []);
+	});
+});


### PR DESCRIPTION
The last two soft spots after the engine-matrix work.

## The HTTP suites ran on PGlite only

So the routes that serve **every request** were never exercised against MySQL or SQLite — the two engines where value encoding and identifier quoting differ. Both `app.test.ts` and `conformance.test.ts` now run across the matrix in `__tests__/engines`.

What the conversion needed, each of which is a way the suites were quietly Postgres-shaped:

- `now()` in seeds → fixed dates through `encodeRow`, since SQLite binds neither `Date` nor `boolean`;
- `drop table … cascade` → a dialect branch (`set foreign_key_checks = 0` on MySQL);
- `select "actionType" … from "auditLog"` → `sql(...)`, which MySQL rejects double-quoted;
- `"isActive" = true` → an encoded value, since MySQL returns tinyint and SQLite integer;
- the JSON `changes` column parsed when it arrives as a string (SQLite).

`app.test.ts` goes from 45 to 180 runs, `conformance.test.ts` to 30.

## `policy/builder.ts` sat at 69%

Ported wholesale from 2.x, and it arrived with **no tests of its own** — `instance.test.ts` exercised `createPack` and `composePacks` in passing and left the rest uncovered.

The part worth pinning is the one with consequences: **every visitor must resolve to some policy**. A pack with no default leaves whoever matches no country rule with no decision at all, which on a consent platform means either no banner where one is required, or a blocked page.

8 tests, covering the fallback logic (appending a world default, leaving an existing one alone, stripping geography from a supplied fallback) and `compactUiSurface` dedupe. 69% → 100% statements.

## Stability

Two consecutive clean four-engine runs at 576 passed, plus 349 on the no-Docker path.

One property worth recording, since it bit me: the suite **cannot be run twice concurrently against the same Postgres and MySQL containers** — two overlapping runs produced 43 failures that neither run produces alone. Not a CI concern, since each job gets its own service containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Expanded HTTP and API conformance coverage across PostgreSQL, MySQL, SQLite, and PGlite.
  * Added broader validation for authentication, consent, legal documents, auditing, CORS, errors, and OpenAPI behavior.
  * Added policy-pack coverage for fallback rules, action handling, ordering, deduplication, and empty configurations.

* **Documentation**
  * Documented cross-database test coverage and updated quality metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->