### PR TITLE
fix(backend): take the write path's tenant from the scope

### DIFF
--- a/.changeset/wild-donkeys-shave.md
+++ b/.changeset/wild-donkeys-shave.md
@@ -38,3 +38,17 @@ embedding c15t in an Effect application.
 - `GET /subjects?externalId=` is two queries regardless of how many subjects
   and policy types are involved, rather than one plus a chunk per hundred
   subjects plus one per policy type.
+
+**New responses on `POST /subjects`**
+
+Both are `400` with `cause.code: "CONFLICT"`, and both replace a silent wrong
+answer rather than rejecting something that used to work:
+
+- A `subjectId` already owned by another tenant. `subject.id` is the primary
+  key and the client chooses it, so two tenants can pick the same one; reusing
+  the row would file one tenant's consent against the other's subject.
+- A resubmission of an already-recorded consent that carries different
+  `purposeIds`. The consent id covers identity and not purposes, so this is
+  indistinguishable from a retry at the key level — answering `200` would tell
+  a client its purposes were stored while the record still said otherwise.
+  Withdraw or supersede the consent instead of resubmitting it.

--- a/internals/migration-fixtures/src/engines.ts
+++ b/internals/migration-fixtures/src/engines.ts
@@ -66,9 +66,49 @@ export function engineByName(name: string): Engine {
  * its own copy of kysely — sharing an instance across installs would risk
  * dual-package hazards between the generator and the release under test.
  */
+/**
+ * Names that read as a scratch database rather than someone's data.
+ *
+ * Deliberately narrow. The documented container uses `c15t`, and anything else
+ * has to be opted into — a generous pattern would defeat the point, because
+ * the failure this guards against is a plausible-looking URL.
+ */
+const DISPOSABLE = /^(c15t|c15t[_-].*|.*[_-](fixture|fixtures|test|tmp))$/i;
+
+/**
+ * Refuses to reset a database that does not look disposable.
+ *
+ * The generated MySQL harness drops every table it finds. Postgres and SQLite
+ * cannot hit this — they get a fresh in-process database per run — so the check
+ * lives with the one engine that talks to a server the operator supplied.
+ */
+export function assertDisposable(url: string, allowAnyDatabase: boolean): void {
+	const name = new URL(url).pathname.replace(/^\//, '');
+
+	if (name === '') {
+		throw new Error(
+			`--mysql-url has no database name (${url}). Point it at a throwaway ` +
+				'database; the fixture run drops every table it finds.'
+		);
+	}
+
+	if (allowAnyDatabase || DISPOSABLE.test(name)) {
+		return;
+	}
+
+	throw new Error(
+		`Refusing to reset MySQL database "${name}": the fixture run drops every ` +
+			'table in it, and that name does not look like a throwaway.\n' +
+			'  Use a disposable database (for example "c15t", "c15t_fixtures" or ' +
+			'anything ending in _test), or pass --allow-any-database if you are ' +
+			'certain.'
+	);
+}
+
 export function connectionSource(
 	engine: Engine,
-	mysqlUrl: string | undefined
+	mysqlUrl: string | undefined,
+	allowAnyDatabase = false
 ): string {
 	switch (engine.name) {
 		case 'sqlite':
@@ -101,6 +141,13 @@ export const teardown = async () => { await db.destroy(); };
 			// run, MySQL is a shared server. Every shape must start from a blank
 			// schema or it captures whatever the previous shape left behind — and
 			// a dirty database changes the migration path, not just the result.
+			//
+			// That reset drops every table it finds, so the URL had better name a
+			// throwaway. Checked here rather than trusted: `--mysql-url` is a
+			// string on a command line, and the cost of getting it wrong is
+			// someone's database rather than a failed run. The name must look
+			// disposable, or the operator has to say so explicitly.
+			assertDisposable(mysqlUrl, allowAnyDatabase);
 			return `
 import { Kysely, MysqlDialect, sql } from 'kysely';
 import { createPool } from 'mysql2';

--- a/internals/migration-fixtures/src/engines.ts
+++ b/internals/migration-fixtures/src/engines.ts
@@ -69,11 +69,13 @@ export function engineByName(name: string): Engine {
 /**
  * Names that read as a scratch database rather than someone's data.
  *
- * Deliberately narrow. The documented container uses `c15t`, and anything else
- * has to be opted into — a generous pattern would defeat the point, because
- * the failure this guards against is a plausible-looking URL.
+ * Deliberately narrow: the exact name the documented container uses, or an
+ * explicit scratch suffix. An earlier version allowed any `c15t_*` / `c15t-*`,
+ * which waved through `c15t_production` and `c15t-prod` — the plausible-looking
+ * names this exists to stop, since a real deployment's database is far more
+ * likely to be called that than `unrelated_db`.
  */
-const DISPOSABLE = /^(c15t|c15t[_-].*|.*[_-](fixture|fixtures|test|tmp))$/i;
+const DISPOSABLE = /^(c15t|.*[_-](fixture|fixtures|test|tests|tmp|scratch))$/i;
 
 /**
  * Refuses to reset a database that does not look disposable.

--- a/internals/migration-fixtures/src/generate.ts
+++ b/internals/migration-fixtures/src/generate.ts
@@ -38,6 +38,7 @@ interface Args {
 	shapes: readonly Shape[];
 	engines: readonly Engine[];
 	mysqlUrl: string | undefined;
+	allowAnyDatabase: boolean;
 	keepWorkspace: boolean;
 }
 
@@ -50,6 +51,9 @@ function parseArgs(argv: readonly string[]): Args {
 	const shapeName = flag('shape');
 	const engineName = flag('engine');
 	const mysqlUrl = flag('mysql-url');
+	// The fixture run drops every table in the MySQL database it is given, so a
+	// name that does not look disposable is refused unless this is passed.
+	const allowAnyDatabase = process.argv.includes('--allow-any-database');
 
 	const engines = engineName
 		? [engineByName(engineName)]
@@ -61,6 +65,7 @@ function parseArgs(argv: readonly string[]): Args {
 		shapes: shapeName ? [shapeByName(shapeName)] : SHAPES,
 		engines,
 		mysqlUrl,
+		allowAnyDatabase,
 		keepWorkspace: argv.includes('--keep-workspace'),
 	};
 }
@@ -70,6 +75,27 @@ function parseArgs(argv: readonly string[]): Args {
  * kysely through fumadb), so fall back to the last range that was declared
  * explicitly.
  */
+/**
+ * The driver versions fixtures are captured with.
+ *
+ * Pinned rather than `latest`, because these decide the physical `dataType`
+ * strings the fixtures record. On `latest`, regenerating after a driver release
+ * moves the fixtures with no c15t release having changed — which destroys the
+ * only property they are for: a fixture diff means a c15t shape really changed.
+ * A `latest` driver can also resolve to something the pinned kysely below
+ * cannot work with, breaking generation outright.
+ *
+ * Set to what `latest` resolved to when this was introduced, so pinning was a
+ * no-op at the time rather than a silent recapture. Bump deliberately, and
+ * expect to review the fixture diff that comes with it.
+ */
+const DRIVER_VERSIONS: Record<string, string> = {
+	'better-sqlite3': '13.0.2',
+	'@electric-sql/pglite': '0.5.4',
+	'kysely-pglite': '0.6.1',
+	mysql2: '3.23.2',
+};
+
 const KYSELY_FALLBACK = '^0.28.15';
 
 async function kyselyRangeFor(version: string): Promise<string> {
@@ -242,8 +268,25 @@ async function generateOne(
 		for (const version of shape.versions) {
 			dependencies[aliasFor(version)] = `npm:@c15t/backend@${version}`;
 		}
+		// Pinned, not `latest`. These drivers decide the `dataType` strings the
+		// fixtures capture, so a driver bump would move the fixtures without any
+		// c15t release having changed — which is exactly the signal the fixtures
+		// exist to give. A `latest` driver can also resolve to something the
+		// pinned kysely below cannot work with, breaking generation outright.
 		for (const dep of engine.deps) {
-			dependencies[dep] = 'latest';
+			// `kysely` is pinned just below, to the range the release itself was
+			// built against — a stronger constraint than a fixed version here.
+			if (dep === 'kysely') {
+				continue;
+			}
+			const pinned = DRIVER_VERSIONS[dep];
+			if (pinned === undefined) {
+				throw new Error(
+					`No pinned version for fixture driver "${dep}". Add one to ` +
+						'DRIVER_VERSIONS so regeneration stays reproducible.'
+				);
+			}
+			dependencies[dep] = pinned;
 		}
 		// Use the kysely the release itself was built against rather than
 		// `latest`. 0.29 dropped the `Migrator` export that kysely-pglite still
@@ -269,7 +312,7 @@ async function generateOne(
 		);
 		await writeFile(
 			join(workspace, 'connection.mjs'),
-			connectionSource(engine, args.mysqlUrl)
+			connectionSource(engine, args.mysqlUrl, args.allowAnyDatabase)
 		);
 		await writeFile(
 			join(workspace, 'introspect.mjs'),

--- a/packages/backend/src/cache/adapters/upstash-redis.ts
+++ b/packages/backend/src/cache/adapters/upstash-redis.ts
@@ -8,7 +8,7 @@
  * @packageDocumentation
  */
 
-import { Redis } from '@upstash/redis';
+import type { Redis } from '@upstash/redis';
 import type { CacheAdapter } from '../types';
 import { GVL_TTL_MS } from '../types';
 
@@ -55,12 +55,42 @@ export interface UpstashRedisAdapterOptions {
 export function createUpstashRedisAdapter(
 	options: UpstashRedisAdapterOptions
 ): CacheAdapter {
-	const client = new Redis({
-		url: options.url,
-		token: options.token,
-	});
+	// Imported on first use rather than at module load. `@upstash/redis` is an
+	// optional peer, and `./cache` re-exports this module unconditionally — so a
+	// top-level import made `import '@c15t/backend/cache'` fail outright for
+	// every deployment that uses only the memory adapter and never installed it.
+	//
+	// The factory stays synchronous because the adapter's methods are already
+	// async; the client is a memoised promise the first call awaits.
+	let pending: Promise<Redis> | undefined;
+	const client = (): Promise<Redis> => {
+		pending ??= import('@upstash/redis').then(
+			(module) => new module.Redis({ url: options.url, token: options.token }),
+			() => {
+				throw new Error(
+					'createUpstashRedisAdapter requires the optional peer dependency ' +
+						'"@upstash/redis". Install it, or pass your own client to ' +
+						'createUpstashRedisAdapterFromClient.'
+				);
+			}
+		);
+		return pending;
+	};
 
-	return createUpstashRedisAdapterFromClient(client);
+	return {
+		async get<T>(key: string): Promise<T | null> {
+			return (await (await client()).get<T>(key)) ?? null;
+		},
+		async set<T>(key: string, value: T, ttlMs = GVL_TTL_MS): Promise<void> {
+			await (await client()).set(key, value, { ex: Math.ceil(ttlMs / 1000) });
+		},
+		async delete(key: string): Promise<void> {
+			await (await client()).del(key);
+		},
+		async has(key: string): Promise<boolean> {
+			return (await (await client()).exists(key)) > 0;
+		},
+	};
 }
 
 /**
@@ -73,7 +103,7 @@ export function createUpstashRedisAdapter(
  *
  * @example
  * ```typescript
- * import { Redis } from '@upstash/redis';
+ * import type { Redis } from '@upstash/redis';
  * import { createUpstashRedisAdapterFromClient } from '@c15t/backend/cache';
  *
  * const redis = new Redis({

--- a/packages/backend/src/db/adopt.test.ts
+++ b/packages/backend/src/db/adopt.test.ts
@@ -148,6 +148,44 @@ const classifiesUnmarkedLegacy = (engine: (typeof ENGINES)[number]) =>
 const canDropNamedConstraint = (engine: (typeof ENGINES)[number]) =>
 	engine.name === 'pglite' || engine.name === 'postgres';
 
+/**
+ * Every foreign key in the database, as `table.column`.
+ *
+ * The same three queries `adopt.ts` uses to observe them — deliberately, so
+ * this compares what the database actually has rather than what our planner
+ * believes it put there.
+ */
+const foreignKeys = Effect.gen(function* () {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql.onDialectOrElse({
+		sqlite: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select m.name as table_name, f."from" as column_name
+				from sqlite_master m join pragma_foreign_key_list(m.name) f
+				where m.type = 'table'
+			`,
+		mysql: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select table_name as table_name, column_name as column_name
+				from information_schema.key_column_usage
+				where table_schema = database()
+					and referenced_table_name is not null
+			`,
+		orElse: () =>
+			sql<{ table_name: string; column_name: string }>`
+				select cl.relname as table_name, att.attname as column_name
+				from pg_constraint con
+				join pg_class cl on cl.oid = con.conrelid
+				join pg_namespace ns on ns.oid = cl.relnamespace
+				join unnest(con.conkey) as k(attnum) on true
+				join pg_attribute att on att.attrelid = con.conrelid
+					and att.attnum = k.attnum
+				where con.contype = 'f' and ns.nspname = current_schema()
+			`,
+	});
+	return new Set(rows.map((row) => `${row.table_name}.${row.column_name}`));
+});
+
 for (const engine of ENGINES) {
 	describe('adopt', () => {
 		it.effect(
@@ -384,6 +422,45 @@ for (const engine of ENGINES) {
 						select ${sql('name')} from ${sql(LEDGER_TABLE)}
 					`;
 					assert.strictEqual(ledger[0]?.name, '1-baseline');
+				}).pipe(Effect.provide(engine.layer)),
+			{ timeout: 60_000 }
+		);
+	});
+
+	describe('adopt: convergence with a fresh install', () => {
+		// SQLite cannot add a foreign key to an existing table at all, so an
+		// adopted SQLite database is legitimately missing them and this
+		// comparison does not apply there.
+		const canAddForeignKeys = engine.name !== 'sqlite';
+
+		(canAddForeignKeys && classifiesUnmarkedLegacy(engine)
+			? it.effect
+			: it.effect.skip)(
+			'an adopted database ends with the same foreign keys as a fresh one',
+			() =>
+				Effect.gen(function* () {
+					// The convergence property adoption exists for, checked on the
+					// constraints rather than the columns. A foreign key skipped
+					// during adoption is never added later: a re-plan classifies the
+					// database as Baseline and short-circuits, so "not yet" is
+					// permanent.
+					yield* resetDatabase;
+					yield* legacyish;
+					const adoption = yield* plan;
+					assert.isUndefined(adoption.blocked);
+					yield* apply(adoption);
+					const adopted = yield* foreignKeys;
+
+					yield* resetDatabase;
+					yield* baseline;
+					const fresh = yield* foreignKeys;
+
+					const missing = [...fresh].filter((fk) => !adopted.has(fk)).sort();
+					assert.deepStrictEqual(
+						missing,
+						[],
+						'foreign keys a fresh install has and an adopted database never gets'
+					);
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);

--- a/packages/backend/src/db/adopt.ts
+++ b/packages/backend/src/db/adopt.ts
@@ -188,6 +188,25 @@ const countOrphans = Effect.fn('adopt.countOrphans')(function* (
 });
 
 /**
+ * Rows that would orphan against a table this plan creates.
+ *
+ * `countOrphans` joins the referenced table, which does not exist yet in that
+ * case. It will be created empty, so every non-null value in the child column
+ * is an orphan by definition.
+ */
+const countUnmatchable = Effect.fn('adopt.countUnmatchable')(function* (
+	table: TableSpec,
+	fk: ForeignKeySpec
+) {
+	const sql = yield* SqlClient.SqlClient;
+	const rows = yield* sql<{ orphans: number | string }>`
+		select count(*) as orphans from ${sql(table.name)}
+		where ${sql(fk.column)} is not null
+	`;
+	return Number(rows[0]?.orphans ?? 0);
+});
+
+/**
  * Works out what adoption would do, without doing any of it.
  *
  * Safe against production, and intended to be exactly what `--dry-run` prints.
@@ -223,6 +242,11 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 		}
 
 		const steps: AdoptionStep[] = [];
+		// Held back and appended after the whole table loop. Steps are built
+		// per table, so a foreign key on an existing table can otherwise be
+		// emitted before the `create table` for the table it points at — which
+		// depends on the order of `TABLES` rather than on anything meaningful.
+		const foreignKeySteps: AdoptionStep[] = [];
 		const orphans: OrphanReport[] = [];
 
 		for (const table of TABLES) {
@@ -249,14 +273,32 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 			// a freshly created one carries them inline.
 			for (const fk of table.foreignKeys) {
 				if (existing.foreignKeys.has(fkKey(table.name, fk.column))) continue;
-				// The referenced table must exist before it can be pointed at. If
-				// we are creating it in this same plan, there is nothing to orphan.
-				if (!existing.tables.has(fk.referencesTable)) continue;
-				if (!present.has(fk.column)) continue;
 
-				const count = yield* countOrphans(table, fk).pipe(
-					Effect.orElseSucceed(() => 0)
-				);
+				// A column or referenced table this plan is about to create counts
+				// as present: both loops above run before these steps do. Skipping
+				// on "does not exist yet" made the gap permanent, because a re-plan
+				// after adoption classifies the database as Baseline and
+				// short-circuits — so `consent.runtimePolicyDecisionId` never got
+				// its foreign key at all, while a fresh install had it.
+				const columnKnown =
+					present.has(fk.column) ||
+					table.columns.some((column) => column.name === fk.column);
+				const referenceKnown =
+					existing.tables.has(fk.referencesTable) ||
+					TABLES.some((spec) => spec.name === fk.referencesTable);
+				if (!columnKnown || !referenceKnown) continue;
+
+				const count = yield* (
+					!present.has(fk.column)
+						? // The column is being added now, so every row is null and
+							// nothing can orphan.
+							Effect.succeed(0)
+						: existing.tables.has(fk.referencesTable)
+							? countOrphans(table, fk)
+							: // The referenced table is created empty by this same plan,
+								// so every non-null value in an existing column orphans.
+								countUnmatchable(table, fk)
+				).pipe(Effect.orElseSucceed(() => 0));
 				if (count > 0) {
 					orphans.push({
 						table: table.name,
@@ -267,7 +309,7 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 					continue;
 				}
 
-				steps.push({
+				foreignKeySteps.push({
 					kind: 'add-foreign-key',
 					description: `Add foreign key "${table.name}"."${fk.column}" -> "${fk.referencesTable}"`,
 					sql: `alter table ${quote(table.name)} add foreign key (${quote(
@@ -278,6 +320,10 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 				});
 			}
 		}
+
+		// After every create-table and add-column, so a key can reference a
+		// table this plan is about to create regardless of `TABLES` order.
+		steps.push(...foreignKeySteps);
 
 		steps.push({
 			kind: 'stamp',

--- a/packages/backend/src/db/connect.ts
+++ b/packages/backend/src/db/connect.ts
@@ -184,7 +184,17 @@ export function withSearchPath(
 	}
 
 	const parsed = new URL(url);
-	parsed.searchParams.set('options', `-c search_path=${schema}`);
+	// Appended to any existing `options`, not substituted for them. A connection
+	// string carrying `?options=-c timezone=UTC` would otherwise lose that
+	// silently — the same class of bug as dropping `sslmode`, which this
+	// function already takes care to preserve.
+	const existing = parsed.searchParams.get('options');
+	parsed.searchParams.set(
+		'options',
+		existing
+			? `${existing} -c search_path=${schema}`
+			: `-c search_path=${schema}`
+	);
 	return parsed.toString();
 }
 

--- a/packages/backend/src/db/insert-once.ts
+++ b/packages/backend/src/db/insert-once.ts
@@ -18,8 +18,8 @@
  *
  * MySQL 8 supports **neither** clause. `on conflict` is Postgres/SQLite
  * syntax, and `returning` is MariaDB's, not MySQL's. Its equivalent is
- * `insert ignore`, which reports the outcome out-of-band as `affectedRows`
- * rather than as a result set.
+ * `on duplicate key update`, which reports the outcome out-of-band as
+ * `affectedRows` rather than as a result set.
  *
  * So the shape of the answer genuinely differs per engine and the branch is
  * real rather than incidental. It is confined to this one function, and the
@@ -41,16 +41,16 @@
  */
 
 import { Effect } from 'effect';
-import { SqlClient } from 'effect/unstable/sql';
+import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { encodeRow, encoder } from './values';
 
 /**
  * How many rows MySQL actually wrote.
  *
- * `insert ignore` returns an OK packet rather than rows: 1 when it inserted,
- * 0 when it skipped a duplicate. Read defensively — this is driver-shaped
- * data crossing into typed code, and a missing field must read as "did not
- * insert" rather than throw.
+ * The statement returns an OK packet rather than rows: 1 when it inserted, 0
+ * when the duplicate's no-op update changed nothing. Read defensively — this
+ * is driver-shaped data crossing into typed code, and a missing field must
+ * read as "did not insert" rather than throw.
  */
 const affectedRows = (result: unknown): number =>
 	typeof result === 'object' &&
@@ -100,9 +100,31 @@ export const insertOnce = Effect.fn('db.insertOnce')(function* (
 
 	return yield* sql.onDialectOrElse({
 		mysql: () =>
-			Effect.map(
-				sql`insert ignore into ${into} ${values}`.raw,
-				(result) => affectedRows(result) > 0
+			// A plain insert, with only the duplicate recovered.
+			//
+			// `insert ignore` was the obvious equivalent and is the wrong one: it
+			// downgrades *every* error to a warning, so a varchar overflow or a
+			// bad date silently truncates on MySQL while the same row errors on
+			// Postgres and SQLite. The engines would then disagree about what was
+			// stored rather than merely about syntax.
+			//
+			// `on duplicate key update <col> = <col>` narrows that correctly but
+			// cannot be read back: mysql2 connects with CLIENT_FOUND_ROWS, so
+			// `affectedRows` is 1 for both a fresh insert and a matched duplicate.
+			// Measured — the cross-tenant subject test passed on three engines and
+			// failed on MySQL because every call reported "created".
+			//
+			// So the duplicate is caught. The objection recorded above is specific
+			// to Postgres, where a failed statement poisons the enclosing
+			// transaction; MySQL rolls back only the statement, so there is no
+			// savepoint to pay for here. Any other failure propagates untouched.
+			sql`insert into ${into} ${values}`.raw.pipe(
+				Effect.as(true),
+				Effect.catchTag('SqlError', (error: SqlError.SqlError) =>
+					error.reason._tag === 'UniqueViolation'
+						? Effect.succeed(false)
+						: Effect.fail(error)
+				)
 			),
 		orElse: () =>
 			Effect.map(

--- a/packages/backend/src/db/mysql.test.ts
+++ b/packages/backend/src/db/mysql.test.ts
@@ -30,6 +30,7 @@ import { SqlClient } from 'effect/unstable/sql';
 import { ENGINES, resetDatabase } from '../__tests__/engines';
 import { apply, plan } from './adopt';
 import { classify } from './classify';
+import { insertOnce } from './insert-once';
 import { up as baseline } from './migrations/1-baseline';
 import { up as indexes } from './migrations/2-hot-path-indexes';
 
@@ -273,5 +274,71 @@ suite('mysql', () => {
 				assert.strictEqual((yield* classify)._tag, 'Baseline');
 			}).pipe(Effect.provide(Mysql)),
 		{ timeout: 120_000 }
+	);
+});
+
+suite('insert-once only suppresses the duplicate', () => {
+	it.effect(
+		'a non-duplicate failure is not swallowed',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+
+				// `insert ignore` — the obvious MySQL equivalent of
+				// `on conflict do nothing` — downgrades every error to a warning,
+				// so this row would be silently truncated to 255 characters here
+				// and rejected outright on Postgres and SQLite. Two engines
+				// disagreeing about what was stored is worse than either answer.
+				const result = yield* Effect.result(
+					insertOnce({
+						into: 'subject',
+						conflictOn: 'id',
+						values: {
+							id: 'x'.repeat(300),
+							externalId: null,
+							identityProvider: 'anonymous',
+							tenantId: null,
+							createdAt: new Date(1_800_000_000_000),
+							updatedAt: new Date(1_800_000_000_000),
+						},
+					})
+				);
+
+				assert.isTrue(result._tag === 'Failure', 'overflow was suppressed');
+
+				const sql = yield* SqlClient.SqlClient;
+				const rows = yield* sql<{ n: number | string }>`
+					select count(*) as n from ${sql('subject')}
+				`;
+				assert.strictEqual(Number(rows[0]?.n), 0, 'wrote a truncated row');
+			}).pipe(Effect.provide(Mysql ?? ENGINES[0]?.layer ?? Mysql!)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
+		'a duplicate still reports "not created" rather than failing',
+		() =>
+			Effect.gen(function* () {
+				yield* reset;
+				yield* baseline;
+
+				const row = {
+					id: 'sub_dup',
+					externalId: null,
+					identityProvider: 'anonymous',
+					tenantId: null,
+					createdAt: new Date(1_800_000_000_000),
+					updatedAt: new Date(1_800_000_000_000),
+				};
+
+				assert.isTrue(
+					yield* insertOnce({ into: 'subject', conflictOn: 'id', values: row })
+				);
+				assert.isFalse(
+					yield* insertOnce({ into: 'subject', conflictOn: 'id', values: row })
+				);
+			}).pipe(Effect.provide(Mysql ?? ENGINES[0]?.layer ?? Mysql!)),
+		{ timeout: 60_000 }
 	);
 });

--- a/packages/backend/src/db/schema-scoping.test.ts
+++ b/packages/backend/src/db/schema-scoping.test.ts
@@ -46,6 +46,20 @@ describe('withSearchPath', () => {
 		assert.strictEqual(out.searchParams.get('options'), '-c search_path=c15t');
 	});
 
+	it('keeps an existing options parameter', () => {
+		const out = new URL(
+			withSearchPath(
+				'postgres://u:p@host:5432/db?options=-c timezone%3DUTC',
+				'c15t'
+			)
+		);
+		// Overwriting would silently drop startup options the operator set —
+		// the same class of loss the sslmode case above guards against.
+		const options = out.searchParams.get('options') ?? '';
+		assert.include(options, '-c timezone=UTC');
+		assert.include(options, '-c search_path=c15t');
+	});
+
 	it('rejects a name that is not a plain identifier', () => {
 		// This lands in a startup parameter rather than a bound value, so it is
 		// refused rather than escaped.

--- a/packages/backend/src/db/tenant-isolation.test.ts
+++ b/packages/backend/src/db/tenant-isolation.test.ts
@@ -225,7 +225,6 @@ for (const engine of ENGINES) {
 					)}`;
 
 					const submission = {
-						subjectId: 'sub_shared',
 						domainId: 'dom_shared',
 						purposeIds: ['analytics'],
 						givenAt: new Date(1_800_000_000_000),
@@ -233,14 +232,17 @@ for (const engine of ENGINES) {
 						userAgent: null,
 					};
 
-					// Byte-identical arguments; different scopes. `submit` takes its
-					// tenant from the scope rather than from its argument, so a test
-					// that passed one in would run both writes as the same tenant
-					// while claiming to prove they are two.
-					yield* submit(submission).pipe(
+					// Identical but for the subject id, which each tenant generates
+					// for itself — `subject.id` is the primary key and globally
+					// unique, so a shared one is a conflict rather than two subjects
+					// (`http/tenant.test.ts` covers that). `submit` takes its tenant
+					// from the scope rather than from its argument, so a test that
+					// passed one in would run both writes as the same tenant while
+					// claiming to prove they are two.
+					yield* submit({ ...submission, subjectId: 'sub_a' }).pipe(
 						Effect.provide(tenantLayer('tenant_a'))
 					);
-					yield* submit(submission).pipe(
+					yield* submit({ ...submission, subjectId: 'sub_b' }).pipe(
 						Effect.provide(tenantLayer('tenant_b'))
 					);
 

--- a/packages/backend/src/db/tenant-isolation.test.ts
+++ b/packages/backend/src/db/tenant-isolation.test.ts
@@ -211,33 +211,38 @@ for (const engine of ENGINES) {
 					yield* baseline;
 					const sql = yield* SqlClient.SqlClient;
 					const encode = yield* encoder;
-					for (const tenant of ['tenant_a', 'tenant_b']) {
-						yield* sql`insert into ${sql('domain')} ${sql.insert(
-							encodeRow(encode, {
-								id: `dom_${tenant}`,
-								name: 'd',
-								tenantId: tenant,
-								createdAt: new Date(1_800_000_000_000),
-								updatedAt: new Date(1_800_000_000_000),
-							})
-						)}`;
-					}
+					// One domain both tenants reference, so the *only* thing that
+					// differs between the two submissions below is the scope they
+					// run under. Seeding a domain per tenant would leave the test
+					// unable to tell "the tenant is in the id" from "the domain is".
+					yield* sql`insert into ${sql('domain')} ${sql.insert(
+						encodeRow(encode, {
+							id: 'dom_shared',
+							name: 'd',
+							createdAt: new Date(1_800_000_000_000),
+							updatedAt: new Date(1_800_000_000_000),
+						})
+					)}`;
 
 					const submission = {
 						subjectId: 'sub_shared',
-						domainId: 'dom_tenant_a',
+						domainId: 'dom_shared',
 						purposeIds: ['analytics'],
 						givenAt: new Date(1_800_000_000_000),
 						ipAddress: null,
 						userAgent: null,
 					};
 
-					yield* submit({ ...submission, tenantId: 'tenant_a' });
-					yield* submit({
-						...submission,
-						domainId: 'dom_tenant_b',
-						tenantId: 'tenant_b',
-					});
+					// Byte-identical arguments; different scopes. `submit` takes its
+					// tenant from the scope rather than from its argument, so a test
+					// that passed one in would run both writes as the same tenant
+					// while claiming to prove they are two.
+					yield* submit(submission).pipe(
+						Effect.provide(tenantLayer('tenant_a'))
+					);
+					yield* submit(submission).pipe(
+						Effect.provide(tenantLayer('tenant_b'))
+					);
 
 					// Structurally identical consent from two tenants is two separate
 					// legal records, so the deterministic id must include the tenant.
@@ -245,6 +250,17 @@ for (const engine of ENGINES) {
 					select count(*) as total from ${sql('consent')}
 				`;
 					assert.strictEqual(Number(rows[0]?.total), 2);
+
+					// And each row carries its own tenant rather than both landing
+					// under one — the failure the HTTP path actually had.
+					const tenants = yield* sql<{ tenantId: string | null }>`
+					select ${sql('tenantId')} from ${sql('consent')}
+					order by ${sql('tenantId')}
+				`;
+					assert.deepStrictEqual(
+						tenants.map((row) => row.tenantId),
+						['tenant_a', 'tenant_b']
+					);
 				}).pipe(Effect.provide(engine.asTenant('tenant_a'))),
 			{ timeout: 60_000 }
 		);

--- a/packages/backend/src/http/auth.ts
+++ b/packages/backend/src/http/auth.ts
@@ -6,7 +6,7 @@
  * During the parallel phase both backends serve the same tenants with the same
  * configured keys, and an auth decision that differed between them would mean
  * a key accepted by one and rejected by the other — or worse, the reverse.
- * `auth.parity.test.ts` pins the agreement across a matrix of inputs.
+ * `auth.test.ts` pins the agreement across a matrix of inputs.
  *
  * The comparison is timing-safe in the same way and to the same degree as the
  * original: equal-length keys are compared in constant time, and unequal

--- a/packages/backend/src/http/context.ts
+++ b/packages/backend/src/http/context.ts
@@ -169,7 +169,18 @@ export const makeRun =
 		const result = await runtime.runPromise(
 			Effect.result(Effect.provide(effect, request))
 		);
-		return result._tag === 'Success'
-			? { ok: true, value: result.success }
-			: { ok: false, failure: toHttp(result.failure) };
+		if (result._tag === 'Success') {
+			return { ok: true, value: result.success };
+		}
+
+		// The client is told nothing about a database failure on purpose — the
+		// message carries table and column names. That only works if the detail
+		// goes *somewhere*, and until now it went nowhere: `toHttp` dropped it
+		// and the response said `DATABASE_ERROR` with no cause recorded, so an
+		// operator debugging a 500 had the status and nothing else.
+		if (result.failure._tag === 'SqlError' && log !== undefined) {
+			log.error(result.failure);
+		}
+
+		return { ok: false, failure: toHttp(result.failure) };
 	};

--- a/packages/backend/src/http/routes/subject.ts
+++ b/packages/backend/src/http/routes/subject.ts
@@ -259,6 +259,15 @@ export function register({ app, options, run }: RouteContext): void {
 						Effect.fail(
 							new BadRequestError({ message: error.message, code: 'CONFLICT' })
 						)
+					),
+					// Same shape, different cause: the identity exists but the
+					// submitted purposes differ from what was recorded. Answering 200
+					// would tell the client its purposes were stored when they were
+					// not.
+					Effect.catchTag('ConsentPurposeConflictError', (error) =>
+						Effect.fail(
+							new BadRequestError({ message: error.message, code: 'CONFLICT' })
+						)
 					)
 				)
 			);

--- a/packages/backend/src/http/routes/subject.ts
+++ b/packages/backend/src/http/routes/subject.ts
@@ -250,7 +250,17 @@ export function register({ app, options, run }: RouteContext): void {
 						consentId: submission.consentId,
 						givenAt,
 					};
-				})
+				}).pipe(
+					// The client chose this `subjectId` and it is already taken by
+					// another tenant. Reported rather than absorbed: writing under the
+					// other tenant's subject would disclose its consents, and dropping
+					// the submission would lose a legal record.
+					Effect.catchTag('SubjectTenantConflictError', (error) =>
+						Effect.fail(
+							new BadRequestError({ message: error.message, code: 'CONFLICT' })
+						)
+					)
+				)
 			);
 
 			if (!result.ok) {

--- a/packages/backend/src/http/tenant.test.ts
+++ b/packages/backend/src/http/tenant.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tenant scoping through the HTTP surface.
+ *
+ * `db/tenant-isolation.test.ts` proves the repository layer scopes correctly
+ * **when it is given a tenant**. That is a different claim from the one that
+ * matters to a deployment, which is that a configured instance writes rows
+ * carrying its tenant and can read them back — and the two came apart.
+ *
+ * The reads took their tenant from the `Tenant` service; the write path took
+ * it from a field on its argument, and `routes/subject.ts` never passed one.
+ * So an instance configured with a tenant wrote every row with a NULL tenant
+ * and then could not see them. Two consequences, both bad on a consent
+ * platform:
+ *
+ * - a tenanted deployment silently loses every consent it records, because
+ *   its own reads filter on a tenant the rows do not have;
+ * - every tenant's rows land in the same NULL bucket, where a single-tenant
+ *   instance pointed at that database reads all of them.
+ *
+ * The repository suite could not catch it: it calls `submit` directly and
+ * passes the tenant itself, which is precisely the step that was missing. It
+ * takes a test at this boundary, so that is what this is.
+ */
+
+import { Effect, ManagedRuntime } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { afterEach, assert, beforeEach, describe, it } from 'vitest';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { up as indexes } from '../db/migrations/2-hot-path-indexes';
+import { encodeRow, encoder } from '../db/values';
+import { createApp } from './app';
+
+const API_KEY = 'sk_test_key';
+const GIVEN_AT = new Date(1_800_000_000_000);
+
+const submission = {
+	subjectId: 'sub_tenanted',
+	domainId: 'dom_1',
+	policyId: 'pol_1',
+	externalId: 'ext_tenanted',
+	purposeIds: ['analytics'],
+	givenAt: GIVEN_AT.toISOString(),
+};
+
+for (const engine of ENGINES) {
+	describe(`tenant through the HTTP surface (${engine.name})`, () => {
+		let runtime: ManagedRuntime.ManagedRuntime<SqlClient.SqlClient, never>;
+
+		const appFor = (tenantId: string | undefined) =>
+			createApp(runtime, { apiKeys: [API_KEY], tenantId });
+
+		const post = (app: ReturnType<typeof createApp>, body: unknown) =>
+			app.request('/subjects', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			});
+
+		beforeEach(async () => {
+			runtime = ManagedRuntime.make(engine.client);
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* baseline;
+					yield* indexes;
+					const sql = yield* SqlClient.SqlClient;
+					const encode = yield* encoder;
+					// Untenanted so every tenant's instance can reference them; the
+					// tenant under test is the only variable.
+					yield* sql`insert into ${sql('domain')} ${sql.insert(
+						encodeRow(encode, {
+							id: 'dom_1',
+							name: 'example.com',
+							createdAt: GIVEN_AT,
+							updatedAt: GIVEN_AT,
+						})
+					)}`;
+					yield* sql`insert into ${sql('consentPolicy')} ${sql.insert(
+						encodeRow(encode, {
+							id: 'pol_1',
+							version: '1.0',
+							type: 'cookie',
+							effectiveDate: GIVEN_AT,
+							isActive: true,
+							createdAt: GIVEN_AT,
+						})
+					)}`;
+				})
+			);
+		});
+
+		afterEach(async () => {
+			await runtime.dispose();
+		});
+
+		const rowTenants = (table: string) =>
+			runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const rows = yield* sql<{ tenantId: string | null }>`
+						select ${sql('tenantId')} from ${sql(table)}
+					`;
+					return rows.map((row) => row.tenantId);
+				})
+			);
+
+		it('writes rows carrying the configured tenant', async () => {
+			const response = await post(appFor('tenant_a'), submission);
+			assert.strictEqual(response.status, 200, await response.text());
+
+			// Every table the submission touches, not just the consent: a subject
+			// or audit entry under the wrong tenant is the same disclosure.
+			for (const table of ['subject', 'consent', 'auditLog']) {
+				assert.deepStrictEqual(
+					await rowTenants(table),
+					['tenant_a'],
+					`${table} row must carry the configured tenant`
+				);
+			}
+		});
+
+		it('reads back what it recorded', async () => {
+			const app = appFor('tenant_a');
+			await post(app, submission);
+
+			const read = await app.request('/subjects?externalId=ext_tenanted', {
+				headers: { Authorization: `Bearer ${API_KEY}` },
+			});
+			const body = (await read.json()) as { subjects: unknown[] };
+
+			// The whole point of a write: an instance that cannot see its own
+			// consent records has silently lost them.
+			assert.strictEqual(body.subjects.length, 1);
+		});
+
+		it('does not read another tenant', async () => {
+			await post(appFor('tenant_a'), submission);
+
+			const read = await appFor('tenant_b').request(
+				'/subjects?externalId=ext_tenanted',
+				{ headers: { Authorization: `Bearer ${API_KEY}` } }
+			);
+			const body = (await read.json()) as { subjects: unknown[] };
+
+			assert.strictEqual(body.subjects.length, 0, 'leaked another tenant');
+		});
+
+		it('does not expose tenanted rows to a single-tenant instance', async () => {
+			await post(appFor('tenant_a'), submission);
+
+			// The bug's second consequence: with writes landing under NULL, an
+			// untenanted instance sharing the database read every tenant's rows.
+			const read = await appFor(undefined).request(
+				'/subjects?externalId=ext_tenanted',
+				{ headers: { Authorization: `Bearer ${API_KEY}` } }
+			);
+			const body = (await read.json()) as { subjects: unknown[] };
+
+			assert.strictEqual(body.subjects.length, 0, 'leaked to a null scope');
+		});
+
+		it('publishes a legal document under the configured tenant', async () => {
+			// `syncCurrent` had the same defect as the consent write: the route
+			// passed no tenant, so a published policy landed under NULL while the
+			// instance's reads filtered on its own tenant.
+			const response = await appFor('tenant_a').request(
+				'/legal-documents/terms/current',
+				{
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${API_KEY}`,
+					},
+					body: JSON.stringify({
+						version: '2.0',
+						hash: 'sha256-terms',
+						effectiveDate: GIVEN_AT.toISOString(),
+					}),
+				}
+			);
+			assert.strictEqual(response.status, 200, await response.text());
+
+			const published = await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					return yield* sql<{ tenantId: string | null }>`
+						select ${sql('tenantId')} from ${sql('consentPolicy')}
+						where ${sql('type')} = ${'terms'}
+					`;
+				})
+			);
+
+			assert.deepStrictEqual(
+				published.map((row) => row.tenantId),
+				['tenant_a']
+			);
+		});
+
+		it('keeps an identical submission from two tenants as two records', async () => {
+			await post(appFor('tenant_a'), submission);
+			await post(appFor('tenant_b'), submission);
+
+			// Byte-identical bodies. The consent id is deterministic, so if the
+			// tenant were not part of it the second would be treated as a replay
+			// and one tenant's consent would go unrecorded.
+			assert.deepStrictEqual((await rowTenants('consent')).sort(), [
+				'tenant_a',
+				'tenant_b',
+			]);
+		});
+	});
+}

--- a/packages/backend/src/http/tenant.test.ts
+++ b/packages/backend/src/http/tenant.test.ts
@@ -232,6 +232,39 @@ for (const engine of ENGINES) {
 			assert.deepStrictEqual(await rowTenants('consent'), ['tenant_a']);
 		});
 
+		it('refuses a resubmission that changes the purposes', async () => {
+			// The consent id covers identity and not purposes, so this arrives
+			// looking exactly like a retry. Answering 200 would tell the client
+			// its purposes were recorded while the stored record still said
+			// something else.
+			const first = await post(appFor('tenant_a'), submission);
+			assert.strictEqual(first.status, 200);
+
+			const changed = await post(appFor('tenant_a'), {
+				...submission,
+				purposeIds: ['analytics', 'marketing'],
+			});
+			assert.strictEqual(changed.status, 400);
+			const body = (await changed.json()) as { cause?: { code?: string } };
+			assert.strictEqual(body.cause?.code, 'CONFLICT');
+		});
+
+		it('still treats an identical resubmission as a replay', async () => {
+			// The conflict check must not cost idempotency: the same purposes in
+			// a different order are the same act.
+			await post(appFor('tenant_a'), {
+				...submission,
+				purposeIds: ['analytics', 'marketing'],
+			});
+			const replay = await post(appFor('tenant_a'), {
+				...submission,
+				purposeIds: ['marketing', 'analytics'],
+			});
+
+			assert.strictEqual(replay.status, 200);
+			assert.deepStrictEqual(await rowTenants('consent'), ['tenant_a']);
+		});
+
 		it('does not join another tenant consent onto its own subject', async () => {
 			// Defence in depth for the same disclosure, independent of the write
 			// path refusing: a cross-tenant consent row planted directly must not

--- a/packages/backend/src/http/tenant.test.ts
+++ b/packages/backend/src/http/tenant.test.ts
@@ -198,16 +198,77 @@ for (const engine of ENGINES) {
 		});
 
 		it('keeps an identical submission from two tenants as two records', async () => {
-			await post(appFor('tenant_a'), submission);
-			await post(appFor('tenant_b'), submission);
+			// Same everything except the subject id, which each tenant generates
+			// for itself. `subject.id` is the primary key and globally unique, so
+			// a shared one is a conflict rather than two subjects — covered
+			// separately below.
+			await post(appFor('tenant_a'), { ...submission, subjectId: 'sub_a' });
+			await post(appFor('tenant_b'), { ...submission, subjectId: 'sub_b' });
 
-			// Byte-identical bodies. The consent id is deterministic, so if the
-			// tenant were not part of it the second would be treated as a replay
-			// and one tenant's consent would go unrecorded.
+			// The consent id is deterministic, so if the tenant were not part of
+			// it the second would be treated as a replay and one tenant's consent
+			// would go unrecorded.
 			assert.deepStrictEqual((await rowTenants('consent')).sort(), [
 				'tenant_a',
 				'tenant_b',
 			]);
+		});
+
+		it('refuses a subjectId another tenant already owns', async () => {
+			// `subject.id` is the primary key and the client chooses it, so two
+			// tenants can name the same subject. Reusing the existing row would
+			// hang tenant B's consent off tenant A's subject — which tenant A then
+			// reads and tenant B cannot. Measured before the fix: tenant A saw 2
+			// consents, one of them tenant B's.
+			const first = await post(appFor('tenant_a'), submission);
+			assert.strictEqual(first.status, 200);
+
+			const second = await post(appFor('tenant_b'), submission);
+			assert.strictEqual(second.status, 400);
+			const body = (await second.json()) as { cause?: { code?: string } };
+			assert.strictEqual(body.cause?.code, 'CONFLICT');
+
+			// And nothing was written under the second tenant.
+			assert.deepStrictEqual(await rowTenants('consent'), ['tenant_a']);
+		});
+
+		it('does not join another tenant consent onto its own subject', async () => {
+			// Defence in depth for the same disclosure, independent of the write
+			// path refusing: a cross-tenant consent row planted directly must not
+			// appear in a tenant's read. The join carries its own tenant
+			// predicate rather than relying on the driving table's.
+			await post(appFor('tenant_a'), submission);
+
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					const encode = yield* encoder;
+					yield* sql`insert into ${sql('consent')} ${sql.insert(
+						encodeRow(encode, {
+							id: 'cns_planted',
+							subjectId: 'sub_tenanted',
+							domainId: 'dom_1',
+							policyId: 'pol_1',
+							purposeIds: '[]',
+							givenAt: GIVEN_AT,
+							tenantId: 'tenant_b',
+						})
+					)}`;
+				})
+			);
+
+			const read = await appFor('tenant_a').request(
+				'/subjects?externalId=ext_tenanted',
+				{ headers: { Authorization: `Bearer ${API_KEY}` } }
+			);
+			const body = (await read.json()) as {
+				subjects: { consents: unknown[] }[];
+			};
+			assert.strictEqual(
+				body.subjects[0]?.consents.length,
+				1,
+				'leaked another tenant consent through the join'
+			);
 		});
 	});
 }

--- a/packages/backend/src/instance.test.ts
+++ b/packages/backend/src/instance.test.ts
@@ -147,6 +147,47 @@ describe('basePath', () => {
 		}
 	}, 60_000);
 
+	it('does not strip a prefix that is not a whole segment', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({
+			database: layer,
+			basePath: '/api/c15t',
+		});
+
+		try {
+			// `startsWith` alone also matches `/api/c15t2/...`, which would be
+			// rewritten to `2/status` and dispatched as if it belonged to this
+			// mount. A neighbouring route on the same host is not ours.
+			const response = await instance.handler(
+				new Request('http://localhost/api/c15t2/status')
+			);
+			assert.strictEqual(response.status, 404);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+
+	it('routes the mount root itself', async () => {
+		const { layer, dispose } = await migrated();
+		const instance = c15tInstance({
+			database: layer,
+			basePath: '/api/self-host',
+		});
+
+		try {
+			// The prefix with nothing after it must still strip to `/` rather
+			// than being treated as a non-match.
+			const response = await instance.handler(
+				new Request('http://localhost/api/self-host')
+			);
+			assert.notStrictEqual(response.status, 500);
+		} finally {
+			await instance.dispose();
+			await dispose();
+		}
+	}, 60_000);
+
 	it('leaves a request alone when no basePath is set', async () => {
 		const { layer, dispose } = await migrated();
 		const instance = c15tInstance({ database: layer });

--- a/packages/backend/src/instance.ts
+++ b/packages/backend/src/instance.ts
@@ -100,11 +100,17 @@ const stripBasePath = (request: Request, basePath?: string): Request => {
 
 	const prefix = basePath.replace(/\/$/, '');
 	const url = new URL(request.url);
-	if (!url.pathname.startsWith(prefix)) {
+	// On a segment boundary, not a string prefix: a mount at `/api/c15t` must
+	// not also swallow `/api/c15t2/status` and hand the router `2/status`.
+	const rest = url.pathname.slice(prefix.length);
+	if (
+		!url.pathname.startsWith(prefix) ||
+		(rest !== '' && !rest.startsWith('/'))
+	) {
 		return request;
 	}
 
-	url.pathname = url.pathname.slice(prefix.length) || '/';
+	url.pathname = rest || '/';
 	return new Request(url, request);
 };
 

--- a/packages/backend/src/migrator.test.ts
+++ b/packages/backend/src/migrator.test.ts
@@ -185,10 +185,15 @@ for (const [name, makeConfig] of CONFIGS) {
 			await migrator.apply();
 			await migrator.dispose();
 
-			// Nothing to assert beyond "this returned" — a pool that cannot be
+			// `dispose` resolving is most of the claim — a pool that cannot be
 			// released hangs the process that opened it, which for a CLI or a
-			// deploy step means a job that never finishes.
-			assert.isTrue(true);
+			// deploy step means a job that never finishes, and this test would
+			// then time out rather than pass.
+			//
+			// What it can still assert is that the pool is actually gone: using
+			// the migrator afterwards must not quietly work off a live
+			// connection.
+			await expect(migrator.plan()).rejects.toThrow();
 		}, 120_000);
 
 		it('reports a refusal rather than throwing', async () => {

--- a/packages/backend/src/observability/evlog.test.ts
+++ b/packages/backend/src/observability/evlog.test.ts
@@ -217,3 +217,46 @@ describe("observability: level 'info'", () => {
 		assert.deepStrictEqual(resolved.exclude, ['/status']);
 	});
 });
+
+describe('a database failure', () => {
+	it('records the cause in the wide event', async () => {
+		const { events, drain } = collect();
+
+		// Its own runtime, because the shared harness migrates a working schema
+		// and this needs a broken one.
+		const runtime = ManagedRuntime.make(
+			PgliteClient.layer({}) as unknown as Layer.Layer<SqlClient.SqlClient>
+		);
+		try {
+			const app = createApp(runtime, {
+				manifest: seed,
+				observability: { drain },
+				apiKeys: ['sk_test'],
+			});
+
+			// No baseline at all, so the read path's first query fails. The
+			// response is deliberately opaque — table and column names in a body
+			// are information disclosure — which only works if the detail is
+			// recorded somewhere. It was not: `toHttp` dropped the error and
+			// nothing else looked at it, so a 500 left an operator with the
+			// status and nothing else.
+			const response = await app.request('/subjects?externalId=ext_1', {
+				headers: { Authorization: 'Bearer sk_test' },
+			});
+			assert.strictEqual(response.status, 500);
+			assert.notInclude(await response.text(), 'subject');
+		} finally {
+			await runtime.dispose();
+		}
+
+		const event = events.at(-1);
+		assert.isDefined(event, 'a failed request emitted no event');
+		// Specifically the SQL failure. A looser check — "the event mentions
+		// error somewhere" — passes either way, because a 500 already sets
+		// `level: 'error'`; the first version of this test did exactly that and
+		// proved nothing. Verified by removing the fix and watching this fail.
+		const recorded = (event as { error?: { name?: string } }).error;
+		assert.isDefined(recorded, 'the wide event carried no error');
+		assert.include(recorded?.name ?? '', 'SqlError');
+	});
+});

--- a/packages/backend/src/observability/log.ts
+++ b/packages/backend/src/observability/log.ts
@@ -52,12 +52,11 @@ export class Log extends Context.Service<Log, RequestLog>()('Log') {}
 /**
  * Records nothing.
  *
- * The default. `@c15t/backend` defaults its logger to `level: 'error'`, so it
- * emits nothing per request, and a deployment upgrading to this package must
- * not suddenly start writing a line per request to stdout. Observability is
- * opt-in for exactly that reason — see `AppOptions.observability`.
+ * Not the default — `AppOptions.observability` defaults to `level: 'warn'`,
+ * which is quiet for a successful request and prints a line for a failed one.
+ * This is what you get by asking for `level: 'silent'`.
  *
- * Also what non-request code gets: migrations, benchmarks and repository
+ * It is also what non-request code gets: migrations, benchmarks and repository
  * tests have no wide event to attach to.
  */
 export const silent: Layer.Layer<Log> = Layer.succeed(Log, {

--- a/packages/backend/src/repository/consent.test.ts
+++ b/packages/backend/src/repository/consent.test.ts
@@ -13,7 +13,7 @@ import { Effect, Layer } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import { up as baseline } from '../db/migrations/1-baseline';
 import { singleTenant } from '../db/tenant';
-import { record } from './consent';
+import { assertSamePurposes, record } from './consent';
 
 // Tests run single-tenant unless a case says otherwise; the scope is a
 // service, so a query cannot run without one.
@@ -163,4 +163,50 @@ describe('consent.record', () => {
 			}).pipe(Effect.provide(Pglite)),
 		{ timeout: 60_000 }
 	);
+});
+
+describe('assertSamePurposes', () => {
+	// The comparison `record` applies on both paths that can find an existing
+	// row. The second — a lost insert race — cannot be forced end to end: PGlite
+	// serialises every query, so the second caller always sees the first's row in
+	// the pre-insert check instead. Covered here so the branch is not merely
+	// written and never executed.
+	const run = <A>(effect: Effect.Effect<A, unknown, never>) =>
+		Effect.runPromise(Effect.result(effect));
+
+	it('accepts an identical set', async () => {
+		const result = await run(assertSamePurposes('["a","b"]', ['a', 'b']));
+		assert.strictEqual(result._tag, 'Success');
+	});
+
+	it('accepts the same set in a different order', async () => {
+		// Order is not part of what was consented to; treating it as a change
+		// would refuse ordinary retries.
+		const result = await run(assertSamePurposes('["b","a"]', ['a', 'b']));
+		assert.strictEqual(result._tag, 'Success');
+	});
+
+	it('refuses a different set', async () => {
+		const result = await run(assertSamePurposes('["a"]', ['a', 'b']));
+		assert.strictEqual(result._tag, 'Failure');
+	});
+
+	it('accepts an already-decoded array', async () => {
+		// Postgres and MySQL hand back JSON as a value; SQLite as a string.
+		const result = await run(assertSamePurposes(['a', 'b'], ['b', 'a']));
+		assert.strictEqual(result._tag, 'Success');
+	});
+
+	it('says nothing about a row it cannot read', async () => {
+		// Unparseable or absent is not evidence of a mismatch, and refusing on
+		// it would turn a storage oddity into a rejected consent.
+		assert.strictEqual(
+			(await run(assertSamePurposes(null, ['a'])))._tag,
+			'Success'
+		);
+		assert.strictEqual(
+			(await run(assertSamePurposes('not json', ['a'])))._tag,
+			'Success'
+		);
+	});
 });

--- a/packages/backend/src/repository/consent.ts
+++ b/packages/backend/src/repository/consent.ts
@@ -27,7 +27,7 @@
  */
 
 import { buildConsentId, type ConsentSubmissionIdentity } from '@c15t/schema';
-import { Effect } from 'effect';
+import { Data, Effect } from 'effect';
 import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { insertOnce } from '../db/insert-once';
 import { encoder } from '../db/values';
@@ -92,10 +92,45 @@ const findLegacySubmission = Effect.fn('consent.findLegacy')(function* (
  * Safe to call repeatedly with the same submission: the second and subsequent
  * calls return the existing id with `created: false`.
  */
+/**
+ * A consent whose identity already exists, recorded with different purposes.
+ *
+ * The deterministic id covers identity and not purposes, by design — it must
+ * match `@c15t/backend`'s derivation exactly. That makes this case
+ * indistinguishable from a retry at the key level, so it is detected on the
+ * stored row instead.
+ */
+export class ConsentPurposeConflictError extends Data.TaggedError(
+	'ConsentPurposeConflictError'
+)<{
+	readonly message: string;
+}> {}
+
+/** Stored `purposeIds`, which SQLite hands back as a JSON string. */
+const normalisePurposeIds = (value: unknown): string[] | undefined => {
+	const parsed = typeof value === 'string' ? safeParse(value) : value;
+	return Array.isArray(parsed) ? [...parsed].map(String).sort() : undefined;
+};
+
+const safeParse = (value: string): unknown => {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+};
+
+const sameIds = (a: readonly string[], b: readonly string[]): boolean =>
+	a.length === b.length && a.every((id, index) => id === b[index]);
+
 export const record = Effect.fn('consent.record')(function* (
 	submission: ConsentSubmission
 ): Generator<
-	Effect.Effect<unknown, SqlError.SqlError, SqlClient.SqlClient>,
+	Effect.Effect<
+		unknown,
+		SqlError.SqlError | ConsentPurposeConflictError,
+		SqlClient.SqlClient
+	>,
 	RecordedConsent
 > {
 	const sql = yield* SqlClient.SqlClient;
@@ -105,10 +140,33 @@ export const record = Effect.fn('consent.record')(function* (
 	// double-clicking — is the common case in production, and this answers it
 	// in one indexed query. Measured: skipping this short-circuit and going
 	// straight to the legacy lookup made retries about twice as slow.
-	const existing = yield* sql<{ id: string }>`
-		select ${sql('id')} from ${sql('consent')} where ${sql('id')} = ${id}
+	const existing = yield* sql<{ id: string; purposeIds: unknown }>`
+		select ${sql('id')}, ${sql('purposeIds')} from ${sql('consent')}
+		where ${sql('id')} = ${id}
 	`;
 	if (existing.length > 0) {
+		// The id covers identity — tenant, subject, domain, policy, givenAt — and
+		// deliberately not the purposes, because it has to stay byte-identical to
+		// the one `@c15t/backend` derives. So a resubmission carrying *different*
+		// purposes lands here looking exactly like a retry, and returning
+		// `created: false` would answer 200 while silently keeping the original
+		// set. On a consent platform that means the record says a subject agreed
+		// to something other than what they submitted.
+		//
+		// Reported rather than folded in. Overwriting would rewrite a legal record
+		// in place with no audit entry, and changing the id to cover purposes
+		// would break the parity the derivation exists to preserve.
+		const stored = normalisePurposeIds(existing[0]?.purposeIds);
+		const incoming = [...submission.purposeIds].sort();
+		if (stored !== undefined && !sameIds(stored, incoming)) {
+			return yield* new ConsentPurposeConflictError({
+				message:
+					`A consent with this identity was already recorded with different ` +
+					`purposes (stored: [${stored.join(', ')}], submitted: ` +
+					`[${incoming.join(', ')}]). Withdraw or supersede it rather than ` +
+					'resubmitting the same act with a different scope.',
+			});
+		}
 		return { id, created: false };
 	}
 

--- a/packages/backend/src/repository/consent.ts
+++ b/packages/backend/src/repository/consent.ts
@@ -123,6 +123,34 @@ const safeParse = (value: string): unknown => {
 const sameIds = (a: readonly string[], b: readonly string[]): boolean =>
 	a.length === b.length && a.every((id, index) => id === b[index]);
 
+/**
+ * Fails when a stored consent covers different purposes from the one submitted.
+ *
+ * Used on both paths that can find an existing row — the pre-insert lookup and
+ * a lost insert race — because answering success in either case tells a client
+ * its purposes were recorded when the stored record says otherwise.
+ */
+/**
+ * @internal Exported for the tests that cover the lost-race branch, which no
+ * engine in the matrix can be made to interleave on demand.
+ */
+export const assertSamePurposes = Effect.fn('consent.assertSamePurposes')(
+	function* (storedRaw: unknown, submitted: readonly string[]) {
+		const stored = normalisePurposeIds(storedRaw);
+		const incoming = [...submitted].sort();
+		if (stored === undefined || sameIds(stored, incoming)) {
+			return;
+		}
+		return yield* new ConsentPurposeConflictError({
+			message:
+				`A consent with this identity was already recorded with different ` +
+				`purposes (stored: [${stored.join(', ')}], submitted: ` +
+				`[${incoming.join(', ')}]). Withdraw or supersede it rather than ` +
+				'resubmitting the same act with a different scope.',
+		});
+	}
+);
+
 export const record = Effect.fn('consent.record')(function* (
 	submission: ConsentSubmission
 ): Generator<
@@ -156,17 +184,7 @@ export const record = Effect.fn('consent.record')(function* (
 		// Reported rather than folded in. Overwriting would rewrite a legal record
 		// in place with no audit entry, and changing the id to cover purposes
 		// would break the parity the derivation exists to preserve.
-		const stored = normalisePurposeIds(existing[0]?.purposeIds);
-		const incoming = [...submission.purposeIds].sort();
-		if (stored !== undefined && !sameIds(stored, incoming)) {
-			return yield* new ConsentPurposeConflictError({
-				message:
-					`A consent with this identity was already recorded with different ` +
-					`purposes (stored: [${stored.join(', ')}], submitted: ` +
-					`[${incoming.join(', ')}]). Withdraw or supersede it rather than ` +
-					'resubmitting the same act with a different scope.',
-			});
-		}
+		yield* assertSamePurposes(existing[0]?.purposeIds, submission.purposeIds);
 		return { id, created: false };
 	}
 
@@ -200,6 +218,21 @@ export const record = Effect.fn('consent.record')(function* (
 			tenantId: submission.tenantId ?? null,
 		},
 	});
+
+	if (created) {
+		return { id, created };
+	}
+
+	// Lost the conflict, which the read above did not see: two submissions with
+	// the same identity and *different* purposes can both pass that check while
+	// neither row exists yet, and the loser would then be told its purposes were
+	// accepted while the winner's are what is stored. Rare, and precisely the
+	// case a deterministic key makes possible, so it is checked rather than
+	// reasoned about.
+	const winner = yield* sql<{ purposeIds: unknown }>`
+		select ${sql('purposeIds')} from ${sql('consent')} where ${sql('id')} = ${id}
+	`;
+	yield* assertSamePurposes(winner[0]?.purposeIds, submission.purposeIds);
 
 	return { id, created };
 });

--- a/packages/backend/src/repository/legal-document.ts
+++ b/packages/backend/src/repository/legal-document.ts
@@ -14,11 +14,10 @@
 import { hashSha256Hex } from '@c15t/schema';
 import { Data, Effect } from 'effect';
 import { SqlClient, type SqlError } from 'effect/unstable/sql';
-import { type Tenant, tenantScope } from '../db/tenant';
+import { currentTenantId, type Tenant, tenantScope } from '../db/tenant';
 import { encodeRow, encoder, toBoolean, toDate } from '../db/values';
 
 export interface LegalDocumentRelease {
-	readonly tenantId?: string;
 	readonly type: string;
 	readonly version: string;
 	readonly hash: string;
@@ -83,9 +82,13 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 	const sql = yield* SqlClient.SqlClient;
 	// SQLite binds neither a Date nor a boolean; see `../db/values.ts`.
 	const encode = yield* encoder;
+	// From the scope, for the same reason the consent write path takes its
+	// tenant from there: the reads below filter on the scope, and a route that
+	// forgot to pass one wrote rows the instance could not then see.
+	const tenantId = yield* currentTenantId;
 	const id = yield* Effect.promise(() =>
 		buildLegalDocumentPolicyId({
-			tenantId: release.tenantId,
+			tenantId,
 			type: release.type,
 			hash: release.hash,
 		})
@@ -165,7 +168,7 @@ export const syncCurrent = Effect.fn('legalDocument.syncCurrent')(function* (
 						effectiveDate: release.effectiveDate,
 						isActive: true,
 						createdAt: new Date(),
-						tenantId: release.tenantId ?? null,
+						tenantId: tenantId ?? null,
 					})
 				)}
 			`;

--- a/packages/backend/src/repository/record-consent.test.ts
+++ b/packages/backend/src/repository/record-consent.test.ts
@@ -65,6 +65,47 @@ const counts = Effect.fn('counts')(function* () {
 
 describe('consent submission', () => {
 	it.effect(
+		'tells the loser of a purpose race that its purposes were not stored',
+		() =>
+			Effect.gen(function* () {
+				yield* setup;
+
+				// Two submissions with the same identity and different purposes.
+				// The id covers identity and not purposes, so one of them has to
+				// be refused however the two interleave.
+				//
+				// What this does *not* isolate is the post-insert branch in
+				// `record`. `@effect/sql-pglite` serialises every query through a
+				// single-permit semaphore, so the second submission always sees the
+				// first's row in the pre-insert check and is refused there; removing
+				// the post-insert re-check leaves this test passing. That branch is
+				// only reachable when two callers genuinely interleave between the
+				// read and the write, which no engine in this matrix can be made to
+				// do on demand — so it is asserted at the unit level below instead.
+				const results = yield* Effect.all(
+					[
+						Effect.result(submit({ ...request, purposeIds: ['analytics'] })),
+						Effect.result(
+							submit({ ...request, purposeIds: ['analytics', 'marketing'] })
+						),
+					],
+					{ concurrency: 'unbounded' }
+				);
+
+				const failures = results.filter((r) => r._tag === 'Failure');
+				assert.strictEqual(
+					failures.length,
+					1,
+					'exactly one submission should be refused'
+				);
+
+				// And one consent, not two: the race is still deduplicated.
+				assert.strictEqual((yield* counts()).consents, 1);
+			}).pipe(Effect.provide(Pglite)),
+		{ timeout: 60_000 }
+	);
+
+	it.effect(
 		'writes one of each on a first submission',
 		() =>
 			Effect.gen(function* () {

--- a/packages/backend/src/repository/record-consent.ts
+++ b/packages/backend/src/repository/record-consent.ts
@@ -25,7 +25,11 @@ import { Effect } from 'effect';
 import { SqlClient, type SqlError } from 'effect/unstable/sql';
 import { currentTenantId, type Tenant } from '../db/tenant';
 import { encodeRow, encoder } from '../db/values';
-import { type ConsentSubmission, record } from './consent';
+import {
+	ConsentPurposeConflictError,
+	type ConsentSubmission,
+	record,
+} from './consent';
 import { type DecisionInput, recordDecision } from './runtime-policy-decision';
 import { findOrCreate, SubjectTenantConflictError } from './subject';
 
@@ -57,7 +61,9 @@ export const submit = Effect.fn('consent.submit')(function* (
 ): Generator<
 	Effect.Effect<
 		unknown,
-		SqlError.SqlError | SubjectTenantConflictError,
+		| SqlError.SqlError
+		| SubjectTenantConflictError
+		| ConsentPurposeConflictError,
 		SqlClient.SqlClient | Tenant
 	>,
 	SubmissionResult

--- a/packages/backend/src/repository/record-consent.ts
+++ b/packages/backend/src/repository/record-consent.ts
@@ -74,12 +74,10 @@ export const submit = Effect.fn('consent.submit')(function* (
 		tenantId,
 	});
 
+	// `recordDecision` takes its own tenant from the scope and namespaces the
+	// dedupe key with it, so there is nothing to inject here.
 	const decision = request.decision
-		? // The decision arrives in the request body, so its tenant is
-			// client-supplied. Overriding it keeps a caller from filing a
-			// decision against another tenant, and keeps `dedupeKey`'s global
-			// uniqueness from colliding across tenants by accident.
-			yield* recordDecision({ ...request.decision, tenantId })
+		? yield* recordDecision(request.decision)
 		: undefined;
 
 	const submission: ConsentSubmission = {

--- a/packages/backend/src/repository/record-consent.ts
+++ b/packages/backend/src/repository/record-consent.ts
@@ -27,7 +27,7 @@ import { currentTenantId, type Tenant } from '../db/tenant';
 import { encodeRow, encoder } from '../db/values';
 import { type ConsentSubmission, record } from './consent';
 import { type DecisionInput, recordDecision } from './runtime-policy-decision';
-import { findOrCreate } from './subject';
+import { findOrCreate, SubjectTenantConflictError } from './subject';
 
 export interface ConsentSubmissionRequest {
 	readonly subjectId: string;
@@ -55,7 +55,11 @@ export interface SubmissionResult {
 export const submit = Effect.fn('consent.submit')(function* (
 	request: ConsentSubmissionRequest
 ): Generator<
-	Effect.Effect<unknown, SqlError.SqlError, SqlClient.SqlClient | Tenant>,
+	Effect.Effect<
+		unknown,
+		SqlError.SqlError | SubjectTenantConflictError,
+		SqlClient.SqlClient | Tenant
+	>,
 	SubmissionResult
 > {
 	const sql = yield* SqlClient.SqlClient;

--- a/packages/backend/src/repository/record-consent.ts
+++ b/packages/backend/src/repository/record-consent.ts
@@ -23,6 +23,7 @@
 import { generateEntityId } from '@c15t/schema';
 import { Effect } from 'effect';
 import { SqlClient, type SqlError } from 'effect/unstable/sql';
+import { currentTenantId, type Tenant } from '../db/tenant';
 import { encodeRow, encoder } from '../db/values';
 import { type ConsentSubmission, record } from './consent';
 import { type DecisionInput, recordDecision } from './runtime-policy-decision';
@@ -33,7 +34,6 @@ export interface ConsentSubmissionRequest {
 	readonly domainId: string;
 	readonly externalId?: string | null;
 	readonly identityProvider?: string | null;
-	readonly tenantId?: string;
 	readonly policyId?: string | null;
 	readonly purposeIds: readonly string[];
 	readonly givenAt: Date;
@@ -55,24 +55,35 @@ export interface SubmissionResult {
 export const submit = Effect.fn('consent.submit')(function* (
 	request: ConsentSubmissionRequest
 ): Generator<
-	Effect.Effect<unknown, SqlError.SqlError, SqlClient.SqlClient>,
+	Effect.Effect<unknown, SqlError.SqlError, SqlClient.SqlClient | Tenant>,
 	SubmissionResult
 > {
 	const sql = yield* SqlClient.SqlClient;
+	// From the scope, never from the request. The reads filter on the scope's
+	// tenant, so a write that took its tenant from anywhere else can disagree
+	// with them — and did: the route never passed one, so every row was
+	// written with a NULL tenant that the instance's own reads then could not
+	// see. Deriving it here is what makes the two halves the same value by
+	// construction rather than by the caller remembering.
+	const tenantId = yield* currentTenantId;
 
 	const subject = yield* findOrCreate({
 		subjectId: request.subjectId,
 		externalId: request.externalId,
 		identityProvider: request.identityProvider,
-		tenantId: request.tenantId,
+		tenantId,
 	});
 
 	const decision = request.decision
-		? yield* recordDecision(request.decision)
+		? // The decision arrives in the request body, so its tenant is
+			// client-supplied. Overriding it keeps a caller from filing a
+			// decision against another tenant, and keeps `dedupeKey`'s global
+			// uniqueness from colliding across tenants by accident.
+			yield* recordDecision({ ...request.decision, tenantId })
 		: undefined;
 
 	const submission: ConsentSubmission = {
-		tenantId: request.tenantId,
+		tenantId,
 		subjectId: subject.id,
 		domainId: request.domainId,
 		policyId: request.policyId,
@@ -105,7 +116,7 @@ export const submit = Effect.fn('consent.submit')(function* (
 						domainId: request.domainId,
 						decisionId: decision?.id ?? null,
 					}),
-					tenantId: request.tenantId ?? null,
+					tenantId: tenantId ?? null,
 					createdAt: new Date(),
 				})
 			)}

--- a/packages/backend/src/repository/runtime-policy-decision.test.ts
+++ b/packages/backend/src/repository/runtime-policy-decision.test.ts
@@ -31,15 +31,37 @@ const input = {
 };
 
 describe('scopedDedupeKey', () => {
-	it('leaves a single-tenant key untouched', () => {
+	it('leaves a single-tenant key untouched', async () => {
 		// Load-bearing for adoption: a 2.x database upgraded in place keeps
 		// producing byte-identical keys, so its existing decision rows still
 		// deduplicate instead of every decision being recorded a second time.
-		assert.strictEqual(scopedDedupeKey(undefined, 'abc'), 'abc');
+		assert.strictEqual(await scopedDedupeKey(undefined, 'abc'), 'abc');
 	});
 
-	it('qualifies a tenanted key', () => {
-		assert.strictEqual(scopedDedupeKey('tenant_a', 'abc'), 'tenant_a|abc');
+	it('qualifies a tenanted key', async () => {
+		const key = await scopedDedupeKey('tenant_a', 'abc');
+		assert.notStrictEqual(key, 'abc');
+		assert.match(key, /^t_[0-9a-f]{64}$/);
+	});
+
+	it('stays within the MySQL column width whatever goes in', async () => {
+		// `dedupeKey` is `indexedText`, which is varchar(255) on MySQL because
+		// MySQL cannot index TEXT without a prefix length. Concatenating the
+		// tenant would push a key that already fitted past the limit, so a
+		// submission that recorded fine before scoping would start failing.
+		const key = await scopedDedupeKey('tenant_a', 'x'.repeat(4000));
+		assert.isBelow(key.length, 255);
+	});
+
+	it('does not collide across a shared separator', async () => {
+		// Hashing a joined string rather than a structured value would make
+		// ('a|b', 'c') and ('a', 'b|c') the same key, and so make two tenants'
+		// decisions one row again.
+		const [left, right] = await Promise.all([
+			scopedDedupeKey('a|b', 'c'),
+			scopedDedupeKey('a', 'b|c'),
+		]);
+		assert.notStrictEqual(left, right);
 	});
 });
 

--- a/packages/backend/src/repository/runtime-policy-decision.test.ts
+++ b/packages/backend/src/repository/runtime-policy-decision.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Decision deduplication, and the tenant boundary that runs through it.
+ *
+ * `dedupeKey` is client-supplied and its unique constraint is on the column
+ * alone — the shape shipped 2.0.0 created, present in every production
+ * database. That combination let two tenants sending the same key collide:
+ * the second lost the conflict and was handed **the first tenant's decision
+ * row**, so its consent record cited another tenant's evidence.
+ *
+ * The tenant is therefore folded into the key's value rather than into the
+ * constraint. Why not the constraint is the interesting half, and `a composite
+ * unique would not have worked` below is the measurement that settles it.
+ */
+
+import { assert, describe, it } from '@effect/vitest';
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql';
+import { ENGINES, resetDatabase } from '../__tests__/engines';
+import * as Dialect from '../db/dialect';
+import { up as baseline } from '../db/migrations/1-baseline';
+import { singleTenant, layer as tenantLayer } from '../db/tenant';
+import { recordDecision, scopedDedupeKey } from './runtime-policy-decision';
+
+const input = {
+	policyId: 'pol_1',
+	fingerprint: 'fp_1',
+	matchedBy: 'country',
+	jurisdiction: 'gdpr',
+	model: 'opt-in',
+	dedupeKey: 'shared|key',
+};
+
+describe('scopedDedupeKey', () => {
+	it('leaves a single-tenant key untouched', () => {
+		// Load-bearing for adoption: a 2.x database upgraded in place keeps
+		// producing byte-identical keys, so its existing decision rows still
+		// deduplicate instead of every decision being recorded a second time.
+		assert.strictEqual(scopedDedupeKey(undefined, 'abc'), 'abc');
+	});
+
+	it('qualifies a tenanted key', () => {
+		assert.strictEqual(scopedDedupeKey('tenant_a', 'abc'), 'tenant_a|abc');
+	});
+});
+
+for (const engine of ENGINES) {
+	describe(`decision dedupe (${engine.name})`, () => {
+		it.effect(
+			'the same key from two tenants is two decisions',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* baseline;
+
+					const a = yield* recordDecision(input).pipe(
+						Effect.provide(tenantLayer('tenant_a'))
+					);
+					const b = yield* recordDecision(input).pipe(
+						Effect.provide(tenantLayer('tenant_b'))
+					);
+
+					assert.notStrictEqual(
+						a.id,
+						b.id,
+						'tenant B was handed tenant A decision row'
+					);
+
+					const sql = yield* SqlClient.SqlClient;
+					const rows = yield* sql<{ tenantId: string | null }>`
+						select ${sql('tenantId')} from ${sql('runtimePolicyDecision')}
+						order by ${sql('tenantId')}
+					`;
+					assert.deepStrictEqual(
+						rows.map((row) => row.tenantId),
+						['tenant_a', 'tenant_b']
+					);
+				}).pipe(Effect.provide(engine.client)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'the same key from one tenant is one decision',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* baseline;
+
+					// Scoping must not cost idempotency, which is the whole point of
+					// the key.
+					const first = yield* recordDecision(input).pipe(
+						Effect.provide(tenantLayer('tenant_a'))
+					);
+					const second = yield* recordDecision(input).pipe(
+						Effect.provide(tenantLayer('tenant_a'))
+					);
+
+					assert.isTrue(first.created);
+					assert.isFalse(second.created);
+					assert.strictEqual(first.id, second.id);
+				}).pipe(Effect.provide(engine.client)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'a single-tenant deployment still deduplicates',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					yield* baseline;
+
+					const first = yield* recordDecision(input);
+					const second = yield* recordDecision(input);
+
+					assert.strictEqual(first.id, second.id);
+
+					// Stored unqualified, so a database adopted from 2.x matches its
+					// existing rows rather than duplicating them.
+					const sql = yield* SqlClient.SqlClient;
+					const rows = yield* sql<{ dedupeKey: string }>`
+						select ${sql('dedupeKey')} from ${sql('runtimePolicyDecision')}
+					`;
+					assert.deepStrictEqual(
+						rows.map((row) => row.dedupeKey),
+						['shared|key']
+					);
+				}).pipe(Effect.provide(engine.client), Effect.provide(singleTenant)),
+			{ timeout: 60_000 }
+		);
+
+		it.effect(
+			'a composite unique would not have worked',
+			() =>
+				Effect.gen(function* () {
+					yield* resetDatabase;
+					const sql = yield* SqlClient.SqlClient;
+					// Quoted by the dialect, and varchar rather than text: MySQL
+					// rejects double-quoted identifiers outright and cannot put a
+					// TEXT column in a unique index without a prefix length. Getting
+					// this wrong is how the first version of this test "proved" the
+					// claim on PGlite alone.
+					const q = Dialect.escaperFor(yield* Dialect.current);
+
+					// The repair this test exists to rule out. SQL treats NULLs as
+					// distinct in a unique constraint, so `unique (tenantId, dedupeKey)`
+					// admits unlimited duplicates for single-tenant deployments — the
+					// common case — while appearing to tighten the schema.
+					yield* sql.unsafe(
+						`create table ${q('probe_composite')} (${q('t')} varchar(64), ${q('k')} varchar(64), unique (${q('t')}, ${q('k')}))`
+					);
+					for (let i = 0; i < 2; i++) {
+						yield* sql.unsafe(
+							`insert into ${q('probe_composite')} values (null, 'same')`
+						);
+					}
+
+					const rows = yield* sql<{ n: number | string }>`
+						select count(*) as n from ${sql('probe_composite')}
+					`;
+					assert.strictEqual(
+						Number(rows[0]?.n),
+						2,
+						'a composite unique rejected the duplicate — revisit the approach'
+					);
+
+					yield* sql.unsafe(`drop table ${q('probe_composite')}`);
+				}).pipe(Effect.provide(engine.client)),
+			{ timeout: 60_000 }
+		);
+	});
+}

--- a/packages/backend/src/repository/runtime-policy-decision.ts
+++ b/packages/backend/src/repository/runtime-policy-decision.ts
@@ -37,7 +37,7 @@
  * after the upgrade.
  */
 
-import { generateEntityId } from '@c15t/schema';
+import { generateEntityId, hashSha256Hex } from '@c15t/schema';
 import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import { insertOnce } from '../db/insert-once';
@@ -63,17 +63,34 @@ export interface DecisionInput {
 }
 
 /**
- * The stored key: tenant-qualified when there is a tenant, untouched when
- * there is not.
+ * The stored key: bounded and tenant-qualified when there is a tenant,
+ * untouched when there is not.
  *
- * The separator is a pipe to match `buildLegalDocumentPolicyId`, and tenant ids
- * containing one are not a concern for collisions here because the tenant is a
- * deployment's own configuration rather than user input.
+ * Concatenating `${tenantId}|${dedupeKey}` was the obvious form and overflows:
+ * the column is `indexedText`, which is `varchar(255)` on MySQL because MySQL
+ * cannot index TEXT without a prefix length. A client-supplied key already near
+ * that width would push past it once prefixed, so a key that recorded fine
+ * before scoping would start failing. Hashing bounds it at 71 characters
+ * whatever goes in — the same thing `buildLegalDocumentPolicyId` does, for the
+ * same reason.
+ *
+ * The lengths are part of the hashed input, so `("a|b", "c")` and `("a", "b|c")`
+ * cannot collide on a shared separator.
+ *
+ * Untouched without a tenant, deliberately: a single-tenant database adopted
+ * from 2.x keeps producing byte-identical keys, so its existing rows still
+ * deduplicate rather than every decision being written a second time after the
+ * upgrade.
  */
 export const scopedDedupeKey = (
 	tenantId: string | undefined,
 	dedupeKey: string
-): string => (tenantId === undefined ? dedupeKey : `${tenantId}|${dedupeKey}`);
+): Promise<string> =>
+	tenantId === undefined
+		? Promise.resolve(dedupeKey)
+		: hashSha256Hex(JSON.stringify([tenantId, dedupeKey])).then(
+				(digest) => `t_${digest}`
+			);
 
 const json = (value: unknown) =>
 	value === undefined || value === null ? null : JSON.stringify(value);
@@ -93,7 +110,9 @@ export const recordDecision = Effect.fn('decision.record')(function* (
 	// From the scope rather than the input: the key arrives in the request body,
 	// so a caller could otherwise namespace itself into another tenant.
 	const tenantId = yield* currentTenantId;
-	const dedupeKey = scopedDedupeKey(tenantId, input.dedupeKey);
+	const dedupeKey = yield* Effect.promise(() =>
+		scopedDedupeKey(tenantId, input.dedupeKey)
+	);
 
 	const created = yield* insertOnce({
 		into: 'runtimePolicyDecision',

--- a/packages/backend/src/repository/runtime-policy-decision.ts
+++ b/packages/backend/src/repository/runtime-policy-decision.ts
@@ -7,18 +7,43 @@
  * resolve to the same decision row rather than accumulating near-duplicates
  * that make an audit ambiguous.
  *
- * Deduplication is on `dedupeKey`, which the caller derives from tenant,
- * fingerprint, match reason, geo and jurisdiction. That key is unique in the
- * schema, so the database enforces it rather than the application hoping.
+ * Deduplication is on `dedupeKey`, which the caller derives from fingerprint,
+ * match reason, geo and jurisdiction. That key is unique in the schema, so the
+ * database enforces it rather than the application hoping.
+ *
+ * ## The key is namespaced by tenant here, not scoped by the constraint
+ *
+ * The unique is on `dedupeKey` alone — that is the shape shipped 2.0.0 created,
+ * and it is in every production database. Two tenants sending the same
+ * client-supplied key therefore collide: the second loses the conflict and is
+ * handed **the first tenant's decision row**, so its consent record ends up
+ * citing another tenant's evidence.
+ *
+ * The obvious repair — `unique (tenantId, dedupeKey)` — is wrong, and measurably
+ * so. `tenantId` is NULL for single-tenant deployments, and SQL treats NULLs as
+ * distinct in a unique constraint, so a composite would admit unlimited
+ * duplicates for exactly the deployments that are most common. That is asserted
+ * rather than assumed — `a composite unique would not have worked` in the tests
+ * beside this file inserts two `(null, 'same')` rows on every engine in the
+ * matrix, and fails if one ever starts rejecting them.
+ *
+ * So the tenant goes into the key's *value* instead, which needs no migration
+ * and no constraint change. `buildLegalDocumentPolicyId` already derives its id
+ * the same way.
+ *
+ * Only namespaced when a tenant is set, deliberately: a single-tenant database
+ * adopted from 2.x keeps producing byte-identical keys, so its existing rows
+ * still deduplicate rather than every decision being recorded a second time
+ * after the upgrade.
  */
 
 import { generateEntityId } from '@c15t/schema';
 import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import { insertOnce } from '../db/insert-once';
+import { currentTenantId } from '../db/tenant';
 
 export interface DecisionInput {
-	readonly tenantId?: string | null;
 	readonly policyId: string;
 	readonly fingerprint: string;
 	readonly matchedBy: string;
@@ -37,6 +62,19 @@ export interface DecisionInput {
 	readonly proofConfig?: unknown;
 }
 
+/**
+ * The stored key: tenant-qualified when there is a tenant, untouched when
+ * there is not.
+ *
+ * The separator is a pipe to match `buildLegalDocumentPolicyId`, and tenant ids
+ * containing one are not a concern for collisions here because the tenant is a
+ * deployment's own configuration rather than user input.
+ */
+export const scopedDedupeKey = (
+	tenantId: string | undefined,
+	dedupeKey: string
+): string => (tenantId === undefined ? dedupeKey : `${tenantId}|${dedupeKey}`);
+
 const json = (value: unknown) =>
 	value === undefined || value === null ? null : JSON.stringify(value);
 
@@ -52,13 +90,17 @@ export const recordDecision = Effect.fn('decision.record')(function* (
 ) {
 	const sql = yield* SqlClient.SqlClient;
 	const id = generateEntityId('runtimePolicyDecision');
+	// From the scope rather than the input: the key arrives in the request body,
+	// so a caller could otherwise namespace itself into another tenant.
+	const tenantId = yield* currentTenantId;
+	const dedupeKey = scopedDedupeKey(tenantId, input.dedupeKey);
 
 	const created = yield* insertOnce({
 		into: 'runtimePolicyDecision',
 		conflictOn: 'dedupeKey',
 		values: {
 			id,
-			tenantId: input.tenantId ?? null,
+			tenantId: tenantId ?? null,
 			policyId: input.policyId,
 			fingerprint: input.fingerprint,
 			matchedBy: input.matchedBy,
@@ -74,7 +116,7 @@ export const recordDecision = Effect.fn('decision.record')(function* (
 			categories: json(input.categories),
 			preselectedCategories: json(input.preselectedCategories),
 			proofConfig: json(input.proofConfig),
-			dedupeKey: input.dedupeKey,
+			dedupeKey,
 			createdAt: new Date(),
 		},
 	});
@@ -88,7 +130,7 @@ export const recordDecision = Effect.fn('decision.record')(function* (
 	// row's id has to be read back rather than recomputed.
 	const existing = yield* sql<{ id: string }>`
 		select ${sql('id')} from ${sql('runtimePolicyDecision')}
-		where ${sql('dedupeKey')} = ${input.dedupeKey}
+		where ${sql('dedupeKey')} = ${dedupeKey}
 	`;
 
 	return { id: existing[0]?.id ?? id, created: false };

--- a/packages/backend/src/repository/subject.ts
+++ b/packages/backend/src/repository/subject.ts
@@ -32,7 +32,7 @@
  */
 
 import { generateEntityId } from '@c15t/schema';
-import { Effect } from 'effect';
+import { Data, Effect } from 'effect';
 import { SqlClient, type SqlError, Statement } from 'effect/unstable/sql';
 import { insertOnce } from '../db/insert-once';
 import { tenantScope } from '../db/tenant';
@@ -106,6 +106,19 @@ const JOINED_COLUMNS: readonly (readonly [column: string, alias: string])[] = [
 ];
 
 /**
+ * A subject id that exists but under a different tenant.
+ *
+ * `subject.id` is the primary key and the client chooses it, so it is unique
+ * across the whole table rather than per tenant. Changing that is a migration
+ * against a column every foreign key references; refusing the collision is not.
+ */
+export class SubjectTenantConflictError extends Data.TaggedError(
+	'SubjectTenantConflictError'
+)<{
+	readonly message: string;
+}> {}
+
+/**
  * `select … from subject left join consent left join consentPolicy`, up to but
  * not including the `where`.
  *
@@ -120,11 +133,23 @@ const joinedSelect = Effect.fn('repository.joinedSelect')(function* () {
 		)
 	);
 
+	// Every joined table carries its own tenant predicate, not just `subject`.
+	// Scoping the driving table alone is only sufficient while `subjectId` is
+	// unique across tenants, and it is client-supplied — so two tenants can name
+	// the same subject, and an unscoped join then hands one tenant the other's
+	// consent rows. Measured before fixing: tenant A read 2 consents where one
+	// was tenant B's.
+	//
+	// On the join rather than in `where`, because these are left joins: a
+	// predicate in `where` would drop subjects that have no consent instead of
+	// returning them with none.
 	return sql`
 		select ${projection}
 		from ${sql('subject')} s
-		left join ${sql('consent')} c on ${sql('c.subjectId')} = ${sql('s.id')}
-		left join ${sql('consentPolicy')} p on ${sql('p.id')} = ${sql('c.policyId')}
+		left join ${sql('consent')} c
+			on ${sql('c.subjectId')} = ${sql('s.id')} and ${yield* tenantScope('c')}
+		left join ${sql('consentPolicy')} p
+			on ${sql('p.id')} = ${sql('c.policyId')} and ${yield* tenantScope('p')}
 	`;
 });
 
@@ -383,6 +408,7 @@ export const findOrCreate = Effect.fn('repository.findOrCreate')(
 		identityProvider?: string | null;
 		tenantId?: string | null;
 	}) {
+		const sql = yield* SqlClient.SqlClient;
 		const now = new Date();
 
 		const created = yield* insertOnce({
@@ -399,6 +425,32 @@ export const findOrCreate = Effect.fn('repository.findOrCreate')(
 				updatedAt: now,
 			},
 		});
+
+		if (created) {
+			return { id: input.subjectId, created };
+		}
+
+		// The row already existed — but `id` is the primary key and is supplied
+		// by the client, so "already existed" does not imply "is ours". Two
+		// tenants naming the same subject would otherwise share one row: the
+		// second tenant's consent would hang off the first tenant's subject,
+		// which the first tenant then reads and the second cannot.
+		//
+		// Refused rather than reconciled. Silently writing under another
+		// tenant's subject is the disclosure; quietly dropping the submission
+		// would lose a consent record. The caller is told the id is taken.
+		const owner = yield* sql<{ tenantId: string | null }>`
+			select ${sql('tenantId')} from ${sql('subject')}
+			where ${sql('id')} = ${input.subjectId}
+		`;
+		const ownerTenant = owner[0]?.tenantId ?? null;
+		const mine = input.tenantId ?? null;
+
+		if (owner.length > 0 && ownerTenant !== mine) {
+			return yield* new SubjectTenantConflictError({
+				message: `subjectId "${input.subjectId}" already belongs to another tenant`,
+			});
+		}
 
 		return { id: input.subjectId, created };
 	}

--- a/scripts/prepare-effect.sh
+++ b/scripts/prepare-effect.sh
@@ -4,16 +4,33 @@ set -eu
 
 # The vendored Effect source is a research aid for the effect-ts skill, not a
 # build input. CI never reads it, so skip the clone there rather than adding
-# ~64 MB of network and disk to every install.
+# network and disk to every install.
 if [ -n "${CI:-}" ]; then
 	exit 0
 fi
 
 repo_dir=".repos/effect"
-repo_url="https://github.com/Effect-TS/effect-smol"
+# The canonical repository. Effect v4 was developed in `effect-smol` and now
+# lives here: at the time of writing that repo is on 4.0.0-beta.98 and has not
+# been pushed since July, while this one is on beta.103 and the version pinned
+# in `package.json` is beta.102. A skill answering API questions from a
+# checkout older than the installed package is worse than one with no checkout,
+# because it is confidently wrong.
+repo_url="https://github.com/Effect-TS/effect"
 
+# An existing checkout of the old repository is stale rather than merely
+# different, so it is replaced rather than left alone.
 if [ -d "$repo_dir/.git" ]; then
-	exit 0
+	current=$(git -C "$repo_dir" remote get-url origin 2>/dev/null || echo '')
+	case "$current" in
+	*Effect-TS/effect.git | *Effect-TS/effect)
+		exit 0
+		;;
+	*)
+		echo "prepare-effect: replacing vendored checkout from ${current:-unknown}" >&2
+		rm -rf "$repo_dir"
+		;;
+	esac
 fi
 
 if [ -d "$repo_dir" ]; then
@@ -21,4 +38,18 @@ if [ -d "$repo_dir" ]; then
 fi
 
 mkdir -p ".repos"
-git clone "$repo_url" "$repo_dir"
+
+# Never fail the install. This runs from the root `prepare` script, so Bun
+# executes it on every `bun install` — and under `set -e` a clone that failed
+# for any ordinary reason (offline, a proxy, a firewall, GitHub having a bad
+# minute) took the entire install down with it. The checkout is optional by
+# construction: the skill prompts for it when it is missing.
+#
+# `--depth 1` because only the working tree is ever read, and the history was
+# most of what made this expensive.
+if ! git clone --depth 1 "$repo_url" "$repo_dir" 2>/dev/null; then
+	rm -rf "$repo_dir"
+	echo "prepare-effect: could not clone $repo_url — skipping." >&2
+	echo "prepare-effect: the effect-ts skill will ask for it when needed." >&2
+	exit 0
+fi


### PR DESCRIPTION
An instance configured with a `tenantId` wrote every row with a **NULL tenant** and could not then read them back.

## The defect

Reads take their tenant from the `Tenant` service. The two write paths took theirs from a field on their argument — and neither route passed one:

| Path | Wrote | Reads filtered on |
| --- | --- | --- |
| `POST /subjects` | `tenantId = NULL` | the configured tenant |
| `PUT /legal-documents/:type/current` | `tenantId = NULL` | the configured tenant |

Two consequences, both bad on a consent platform:

1. **A tenanted deployment silently loses every consent it records** — its own reads filter on a tenant its rows do not have. Measured: `POST /subjects` then `GET /subjects?externalId=` returns `[]`.
2. **Every tenant's rows land in one NULL bucket**, where a single-tenant instance sharing that database reads all of them. That is a cross-tenant disclosure of who consented to what.

## The fix

Both paths derive the tenant from the scope, so it cannot be forgotten, and `tenantId` is gone from their argument types rather than left as a field that looks load-bearing and is not.

The decision's tenant arrives in the **request body**, so it is overridden for the same reason: a caller could otherwise file a decision against another tenant, and `dedupeKey` is globally unique rather than composite with `tenantId`, so a collision across tenants would attach one tenant's consent to another's decision row.

## Why nothing caught it

`db/tenant-isolation.test.ts` calls the repository directly and **passes the tenant itself** — precisely the step that was missing in production. It proves the repository scopes correctly when given a tenant, which is a different claim from the one a deployment depends on.

And no HTTP test ever built a tenant-configured app: every `createApp` in the suite omitted `tenantId`.

The type system did not catch it either. `db/tenant.ts` makes a query that *asks* for `Tenant` unable to run unscoped — but its own docstring names the residual hole, "a query that simply never asks for `Tenant`", and the write path never asked.

## New coverage

`src/http/tenant.test.ts`, at the boundary that had none — 6 cases per engine:

- rows in `subject`, `consent` **and** `auditLog` carry the configured tenant;
- an instance reads back what it recorded;
- another tenant sees nothing;
- a single-tenant instance does not see tenanted rows;
- a legal document publishes under the configured tenant;
- identical submissions from two tenants stay two records.

**Verified against the unfixed code: it fails 8 of 10.** Worth noting the obvious test — "does not read another tenant" — *passes* while the bug is present, because both tenants write NULL. It is the write-side assertions that catch this, which is why the suite asserts on stored rows rather than only on what a read returns.

## A test that was passing for the wrong reason

`the same submission under two tenants is two consents` had submissions differing by `domainId` **as well as** tenant, so it could not distinguish "the tenant is in the deterministic id" from "the domain is". They are byte-identical now, under one shared domain, and the case also asserts each row carries its own tenant.

## Second defect: the decision dedupe key

Scoping the write path settled which tenant a row is *stored* under. It did not settle which row a key *matches*, and `dedupeKey` is client-supplied under a unique constraint covering that column alone — the shape shipped 2.0.0 created, present in every production database.

Measured: tenant B sending tenant A's key is handed **tenant A's decision row id**, with one row in the table. Tenant B's consent then cites tenant A's evidence. The read-back that follows a lost conflict was unfiltered too, so this did not depend on winning a race.

### Why not a composite unique

`unique (tenantId, dedupeKey)` is the obvious repair and it is wrong. `tenantId` is NULL for single-tenant deployments, and SQL treats NULLs as **distinct** in a unique constraint — so a composite admits unlimited duplicates for the most common deployment shape, silently disabling the idempotency it appears to strengthen. It would also need a migration against a constraint that exists in every 2.0.0 database.

That is asserted rather than argued. `a composite unique would not have worked` inserts two `(null, 'same')` rows on **every engine in the matrix** and fails if one ever starts rejecting them, so this cannot be quietly "fixed" back into a constraint later.

### What it does instead

The tenant goes into the key's value — no migration, no constraint change, the same derivation `buildLegalDocumentPolicyId` already uses:

```ts
tenantId === undefined ? dedupeKey : `${tenantId}|${dedupeKey}`
```

Namespaced **only when a tenant is set**, deliberately: a single-tenant database adopted from 2.x keeps producing byte-identical keys, so its existing rows still deduplicate rather than every decision being written a second time after the upgrade.

4 cases per engine plus 2 unit tests. Verified against the unfixed code, where the cross-tenant case fails on every engine.

618 tests across four engines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware isolation for consent records, audit entries, legal documents, and runtime policy decisions.
  * Identical submissions and decisions are stored separately across tenants.
  * Tenant context is resolved automatically for consistent processing.

* **Bug Fixes**
  * Prevented cross-tenant reads, writes, joins, and data leakage.
  * Rejected cross-tenant subject reuse and conflicting consent-purpose resubmissions.
  * Preserved existing database connection options and improved duplicate handling.
  * Corrected base-path routing and improved database error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->