### PR TITLE
refactor!: rename the c15t package to @c15t/core

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
 	"commit": false,
 	"linked": [
 		[
-			"c15t",
+			"@c15t/core",
 			"@c15t/backend",
 			"@c15t/cli",
 			"@c15t/dev-tools",

--- a/.github/workflows/script-vendor-monitor.yml
+++ b/.github/workflows/script-vendor-monitor.yml
@@ -53,7 +53,7 @@ jobs:
           bunx "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium
 
       - name: Build c15t core
-        run: bun turbo run build --filter=c15t
+        run: bun turbo run build --filter=@c15t/core
 
       - name: Run live vendor probes
         working-directory: packages/scripts

--- a/apps/storybook-svelte/package.json
+++ b/apps/storybook-svelte/package.json
@@ -9,7 +9,7 @@
 		"test-storybook": "test-storybook --url ${STORYBOOK_URL:-http://127.0.0.1:6006}"
 	},
 	"dependencies": {
-		"c15t": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/ui": "workspace:*",
 		"@c15t/svelte": "workspace:*",
 		"@c15t/conformance": "workspace:*",

--- a/apps/storybook-svelte/src/StorybookConsentProvider.svelte
+++ b/apps/storybook-svelte/src/StorybookConsentProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ConsentManagerProvider } from '@c15t/svelte';
-	import { clearConsentRuntimeCache } from 'c15t';
+	import { clearConsentRuntimeCache } from '@c15t/core';
 	import { untrack, type Snippet } from 'svelte';
 	import type { ConsentManagerOptions } from '../../../packages/svelte/src/lib/types';
 	import {

--- a/apps/storybook-svelte/src/StorybookIABProvider.svelte
+++ b/apps/storybook-svelte/src/StorybookIABProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ConsentManagerProvider } from '@c15t/svelte';
-	import { clearConsentRuntimeCache } from 'c15t';
+	import { clearConsentRuntimeCache } from '@c15t/core';
 	import { untrack, type Snippet } from 'svelte';
 	import type { ConsentManagerOptions } from '../../../packages/svelte/src/lib/types';
 	import {

--- a/benchmarks/bundle-test-app/app/core-only/page.tsx
+++ b/benchmarks/bundle-test-app/app/core-only/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import { useEffect, useState } from 'react';
 
 export default function CoreOnlyPage() {

--- a/benchmarks/bundle-test-app/app/v3-react-full-aggregate/page.tsx
+++ b/benchmarks/bundle-test-app/app/v3-react-full-aggregate/page.tsx
@@ -2,6 +2,7 @@
 
 import '@c15t/react/styles.css';
 
+import type { AllConsentNames } from '@c15t/core';
 import {
 	ConsentBanner,
 	ConsentDialog,
@@ -13,7 +14,6 @@ import {
 	useHasConsented,
 	useSaveConsents,
 } from '@c15t/react/v3';
-import type { AllConsentNames } from 'c15t';
 
 const CATEGORIES: AllConsentNames[] = [
 	'necessary',
@@ -55,7 +55,10 @@ function TestComponent() {
 			<p>Has consented: {String(hasConsented)}</p>
 			<div>
 				{CATEGORIES.map((category) => (
-					<label key={category} style={{ display: 'block' }}>
+					<label
+						key={category}
+						style={{ display: 'block' }}
+					>
 						<input
 							checked={draft.values[category]}
 							disabled={category === 'necessary'}
@@ -67,7 +70,10 @@ function TestComponent() {
 				))}
 			</div>
 			<pre>{JSON.stringify(consents, null, 2)}</pre>
-			<button onClick={() => saveConsents('all')} type="button">
+			<button
+				onClick={() => saveConsents('all')}
+				type="button"
+			>
 				Accept All
 			</button>
 		</div>

--- a/benchmarks/bundle-test-app/app/v3-react-full-split/page.tsx
+++ b/benchmarks/bundle-test-app/app/v3-react-full-split/page.tsx
@@ -2,6 +2,7 @@
 
 import '@c15t/react/styles.css';
 
+import type { AllConsentNames } from '@c15t/core';
 import { ConsentBanner } from '@c15t/react/v3/consent-banner';
 import { ConsentDialog } from '@c15t/react/v3/consent-dialog';
 import { ConsentWidget } from '@c15t/react/v3/consent-widget';
@@ -12,7 +13,6 @@ import {
 	useSaveConsents,
 } from '@c15t/react/v3/hooks';
 import { ConsentProvider } from '@c15t/react/v3/provider';
-import type { AllConsentNames } from 'c15t';
 
 const CATEGORIES: AllConsentNames[] = [
 	'necessary',
@@ -54,7 +54,10 @@ function TestComponent() {
 			<p>Has consented: {String(hasConsented)}</p>
 			<div>
 				{CATEGORIES.map((category) => (
-					<label key={category} style={{ display: 'block' }}>
+					<label
+						key={category}
+						style={{ display: 'block' }}
+					>
 						<input
 							checked={draft.values[category]}
 							disabled={category === 'necessary'}
@@ -66,7 +69,10 @@ function TestComponent() {
 				))}
 			</div>
 			<pre>{JSON.stringify(consents, null, 2)}</pre>
-			<button onClick={() => saveConsents('all')} type="button">
+			<button
+				onClick={() => saveConsents('all')}
+				type="button"
+			>
 				Accept All
 			</button>
 		</div>

--- a/benchmarks/bundle-test-app/app/v3-react-full/diagnostics.tsx
+++ b/benchmarks/bundle-test-app/app/v3-react-full/diagnostics.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { AllConsentNames } from '@c15t/core';
+import type { Script } from '@c15t/core/v3/modules/script-loader';
 import {
 	ConsentDialogLink,
 	useConsent,
@@ -9,8 +11,6 @@ import {
 	useIframeBlocker,
 	useSaveConsents,
 } from '@c15t/react/v3';
-import type { AllConsentNames } from 'c15t';
-import type { Script } from 'c15t/v3/modules/script-loader';
 import type { CSSProperties } from 'react';
 import { useEffect, useState } from 'react';
 

--- a/benchmarks/bundle-test-app/app/v3-react-full/page.tsx
+++ b/benchmarks/bundle-test-app/app/v3-react-full/page.tsx
@@ -17,6 +17,7 @@ import '@c15t/react/styles.css';
  * below for live confirmation.
  */
 
+import type { Script } from '@c15t/core/v3/modules/script-loader';
 import {
 	ConsentBanner,
 	ConsentDialog,
@@ -24,7 +25,6 @@ import {
 	ConsentProvider,
 	ConsentWidget,
 } from '@c15t/react/v3';
-import type { Script } from 'c15t/v3/modules/script-loader';
 import { lazy, Suspense } from 'react';
 
 const Diagnostics = lazy(() => import('./diagnostics'));

--- a/benchmarks/bundle-test-app/app/v3-react-standard-script-loader/page.tsx
+++ b/benchmarks/bundle-test-app/app/v3-react-standard-script-loader/page.tsx
@@ -2,6 +2,8 @@
 
 import '@c15t/react/styles.css';
 
+import type { AllConsentNames } from '@c15t/core';
+import type { Script } from '@c15t/core/v3/modules/script-loader';
 import { ConsentBanner } from '@c15t/react/v3/consent-banner';
 import { ConsentDialog } from '@c15t/react/v3/consent-dialog';
 import { ConsentWidget } from '@c15t/react/v3/consent-widget';
@@ -12,8 +14,6 @@ import {
 	useSaveConsents,
 } from '@c15t/react/v3/hooks';
 import { ConsentProvider } from '@c15t/react/v3/provider';
-import type { AllConsentNames } from 'c15t';
-import type { Script } from 'c15t/v3/modules/script-loader';
 
 const DEMO_SCRIPTS: Script[] = [
 	{
@@ -86,7 +86,10 @@ function TestComponent() {
 			<p>Has consented: {String(hasConsented)}</p>
 			<div>
 				{CATEGORIES.map((category) => (
-					<label key={category} style={{ display: 'block' }}>
+					<label
+						key={category}
+						style={{ display: 'block' }}
+					>
 						<input
 							checked={draft.values[category]}
 							disabled={category === 'necessary'}
@@ -98,7 +101,10 @@ function TestComponent() {
 				))}
 			</div>
 			<pre>{JSON.stringify(consents, null, 2)}</pre>
-			<button onClick={() => saveConsents('all')} type="button">
+			<button
+				onClick={() => saveConsents('all')}
+				type="button"
+			>
 				Accept All
 			</button>
 		</div>

--- a/benchmarks/bundle-test-app/next.config.ts
+++ b/benchmarks/bundle-test-app/next.config.ts
@@ -14,7 +14,7 @@ const transpilePackages = [
 	'@c15t/benchmarking',
 	'@c15t/react',
 	'@c15t/nextjs',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config = {

--- a/benchmarks/bundle-test-app/package.json
+++ b/benchmarks/bundle-test-app/package.json
@@ -13,10 +13,10 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
-		"c15t": "workspace:*",
 		"@c15t/react": "workspace:*",
 		"@c15t/nextjs": "workspace:*"
 	},

--- a/benchmarks/core-benchmarks/package.json
+++ b/benchmarks/core-benchmarks/package.json
@@ -22,8 +22,8 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
-		"@c15t/iab": "workspace:*",
-		"c15t": "workspace:*"
+		"@c15t/core": "workspace:*",
+		"@c15t/iab": "workspace:*"
 	},
 	"devDependencies": {
 		"typescript": "6.0.3"

--- a/benchmarks/core-benchmarks/src/hosted-init-compare.ts
+++ b/benchmarks/core-benchmarks/src/hosted-init-compare.ts
@@ -14,12 +14,12 @@
  */
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import {
 	createConsentKernel,
 	createHostedTransport,
 	type InitResponse,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/iab-compare.ts
+++ b/benchmarks/core-benchmarks/src/iab-compare.ts
@@ -14,9 +14,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
  * framework overhead is the acceptAll/rejectAll orchestration.
  */
 import { join } from 'node:path';
+import type { GlobalVendorList } from '@c15t/core/v3';
+import { createConsentKernel } from '@c15t/core/v3';
 import { createIAB } from '@c15t/iab/v3';
-import type { GlobalVendorList } from 'c15t/v3';
-import { createConsentKernel } from 'c15t/v3';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/iframe-blocker-compare.ts
+++ b/benchmarks/core-benchmarks/src/iframe-blocker-compare.ts
@@ -13,9 +13,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
  *   - 100 iframes, install + consent grant
  */
 import { join } from 'node:path';
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
-import { createConsentKernel } from 'c15t/v3';
-import { createIframeBlocker } from 'c15t/v3/modules/iframe-blocker';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
+import { createConsentKernel } from '@c15t/core/v3';
+import { createIframeBlocker } from '@c15t/core/v3/modules/iframe-blocker';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/network-blocker-compare.ts
+++ b/benchmarks/core-benchmarks/src/network-blocker-compare.ts
@@ -15,12 +15,12 @@ import { mkdirSync, writeFileSync } from 'node:fs';
  *   - install/dispose lifecycle cost
  */
 import { join } from 'node:path';
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
-import { createConsentKernel } from 'c15t/v3';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
+import { createConsentKernel } from '@c15t/core/v3';
 import {
 	createNetworkBlocker,
 	type NetworkBlockerRule,
-} from 'c15t/v3/modules/network-blocker';
+} from '@c15t/core/v3/modules/network-blocker';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/persistence-compare.ts
+++ b/benchmarks/core-benchmarks/src/persistence-compare.ts
@@ -18,9 +18,9 @@ import {
 	configureConsentManager,
 	createConsentManagerStore,
 	deleteConsentFromStorage,
-} from 'c15t';
-import { createConsentKernel } from 'c15t/v3';
-import { createPersistence } from 'c15t/v3/modules/persistence';
+} from '@c15t/core';
+import { createConsentKernel } from '@c15t/core/v3';
+import { createPersistence } from '@c15t/core/v3/modules/persistence';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/rich-init-compare.ts
+++ b/benchmarks/core-benchmarks/src/rich-init-compare.ts
@@ -8,12 +8,12 @@ import { mkdirSync, writeFileSync } from 'node:fs';
  * it onto the store/snapshot. Isolates framework overhead from network.
  */
 import { join } from 'node:path';
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import {
 	createConsentKernel,
 	type InitResponse,
 	type KernelTransport,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/run-v3.ts
+++ b/benchmarks/core-benchmarks/src/run-v3.ts
@@ -20,7 +20,7 @@ import {
 	summarizeMetric,
 	writeJson,
 } from '@c15t/benchmarking';
-import { createConsentKernel } from 'c15t/v3';
+import { createConsentKernel } from '@c15t/core/v3';
 
 function measureSync(iterations: number, fn: () => void): number[] {
 	const samples: number[] = [];

--- a/benchmarks/core-benchmarks/src/run.ts
+++ b/benchmarks/core-benchmarks/src/run.ts
@@ -20,7 +20,7 @@ import {
 	deleteConsentFromStorage,
 	getConsentFromStorage,
 	saveConsentToStorage,
-} from 'c15t';
+} from '@c15t/core';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/core-benchmarks/src/script-loading-compare.ts
+++ b/benchmarks/core-benchmarks/src/script-loading-compare.ts
@@ -24,12 +24,12 @@ import {
 	configureConsentManager,
 	createConsentManagerStore,
 	type Script as V2Script,
-} from 'c15t';
-import { createConsentKernel } from 'c15t/v3';
+} from '@c15t/core';
+import { createConsentKernel } from '@c15t/core/v3';
 import {
 	createScriptLoader,
 	type Script as V3Script,
-} from 'c15t/v3/modules/script-loader';
+} from '@c15t/core/v3/modules/script-loader';
 import { ensureBenchmarkDom } from './runtime-setup';
 
 ensureBenchmarkDom();

--- a/benchmarks/css-layer-preview/next.config.ts
+++ b/benchmarks/css-layer-preview/next.config.ts
@@ -5,7 +5,7 @@ const transpilePackages = [
 	'@c15t/react',
 	'@c15t/nextjs',
 	'@c15t/ui',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/micro/cookie.bench.ts
+++ b/benchmarks/micro/cookie.bench.ts
@@ -6,7 +6,7 @@ import {
 	getRootDomain,
 	saveConsentToStorage,
 	setCookie,
-} from 'c15t';
+} from '@c15t/core';
 import { bench, runMicroBenchmarkSuite } from './wrapper';
 
 // Mock localStorage for Node.js environment

--- a/benchmarks/micro/has-condition.bench.ts
+++ b/benchmarks/micro/has-condition.bench.ts
@@ -1,4 +1,4 @@
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import { bench, runMicroBenchmarkSuite } from './wrapper';
 
 // Create store once for condition evaluation benchmarks

--- a/benchmarks/micro/script-loader.bench.ts
+++ b/benchmarks/micro/script-loader.bench.ts
@@ -2,7 +2,7 @@ import {
 	configureConsentManager,
 	createConsentManagerStore,
 	type Script,
-} from 'c15t';
+} from '@c15t/core';
 import { bench, runMicroBenchmarkSuite } from './wrapper';
 
 // Mock DOM for Node.js environment

--- a/benchmarks/micro/store.bench.ts
+++ b/benchmarks/micro/store.bench.ts
@@ -1,4 +1,4 @@
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import { bench, runMicroBenchmarkSuite } from './wrapper';
 
 // Pre-create a manager for benchmarks that need it

--- a/benchmarks/micro/translations.bench.ts
+++ b/benchmarks/micro/translations.bench.ts
@@ -1,10 +1,10 @@
-import { enTranslations } from '@c15t/translations';
 import {
 	deepMergeTranslations,
 	detectBrowserLanguage,
 	mergeTranslationConfigs,
 	prepareTranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
+import { enTranslations } from '@c15t/translations';
 import { bench, runMicroBenchmarkSuite } from './wrapper';
 
 // Sample partial override (simulates user customization)

--- a/benchmarks/nextjs-browser-bench/app/_bench/v3-provider.tsx
+++ b/benchmarks/nextjs-browser-bench/app/_bench/v3-provider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createManifestTransport } from '@c15t/core/v3';
 import {
 	ConsentBanner,
 	ConsentBoundary,
@@ -9,7 +10,6 @@ import {
 	type ConsentProviderOptions,
 	type InitialDataPromise,
 } from '@c15t/nextjs/v3';
-import { createManifestTransport } from 'c15t/v3';
 import { type ReactNode, useMemo } from 'react';
 import { getState, type NextjsBenchScenario } from './state';
 import { NextjsV3BenchmarkProbe } from './v3-probe';

--- a/benchmarks/nextjs-browser-bench/next.config.ts
+++ b/benchmarks/nextjs-browser-bench/next.config.ts
@@ -10,7 +10,7 @@ const transpilePackages = [
 	'@c15t/iab',
 	'@c15t/react',
 	'@c15t/nextjs',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/nextjs-browser-bench/package.json
+++ b/benchmarks/nextjs-browser-bench/package.json
@@ -12,9 +12,9 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/nextjs": "workspace:*",
-		"c15t": "workspace:*",
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7"

--- a/benchmarks/no-tw-test/next.config.ts
+++ b/benchmarks/no-tw-test/next.config.ts
@@ -5,7 +5,7 @@ const transpilePackages = [
 	'@c15t/react',
 	'@c15t/nextjs',
 	'@c15t/ui',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/nuxt-browser-bench/package.json
+++ b/benchmarks/nuxt-browser-bench/package.json
@@ -12,8 +12,8 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/vue": "workspace:*",
-		"c15t": "workspace:*",
 		"nuxt": "4.5.1",
 		"vue": "3.5.40"
 	},

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -14,8 +14,8 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"mitata": "^1.0.34",
-		"c15t": "workspace:*",
 		"@c15t/react": "workspace:*",
 		"@c15t/translations": "workspace:*"
 	},

--- a/benchmarks/react-browser-bench/app/vanilla-core/page.tsx
+++ b/benchmarks/react-browser-bench/app/vanilla-core/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { configureConsentManager, createConsentManagerStore } from 'c15t';
+import { configureConsentManager, createConsentManagerStore } from '@c15t/core';
 import { useEffect, useRef, useState } from 'react';
 import { getBenchState } from '../_bench/state';
 

--- a/benchmarks/react-browser-bench/next.config.ts
+++ b/benchmarks/react-browser-bench/next.config.ts
@@ -29,7 +29,7 @@ const transpilePackages = [
 	'@c15t/react',
 	'@c15t/nextjs',
 	'@c15t/ui',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/react-browser-bench/package.json
+++ b/benchmarks/react-browser-bench/package.json
@@ -13,9 +13,9 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/react": "workspace:*",
-		"c15t": "workspace:*",
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7"

--- a/benchmarks/script-lifecycle-bench/app/_bench/fixtures.ts
+++ b/benchmarks/script-lifecycle-bench/app/_bench/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 
 export type ScriptLifecycleScenarioName =
 	| 'grant-standard'

--- a/benchmarks/script-lifecycle-bench/app/_bench/provider.tsx
+++ b/benchmarks/script-lifecycle-bench/app/_bench/provider.tsx
@@ -7,7 +7,7 @@ import {
 	generateSubjectId,
 	type Script,
 	saveConsentToStorage,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	createContext,
 	type ReactNode,

--- a/benchmarks/script-lifecycle-bench/app/script-count/_components/fixtures.ts
+++ b/benchmarks/script-lifecycle-bench/app/script-count/_components/fixtures.ts
@@ -1,5 +1,5 @@
-import type { Script as V2Script } from 'c15t';
-import type { Script as V3Script } from 'c15t/v3/modules/script-loader';
+import type { Script as V2Script } from '@c15t/core';
+import type { Script as V3Script } from '@c15t/core/v3/modules/script-loader';
 
 export type ScriptCountVersion = 'v2' | 'v3';
 

--- a/benchmarks/script-lifecycle-bench/next.config.ts
+++ b/benchmarks/script-lifecycle-bench/next.config.ts
@@ -9,7 +9,7 @@ const transpilePackages = [
 	'@c15t/benchmarking',
 	'@c15t/react',
 	'@c15t/nextjs',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/script-lifecycle-bench/package.json
+++ b/benchmarks/script-lifecycle-bench/package.json
@@ -13,8 +13,8 @@
 	},
 	"dependencies": {
 		"@c15t/benchmarking": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/react": "workspace:*",
-		"c15t": "workspace:*",
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7"

--- a/benchmarks/shared/src/fixtures.ts
+++ b/benchmarks/shared/src/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Script, Translations } from 'c15t';
+import type { Script, Translations } from '@c15t/core';
 import type { BenchmarkFixtureDescriptor } from './schema';
 
 export interface CoreBenchmarkFixture extends BenchmarkFixtureDescriptor {

--- a/benchmarks/sveltekit-browser-bench/package.json
+++ b/benchmarks/sveltekit-browser-bench/package.json
@@ -9,9 +9,9 @@
 		"check-types": "svelte-check --tsconfig ./tsconfig.json"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/schema": "workspace:*",
-		"@c15t/svelte": "workspace:*",
-		"c15t": "workspace:*"
+		"@c15t/svelte": "workspace:*"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-node": "^5.2.12",

--- a/benchmarks/tw3-test/next.config.ts
+++ b/benchmarks/tw3-test/next.config.ts
@@ -5,7 +5,7 @@ const transpilePackages = [
 	'@c15t/react',
 	'@c15t/nextjs',
 	'@c15t/ui',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/benchmarks/tw4-test/next.config.ts
+++ b/benchmarks/tw4-test/next.config.ts
@@ -5,7 +5,7 @@ const transpilePackages = [
 	'@c15t/react',
 	'@c15t/nextjs',
 	'@c15t/ui',
-	'c15t',
+	'@c15t/core',
 ];
 
 const config: NextConfig = {

--- a/bun.lock
+++ b/bun.lock
@@ -126,9 +126,9 @@
       "name": "@c15t/storybook-svelte",
       "dependencies": {
         "@c15t/conformance": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/svelte": "workspace:*",
         "@c15t/ui": "workspace:*",
-        "c15t": "workspace:*",
         "svelte": "^5.56.4",
       },
       "devDependencies": {
@@ -162,9 +162,9 @@
       "name": "@c15t/benchmarks",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/react": "workspace:*",
         "@c15t/translations": "workspace:*",
-        "c15t": "workspace:*",
         "mitata": "^1.0.34",
       },
       "devDependencies": {
@@ -191,9 +191,9 @@
       "name": "@c15t/next-bundle-bench",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/nextjs": "workspace:*",
         "@c15t/react": "workspace:*",
-        "c15t": "workspace:*",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -209,8 +209,8 @@
       "name": "@c15t/core-benchmarks",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/iab": "workspace:*",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "typescript": "6.0.3",
@@ -237,9 +237,9 @@
       "name": "@c15t/nextjs-browser-bench",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/nextjs": "workspace:*",
-        "c15t": "workspace:*",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -271,8 +271,8 @@
       "name": "@c15t/nuxt-browser-bench",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/vue": "workspace:*",
-        "c15t": "workspace:*",
         "nuxt": "4.5.1",
         "vue": "3.5.40",
       },
@@ -285,9 +285,9 @@
       "name": "@c15t/react-browser-bench",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/react": "workspace:*",
-        "c15t": "workspace:*",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -302,8 +302,8 @@
       "name": "@c15t/script-lifecycle-bench",
       "dependencies": {
         "@c15t/benchmarking": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/react": "workspace:*",
-        "c15t": "workspace:*",
         "next": "16.2.10",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -328,9 +328,9 @@
     "benchmarks/sveltekit-browser-bench": {
       "name": "@c15t/sveltekit-browser-bench",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@c15t/svelte": "workspace:*",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "@sveltejs/adapter-node": "^5.2.12",
@@ -406,6 +406,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@c15t/backend": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/dev-tools": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/nextjs": "workspace:*",
@@ -421,7 +422,6 @@
         "@radix-ui/react-tabs": "1.1.16",
         "@upstash/redis": "^1.38.0",
         "@vercel/analytics": "2.0.1",
-        "c15t": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "geist": "^1.7.2",
         "jose": "6.2.3",
@@ -467,13 +467,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@c15t/backend": "workspace:*",
+        "@c15t/core": "workspace:*",
         "@c15t/dev-tools": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/node-sdk": "workspace:*",
         "@c15t/svelte": "workspace:*",
         "@c15t/translations": "workspace:*",
         "@libsql/kysely-libsql": "^0.4.1",
-        "c15t": "workspace:*",
         "kysely": "^0.28.11",
       },
       "devDependencies": {
@@ -517,8 +517,8 @@
       "name": "@c15t/conformance",
       "version": "0.0.1",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "axe-core": "4.11.0",
-        "c15t": "workspace:*",
         "storybook": "10.3.1",
       },
       "devDependencies": {
@@ -624,7 +624,7 @@
       },
     },
     "packages/core": {
-      "name": "c15t",
+      "name": "@c15t/core",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
         "@c15t/schema": "workspace:*",
@@ -643,12 +643,12 @@
       "name": "@c15t/dev-tools",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@radix-ui/react-accordion": "1.2.15",
         "@radix-ui/react-scroll-area": "^1.2.13",
         "@radix-ui/react-slot": "1.3.0",
         "@radix-ui/react-switch": "1.3.2",
         "@radix-ui/react-tooltip": "^1.2.11",
-        "c15t": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "lucide-react": "^1.23.0",
         "motion": "^12.42.2",
@@ -677,9 +677,9 @@
       "name": "@c15t/iab",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@iabtechlabtcf/core": "^1.5.21",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
@@ -706,10 +706,10 @@
       "name": "@c15t/nextjs",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/react": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@c15t/translations": "workspace:*",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "@c15t/conformance": "workspace:*",
@@ -749,12 +749,12 @@
       "name": "@c15t/react",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@c15t/translations": "workspace:*",
         "@c15t/ui": "workspace:*",
         "@types/google.maps": "3.65.3",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "@c15t/backend": "workspace:*",
@@ -789,9 +789,9 @@
       "name": "@c15t/scripts",
       "version": "2.2.0-canary-20260727202135",
       "devDependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
-        "c15t": "workspace:*",
         "playwright": "1.58.2",
         "typescript": "7.0.2",
       },
@@ -813,10 +813,10 @@
       "name": "@c15t/svelte",
       "version": "2.0.0-rc.4",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/iab": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@c15t/ui": "workspace:*",
-        "c15t": "workspace:*",
         "clsx": "2.1.1",
       },
       "devDependencies": {
@@ -850,8 +850,8 @@
       "name": "@c15t/ui",
       "version": "2.2.0-canary-20260731105620",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/translations": "workspace:*",
-        "c15t": "workspace:*",
       },
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
@@ -866,10 +866,10 @@
     "packages/vue": {
       "name": "@c15t/vue",
       "dependencies": {
+        "@c15t/core": "workspace:*",
         "@c15t/schema": "workspace:*",
         "@c15t/ui": "workspace:*",
         "@vueuse/core": "^14.3.0",
-        "c15t": "workspace:*",
         "defu": "^6.1.4",
         "ufo": "^1.6.1",
         "vue": "^3.5.39",
@@ -1109,6 +1109,8 @@
     "@c15t/cli": ["@c15t/cli@workspace:packages/cli"],
 
     "@c15t/conformance": ["@c15t/conformance@workspace:internals/conformance"],
+
+    "@c15t/core": ["@c15t/core@workspace:packages/core"],
 
     "@c15t/core-benchmarks": ["@c15t/core-benchmarks@workspace:benchmarks/core-benchmarks"],
 
@@ -2753,8 +2755,6 @@
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
-
-    "c15t": ["c15t@workspace:packages/core"],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
@@ -5214,6 +5214,8 @@
 
     "@c15t/cli/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "@c15t/core/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
     "@c15t/css-layer-preview/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
     "@c15t/dev-tools/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -5891,8 +5893,6 @@
     "bun-types/@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
     "c12/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
-
-    "c15t/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "caching-transform/make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 

--- a/examples/demo/components/demo/integration-states-demo.tsx
+++ b/examples/demo/components/demo/integration-states-demo.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { AllConsentNames } from '@c15t/core';
 import {
 	ConsentManagerProvider,
 	Frame,
@@ -9,7 +10,6 @@ import {
 	type YouTubeEmbedProps,
 } from '@c15t/react';
 import { Button as C15tButton } from '@c15t/react/primitives';
-import type { AllConsentNames } from 'c15t';
 import { RotateCcw } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Button } from '../ui/button';

--- a/examples/demo/lib/scenarios.ts
+++ b/examples/demo/lib/scenarios.ts
@@ -9,9 +9,9 @@
  * - The c15t CLI config (`c15t-backend.config.ts`)
  */
 
+import { type PolicyConfig, policyPackPresets } from '@c15t/core';
 import type { Translations } from '@c15t/translations';
 import { baseTranslations } from '@c15t/translations/all';
-import { type PolicyConfig, policyPackPresets } from 'c15t';
 
 export const DEMO_POLICY_SNAPSHOT_KEY =
 	process.env.C15T_POLICY_SNAPSHOT_KEY ?? 'demo-policy-snapshot-key';

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -12,6 +12,7 @@
 	},
 	"dependencies": {
 		"@c15t/backend": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/dev-tools": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/nextjs": "workspace:*",
@@ -27,7 +28,6 @@
 		"@radix-ui/react-tabs": "1.1.16",
 		"@upstash/redis": "^1.38.0",
 		"@vercel/analytics": "2.0.1",
-		"c15t": "workspace:*",
 		"class-variance-authority": "^0.7.1",
 		"geist": "^1.7.2",
 		"jose": "6.2.3",

--- a/examples/sveltekit-demo/package.json
+++ b/examples/sveltekit-demo/package.json
@@ -13,13 +13,13 @@
 	},
 	"dependencies": {
 		"@c15t/backend": "workspace:*",
+		"@c15t/core": "workspace:*",
 		"@c15t/dev-tools": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/node-sdk": "workspace:*",
 		"@c15t/svelte": "workspace:*",
 		"@c15t/translations": "workspace:*",
 		"@libsql/kysely-libsql": "^0.4.1",
-		"c15t": "workspace:*",
 		"kysely": "^0.28.11"
 	},
 	"devDependencies": {

--- a/examples/sveltekit-demo/src/lib/bench/banner-visibility-v2.svelte
+++ b/examples/sveltekit-demo/src/lib/bench/banner-visibility-v2.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { ConsentStoreState } from 'c15t';
+	import type { ConsentStoreState } from '@c15t/core';
 	import {
 		clearConsentRuntimeCache,
 		getOrCreateConsentRuntime,
-	} from 'c15t';
+	} from '@c15t/core';
 	import { onMount } from 'svelte';
 	import { observeBannerVisibility, getBenchState } from './banner-state';
 	import BenchmarkBanner from './benchmark-banner.svelte';

--- a/examples/sveltekit-demo/src/lib/bench/script-count-state.ts
+++ b/examples/sveltekit-demo/src/lib/bench/script-count-state.ts
@@ -1,4 +1,4 @@
-import type { Script as V2Script } from 'c15t';
+import type { Script as V2Script } from '@c15t/core';
 import type { Script as V3Script } from '../../../../../packages/core/src/v3/modules/script-loader';
 
 export type ScriptCountVersion = 'v2' | 'v3';

--- a/examples/sveltekit-demo/src/lib/bench/script-count-v2.svelte
+++ b/examples/sveltekit-demo/src/lib/bench/script-count-v2.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import type { ConsentStoreState } from 'c15t';
+	import type { ConsentStoreState } from '@c15t/core';
 	import {
 		clearConsentRuntimeCache,
 		getOrCreateConsentRuntime,
-	} from 'c15t';
+	} from '@c15t/core';
 	import { onMount } from 'svelte';
 	import {
 		createInitialBenchState,

--- a/internals/bundle-analysis-action/action.yml
+++ b/internals/bundle-analysis-action/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: false
   transitive_roots:
     description: "Comma-separated package names to report transitive workspace impact for"
-    default: "c15t,@c15t/react"
+    default: "@c15t/core,@c15t/react"
     required: false
 
 outputs:

--- a/internals/conformance/package.json
+++ b/internals/conformance/package.json
@@ -22,8 +22,8 @@
 		"test": "bun test --preload ./test-setup.ts"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"axe-core": "4.11.0",
-		"c15t": "workspace:*",
 		"storybook": "10.3.1"
 	},
 	"devDependencies": {

--- a/internals/conformance/src/contract/events.ts
+++ b/internals/conformance/src/contract/events.ts
@@ -6,7 +6,7 @@
  * `runEventContractConformance(driver)` suite asserts against this contract.
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 
 /** All public event names. Keep in sync with provider prop types across frameworks. */
 export const EVENT_NAMES = [

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,4 +1,4 @@
-# c15t
+# @c15t/core
 
 > Core JavaScript consent management docs for c15t, including client modes, script loading, callbacks, and integrations.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://c15t.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=c15t" target="_blank" rel="noopener noreferrer">
+  <a href="https://c15t.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=%40c15t%2Fcore" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="../../docs/assets/c15t-banner-readme-dark.svg" type="image/svg+xml">
       <img src="../../docs/assets/c15t-banner-readme-light.svg" alt="c15t Banner" type="image/svg+xml">
@@ -10,12 +10,12 @@
 # c15t: Developer-First Consent Management Platform
 
 <p>
-<a href="https://www.npmjs.com/package/c15t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/c15t.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/npm/c15t.svg?variant=outline&mode=light" alt="Latest NPM Version"></picture></a>
+<a href="https://www.npmjs.com/package/@c15t/core"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/%40c15t%2Fcore.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/npm/%40c15t%2Fcore.svg?variant=outline&mode=light" alt="Latest NPM Version"></picture></a>
 <a href="https://github.com/c15t/c15t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/c15t/c15t/stars.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/github/c15t/c15t/stars.svg?variant=outline&mode=light" alt="Stars"></picture></a>
 <a href="https://github.com/c15t/c15t/blob/main/LICENSE.md"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/c15t/c15t/license.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/github/c15t/c15t/license.svg?variant=outline&mode=light" alt="License"></picture></a>
 <a href="https://c15t.link/discord"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/discord/1312171102268690493.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/discord/1312171102268690493.svg?variant=outline&mode=light" alt="Discord"></picture></a>
 <a href="https://skills.sh/c15t/skills/c15t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/skills/c15t/skills/c15t.svg?variant=outline&mode=dark"><img src="https://shieldcn.dev/skills/c15t/skills/c15t.svg?variant=outline&mode=light" alt="Skills"></picture></a>
-<a href="https://inth.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=c15t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/badge/Made%20By-Inth-ffc803.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAzOTMgNDAwIj48cGF0aCBmaWxsPSIjMDAwIiBkPSJNMTgyLjY2MiAwdjM2Ljg5NWgtNTkuMDMxdjgyLjczM2g1OS4wMzF2MzYuODkzSDI3LjQ4MnYtMzYuODkzaDU5LjAzVjM2Ljg5NWgtNTkuMDNWMHpNMzIxLjk0MSA4OS44NVYwaDM1LjM1NXYxNTYuNTIxaC0yNS43MTNsLTg2LjEzNy05MC4zNjR2OTAuMzY0aC0zNS4zNTVWMGgyNi4zNTV6Ii8%2BPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzE4LjU3MSAxODUuNzE0aDc0LjI4NlY0MDBIMFYxODUuNzE0aDI3Mi44NTd2LTQ3LjE0M3ptLTI5MS4wOSAyOC45Njl2MzcuMTE4aDU4LjEzN3YxMTkuNjI4aDM2Ljg5NVYyNTEuODAxaDU4LjU4NHYtMzcuMTE4em0xODIuNjEuMjI0djE1Ni41MjJoMzYuODk0VjMxMy41OWg3My4zNDF2NTcuODM5aDM3LjExOFYyMTQuOTA3aC0zNy4xMTh2NjEuNzg4aC03My4zNDF2LTYxLjc4OHoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg%3D%3D&color=ffc803&labelTextColor=000000&valueColor=000000&mode=dark"><img src="https://shieldcn.dev/badge/Made%20By-Inth-ffc803.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAzOTMgNDAwIj48cGF0aCBmaWxsPSIjMDAwIiBkPSJNMTgyLjY2MiAwdjM2Ljg5NWgtNTkuMDMxdjgyLjczM2g1OS4wMzF2MzYuODkzSDI3LjQ4MnYtMzYuODkzaDU5LjAzVjM2Ljg5NWgtNTkuMDNWMHpNMzIxLjk0MSA4OS44NVYwaDM1LjM1NXYxNTYuNTIxaC0yNS43MTNsLTg2LjEzNy05MC4zNjR2OTAuMzY0aC0zNS4zNTVWMGgyNi4zNTV6Ii8%2BPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzE4LjU3MSAxODUuNzE0aDc0LjI4NlY0MDBIMFYxODUuNzE0aDI3Mi44NTd2LTQ3LjE0M3ptLTI5MS4wOSAyOC45Njl2MzcuMTE4aDU4LjEzN3YxMTkuNjI4aDM2Ljg5NVYyNTEuODAxaDU4LjU4NHYtMzcuMTE4em0xODIuNjEuMjI0djE1Ni41MjJoMzYuODk0VjMxMy41OWg3My4zNDF2NTcuODM5aDM3LjExOFYyMTQuOTA3aC0zNy4xMTh2NjEuNzg4aC03My4zNDF2LTYxLjc4OHoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg%3D%3D&color=ffc803&labelTextColor=000000&valueColor=000000&mode=light" alt="Made by Inth"></picture></a>
+<a href="https://inth.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=%40c15t%2Fcore"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/badge/Made%20By-Inth-ffc803.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAzOTMgNDAwIj48cGF0aCBmaWxsPSIjMDAwIiBkPSJNMTgyLjY2MiAwdjM2Ljg5NWgtNTkuMDMxdjgyLjczM2g1OS4wMzF2MzYuODkzSDI3LjQ4MnYtMzYuODkzaDU5LjAzVjM2Ljg5NWgtNTkuMDNWMHpNMzIxLjk0MSA4OS44NVYwaDM1LjM1NXYxNTYuNTIxaC0yNS43MTNsLTg2LjEzNy05MC4zNjR2OTAuMzY0aC0zNS4zNTVWMGgyNi4zNTV6Ii8%2BPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzE4LjU3MSAxODUuNzE0aDc0LjI4NlY0MDBIMFYxODUuNzE0aDI3Mi44NTd2LTQ3LjE0M3ptLTI5MS4wOSAyOC45Njl2MzcuMTE4aDU4LjEzN3YxMTkuNjI4aDM2Ljg5NVYyNTEuODAxaDU4LjU4NHYtMzcuMTE4em0xODIuNjEuMjI0djE1Ni41MjJoMzYuODk0VjMxMy41OWg3My4zNDF2NTcuODM5aDM3LjExOFYyMTQuOTA3aC0zNy4xMTh2NjEuNzg4aC03My4zNDF2LTYxLjc4OHoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg%3D%3D&color=ffc803&labelTextColor=000000&valueColor=000000&mode=dark"><img src="https://shieldcn.dev/badge/Made%20By-Inth-ffc803.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAzOTMgNDAwIj48cGF0aCBmaWxsPSIjMDAwIiBkPSJNMTgyLjY2MiAwdjM2Ljg5NWgtNTkuMDMxdjgyLjczM2g1OS4wMzF2MzYuODkzSDI3LjQ4MnYtMzYuODkzaDU5LjAzVjM2Ljg5NWgtNTkuMDNWMHpNMzIxLjk0MSA4OS44NVYwaDM1LjM1NXYxNTYuNTIxaC0yNS43MTNsLTg2LjEzNy05MC4zNjR2OTAuMzY0aC0zNS4zNTVWMGgyNi4zNTV6Ii8%2BPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzE4LjU3MSAxODUuNzE0aDc0LjI4NlY0MDBIMFYxODUuNzE0aDI3Mi44NTd2LTQ3LjE0M3ptLTI5MS4wOSAyOC45Njl2MzcuMTE4aDU4LjEzN3YxMTkuNjI4aDM2Ljg5NVYyNTEuODAxaDU4LjU4NHYtMzcuMTE4em0xODIuNjEuMjI0djE1Ni41MjJoMzYuODk0VjMxMy41OWg3My4zNDF2NTcuODM5aDM3LjExOFYyMTQuOTA3aC0zNy4xMTh2NjEuNzg4aC03My4zNDF2LTYxLjc4OHoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPjwvc3ZnPg%3D%3D&color=ffc803&labelTextColor=000000&valueColor=000000&mode=light" alt="Made by Inth"></picture></a>
 </p>
 
 Headless JavaScript consent management platform for cookie banners, privacy preferences, consent storage, and consent-aware script gating.
@@ -58,7 +58,7 @@ The CLI will:
 ## Manual Installation
 
 ```bash
-pnpm add c15t
+pnpm add @c15t/core
 ```
 
 To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/javascript/quickstart#manual-setup).
@@ -73,7 +73,7 @@ To manually install, follow the guide in our [docs – manual setup](https://c15
 
 ```typescript
 // Example usage
-import { ConsentManager } from 'c15t'
+import { ConsentManager } from '@c15t/core'
 
 const consentManager = new ConsentManager({
   // Your configuration
@@ -133,4 +133,4 @@ Our preference is that you make use of GitHub's private vulnerability reporting 
 
 ---
 
-**Built by [Inth](https://inth.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=c15t)**
+**Built by [Inth](https://inth.com?utm_source=npm&utm_medium=readme&utm_campaign=oss_readme&utm_content=%40c15t%2Fcore)**

--- a/packages/core/SKILL.md
+++ b/packages/core/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: c15t-docs
-description: Read and search the c15t documentation. Use when working with c15t — its setup, configuration, API, and behavior.
+name: c15t-core-docs
+description: Read and search the @c15t/core documentation. Use when working with @c15t/core — its setup, configuration, API, and behavior.
 metadata:
   source: leadtype
 ---
-# c15t documentation
+# @c15t/core documentation
 
 Core JavaScript consent management docs for c15t, including client modes, script loading, callbacks, and integrations.
 
-To work with c15t, read its bundled docs — they ship with the package and are version-matched to the installed code:
+To work with @c15t/core, read its bundled docs — they ship with the package and are version-matched to the installed code:
 
 - Start with `./AGENTS.md`; it links every per-topic Markdown file under `./docs/`.
 - Prefer these local files over fetching anything over the network.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "c15t",
+	"name": "@c15t/core",
 	"version": "2.2.0-canary-20260731105620",
 	"description": "Headless JavaScript consent management platform for cookie banners, privacy preferences, consent storage, and script gating.",
 	"keywords": [
@@ -107,8 +107,8 @@
 	],
 	"scripts": {
 		"prebuild": "genversion --esm --semi src/version.ts",
-		"build": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs && bun ../../scripts/generate-package-docs.ts c15t",
-		"build:docs": "bun ../../scripts/generate-package-docs.ts c15t",
+		"build": "bun prebuild && rslib build && bun ../../scripts/normalize-dist-types.mjs && bun ../../scripts/generate-package-docs.ts @c15t/core",
+		"build:docs": "bun ../../scripts/generate-package-docs.ts @c15t/core",
 		"check-types": "bun prebuild && tsc --noEmit",
 		"check-types:test": "tsc -p tsconfig.test.json",
 		"dev": "sh -c 'bun prebuild && rslib build --no-dts --no-clean && rslib build --watch --no-dts --no-clean'",

--- a/packages/core/readme.json
+++ b/packages/core/readme.json
@@ -17,7 +17,7 @@
 	],
 	"manualInstallation": [
 		"",
-		"```bash\npnpm add c15t\n```",
+		"```bash\npnpm add @c15t/core\n```",
 		"",
 		"To manually install, follow the guide in our [docs – manual setup](https://c15t.com/docs/frameworks/javascript/quickstart#manual-setup)."
 	],
@@ -27,13 +27,13 @@
 		"Manage user consent across your application",
 		"Customize consent banners and preference centers",
 		"For full implementation details, see the [JavaScript quickstart docs](https://c15t.com/docs/frameworks/javascript/quickstart)",
-		"```typescript\n// Example usage\nimport { ConsentManager } from 'c15t'\n\nconst consentManager = new ConsentManager({\n  // Your configuration\n})\n```"
+		"```typescript\n// Example usage\nimport { ConsentManager } from '@c15t/core'\n\nconst consentManager = new ConsentManager({\n  // Your configuration\n})\n```"
 	],
 	"docsLink": "https://c15t.com/docs/frameworks/javascript/quickstart",
 	"quickStartLink": "https://c15t.com/docs/frameworks/javascript/quickstart",
 	"githubLink": "https://github.com/c15t/c15t",
 	"showCLIGeneration": true,
-	"npmName": "c15t",
+	"npmName": "@c15t/core",
 	"customSections": {
 		"Deployment Modes": "- **Hosted on inth.com**: Hosted backend with policy storage, audit history, and hosted infrastructure\n- **Self-hosted backend**: Run @c15t/backend with your own database and infrastructure\n- **Offline mode**: Store consent locally in the browser for development, previews, static sites, or controlled fallback scenarios",
 		"Related Packages": "- [@c15t/react](https://www.npmjs.com/package/@c15t/react): React cookie banner, consent dialog, preference center, and headless hooks\n- [@c15t/nextjs](https://www.npmjs.com/package/@c15t/nextjs): Next.js App Router and Pages Router integration\n- [@c15t/scripts](https://www.npmjs.com/package/@c15t/scripts): Consent-aware analytics, tag manager, pixel, and widget loaders\n- [@c15t/backend](https://www.npmjs.com/package/@c15t/backend): Self-hostable consent backend"

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -63,12 +63,12 @@
 		"not op_mini all"
 	],
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@radix-ui/react-accordion": "1.2.15",
 		"@radix-ui/react-scroll-area": "^1.2.13",
 		"@radix-ui/react-slot": "1.3.0",
 		"@radix-ui/react-switch": "1.3.2",
 		"@radix-ui/react-tooltip": "^1.2.11",
-		"c15t": "workspace:*",
 		"class-variance-authority": "^0.7.1",
 		"lucide-react": "^1.23.0",
 		"motion": "^12.42.2",

--- a/packages/dev-tools/src/__tests__/core/reset-consents.test.ts
+++ b/packages/dev-tools/src/__tests__/core/reset-consents.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StoreApi } from 'zustand/vanilla';
 import { resetAllConsents } from '../../core/reset-consents';

--- a/packages/dev-tools/src/__tests__/core/store-connector.test.ts
+++ b/packages/dev-tools/src/__tests__/core/store-connector.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StoreApi } from 'zustand/vanilla';
 import { createStoreConnector } from '../../core/store-connector';

--- a/packages/dev-tools/src/__tests__/core/store-instrumentation.test.ts
+++ b/packages/dev-tools/src/__tests__/core/store-instrumentation.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { describe, expect, it, vi } from 'vitest';
 import type { StoreApi } from 'zustand/vanilla';
 import { registerStoreInstrumentation } from '../../core/store-instrumentation';

--- a/packages/dev-tools/src/__tests__/panels/iab.test.ts
+++ b/packages/dev-tools/src/__tests__/panels/iab.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderIabPanel } from '../../panels/iab';
 

--- a/packages/dev-tools/src/__tests__/panels/location.test.ts
+++ b/packages/dev-tools/src/__tests__/panels/location.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderLocationPanel } from '../../panels/location';
 

--- a/packages/dev-tools/src/__tests__/panels/policy.test.ts
+++ b/packages/dev-tools/src/__tests__/panels/policy.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { renderPolicyPanel } from '../../panels/policy';
 

--- a/packages/dev-tools/src/__tests__/panels/scripts.test.ts
+++ b/packages/dev-tools/src/__tests__/panels/scripts.test.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderScriptsPanel } from '../../panels/scripts';
 

--- a/packages/dev-tools/src/core/debug-bundle.ts
+++ b/packages/dev-tools/src/core/debug-bundle.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import type { DevToolsState, EventLogEntry } from './state-manager';
 import type { ConnectionDiagnostics } from './store-connector';
 

--- a/packages/dev-tools/src/core/devtools.ts
+++ b/packages/dev-tools/src/core/devtools.ts
@@ -7,7 +7,7 @@ import {
 	type ConsentStoreState,
 	type ScriptDebugEvent,
 	subscribeToScriptDebugEvents,
-} from 'c15t';
+} from '@c15t/core';
 import { createPanel, type PanelInstance } from '../components/panel';
 import { createTabs, type TabsInstance } from '../components/tabs';
 import {

--- a/packages/dev-tools/src/core/override-storage.ts
+++ b/packages/dev-tools/src/core/override-storage.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 
 const DEVTOOLS_OVERRIDES_STORAGE_KEY = 'c15t-devtools-overrides';
 

--- a/packages/dev-tools/src/core/panel-renderer.ts
+++ b/packages/dev-tools/src/core/panel-renderer.ts
@@ -3,7 +3,7 @@
  * Shared logic for rendering DevTools panels
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { renderActionsPanel } from '../panels/actions';
 import { renderConsentsPanel } from '../panels/consents';
 import { renderEventsPanel } from '../panels/events';

--- a/packages/dev-tools/src/core/reset-consents.ts
+++ b/packages/dev-tools/src/core/reset-consents.ts
@@ -3,7 +3,7 @@
  * Centralized logic for resetting all consent data
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import type { StoreApi } from 'zustand/vanilla';
 import type { StateManager } from './state-manager';
 

--- a/packages/dev-tools/src/core/store-connector.ts
+++ b/packages/dev-tools/src/core/store-connector.ts
@@ -3,7 +3,7 @@
  * Connects to the c15tStore exposed on the window object
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import type { StoreApi } from 'zustand/vanilla';
 
 /**

--- a/packages/dev-tools/src/core/store-instrumentation.ts
+++ b/packages/dev-tools/src/core/store-instrumentation.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import type { StoreApi } from 'zustand/vanilla';
 import type { EventLogEntry } from './state-manager';
 

--- a/packages/dev-tools/src/panels/actions.ts
+++ b/packages/dev-tools/src/panels/actions.ts
@@ -3,7 +3,7 @@
  * Quick actions for developers
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import {
 	createButton,
 	createDisconnectedState,

--- a/packages/dev-tools/src/panels/consents.ts
+++ b/packages/dev-tools/src/panels/consents.ts
@@ -3,7 +3,7 @@
  * Displays and manages consent state
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import {
 	createButton,
 	createDisconnectedState,

--- a/packages/dev-tools/src/panels/dom-scanner.ts
+++ b/packages/dev-tools/src/panels/dom-scanner.ts
@@ -3,7 +3,7 @@
  * Scans the DOM for external scripts and iframes, cross-referencing with c15t config
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { createButton, createSection } from '../components/ui';
 import { div, span } from '../core/renderer';
 

--- a/packages/dev-tools/src/panels/iab.ts
+++ b/packages/dev-tools/src/panels/iab.ts
@@ -3,7 +3,7 @@
  * Displays IAB TCF information including TC String, purposes, and vendors
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import {
 	createBadge,
 	createButton,

--- a/packages/dev-tools/src/panels/location.ts
+++ b/packages/dev-tools/src/panels/location.ts
@@ -3,7 +3,7 @@
  * Displays and manages location/language overrides
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import {
 	createButton,
 	createDisconnectedState,

--- a/packages/dev-tools/src/panels/policy.ts
+++ b/packages/dev-tools/src/panels/policy.ts
@@ -3,7 +3,7 @@
  * Displays detailed runtime policy-pack diagnostics from /init
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { createDisconnectedState, createSection } from '../components/ui';
 import { clearElement, div, span } from '../core/renderer';
 import componentStyles from '../styles/components.module.css';

--- a/packages/dev-tools/src/panels/scripts.ts
+++ b/packages/dev-tools/src/panels/scripts.ts
@@ -3,7 +3,7 @@
  * Displays script loading status and configuration
  */
 
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import {
 	createBadge,
 	createDisconnectedState,

--- a/packages/dev-tools/src/utils/init-source.ts
+++ b/packages/dev-tools/src/utils/init-source.ts
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 
 export function formatInitSource(
 	source: ConsentStoreState['initDataSource'],

--- a/packages/dev-tools/tsconfig.json
+++ b/packages/dev-tools/tsconfig.json
@@ -6,8 +6,8 @@
 		"paths": {
 			"@c15t/ui/theme": ["../ui/dist-types/theme/index.d.ts"],
 			"@c15t/ui/utils": ["../ui/dist-types/utils/index.d.ts"],
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/*": ["../core/dist-types/*"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/*": ["../core/dist-types/*"],
 			"~/*": ["./src/*"]
 		}
 	},

--- a/packages/iab/package.json
+++ b/packages/iab/package.json
@@ -66,9 +66,9 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/schema": "workspace:*",
-		"@iabtechlabtcf/core": "^1.5.21",
-		"c15t": "workspace:*"
+		"@iabtechlabtcf/core": "^1.5.21"
 	},
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",

--- a/packages/iab/src/__tests__/iab-initializer.test.ts.todo
+++ b/packages/iab/src/__tests__/iab-initializer.test.ts.todo
@@ -6,7 +6,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ConsentStoreState, GlobalVendorList } from 'c15t';
+import type { ConsentStoreState, GlobalVendorList } from '@c15t/core';
 import { initializeIABMode } from '../init/iab-initializer';
 import { createMockStoreState } from './tcf/test-setup';
 
@@ -28,7 +28,7 @@ vi.mock('../tcf', () => ({
 }));
 
 // Mock cookie module (imported from c15t in iab-initializer)
-vi.mock('c15t', async (importOriginal) => {
+vi.mock('@c15t/core', async (importOriginal) => {
 	const actual = await importOriginal<Record<string, unknown>>();
 	return {
 		...actual,
@@ -328,7 +328,7 @@ describe('initializeIABMode', () => {
 
 	describe('Persisted consent restoration', () => {
 		it('should merge stored custom vendor consents', async () => {
-			const { getConsentFromStorage } = await import('c15t');
+			const { getConsentFromStorage } = await import('@c15t/core');
 			vi.mocked(getConsentFromStorage).mockReturnValue({
 				iabCustomVendorConsents: {
 					'custom-1': true,

--- a/packages/iab/src/__tests__/tcf/store.test.ts
+++ b/packages/iab/src/__tests__/tcf/store.test.ts
@@ -8,8 +8,8 @@ import type {
 	ConsentManagerInterface,
 	ConsentStoreState,
 	GlobalVendorList,
-} from 'c15t';
-import { generateSubjectId, saveConsentToStorage } from 'c15t';
+} from '@c15t/core';
+import { generateSubjectId, saveConsentToStorage } from '@c15t/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateTCString, iabPurposesToC15tConsents } from '../../tcf/index';
 import type { NonIABVendor } from '../../tcf/non-iab-vendor';

--- a/packages/iab/src/factory.ts
+++ b/packages/iab/src/factory.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import type { IABConfig, IABModule } from 'c15t';
+import type { IABConfig, IABModule } from '@c15t/core';
 import { initializeIABMode } from './init/iab-initializer';
 import { fetchGVL } from './tcf/fetch-gvl';
 import { createIABManager } from './tcf/store';

--- a/packages/iab/src/headless/banner-summary.ts
+++ b/packages/iab/src/headless/banner-summary.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import type { IABManager } from 'c15t';
+import type { IABManager } from '@c15t/core';
 import type { HeadlessIABBannerState } from './types';
 
 const MAX_BANNER_DISPLAY_ITEMS = 5;

--- a/packages/iab/src/headless/dialog-data.ts
+++ b/packages/iab/src/headless/dialog-data.ts
@@ -8,7 +8,7 @@
  * @packageDocumentation
  */
 
-import type { IABManager } from 'c15t';
+import type { IABManager } from '@c15t/core';
 
 /**
  * Processed GVL data ready for rendering in a consent dialog.

--- a/packages/iab/src/index.ts
+++ b/packages/iab/src/index.ts
@@ -25,7 +25,7 @@ export type {
 	IABManager,
 	IABModule,
 	IABState,
-} from 'c15t';
+} from '@c15t/core';
 export { type IABUserConfig, iab } from './factory';
 export { fetchGVL } from './tcf/fetch-gvl';
 export {

--- a/packages/iab/src/init/iab-initializer.ts
+++ b/packages/iab/src/init/iab-initializer.ts
@@ -9,8 +9,8 @@ import type {
 	GlobalVendorList,
 	IABConfig,
 	IABState,
-} from 'c15t';
-import { getConsentFromStorage } from 'c15t';
+} from '@c15t/core';
+import { getConsentFromStorage } from '@c15t/core';
 import { version } from '../version';
 
 /** Store access methods needed by the IAB initializer. */

--- a/packages/iab/src/tcf/cmp-api.ts
+++ b/packages/iab/src/tcf/cmp-api.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { CMPApi, CMPApiConfig, GlobalVendorList } from 'c15t';
+import type { CMPApi, CMPApiConfig, GlobalVendorList } from '@c15t/core';
 import { CMP_ID, CMP_VERSION } from './cmp-defaults';
 import { IAB_STORAGE_KEYS } from './constants';
 import type {

--- a/packages/iab/src/tcf/fetch-gvl.ts
+++ b/packages/iab/src/tcf/fetch-gvl.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import { GVL_ENDPOINT } from './constants';
 
 /**

--- a/packages/iab/src/tcf/iab-tcf-types.ts
+++ b/packages/iab/src/tcf/iab-tcf-types.ts
@@ -8,6 +8,8 @@
  * @packageDocumentation
  */
 
+// GVL types come through c15t core (which re-exports from @c15t/schema)
+export type { GlobalVendorList } from '@c15t/core';
 // GVL sub-types imported from @c15t/schema for IAB-specific usage
 // These are not re-exported by c15t core, so we re-export from schema directly
 export type {
@@ -20,10 +22,8 @@ export type {
 	GVLVendor,
 	GVLVendorUrl,
 } from '@c15t/schema/types';
-// GVL types come through c15t core (which re-exports from @c15t/schema)
-export type { GlobalVendorList } from 'c15t';
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 
 /**
  * TCF consent data structure for generating TC Strings.

--- a/packages/iab/src/tcf/index.ts
+++ b/packages/iab/src/tcf/index.ts
@@ -8,7 +8,12 @@
  */
 
 // Types (re-exported from core for convenience)
-export type { CMPApi, CMPApiConfig, FetchGVLResult, IABConfig } from 'c15t';
+export type {
+	CMPApi,
+	CMPApiConfig,
+	FetchGVLResult,
+	IABConfig,
+} from '@c15t/core';
 // CMP API
 export { createCMPApi } from './cmp-api';
 // Constants

--- a/packages/iab/src/tcf/purpose-mapping.ts
+++ b/packages/iab/src/tcf/purpose-mapping.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 
 /**
  * Maps IAB TCF purpose IDs to c15t consent categories.

--- a/packages/iab/src/tcf/store.ts
+++ b/packages/iab/src/tcf/store.ts
@@ -6,13 +6,13 @@ import type {
 	IABConfig,
 	IABManager,
 	IABState,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	applyPolicyPurposeAllowlist,
 	generateSubjectId,
 	getEffectivePolicy,
 	saveConsentToStorage,
-} from 'c15t';
+} from '@c15t/core';
 import { CMP_ID, CMP_VERSION } from './cmp-defaults';
 import type { NonIABVendor } from './non-iab-vendor';
 

--- a/packages/iab/src/tcf/tc-string.ts
+++ b/packages/iab/src/tcf/tc-string.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import type { TCFConsentData } from './iab-tcf-types';
 import { getTCFCore } from './lazy-load';
 

--- a/packages/iab/src/tcf/types.ts
+++ b/packages/iab/src/tcf/types.ts
@@ -17,4 +17,4 @@ export type {
 	IABManager,
 	IABModule,
 	IABState,
-} from 'c15t';
+} from '@c15t/core';

--- a/packages/iab/src/v3/__tests__/headless.test.ts
+++ b/packages/iab/src/v3/__tests__/headless.test.ts
@@ -1,4 +1,4 @@
-import type { NonIABVendor } from 'c15t/v3';
+import type { NonIABVendor } from '@c15t/core/v3';
 import { describe, expect, test } from 'vitest';
 import { completeGVL } from '../../__tests__/tcf/fixtures/gvl-sample';
 import { processGVLForDialog, resolveIABBannerSummary } from '../headless';

--- a/packages/iab/src/v3/__tests__/iab.test.ts
+++ b/packages/iab/src/v3/__tests__/iab.test.ts
@@ -9,8 +9,8 @@
  * - dispose cleans up the CMP API + kernel subscription.
  */
 
-import type { GlobalVendorList } from 'c15t/v3';
-import { createConsentKernel } from 'c15t/v3';
+import type { GlobalVendorList } from '@c15t/core/v3';
+import { createConsentKernel } from '@c15t/core/v3';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createIAB } from '../index';
 import { setMockGVL } from '../tcf/fetch-gvl';

--- a/packages/iab/src/v3/__tests__/tc-string.test.ts
+++ b/packages/iab/src/v3/__tests__/tc-string.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import { createConsentKernel } from 'c15t/v3';
+import { createConsentKernel } from '@c15t/core/v3';
 import { describe, expect, test } from 'vitest';
 import { MINIMAL_TC_STRING } from '../../__tests__/tcf/fixtures/tc-strings';
 import {

--- a/packages/iab/src/v3/headless/dialog-data.ts
+++ b/packages/iab/src/v3/headless/dialog-data.ts
@@ -9,7 +9,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList, NonIABVendor } from 'c15t/v3';
+import type { GlobalVendorList, NonIABVendor } from '@c15t/core/v3';
 import type {
 	HeadlessIABDialogData,
 	HeadlessIABProcessedFeature,

--- a/packages/iab/src/v3/headless/types.ts
+++ b/packages/iab/src/v3/headless/types.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList, NonIABVendor } from 'c15t/v3';
+import type { GlobalVendorList, NonIABVendor } from '@c15t/core/v3';
 
 export type HeadlessIABBannerAction = 'accept' | 'reject' | 'customize';
 export type HeadlessIABDialogAction = 'accept' | 'reject' | 'customize';

--- a/packages/iab/src/v3/index.ts
+++ b/packages/iab/src/v3/index.ts
@@ -20,13 +20,13 @@
  * (`createCMPApi`), stub installer (`initializeIABStub`).
  */
 
-import type { CMPApi } from 'c15t';
+import type { CMPApi } from '@c15t/core';
 import type {
 	ConsentKernel,
 	ConsentSnapshot,
 	GlobalVendorList,
 	NonIABVendor,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 import { createCMPApi } from './tcf/cmp-api';
 import { clearGVLCache, fetchGVL } from './tcf/fetch-gvl';
 import { getTCFCore } from './tcf/lazy-load';
@@ -390,8 +390,8 @@ export function createIAB(options: CreateIABOptions): IABHandle {
 	};
 }
 
-export type { CMPApi } from 'c15t';
-export type { GlobalVendorList, NonIABVendor } from 'c15t/v3';
+export type { CMPApi } from '@c15t/core';
+export type { GlobalVendorList, NonIABVendor } from '@c15t/core/v3';
 export {
 	type HeadlessIABBannerAction,
 	type HeadlessIABBannerState,

--- a/packages/iab/src/v3/tcf/cmp-api.ts
+++ b/packages/iab/src/v3/tcf/cmp-api.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { CMPApi, CMPApiConfig, GlobalVendorList } from 'c15t';
+import type { CMPApi, CMPApiConfig, GlobalVendorList } from '@c15t/core';
 import { CMP_ID, CMP_VERSION } from './cmp-defaults';
 import { IAB_STORAGE_KEYS } from './constants';
 import type {

--- a/packages/iab/src/v3/tcf/fetch-gvl.ts
+++ b/packages/iab/src/v3/tcf/fetch-gvl.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import { GVL_ENDPOINT } from './constants';
 
 /**

--- a/packages/iab/src/v3/tcf/iab-tcf-types.ts
+++ b/packages/iab/src/v3/tcf/iab-tcf-types.ts
@@ -8,6 +8,8 @@
  * @packageDocumentation
  */
 
+// GVL types come through c15t core (which re-exports from @c15t/schema)
+export type { GlobalVendorList } from '@c15t/core';
 // GVL sub-types imported from @c15t/schema for IAB-specific usage
 // These are not re-exported by c15t core, so we re-export from schema directly
 export type {
@@ -20,10 +22,8 @@ export type {
 	GVLVendor,
 	GVLVendorUrl,
 } from '@c15t/schema/types';
-// GVL types come through c15t core (which re-exports from @c15t/schema)
-export type { GlobalVendorList } from 'c15t';
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 
 /**
  * TCF consent data structure for generating TC Strings.

--- a/packages/iab/src/v3/tcf/index.ts
+++ b/packages/iab/src/v3/tcf/index.ts
@@ -8,7 +8,12 @@
  */
 
 // Types (re-exported from core for convenience)
-export type { CMPApi, CMPApiConfig, FetchGVLResult, IABConfig } from 'c15t';
+export type {
+	CMPApi,
+	CMPApiConfig,
+	FetchGVLResult,
+	IABConfig,
+} from '@c15t/core';
 // CMP API
 export { createCMPApi } from './cmp-api';
 // Constants

--- a/packages/iab/src/v3/tcf/purpose-mapping.ts
+++ b/packages/iab/src/v3/tcf/purpose-mapping.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 
 /**
  * Maps IAB TCF purpose IDs to c15t consent categories.

--- a/packages/iab/src/v3/tcf/store.ts
+++ b/packages/iab/src/v3/tcf/store.ts
@@ -6,13 +6,13 @@ import type {
 	IABConfig,
 	IABManager,
 	IABState,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	applyPolicyPurposeAllowlist,
 	generateSubjectId,
 	getEffectivePolicy,
 	saveConsentToStorage,
-} from 'c15t';
+} from '@c15t/core';
 import { CMP_ID, CMP_VERSION } from './cmp-defaults';
 import type { NonIABVendor } from './non-iab-vendor';
 

--- a/packages/iab/src/v3/tcf/tc-string.ts
+++ b/packages/iab/src/v3/tcf/tc-string.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import type { TCFConsentData } from './iab-tcf-types';
 import { getTCFCore } from './lazy-load';
 

--- a/packages/iab/src/v3/tcf/types.ts
+++ b/packages/iab/src/v3/tcf/types.ts
@@ -17,4 +17,4 @@ export type {
 	IABManager,
 	IABModule,
 	IABState,
-} from 'c15t';
+} from '@c15t/core';

--- a/packages/iab/tsconfig.json
+++ b/packages/iab/tsconfig.json
@@ -4,7 +4,7 @@
 		"rootDir": "src",
 		"lib": ["dom", "esnext"],
 		"paths": {
-			"c15t": ["../core/dist-types/index.d.ts"]
+			"@c15t/core": ["../core/dist-types/index.d.ts"]
 		}
 	},
 	"include": ["src"],

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -150,10 +150,10 @@
 		"test:watch": "bun prebuild && vitest --passWithNoTests"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/react": "workspace:*",
 		"@c15t/schema": "workspace:*",
-		"@c15t/translations": "workspace:*",
-		"c15t": "workspace:*"
+		"@c15t/translations": "workspace:*"
 	},
 	"devDependencies": {
 		"@c15t/conformance": "workspace:*",

--- a/packages/nextjs/src/__tests__/conformance.test.tsx
+++ b/packages/nextjs/src/__tests__/conformance.test.tsx
@@ -29,6 +29,13 @@ import {
 	type SuiteApi,
 	type TestDriver,
 } from '@c15t/conformance';
+import type { AllConsentNames } from '@c15t/core';
+import type {
+	KernelActiveUI,
+	KernelConfig,
+	ResolvedPolicy,
+	TranslationsResponse,
+} from '@c15t/core/v3';
 import {
 	ConsentBanner,
 	ConsentDialog,
@@ -36,13 +43,6 @@ import {
 	ConsentWidget,
 	useSnapshot,
 } from '@c15t/react/v3';
-import type { AllConsentNames } from 'c15t';
-import type {
-	KernelActiveUI,
-	KernelConfig,
-	ResolvedPolicy,
-	TranslationsResponse,
-} from 'c15t/v3';
 import { type ReactElement, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -8,8 +8,8 @@
  * @see {@link ./middleware} for Next.js middleware integration
  */
 
+export { buildPrefetchScript, type PrefetchOptions } from '@c15t/core';
 export * from '@c15t/react';
-export { buildPrefetchScript, type PrefetchOptions } from 'c15t';
 export { C15tPrefetch } from './libs/browser-initial-data';
 export { fetchInitialData } from './libs/initial-data';
 export type {

--- a/packages/nextjs/src/libs/browser-initial-data.tsx
+++ b/packages/nextjs/src/libs/browser-initial-data.tsx
@@ -1,4 +1,4 @@
-import { buildPrefetchScript } from 'c15t';
+import { buildPrefetchScript } from '@c15t/core';
 import Script from 'next/script';
 import type { C15tPrefetchProps } from '~/types';
 

--- a/packages/nextjs/src/libs/initial-data.ts
+++ b/packages/nextjs/src/libs/initial-data.ts
@@ -1,9 +1,9 @@
+import type { SSRInitialData } from '@c15t/core';
 import {
 	createSSRInitCacheKey,
 	fetchSSRData,
 	normalizeBackendURL,
 } from '@c15t/react/server';
-import type { SSRInitialData } from 'c15t';
 import { unstable_cache } from 'next/cache';
 import { headers as nextHeaders } from 'next/headers';
 import type { FetchInitialDataOptions } from '~/types';

--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -1,6 +1,6 @@
+import type { PrefetchOptions } from '@c15t/core';
 import type { ConsentManagerProviderProps } from '@c15t/react';
 import type { FetchSSRDataOptionsBase } from '@c15t/react/server';
-import type { PrefetchOptions } from 'c15t';
 
 export type InitialDataPromise = NonNullable<
 	ConsentManagerProviderProps['options']['store']

--- a/packages/nextjs/src/v3/__tests__/end-to-end.test.tsx
+++ b/packages/nextjs/src/v3/__tests__/end-to-end.test.tsx
@@ -9,8 +9,8 @@
  *    roundtrip completes.
  */
 
+import type { KernelConfig } from '@c15t/core/v3';
 import { useConsent, useSnapshot } from '@c15t/react/v3';
-import type { KernelConfig } from 'c15t/v3';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentBoundary } from '../boundary';

--- a/packages/nextjs/src/v3/__tests__/server.test.ts
+++ b/packages/nextjs/src/v3/__tests__/server.test.ts
@@ -6,7 +6,7 @@
  * headers independently. No real Next.js request context is needed.
  */
 
-import type { KernelConfig } from 'c15t/v3';
+import type { KernelConfig } from '@c15t/core/v3';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { readInitialConsentConfig } from '../server';
 

--- a/packages/nextjs/src/v3/api.ts
+++ b/packages/nextjs/src/v3/api.ts
@@ -1,3 +1,4 @@
+import { c15tVersionHeaders } from '@c15t/core/v3';
 import type {
 	ConsentManifest,
 	ConsentManifestGVLReference,
@@ -5,7 +6,6 @@ import type {
 	InitOutput,
 } from '@c15t/schema/types';
 import { resolveBackendURL, resolveInitFromManifest } from '@c15t/schema/types';
-import { c15tVersionHeaders } from 'c15t/v3';
 import { extractConsentRequestInputs } from './headers';
 
 const DEFAULT_MANIFEST_REVALIDATE_SECONDS = 300;

--- a/packages/nextjs/src/v3/boundary.tsx
+++ b/packages/nextjs/src/v3/boundary.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { KernelConfig } from '@c15t/core/v3';
+import type { Script } from '@c15t/core/v3/modules/script-loader';
 /**
  * Client boundary for the v3 Next.js adapter.
  *
@@ -16,8 +18,6 @@ import {
 	ConsentProvider,
 	type ConsentProviderOptions,
 } from '@c15t/react/v3/provider';
-import type { KernelConfig } from 'c15t/v3';
-import type { Script } from 'c15t/v3/modules/script-loader';
 import type { ReactNode } from 'react';
 
 export interface ConsentBoundaryProps {

--- a/packages/nextjs/src/v3/index.ts
+++ b/packages/nextjs/src/v3/index.ts
@@ -29,9 +29,8 @@
  * - No module-level runtime cache — Fluid Compute safe by construction.
  */
 
+export { buildPrefetchScript, type PrefetchOptions } from '@c15t/core';
 export * from '@c15t/react/v3';
-
-export { buildPrefetchScript, type PrefetchOptions } from 'c15t';
 export type { ConsentBoundaryProps } from './boundary';
 export { ConsentBoundary } from './boundary';
 export { C15tPrefetch } from './libs/browser-initial-data';

--- a/packages/nextjs/src/v3/libs/browser-initial-data.tsx
+++ b/packages/nextjs/src/v3/libs/browser-initial-data.tsx
@@ -1,4 +1,4 @@
-import { buildPrefetchScript } from 'c15t';
+import { buildPrefetchScript } from '@c15t/core';
 import Script from 'next/script';
 import type { C15tPrefetchProps } from '~/v3/types';
 

--- a/packages/nextjs/src/v3/libs/initial-data.ts
+++ b/packages/nextjs/src/v3/libs/initial-data.ts
@@ -1,9 +1,9 @@
+import type { SSRInitialData } from '@c15t/core';
 import {
 	createSSRInitCacheKey,
 	fetchSSRData,
 	normalizeBackendURL,
 } from '@c15t/react/v3/server';
-import type { SSRInitialData } from 'c15t';
 import { unstable_cache } from 'next/cache';
 import { headers as nextHeaders } from 'next/headers';
 import type { FetchInitialDataOptions } from '~/v3/types';

--- a/packages/nextjs/src/v3/rsc/banner.tsx
+++ b/packages/nextjs/src/v3/rsc/banner.tsx
@@ -20,7 +20,7 @@
  * banner should show (returning users get zero banner bytes, client or
  * server). Same data-testids and DOM shape as the client `ConsentBanner`.
  */
-import type { KernelConfig } from 'c15t/v3';
+import type { KernelConfig } from '@c15t/core/v3';
 import type { ReactNode } from 'react';
 import { RscBannerActions, RscBannerGate } from './islands';
 

--- a/packages/nextjs/src/v3/server.ts
+++ b/packages/nextjs/src/v3/server.ts
@@ -21,15 +21,15 @@
  * is a plain async function, not an action.
  */
 
-import { type InitOutput, resolveBackendURL } from '@c15t/schema/types';
 import {
 	createManifestTransport,
 	type KernelConfig,
 	type KernelOverrides,
 	mergeInitOutputIntoKernelConfig,
 	mergeInitResponseIntoKernelConfig,
-} from 'c15t/v3';
-import { readStoredConsentFromCookie } from 'c15t/v3/modules/persistence';
+} from '@c15t/core/v3';
+import { readStoredConsentFromCookie } from '@c15t/core/v3/modules/persistence';
+import { type InitOutput, resolveBackendURL } from '@c15t/schema/types';
 import { cookies, headers } from 'next/headers';
 import {
 	consentInputsToOverrides,
@@ -131,7 +131,7 @@ export async function readInitialConsentConfig(
  * Type alias re-exported for convenience — consumers never need to import
  * from `c15t/v3` directly for SSR.
  */
-export type { KernelConfig } from 'c15t/v3';
+export type { KernelConfig } from '@c15t/core/v3';
 
 // -- Optional: server-side prefetch of the init roundtrip -------------------
 

--- a/packages/nextjs/src/v3/types.ts
+++ b/packages/nextjs/src/v3/types.ts
@@ -1,6 +1,6 @@
+import type { PrefetchOptions } from '@c15t/core';
 import type { ConsentManagerProviderProps } from '@c15t/react/v3';
 import type { FetchSSRDataOptionsBase } from '@c15t/react/v3/server';
-import type { PrefetchOptions } from 'c15t';
 
 export type InitialDataPromise = NonNullable<
 	ConsentManagerProviderProps['options']['store']

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -9,8 +9,8 @@
 			"@c15t/react/*": ["../react/dist-types/*"],
 			"@c15t/schema": ["../schema/dist-types/index.d.ts"],
 			"@c15t/schema/*": ["../schema/dist-types/*"],
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/*": ["../core/dist-types/*"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/*": ["../core/dist-types/*"],
 			"~/*": ["./src/*"]
 		}
 	},

--- a/packages/nextjs/vitest.config.ts
+++ b/packages/nextjs/vitest.config.ts
@@ -11,28 +11,28 @@ export default mergeConfig(
 		resolve: {
 			alias: {
 				'~': resolve(__dirname, './src'),
-				'c15t/v3/modules/script-loader': resolve(
+				'@c15t/core/v3/modules/script-loader': resolve(
 					__dirname,
 					'../core/src/v3/modules/script-loader/index.ts'
 				),
-				'c15t/v3/modules/network-blocker': resolve(
+				'@c15t/core/v3/modules/network-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/network-blocker/index.ts'
 				),
-				'c15t/v3/modules/iframe-blocker': resolve(
+				'@c15t/core/v3/modules/iframe-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/iframe-blocker/index.ts'
 				),
-				'c15t/v3/modules/persistence': resolve(
+				'@c15t/core/v3/modules/persistence': resolve(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
-				'c15t/v3/modules/window-debug': resolve(
+				'@c15t/core/v3/modules/window-debug': resolve(
 					__dirname,
 					'../core/src/v3/modules/window-debug/index.ts'
 				),
-				'c15t/v3': resolve(__dirname, '../core/src/v3/index.ts'),
-				c15t: resolve(__dirname, '../core/src/index.ts'),
+				'@c15t/core/v3': resolve(__dirname, '../core/src/v3/index.ts'),
+				'@c15t/core': resolve(__dirname, '../core/src/index.ts'),
 				'@c15t/react/v3/provider': resolve(
 					__dirname,
 					'../react/dist/v3/provider.js'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -317,12 +317,12 @@
 		"not op_mini all"
 	],
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/schema": "workspace:*",
 		"@c15t/translations": "workspace:*",
 		"@c15t/ui": "workspace:*",
-		"@types/google.maps": "3.65.3",
-		"c15t": "workspace:*"
+		"@types/google.maps": "3.65.3"
 	},
 	"devDependencies": {
 		"@c15t/backend": "workspace:*",

--- a/packages/react/src/__tests__/conformance.test.tsx
+++ b/packages/react/src/__tests__/conformance.test.tsx
@@ -27,7 +27,7 @@ import {
 	type ConsentManagerOptions,
 	clearConsentRuntimeCache,
 	getOrCreateConsentRuntime,
-} from 'c15t';
+} from '@c15t/core';
 import type { ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';

--- a/packages/react/src/__tests__/conformance.v3.test.tsx
+++ b/packages/react/src/__tests__/conformance.v3.test.tsx
@@ -18,15 +18,15 @@ import {
 	type SuiteApi,
 	type TestDriver,
 } from '@c15t/conformance';
-import type { GlobalVendorList } from '@c15t/schema/types';
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type {
 	ConsentKernel,
 	KernelActiveUI,
 	KernelConfig,
 	ResolvedPolicy,
 	TranslationsResponse,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
+import type { GlobalVendorList } from '@c15t/schema/types';
 import { type ReactElement, useContext, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';

--- a/packages/react/src/components/__tests__/theme-regressions.test.tsx
+++ b/packages/react/src/components/__tests__/theme-regressions.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { createRef } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
+++ b/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/components/consent-banner/__tests__/policy-actions.test.tsx
+++ b/packages/react/src/components/consent-banner/__tests__/policy-actions.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/components/consent-banner/atoms/root.tsx
+++ b/packages/react/src/components/consent-banner/atoms/root.tsx
@@ -72,7 +72,7 @@ interface ConsentBannerRootProps extends HTMLAttributes<HTMLDivElement> {
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.
@@ -223,7 +223,7 @@ interface ConsentBannerRootChildrenProps
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 }
 
 /**

--- a/packages/react/src/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/components/consent-banner/consent-banner.tsx
@@ -183,7 +183,7 @@ export interface ConsentBannerProps {
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/components/consent-dialog-trigger/__tests__/consent-dialog-trigger-toolbar.test.tsx
+++ b/packages/react/src/components/consent-dialog-trigger/__tests__/consent-dialog-trigger-toolbar.test.tsx
@@ -1,6 +1,6 @@
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-dialog-trigger.module.js';
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';

--- a/packages/react/src/components/consent-dialog/atoms/root.tsx
+++ b/packages/react/src/components/consent-dialog/atoms/root.tsx
@@ -52,7 +52,7 @@ export interface ConsentDialogRootProps
 	 * Which consent models this dialog responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * When true, the component will not apply any internal styles.

--- a/packages/react/src/components/consent-dialog/consent-dialog.tsx
+++ b/packages/react/src/components/consent-dialog/consent-dialog.tsx
@@ -105,7 +105,7 @@ export interface ConsentDialogProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/components/consent-widget/__tests__/policy-actions.test.tsx
+++ b/packages/react/src/components/consent-widget/__tests__/policy-actions.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { ConsentWidget } from '~/components/consent-widget';

--- a/packages/react/src/components/consent-widget/atoms/accordion.tsx
+++ b/packages/react/src/components/consent-widget/atoms/accordion.tsx
@@ -1,5 +1,5 @@
+import type { AllConsentNames, ConsentType } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-widget.module.js';
-import type { AllConsentNames, ConsentType } from 'c15t';
 import {
 	type ComponentPropsWithoutRef,
 	createContext,

--- a/packages/react/src/components/frame/atoms.tsx
+++ b/packages/react/src/components/frame/atoms.tsx
@@ -1,6 +1,6 @@
 import { TEST_IDS } from '@c15t/conformance/contract/test-ids';
+import type { AllConsentNames } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/frame.module.js';
-import type { AllConsentNames } from 'c15t';
 import { forwardRef, type Ref } from 'react';
 import { useTranslations } from '~/hooks/use-translations';
 import { Box, type BoxProps } from '../shared/primitives/box';

--- a/packages/react/src/components/frame/frame.tsx
+++ b/packages/react/src/components/frame/frame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import { forwardRef, useEffect, useState } from 'react';
 import { useConsentManager } from '~/hooks/use-consent-manager';
 import { useTranslations } from '~/hooks/use-translations';

--- a/packages/react/src/components/frame/index.ts
+++ b/packages/react/src/components/frame/index.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import * as atoms from './atoms';
 import { Frame as FrameComponent } from './frame';
 import type { FrameCompoundComponent } from './types';

--- a/packages/react/src/components/frame/types.ts
+++ b/packages/react/src/components/frame/types.ts
@@ -1,4 +1,4 @@
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type { ComponentPropsWithRef, FC, ReactNode } from 'react';
 import type * as Atom from './atoms';
 

--- a/packages/react/src/components/iab-consent-banner/atoms/root.tsx
+++ b/packages/react/src/components/iab-consent-banner/atoms/root.tsx
@@ -30,7 +30,7 @@ interface IABConsentBannerRootProps extends HTMLAttributes<HTMLDivElement> {
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 	/**
 	 * Override the UI source identifier sent with consent API calls.
 	 * @default 'iab_banner'
@@ -85,7 +85,7 @@ interface IABConsentBannerRootChildrenProps
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 }
 
 const IABConsentBannerRootChildren = forwardRef<

--- a/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
+++ b/packages/react/src/components/iab-consent-banner/iab-consent-banner.tsx
@@ -59,7 +59,7 @@ export interface IABConsentBannerProps {
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/components/iab-consent-dialog/atoms/root.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/root.tsx
@@ -28,7 +28,7 @@ interface IABConsentDialogRootProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 	/**
 	 * Override the UI source identifier sent with consent API calls.
 	 * @default 'iab_dialog'

--- a/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import type { GlobalVendorList } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
-import type { GlobalVendorList } from 'c15t';
 import { type FC, useEffect, useState } from 'react';
 import * as PreferenceItem from '~/components/shared/ui/preference-item';
 import * as Switch from '~/components/shared/ui/switch';

--- a/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -106,7 +106,7 @@ export interface IABConsentDialogProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/components/iab-consent-dialog/use-iab-translations.ts
+++ b/packages/react/src/components/iab-consent-dialog/use-iab-translations.ts
@@ -1,4 +1,4 @@
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { useTranslations } from '~/hooks/use-translations';
 
 /**

--- a/packages/react/src/components/iab/__tests__/fixtures/mock-consent-state.ts
+++ b/packages/react/src/components/iab/__tests__/fixtures/mock-consent-state.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 
 /**
  * Mock GVL for React component testing

--- a/packages/react/src/components/integrations/__tests__/integrations.test.tsx
+++ b/packages/react/src/components/integrations/__tests__/integrations.test.tsx
@@ -1,4 +1,4 @@
-import { type ConsentStoreState, defaultTranslationConfig } from 'c15t';
+import { type ConsentStoreState, defaultTranslationConfig } from '@c15t/core';
 import { createRef, type ReactNode, useRef, useState } from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/components/integrations/google-map.tsx
+++ b/packages/react/src/components/integrations/google-map.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames, Script } from 'c15t';
+import type { AllConsentNames, Script } from '@c15t/core';
 import {
 	type ComponentPropsWithRef,
 	forwardRef,

--- a/packages/react/src/components/integrations/shared.tsx
+++ b/packages/react/src/components/integrations/shared.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 import { useTranslations } from '~/hooks/use-translations';
 import { FrameButton, FrameRoot, FrameTitle } from '../frame';

--- a/packages/react/src/components/integrations/youtube-embed.tsx
+++ b/packages/react/src/components/integrations/youtube-embed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import {
 	type ComponentPropsWithRef,
 	type CSSProperties,

--- a/packages/react/src/components/shared/primitives/button.tsx
+++ b/packages/react/src/components/shared/primitives/button.tsx
@@ -1,4 +1,4 @@
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import { forwardRef, type MouseEvent, useCallback } from 'react';
 import { useConsentTracking } from '~/context/consent-tracking-context';
 import { useConsentManager } from '~/hooks/use-consent-manager';

--- a/packages/react/src/components/shared/primitives/legal-links/index.tsx
+++ b/packages/react/src/components/shared/primitives/legal-links/index.tsx
@@ -1,7 +1,7 @@
+import type { LegalLinks as LegalLinksType } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/primitives/legal-links.module.js';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
 import { useContext, useMemo } from 'react';
 import { ConsentStateContext } from '~/context/consent-manager-context';
 import { useStyles } from '~/hooks/use-styles';

--- a/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
+++ b/packages/react/src/components/shared/ui/__tests__/branding.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ReactElement } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/components/shared/ui/branding.tsx
+++ b/packages/react/src/components/shared/ui/branding.tsx
@@ -1,11 +1,11 @@
+import type { Branding } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
 import {
 	resolveStyles,
 	resolveTranslations,
 	sanitizeDOMStyleProps,
 } from '@c15t/ui/utils';
-import type { Branding } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
 import type { SVGProps } from 'react';
 import { useContext, useMemo } from 'react';
 import { ConsentStateContext } from '~/context/consent-manager-context';

--- a/packages/react/src/context/consent-manager-context.ts
+++ b/packages/react/src/context/consent-manager-context.ts
@@ -5,7 +5,7 @@
  * Provides the context for sharing consent management state across components.
  */
 
-import type { ConsentManagerInterface, ConsentStoreState } from 'c15t';
+import type { ConsentManagerInterface, ConsentStoreState } from '@c15t/core';
 import { createContext } from 'react';
 
 /**

--- a/packages/react/src/headless.ts
+++ b/packages/react/src/headless.ts
@@ -12,7 +12,7 @@ export {
 	policyPackPresets,
 	// Translation utilities
 	prepareTranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 export { useColorScheme } from './hooks/use-color-scheme';
 export {
 	type ConsentDialogTriggerVisibility,

--- a/packages/react/src/hooks/__tests__/use-consent-dialog-trigger.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-consent-dialog-trigger.test.tsx
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/context/consent-manager-context';

--- a/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-consent-manager.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/context/consent-manager-context';
@@ -10,9 +10,10 @@ import {
 import { useConsentManager } from '../use-consent-manager';
 
 // Mock the c15t package
-vi.mock('c15t', async () => {
-	const originalModule = await vi.importActual('c15t');
-	const { createConsentManagerStore } = originalModule as typeof import('c15t');
+vi.mock('@c15t/core', async () => {
+	const originalModule = await vi.importActual('@c15t/core');
+	const { createConsentManagerStore } =
+		originalModule as typeof import('@c15t/core');
 
 	const createMockConsentManager = () => ({
 		getCallbacks: () => ({}),

--- a/packages/react/src/hooks/__tests__/use-headless-consent-ui.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-headless-consent-ui.test.tsx
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/context/consent-manager-context';

--- a/packages/react/src/hooks/__tests__/use-translations.test.tsx
+++ b/packages/react/src/hooks/__tests__/use-translations.test.tsx
@@ -1,4 +1,4 @@
-import type { Translations } from 'c15t';
+import type { Translations } from '@c15t/core';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import {

--- a/packages/react/src/hooks/__tests__/v3-correctness-gates.test.tsx
+++ b/packages/react/src/hooks/__tests__/v3-correctness-gates.test.tsx
@@ -23,8 +23,8 @@
  * `useConsent('marketing')` returns a fresh value after consent
  * changes, with no useCallback dance required.
  */
-import type { ConsentManagerInterface } from 'c15t';
-import { createConsentManagerStore } from 'c15t';
+import type { ConsentManagerInterface } from '@c15t/core';
+import { createConsentManagerStore } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 
 const createMockConsentManager = (): ConsentManagerInterface => ({

--- a/packages/react/src/hooks/use-consent-manager.ts
+++ b/packages/react/src/hooks/use-consent-manager.ts
@@ -3,8 +3,8 @@
  * Hook for accessing and managing consent state.
  */
 
-import type { ConsentManagerInterface, ConsentStoreState } from 'c15t';
-import { has as evaluateHas } from 'c15t';
+import type { ConsentManagerInterface, ConsentStoreState } from '@c15t/core';
+import { has as evaluateHas } from '@c15t/core';
 import { useCallback, useContext, useRef } from 'react';
 import { ConsentStateContext } from '../context/consent-manager-context';
 

--- a/packages/react/src/hooks/use-consent-script.ts
+++ b/packages/react/src/hooks/use-consent-script.ts
@@ -5,7 +5,7 @@ import type {
 	HasCondition,
 	Script,
 	ScriptCallbackInfo,
-} from 'c15t';
+} from '@c15t/core';
 import { useContext, useEffect, useRef, useState } from 'react';
 import {
 	ConsentStateContext,

--- a/packages/react/src/hooks/use-translations.ts
+++ b/packages/react/src/hooks/use-translations.ts
@@ -1,8 +1,8 @@
 'use client';
 
+import type { Translations } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { Translations } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
 import { useMemo } from 'react';
 import { useConsentManager } from './use-consent-manager';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,7 +8,7 @@ export type {
 	Overrides,
 	PolicyPackPresets,
 	Translations,
-} from 'c15t';
+} from '@c15t/core';
 
 export {
 	configureConsentManager,
@@ -17,7 +17,7 @@ export {
 	mergeTranslationConfigs,
 	policyPackPresets,
 	prepareTranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 export {
 	ConsentBanner,
 	type ConsentBannerProps,

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -1,4 +1,4 @@
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { useConsentManager } from '~/hooks/use-consent-manager';

--- a/packages/react/src/providers/__tests__/test-helpers.tsx
+++ b/packages/react/src/providers/__tests__/test-helpers.tsx
@@ -5,7 +5,7 @@ import type {
 	PostConsentOutput,
 	VerifyConsentInput,
 	VerifyConsentOutput,
-} from 'c15t';
+} from '@c15t/core';
 
 import { beforeEach, type Mock, vi } from 'vitest';
 import { type ConsentManagerOptions, useConsentManager } from '~/index';
@@ -30,9 +30,10 @@ const { mockFetch, mockConfigureConsentManager, fetchCallMap, runtimeCache } =
 	hoistedMocks;
 
 // Mock c15t module at module level (hoisted by vitest)
-vi.mock('c15t', async () => {
-	const originalModule = await vi.importActual('c15t');
-	const { createConsentManagerStore } = originalModule as typeof import('c15t');
+vi.mock('@c15t/core', async () => {
+	const originalModule = await vi.importActual('@c15t/core');
+	const { createConsentManagerStore } =
+		originalModule as typeof import('@c15t/core');
 
 	const createMockConsentManager = (options: ConsentManagerOptions) => {
 		// Call the mock for tracking

--- a/packages/react/src/providers/consent-manager-provider.tsx
+++ b/packages/react/src/providers/consent-manager-provider.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { generateThemeCSS } from '@c15t/ui/theme';
-import { deepMerge } from '@c15t/ui/utils';
 import {
 	clearConsentRuntimeCache as baseClearCache,
 	type Callbacks,
 	type ConsentStoreState,
 	getOrCreateConsentRuntime,
-} from 'c15t';
+} from '@c15t/core';
+import { generateThemeCSS } from '@c15t/ui/theme';
+import { deepMerge } from '@c15t/ui/utils';
 import { startTransition, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ConsentStateContext,

--- a/packages/react/src/server/fetch-ssr-data.ts
+++ b/packages/react/src/server/fetch-ssr-data.ts
@@ -1,4 +1,4 @@
-import type { InitOutput, SSRInitialData } from 'c15t';
+import type { InitOutput, SSRInitialData } from '@c15t/core';
 import { version } from '../version';
 import { extractRelevantHeaders } from './headers';
 import { normalizeBackendURL } from './normalize-url';

--- a/packages/react/src/server/init-cache-key.ts
+++ b/packages/react/src/server/init-cache-key.ts
@@ -1,4 +1,4 @@
-import type { Overrides } from 'c15t';
+import type { Overrides } from '@c15t/core';
 import { extractRelevantHeaders } from './headers';
 
 /**

--- a/packages/react/src/server/types.ts
+++ b/packages/react/src/server/types.ts
@@ -1,4 +1,4 @@
-import type { Overrides, SSRInitialData } from 'c15t';
+import type { Overrides, SSRInitialData } from '@c15t/core';
 
 /**
  * Base options for SSR data fetching, shared across framework integrations.

--- a/packages/react/src/v3/__tests__/provider.test.tsx
+++ b/packages/react/src/v3/__tests__/provider.test.tsx
@@ -1,4 +1,4 @@
-import type { InitOutput } from 'c15t';
+import type { InitOutput } from '@c15t/core';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/__tests__/render-count-bench.test.tsx
+++ b/packages/react/src/v3/__tests__/render-count-bench.test.tsx
@@ -12,7 +12,7 @@
  * Output is stashed in .benchmarks/current/react-v3/render-counts.json so
  * it can feed the continuous-monitoring scoreboard.
  */
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { Profiler, type ReactNode } from 'react';
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/component-hooks/use-consent-manager.ts
+++ b/packages/react/src/v3/component-hooks/use-consent-manager.ts
@@ -7,13 +7,13 @@ import {
 	type HasCondition,
 	type Model,
 	type TranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 import type {
 	ConsentState,
 	KernelActiveUI,
 	KernelIABState,
 	PolicyUiSurfaceConfig,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 import { useCallback, useMemo } from 'react';
 import { useConsentDraft } from '../draft';
 import {

--- a/packages/react/src/v3/component-hooks/use-translations.ts
+++ b/packages/react/src/v3/component-hooks/use-translations.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Translations } from 'c15t';
+import type { Translations } from '@c15t/core';
 import { useMemo } from 'react';
 import { useTranslations as useKernelTranslations } from '../hooks';
 import { defaultTranslationConfig } from '../utils/default-translation-config';

--- a/packages/react/src/v3/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
+++ b/packages/react/src/v3/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/components/consent-banner/__tests__/policy-actions.test.tsx
+++ b/packages/react/src/v3/components/consent-banner/__tests__/policy-actions.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/components/consent-banner/atoms/root.tsx
+++ b/packages/react/src/v3/components/consent-banner/atoms/root.tsx
@@ -77,7 +77,7 @@ interface ConsentBannerRootProps extends HTMLAttributes<HTMLDivElement> {
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.
@@ -230,7 +230,7 @@ interface ConsentBannerRootChildrenProps
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 }
 
 /**

--- a/packages/react/src/v3/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/v3/components/consent-banner/consent-banner.tsx
@@ -184,7 +184,7 @@ export interface ConsentBannerProps {
 	 * Which consent models this banner responds to.
 	 * @default ['opt-in']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/v3/components/consent-dialog/atoms/root.tsx
+++ b/packages/react/src/v3/components/consent-dialog/atoms/root.tsx
@@ -52,7 +52,7 @@ export interface ConsentDialogRootProps
 	 * Which consent models this dialog responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * When true, the component will not apply any internal styles.

--- a/packages/react/src/v3/components/consent-dialog/consent-dialog.tsx
+++ b/packages/react/src/v3/components/consent-dialog/consent-dialog.tsx
@@ -105,7 +105,7 @@ export interface ConsentDialogProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['opt-in', 'opt-out']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/v3/components/consent-widget/__tests__/policy-actions.test.tsx
+++ b/packages/react/src/v3/components/consent-widget/__tests__/policy-actions.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/components/consent-widget/atoms/accordion.tsx
+++ b/packages/react/src/v3/components/consent-widget/atoms/accordion.tsx
@@ -1,5 +1,5 @@
+import type { AllConsentNames, ConsentType } from '@c15t/core';
 import accordionStyles from '@c15t/ui/styles/v3/accordion';
-import type { AllConsentNames, ConsentType } from 'c15t';
 import {
 	type ComponentPropsWithoutRef,
 	createContext,

--- a/packages/react/src/v3/components/frame/atoms.tsx
+++ b/packages/react/src/v3/components/frame/atoms.tsx
@@ -1,5 +1,5 @@
+import type { AllConsentNames } from '@c15t/core';
 import styles from '@c15t/ui/styles/v3/frame';
-import type { AllConsentNames } from 'c15t';
 import { forwardRef, type Ref } from 'react';
 import { useTranslations } from '~/v3/component-hooks/use-translations';
 import { Box, type BoxProps } from '../shared/primitives/box';

--- a/packages/react/src/v3/components/frame/frame.tsx
+++ b/packages/react/src/v3/components/frame/frame.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import { forwardRef, useEffect, useState } from 'react';
 import { useConsentManager } from '~/v3/component-hooks/use-consent-manager';
 import { useTranslations } from '~/v3/component-hooks/use-translations';

--- a/packages/react/src/v3/components/frame/index.ts
+++ b/packages/react/src/v3/components/frame/index.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import * as atoms from './atoms';
 import { Frame as FrameComponent } from './frame';
 import type { FrameCompoundComponent } from './types';

--- a/packages/react/src/v3/components/frame/types.ts
+++ b/packages/react/src/v3/components/frame/types.ts
@@ -1,4 +1,4 @@
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type { ComponentPropsWithRef, FC, ReactNode } from 'react';
 import type * as Atom from './atoms';
 

--- a/packages/react/src/v3/components/iab-consent-banner/atoms/root.tsx
+++ b/packages/react/src/v3/components/iab-consent-banner/atoms/root.tsx
@@ -35,7 +35,7 @@ interface IABConsentBannerRootProps extends HTMLAttributes<HTMLDivElement> {
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 	/**
 	 * Override the UI source identifier sent with consent API calls.
 	 * @default 'iab_banner'
@@ -90,7 +90,7 @@ interface IABConsentBannerRootChildrenProps
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 }
 
 const IABConsentBannerRootChildren = forwardRef<

--- a/packages/react/src/v3/components/iab-consent-banner/iab-consent-banner.tsx
+++ b/packages/react/src/v3/components/iab-consent-banner/iab-consent-banner.tsx
@@ -60,7 +60,7 @@ export interface IABConsentBannerProps {
 	 * Which consent models this banner responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/root.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/root.tsx
@@ -29,7 +29,7 @@ interface IABConsentDialogRootProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 	/**
 	 * Override the UI source identifier sent with consent API calls.
 	 * @default 'iab_dialog'

--- a/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/atoms/vendor-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import type { GlobalVendorList } from '@c15t/core';
 import styles from '@c15t/ui/styles/v3/iab-consent-dialog';
-import type { GlobalVendorList } from 'c15t';
 import { type FC, useEffect, useState } from 'react';
 import * as PreferenceItem from '~/v3/components/shared/ui/preference-item';
 import * as Switch from '~/v3/components/shared/ui/switch';

--- a/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
+++ b/packages/react/src/v3/components/iab-consent-dialog/iab-consent-dialog.tsx
@@ -104,7 +104,7 @@ export interface IABConsentDialogProps {
 	 * Which consent models this dialog responds to.
 	 * @default ['iab']
 	 */
-	models?: import('c15t').Model[];
+	models?: import('@c15t/core').Model[];
 
 	/**
 	 * Override the UI source identifier sent with consent API calls.

--- a/packages/react/src/v3/components/iab/__tests__/fixtures/mock-consent-state.ts
+++ b/packages/react/src/v3/components/iab/__tests__/fixtures/mock-consent-state.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 
 /**
  * Mock GVL for React component testing

--- a/packages/react/src/v3/components/shared/primitives/button.tsx
+++ b/packages/react/src/v3/components/shared/primitives/button.tsx
@@ -1,4 +1,4 @@
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import { forwardRef, type MouseEvent, useCallback } from 'react';
 import { useSaveConsents, useSetActiveUI, useSetConsent } from '~/v3/hooks';
 import { useTheme } from '~/v3/hooks/use-theme';

--- a/packages/react/src/v3/components/shared/primitives/legal-links/index.tsx
+++ b/packages/react/src/v3/components/shared/primitives/legal-links/index.tsx
@@ -1,6 +1,6 @@
+import type { LegalLinks as LegalLinksType } from '@c15t/core';
 import styles from '@c15t/ui/styles/v3/legal-links';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType } from 'c15t';
 import { useContext, useMemo, useSyncExternalStore } from 'react';
 import { KernelContext } from '~/v3/context';
 import { useUIConfig, V3UIConfigContext } from '~/v3/ui-config-context';

--- a/packages/react/src/v3/components/shared/ui/__tests__/branding.test.tsx
+++ b/packages/react/src/v3/components/shared/ui/__tests__/branding.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { ComponentProps, ReactElement } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';

--- a/packages/react/src/v3/components/shared/ui/branding.tsx
+++ b/packages/react/src/v3/components/shared/ui/branding.tsx
@@ -1,5 +1,5 @@
+import type { Branding } from '@c15t/core';
 import styles from '@c15t/ui/styles/v3/branding';
-import type { Branding } from 'c15t';
 import type { SVGProps } from 'react';
 import { useTranslations } from '~/v3/component-hooks/use-translations';
 import { useBranding } from '~/v3/hooks';

--- a/packages/react/src/v3/context.ts
+++ b/packages/react/src/v3/context.ts
@@ -1,4 +1,4 @@
-import type { ConsentKernel } from 'c15t/v3';
+import type { ConsentKernel } from '@c15t/core/v3';
 import { createContext } from 'react';
 
 /**

--- a/packages/react/src/v3/context/consent-manager-context.ts
+++ b/packages/react/src/v3/context/consent-manager-context.ts
@@ -5,7 +5,7 @@
  * Provides the context for sharing consent management state across components.
  */
 
-import type { ConsentManagerInterface, ConsentStoreState } from 'c15t';
+import type { ConsentManagerInterface, ConsentStoreState } from '@c15t/core';
 import { createContext } from 'react';
 
 /**

--- a/packages/react/src/v3/draft.tsx
+++ b/packages/react/src/v3/draft.tsx
@@ -21,8 +21,8 @@
  * the kernel's new consents.
  */
 
-import type { AllConsentNames } from 'c15t';
-import type { ConsentState } from 'c15t/v3';
+import type { AllConsentNames } from '@c15t/core';
+import type { ConsentState } from '@c15t/core/v3';
 import {
 	createContext,
 	type ReactNode,

--- a/packages/react/src/v3/headless.ts
+++ b/packages/react/src/v3/headless.ts
@@ -12,7 +12,7 @@ export {
 	policyPackPresets,
 	// Translation utilities
 	prepareTranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 export { useColorScheme } from './hooks/use-color-scheme';
 export {
 	type ConsentDialogTriggerVisibility,

--- a/packages/react/src/v3/hooks.ts
+++ b/packages/react/src/v3/hooks.ts
@@ -19,7 +19,7 @@
  * invalidation correctly.
  */
 
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type {
 	ConsentKernel,
 	ConsentSnapshot,
@@ -36,7 +36,7 @@ import type {
 	PolicyScopeMode,
 	PolicyUiSurfaceConfig,
 	ResolvedPolicy,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { KernelContext } from './context';
 

--- a/packages/react/src/v3/hooks/__tests__/use-consent-dialog-trigger.test.tsx
+++ b/packages/react/src/v3/hooks/__tests__/use-consent-dialog-trigger.test.tsx
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/v3/context/consent-manager-context';

--- a/packages/react/src/v3/hooks/__tests__/use-consent-manager.test.tsx
+++ b/packages/react/src/v3/hooks/__tests__/use-consent-manager.test.tsx
@@ -1,5 +1,5 @@
-import type { ConsentStoreState } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/v3/context/consent-manager-context';
@@ -10,9 +10,10 @@ import {
 import { useConsentManager } from '../use-consent-manager';
 
 // Mock the c15t package
-vi.mock('c15t', async () => {
-	const originalModule = await vi.importActual('c15t');
-	const { createConsentManagerStore } = originalModule as typeof import('c15t');
+vi.mock('@c15t/core', async () => {
+	const originalModule = await vi.importActual('@c15t/core');
+	const { createConsentManagerStore } =
+		originalModule as typeof import('@c15t/core');
 
 	const createMockConsentManager = () => ({
 		getCallbacks: () => ({}),

--- a/packages/react/src/v3/hooks/__tests__/use-headless-consent-ui.test.tsx
+++ b/packages/react/src/v3/hooks/__tests__/use-headless-consent-ui.test.tsx
@@ -1,4 +1,4 @@
-import type { ConsentStoreState } from 'c15t';
+import type { ConsentStoreState } from '@c15t/core';
 import { describe, expect, test, vi } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { ConsentStateContext } from '~/v3/context/consent-manager-context';

--- a/packages/react/src/v3/hooks/__tests__/use-translations.test.tsx
+++ b/packages/react/src/v3/hooks/__tests__/use-translations.test.tsx
@@ -1,4 +1,4 @@
-import type { Translations } from 'c15t';
+import type { Translations } from '@c15t/core';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import {

--- a/packages/react/src/v3/hooks/use-consent-manager.ts
+++ b/packages/react/src/v3/hooks/use-consent-manager.ts
@@ -3,8 +3,8 @@
  * Hook for accessing and managing consent state.
  */
 
-import type { ConsentManagerInterface, ConsentStoreState } from 'c15t';
-import { has as evaluateHas } from 'c15t';
+import type { ConsentManagerInterface, ConsentStoreState } from '@c15t/core';
+import { has as evaluateHas } from '@c15t/core';
 import { useCallback, useContext, useRef } from 'react';
 import { ConsentStateContext } from '../context/consent-manager-context';
 

--- a/packages/react/src/v3/hooks/use-iab-consent-manager.ts
+++ b/packages/react/src/v3/hooks/use-iab-consent-manager.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ActiveUI, Model, TranslationConfig } from 'c15t';
+import type { ActiveUI, Model, TranslationConfig } from '@c15t/core';
 import { useCallback, useMemo } from 'react';
 import {
 	useActiveUI,

--- a/packages/react/src/v3/hooks/use-translations.ts
+++ b/packages/react/src/v3/hooks/use-translations.ts
@@ -1,7 +1,7 @@
 'use client';
 
+import type { Translations } from '@c15t/core';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { Translations } from 'c15t';
 import { useMemo } from 'react';
 import { defaultTranslationConfig } from '../utils/default-translation-config';
 import { useConsentManager } from './use-consent-manager';

--- a/packages/react/src/v3/iab-context.tsx
+++ b/packages/react/src/v3/iab-context.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import type {
+	GlobalVendorList,
+	KernelIABState,
+	NonIABVendor,
+} from '@c15t/core/v3';
 import { type CreateIABOptions, createIAB, type IABHandle } from '@c15t/iab/v3';
-import type { GlobalVendorList, KernelIABState, NonIABVendor } from 'c15t/v3';
 import {
 	createContext,
 	type ReactNode,

--- a/packages/react/src/v3/iab-v3-module.d.ts
+++ b/packages/react/src/v3/iab-v3-module.d.ts
@@ -1,6 +1,10 @@
 declare module '@c15t/iab/v3' {
-	import type { CMPApi, IABConfig } from 'c15t';
-	import type { ConsentKernel, GlobalVendorList, NonIABVendor } from 'c15t/v3';
+	import type { CMPApi, IABConfig } from '@c15t/core';
+	import type {
+		ConsentKernel,
+		GlobalVendorList,
+		NonIABVendor,
+	} from '@c15t/core/v3';
 
 	export interface CreateIABOptions
 		extends Partial<
@@ -33,7 +37,7 @@ declare module '@c15t/iab/v3' {
 }
 
 declare module '@c15t/iab/v3/headless' {
-	import type { GlobalVendorList, NonIABVendor } from 'c15t/v3';
+	import type { GlobalVendorList, NonIABVendor } from '@c15t/core/v3';
 
 	export type HeadlessIABBannerAction = 'accept' | 'reject' | 'customize';
 	export type HeadlessIABDialogAction = 'accept' | 'reject' | 'customize';

--- a/packages/react/src/v3/index.ts
+++ b/packages/react/src/v3/index.ts
@@ -47,12 +47,12 @@ export type {
 	SavePayload,
 	SaveResult,
 	Unsubscribe,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 export {
 	createConsentKernel,
 	createHostedTransport,
 	createOfflineTransport,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
 export { ConsentDialog, ConsentWidget } from './aggregate-components';
 export type {
 	ConsentBannerButton,

--- a/packages/react/src/v3/module-hooks/iframe-blocker.ts
+++ b/packages/react/src/v3/module-hooks/iframe-blocker.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { IframeBlockerHandle } from 'c15t/v3/modules/iframe-blocker';
+import type { IframeBlockerHandle } from '@c15t/core/v3/modules/iframe-blocker';
 import { useEffect, useRef } from 'react';
 import { useRequiredKernel } from './shared';
 
@@ -32,7 +32,7 @@ export function useIframeBlocker(
 
 	useEffect(() => {
 		let disposed = false;
-		void import('c15t/v3/modules/iframe-blocker').then(
+		void import('@c15t/core/v3/modules/iframe-blocker').then(
 			({ createIframeBlocker }) => {
 				if (disposed) return;
 				const created = createIframeBlocker({

--- a/packages/react/src/v3/module-hooks/network-blocker.ts
+++ b/packages/react/src/v3/module-hooks/network-blocker.ts
@@ -4,7 +4,7 @@ import {
 	type BlockedRequestInfo,
 	type NetworkBlockerHandle,
 	type NetworkBlockerRule,
-} from 'c15t/v3/modules/network-blocker';
+} from '@c15t/core/v3/modules/network-blocker';
 import { useEffect, useRef } from 'react';
 import { useRequiredKernel } from './shared';
 
@@ -62,7 +62,7 @@ export function useNetworkBlocker(
 
 	useEffect(() => {
 		let disposed = false;
-		void import('c15t/v3/modules/network-blocker').then(
+		void import('@c15t/core/v3/modules/network-blocker').then(
 			({ createNetworkBlocker }) => {
 				if (disposed) return;
 				const created = createNetworkBlocker({

--- a/packages/react/src/v3/module-hooks/persistence.ts
+++ b/packages/react/src/v3/module-hooks/persistence.ts
@@ -4,7 +4,7 @@ import {
 	createPersistence,
 	type PersistenceHandle,
 	type PersistenceOptions,
-} from 'c15t/v3/modules/persistence';
+} from '@c15t/core/v3/modules/persistence';
 import { useEffect, useState } from 'react';
 import { useRequiredKernel } from './shared';
 

--- a/packages/react/src/v3/module-hooks/script-loader.ts
+++ b/packages/react/src/v3/module-hooks/script-loader.ts
@@ -4,7 +4,7 @@ import {
 	type Script,
 	type ScriptLoaderDebugEvent,
 	type ScriptLoaderHandle,
-} from 'c15t/v3/modules/script-loader';
+} from '@c15t/core/v3/modules/script-loader';
 import { useEffect, useRef, useState } from 'react';
 import { useRequiredKernel } from './shared';
 
@@ -49,7 +49,7 @@ export function useScriptLoader(
 
 	useEffect(() => {
 		let disposed = false;
-		void import('c15t/v3/modules/script-loader').then(
+		void import('@c15t/core/v3/modules/script-loader').then(
 			({ createScriptLoader }) => {
 				if (disposed) return;
 				const created = createScriptLoader({

--- a/packages/react/src/v3/module-hooks/shared.ts
+++ b/packages/react/src/v3/module-hooks/shared.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ConsentKernel } from 'c15t/v3';
+import type { ConsentKernel } from '@c15t/core/v3';
 import { useContext } from 'react';
 import { KernelContext } from '../context';
 

--- a/packages/react/src/v3/provider.tsx
+++ b/packages/react/src/v3/provider.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { buildDefaultOptInPolicy, type InitOutput } from '@c15t/schema/types';
-import { deepMergeTranslations, type Translations } from '@c15t/translations';
 import type {
 	AllConsentNames,
 	Callbacks,
@@ -17,7 +15,7 @@ import type {
 	StoreOptions,
 	TranslationConfig,
 	User,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	buildSubjectPostBody,
 	type ConsentKernel,
@@ -34,13 +32,15 @@ import {
 	type KernelUser,
 	mapInitOutputToInitResponse,
 	type TranslationsResponse,
-} from 'c15t/v3';
-import type { Script } from 'c15t/v3/modules/script-loader';
+} from '@c15t/core/v3';
+import type { Script } from '@c15t/core/v3/modules/script-loader';
 import {
 	createWindowDebug,
 	resolveWindowDebugMode,
 	type WindowDebugMode,
-} from 'c15t/v3/modules/window-debug';
+} from '@c15t/core/v3/modules/window-debug';
+import { buildDefaultOptInPolicy, type InitOutput } from '@c15t/schema/types';
+import { deepMergeTranslations, type Translations } from '@c15t/translations';
 import type { ReactNode } from 'react';
 import {
 	lazy,
@@ -758,7 +758,7 @@ function ScriptsMount({
 	useEffect(() => {
 		if (!kernel) return;
 		let disposed = false;
-		void import('c15t/v3/modules/script-loader').then(
+		void import('@c15t/core/v3/modules/script-loader').then(
 			({ createScriptLoader }) => {
 				if (disposed) return;
 				const created = createScriptLoader({
@@ -800,7 +800,7 @@ function NetworkBlockerMount({
 	useEffect(() => {
 		if (!kernel) return;
 		let disposed = false;
-		void import('c15t/v3/modules/network-blocker').then(
+		void import('@c15t/core/v3/modules/network-blocker').then(
 			({ createNetworkBlocker }) => {
 				if (disposed) return;
 				const latest = latestOptionsRef.current;

--- a/packages/react/src/v3/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/v3/providers/__tests__/provider-basic.test.tsx
@@ -1,4 +1,4 @@
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { useConsentManager } from '~/v3/hooks/use-consent-manager';

--- a/packages/react/src/v3/providers/__tests__/test-helpers.tsx
+++ b/packages/react/src/v3/providers/__tests__/test-helpers.tsx
@@ -5,7 +5,7 @@ import type {
 	PostConsentOutput,
 	VerifyConsentInput,
 	VerifyConsentOutput,
-} from 'c15t';
+} from '@c15t/core';
 
 import { beforeEach, type Mock, vi } from 'vitest';
 import { type ConsentManagerOptions, useConsentManager } from '~/v3/index';
@@ -29,9 +29,10 @@ const { mockFetch, mockConfigureConsentManager, fetchCallMap, runtimeCache } =
 	}));
 
 // Mock c15t module at module level (hoisted by vitest)
-vi.mock('c15t', async () => {
-	const originalModule = await vi.importActual('c15t');
-	const { createConsentManagerStore } = originalModule as typeof import('c15t');
+vi.mock('@c15t/core', async () => {
+	const originalModule = await vi.importActual('@c15t/core');
+	const { createConsentManagerStore } =
+		originalModule as typeof import('@c15t/core');
 
 	const createMockConsentManager = (options: ConsentManagerOptions) => {
 		// Call the mock for tracking

--- a/packages/react/src/v3/providers/consent-manager-provider.tsx
+++ b/packages/react/src/v3/providers/consent-manager-provider.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { generateThemeCSS } from '@c15t/ui/theme';
-import { deepMerge } from '@c15t/ui/utils';
 import {
 	clearConsentRuntimeCache as baseClearCache,
 	type Callbacks,
 	type ConsentStoreState,
 	defaultTranslationConfig,
 	getOrCreateConsentRuntime,
-} from 'c15t';
-import type { KernelBranding } from 'c15t/v3';
+} from '@c15t/core';
+import type { KernelBranding } from '@c15t/core/v3';
+import { generateThemeCSS } from '@c15t/ui/theme';
+import { deepMerge } from '@c15t/ui/utils';
 import { startTransition, useEffect, useMemo, useRef, useState } from 'react';
 import { version } from '../../version';
 import {

--- a/packages/react/src/v3/server/fetch-ssr-data.ts
+++ b/packages/react/src/v3/server/fetch-ssr-data.ts
@@ -1,4 +1,4 @@
-import type { InitOutput, SSRInitialData } from 'c15t';
+import type { InitOutput, SSRInitialData } from '@c15t/core';
 import { extractRelevantHeaders } from './headers';
 import { normalizeBackendURL } from './normalize-url';
 import type { FetchSSRDataOptions } from './types';

--- a/packages/react/src/v3/server/init-cache-key.ts
+++ b/packages/react/src/v3/server/init-cache-key.ts
@@ -1,4 +1,4 @@
-import type { Overrides } from 'c15t';
+import type { Overrides } from '@c15t/core';
 import { extractRelevantHeaders } from './headers';
 
 /**

--- a/packages/react/src/v3/server/types.ts
+++ b/packages/react/src/v3/server/types.ts
@@ -1,4 +1,4 @@
-import type { Overrides, SSRInitialData } from 'c15t';
+import type { Overrides, SSRInitialData } from '@c15t/core';
 
 /**
  * Base options for SSR data fetching, shared across framework integrations.

--- a/packages/react/src/v3/ui-config-context.ts
+++ b/packages/react/src/v3/ui-config-context.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import type { LegalLinks } from 'c15t';
+import type { LegalLinks } from '@c15t/core';
 import { createContext, useContext } from 'react';
 import type { ReactComponentSlots } from '~/v3/types/slots';
 

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -23,8 +23,8 @@
 			"@c15t/ui/utils": ["../ui/dist-types/utils/index.d.ts"],
 			"@c15t/schema": ["../schema/dist-types/index.d.ts"],
 			"@c15t/schema/config": ["../schema/dist-types/config/index.d.ts"],
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/*": ["../core/dist-types/*"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/*": ["../core/dist-types/*"],
 			"~/*": ["./src/*"]
 		}
 	},

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -22,28 +22,28 @@ export default mergeConfig(
 				// Resolve core package to source so Vite can handle its dynamic
 				// imports natively. rslib emits webpack-style chunks that Vite's
 				// browser bundler cannot analyse.
-				'c15t/v3/modules/script-loader': resolve(
+				'@c15t/core/v3/modules/script-loader': resolve(
 					__dirname,
 					'../core/src/v3/modules/script-loader/index.ts'
 				),
-				'c15t/v3/modules/network-blocker': resolve(
+				'@c15t/core/v3/modules/network-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/network-blocker/index.ts'
 				),
-				'c15t/v3/modules/iframe-blocker': resolve(
+				'@c15t/core/v3/modules/iframe-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/iframe-blocker/index.ts'
 				),
-				'c15t/v3/modules/persistence': resolve(
+				'@c15t/core/v3/modules/persistence': resolve(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
-				'c15t/v3/modules/window-debug': resolve(
+				'@c15t/core/v3/modules/window-debug': resolve(
 					__dirname,
 					'../core/src/v3/modules/window-debug/index.ts'
 				),
-				'c15t/v3': resolve(__dirname, '../core/src/v3/index.ts'),
-				c15t: resolve(__dirname, '../core/src/index.ts'),
+				'@c15t/core/v3': resolve(__dirname, '../core/src/v3/index.ts'),
+				'@c15t/core': resolve(__dirname, '../core/src/index.ts'),
 				'@c15t/schema/types': resolve(__dirname, '../schema/src/types.ts'),
 				'@c15t/schema/config': resolve(
 					__dirname,

--- a/packages/scripts/live-vendors/README.md
+++ b/packages/scripts/live-vendors/README.md
@@ -12,7 +12,7 @@ the Microsoft Clarity loader change that silently broke bootstrap assumptions.
 The probes exercise the built `c15t` package, so build core first:
 
 ```sh
-bun turbo run build --filter=c15t
+bun turbo run build --filter=@c15t/core
 bunx playwright install --with-deps chromium
 ```
 

--- a/packages/scripts/live-vendors/harness/entry.ts
+++ b/packages/scripts/live-vendors/harness/entry.ts
@@ -6,7 +6,7 @@
  * production `c15t` script loader and runs the probe checks defined in
  * `../vendors`.
  */
-import { type ConsentState, loadScripts } from 'c15t';
+import { type ConsentState, loadScripts } from '@c15t/core';
 import type {
 	LiveProbeCheckResult,
 	LiveProbeLoadOutcome,

--- a/packages/scripts/live-vendors/types.ts
+++ b/packages/scripts/live-vendors/types.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 
 /**
  * Depth of a live vendor probe.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -251,9 +251,9 @@
 		"not op_mini all"
 	],
 	"devDependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",
-		"c15t": "workspace:*",
 		"playwright": "1.58.2",
 		"typescript": "7.0.2"
 	},

--- a/packages/scripts/src/__tests__/helpers.ts
+++ b/packages/scripts/src/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import type { ConsentState, Script, ScriptCallbackInfo } from 'c15t';
+import type { ConsentState, Script, ScriptCallbackInfo } from '@c15t/core';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 import {
 	type BuiltInScriptIntegrationKey,

--- a/packages/scripts/src/engine.test.ts
+++ b/packages/scripts/src/engine.test.ts
@@ -1,4 +1,7 @@
-import { type ScriptDebugEvent, subscribeToScriptDebugEvents } from 'c15t';
+import {
+	type ScriptDebugEvent,
+	subscribeToScriptDebugEvents,
+} from '@c15t/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createCallbackInfo,

--- a/packages/scripts/src/engine/runtime.ts
+++ b/packages/scripts/src/engine/runtime.ts
@@ -4,7 +4,7 @@ import {
 	type Script,
 	type ScriptCallbackInfo,
 	type ScriptLifecycleCallback,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	type ManifestStep,
 	type ResolvedManifest,

--- a/packages/scripts/src/registry.test.ts
+++ b/packages/scripts/src/registry.test.ts
@@ -1,4 +1,4 @@
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import { describe, expect, it } from 'vitest';
 import packageJson from '../package.json' with { type: 'json' };
 import { expectScriptMatchesIntegration } from './__tests__/helpers';

--- a/packages/scripts/src/resolve.ts
+++ b/packages/scripts/src/resolve.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { compileManifest } from './engine/compile';
 import { resolvedManifestToScript } from './engine/runtime';
 import type { ResolvedManifest, VendorManifest } from './types';

--- a/packages/scripts/src/types.ts
+++ b/packages/scripts/src/types.ts
@@ -1,4 +1,4 @@
-import type { AllConsentNames, HasCondition } from 'c15t';
+import type { AllConsentNames, HasCondition } from '@c15t/core';
 
 export const VENDOR_MANIFEST_KIND = 'c15t.vendor-manifest';
 export const VENDOR_MANIFEST_SCHEMA_VERSION = 1;

--- a/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/linkedin-insights.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/meta-pixel.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { buildQueuePixelInstall } from '../_shared/install-builders';

--- a/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/microsoft-uet.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/reddit-pixel.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { buildQueuePixelInstall } from '../_shared/install-builders';

--- a/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/snapchat-pixel.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { buildQueuePixelInstall } from '../_shared/install-builders';

--- a/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/tiktok-pixel.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
+++ b/packages/scripts/src/vendors/ads-and-pixels/x-pixel.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/adobe-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/adobe-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/ahrefs-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/ahrefs-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/amplitude.ts
+++ b/packages/scripts/src/vendors/analytics/amplitude.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/clearbit.ts
+++ b/packages/scripts/src/vendors/analytics/clearbit.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/cloudflare-web-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/cloudflare-web-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/databuddy.ts
+++ b/packages/scripts/src/vendors/analytics/databuddy.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/fathom-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/fathom-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { booleanDataAttribute } from '../_shared/attributes';

--- a/packages/scripts/src/vendors/analytics/google-tag.ts
+++ b/packages/scripts/src/vendors/analytics/google-tag.ts
@@ -1,4 +1,4 @@
-import type { AllConsentNames, Script } from 'c15t';
+import type { AllConsentNames, Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import {
 	runtimeDateValue,

--- a/packages/scripts/src/vendors/analytics/heap.ts
+++ b/packages/scripts/src/vendors/analytics/heap.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import {

--- a/packages/scripts/src/vendors/analytics/hightouch.ts
+++ b/packages/scripts/src/vendors/analytics/hightouch.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/hotjar.ts
+++ b/packages/scripts/src/vendors/analytics/hotjar.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/logrocket.ts
+++ b/packages/scripts/src/vendors/analytics/logrocket.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/matomo-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/matomo-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { joinUrlPath, stripTrailingSlashes } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
+++ b/packages/scripts/src/vendors/analytics/microsoft-clarity.ts
@@ -1,4 +1,4 @@
-import type { ConsentState, Script, ScriptCallbackInfo } from 'c15t';
+import type { ConsentState, Script, ScriptCallbackInfo } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/mixpanel-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/pirsch.ts
+++ b/packages/scripts/src/vendors/analytics/pirsch.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/plausible-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/plausible-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/analytics/posthog.ts
+++ b/packages/scripts/src/vendors/analytics/posthog.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { stripTrailingSlashes } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/promptwatch.ts
+++ b/packages/scripts/src/vendors/analytics/promptwatch.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/rudderstack.ts
+++ b/packages/scripts/src/vendors/analytics/rudderstack.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl, trimToUndefined } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/rybbit-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/rybbit-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { booleanDataAttribute } from '../_shared/attributes';

--- a/packages/scripts/src/vendors/analytics/segment.ts
+++ b/packages/scripts/src/vendors/analytics/segment.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { resolveScriptUrl } from '../_shared/script-url';

--- a/packages/scripts/src/vendors/analytics/umami-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/umami-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 import { booleanDataAttribute, listDataAttribute } from '../_shared/attributes';

--- a/packages/scripts/src/vendors/analytics/vercel-analytics.ts
+++ b/packages/scripts/src/vendors/analytics/vercel-analytics.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/functional/crisp.ts
+++ b/packages/scripts/src/vendors/functional/crisp.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/functional/intercom.ts
+++ b/packages/scripts/src/vendors/functional/intercom.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import { type VendorManifest, vendorManifestContract } from '../../types';
 

--- a/packages/scripts/src/vendors/tag-managers/google-tag-manager.ts
+++ b/packages/scripts/src/vendors/tag-managers/google-tag-manager.ts
@@ -1,4 +1,4 @@
-import type { Script } from 'c15t';
+import type { Script } from '@c15t/core';
 import { resolveManifest } from '../../resolve';
 import {
 	runtimeTimestampValue,

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -5,8 +5,8 @@
 		"moduleResolution": "bundler",
 		"types": ["@vitest/browser/matchers"],
 		"paths": {
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/*": ["../core/dist-types/*"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/*": ["../core/dist-types/*"],
 			"~/*": ["./src/*"]
 		}
 	},

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -87,10 +87,10 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/iab": "workspace:*",
 		"@c15t/schema": "workspace:*",
 		"@c15t/ui": "workspace:*",
-		"c15t": "workspace:*",
 		"clsx": "2.1.1"
 	},
 	"devDependencies": {

--- a/packages/svelte/src/__tests__/conformance.test.ts
+++ b/packages/svelte/src/__tests__/conformance.test.ts
@@ -26,14 +26,14 @@ import {
 	type SuiteApi,
 	type TestDriver,
 } from '@c15t/conformance';
-import type { GlobalVendorList } from '@c15t/schema/types';
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type {
 	ConsentKernel,
 	KernelActiveUI,
 	KernelConfig,
 	ResolvedPolicy,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
+import type { GlobalVendorList } from '@c15t/schema/types';
 import { mount, unmount } from 'svelte';
 import { describe, expect, test } from 'vitest';
 import type { ConsentManagerOptions } from '../lib/types';

--- a/packages/svelte/src/__tests__/fixtures/banner-fixture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/banner-fixture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Model } from 'c15t';
+import type { Model } from '@c15t/core';
 import ConsentBanner from '../../lib/components/consent-banner.svelte';
 import ConsentManagerProvider from '../../lib/components/consent-manager-provider.svelte';
 import type { ConsentManagerOptions } from '../../lib/types';

--- a/packages/svelte/src/__tests__/fixtures/conformance-fixture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/conformance-fixture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ConsentKernel } from 'c15t/v3';
+import type { ConsentKernel } from '@c15t/core/v3';
 import ConsentBanner from '../../lib/components/consent-banner.svelte';
 import ConsentDialog from '../../lib/components/consent-dialog.svelte';
 import ConsentManagerProvider from '../../lib/components/consent-manager-provider.svelte';

--- a/packages/svelte/src/__tests__/fixtures/conformance-kernel-capture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/conformance-kernel-capture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ConsentKernel } from 'c15t/v3';
+import type { ConsentKernel } from '@c15t/core/v3';
 import { getConsentKernel } from '../../lib/context.svelte';
 
 let {

--- a/packages/svelte/src/__tests__/fixtures/context-reader.svelte
+++ b/packages/svelte/src/__tests__/fixtures/context-reader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { resolveTranslations } from '@c15t/ui/utils';
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../../lib/context.svelte';
 
 const consent = getConsentContext();

--- a/packages/svelte/src/__tests__/fixtures/context-reader.svelte
+++ b/packages/svelte/src/__tests__/fixtures/context-reader.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { resolveTranslations } from '@c15t/ui/utils';
 import { defaultTranslationConfig } from '@c15t/core';
+import { resolveTranslations } from '@c15t/ui/utils';
 import { getConsentContext, getThemeContext } from '../../lib/context.svelte';
 
 const consent = getConsentContext();

--- a/packages/svelte/src/__tests__/fixtures/dialog-fixture.svelte
+++ b/packages/svelte/src/__tests__/fixtures/dialog-fixture.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Model } from 'c15t';
+import type { Model } from '@c15t/core';
 import ConsentDialog from '../../lib/components/consent-dialog.svelte';
 import ConsentManagerProvider from '../../lib/components/consent-manager-provider.svelte';
 import type { ConsentManagerOptions } from '../../lib/types';

--- a/packages/svelte/src/__tests__/iab-translations.test.ts
+++ b/packages/svelte/src/__tests__/iab-translations.test.ts
@@ -5,8 +5,8 @@
  * with deep merge fallback to defaults.
  */
 
-import type { TranslationConfig } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { TranslationConfig } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { describe, expect, it } from 'vitest';
 import { getIABTranslations } from '../lib/iab-translations';
 

--- a/packages/svelte/src/__tests__/iab-types.test.ts
+++ b/packages/svelte/src/__tests__/iab-types.test.ts
@@ -5,7 +5,7 @@
  * into UI-friendly processed format.
  */
 
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import { describe, expect, test } from 'vitest';
 import { type NonIABVendor, processGVLData } from '../lib/iab-types';
 

--- a/packages/svelte/src/components/__tests__/active-ui-transitions.e2e.test.ts
+++ b/packages/svelte/src/components/__tests__/active-ui-transitions.e2e.test.ts
@@ -7,8 +7,8 @@
  * Mirrors: packages/react/src/components/__tests__/active-ui-transitions.e2e.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import BannerDialogFixture from '../../__tests__/fixtures/banner-dialog-fixture.svelte';
 import BannerFixture from '../../__tests__/fixtures/banner-fixture.svelte';

--- a/packages/svelte/src/components/__tests__/consent-dialog-link.test.ts
+++ b/packages/svelte/src/components/__tests__/consent-dialog-link.test.ts
@@ -5,8 +5,8 @@
  * with action="open-consent-dialog" and noStyle=true by default.
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import DialogLinkFixture from '../../__tests__/fixtures/dialog-link-fixture.svelte';
 import type { ConsentManagerOptions } from '../../lib/types';

--- a/packages/svelte/src/components/__tests__/consent-dialog-trigger.test.ts
+++ b/packages/svelte/src/components/__tests__/consent-dialog-trigger.test.ts
@@ -5,8 +5,8 @@
  * and aria attributes.
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import FullFlowFixture from '../../__tests__/fixtures/full-flow-fixture.svelte';
 import type { ConsentManagerOptions } from '../../lib/types';

--- a/packages/svelte/src/components/__tests__/consent-flow.e2e.test.ts
+++ b/packages/svelte/src/components/__tests__/consent-flow.e2e.test.ts
@@ -6,8 +6,8 @@
  * Mirrors: packages/react/src/components/__tests__/consent-flow.e2e.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import BannerDialogFixture from '../../__tests__/fixtures/banner-dialog-fixture.svelte';
 import BannerFixture from '../../__tests__/fixtures/banner-fixture.svelte';

--- a/packages/svelte/src/components/__tests__/provider-basic.test.ts
+++ b/packages/svelte/src/components/__tests__/provider-basic.test.ts
@@ -4,8 +4,8 @@
  * Mirrors: packages/react/src/providers/__tests__/provider-basic.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { render } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import ContextConsumerFixture from '../../__tests__/fixtures/context-consumer-fixture.svelte';
 import ProviderOnlyFixture from '../../__tests__/fixtures/provider-only-fixture.svelte';

--- a/packages/svelte/src/components/__tests__/provider-context.test.ts
+++ b/packages/svelte/src/components/__tests__/provider-context.test.ts
@@ -4,8 +4,8 @@
  * Mirrors: packages/react/src/providers/__tests__/provider-context.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test } from 'vitest';
 import ContextConsumerFixture from '../../__tests__/fixtures/context-consumer-fixture.svelte';
 

--- a/packages/svelte/src/components/__tests__/provider-errors.test.ts
+++ b/packages/svelte/src/components/__tests__/provider-errors.test.ts
@@ -4,8 +4,8 @@
  * Mirrors: packages/react/src/providers/__tests__/provider-errors.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import ContextConsumerFixture from '../../__tests__/fixtures/context-consumer-fixture.svelte';
 

--- a/packages/svelte/src/components/__tests__/provider-rendering.test.ts
+++ b/packages/svelte/src/components/__tests__/provider-rendering.test.ts
@@ -4,8 +4,8 @@
  * Mirrors: packages/react/src/providers/__tests__/provider-hydration.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test } from 'vitest';
 import BannerFixture from '../../__tests__/fixtures/banner-fixture.svelte';
 import ProviderOnlyFixture from '../../__tests__/fixtures/provider-only-fixture.svelte';

--- a/packages/svelte/src/components/__tests__/translations.test.ts
+++ b/packages/svelte/src/components/__tests__/translations.test.ts
@@ -4,9 +4,9 @@
  * Mirrors: packages/react/src/hooks/__tests__/use-translations.test.tsx
  */
 
+import type { Translations } from '@c15t/core';
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { render, screen, waitFor } from '@testing-library/svelte';
-import type { Translations } from 'c15t';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test } from 'vitest';
 import ContextConsumerFixture from '../../__tests__/fixtures/context-consumer-fixture.svelte';
 

--- a/packages/svelte/src/components/__tests__/ui-source-tracking.e2e.test.ts
+++ b/packages/svelte/src/components/__tests__/ui-source-tracking.e2e.test.ts
@@ -6,8 +6,8 @@
  * Mirrors: packages/react/src/components/__tests__/ui-source-tracking.e2e.test.tsx
  */
 
+import { clearConsentRuntimeCache } from '@c15t/core';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
-import { clearConsentRuntimeCache } from 'c15t';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import BannerDialogFixture from '../../__tests__/fixtures/banner-dialog-fixture.svelte';
 import BannerFixture from '../../__tests__/fixtures/banner-fixture.svelte';

--- a/packages/svelte/src/lib/components/branding.svelte
+++ b/packages/svelte/src/lib/components/branding.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
 import { resolveTranslations } from '@c15t/ui/utils';
-import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { resolveComponentStyles } from '../utils';
 import C15TIconOnly from './icons/c15-t-icon-only.svelte';

--- a/packages/svelte/src/lib/components/branding.svelte
+++ b/packages/svelte/src/lib/components/branding.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
 import { resolveTranslations } from '@c15t/ui/utils';
-import { defaultTranslationConfig } from 'c15t';
+import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { resolveComponentStyles } from '../utils';
 import C15TIconOnly from './icons/c15-t-icon-only.svelte';

--- a/packages/svelte/src/lib/components/consent-banner.svelte
+++ b/packages/svelte/src/lib/components/consent-banner.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { LegalLinks as LegalLinksType, Model } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-banner.module.js';
 import {
 	getTextDirection,
@@ -10,8 +12,6 @@ import {
 	resolveTranslations,
 	shouldFillPolicyActions,
 } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType, Model } from '@c15t/core';
-import { defaultTranslationConfig } from '@c15t/core';
 import { focusTrap } from '../actions/focus-trap';
 // Banner uses custom portal/focus-trap/scroll-lock actions (not Ark UI's built-in)
 // because the banner is not an Ark Dialog - it's a simpler container that

--- a/packages/svelte/src/lib/components/consent-banner.svelte
+++ b/packages/svelte/src/lib/components/consent-banner.svelte
@@ -10,8 +10,8 @@ import {
 	resolveTranslations,
 	shouldFillPolicyActions,
 } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType, Model } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { LegalLinks as LegalLinksType, Model } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { focusTrap } from '../actions/focus-trap';
 // Banner uses custom portal/focus-trap/scroll-lock actions (not Ark UI's built-in)
 // because the banner is not an Ark Dialog - it's a simpler container that

--- a/packages/svelte/src/lib/components/consent-button.svelte
+++ b/packages/svelte/src/lib/components/consent-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { buttonVariants } from '@c15t/ui/styles/primitives';
-import type { AllConsentNames } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
 import type { Snippet } from 'svelte';
 import type { HTMLButtonAttributes } from 'svelte/elements';
 import { getConsentContext, getThemeContext } from '../context.svelte';

--- a/packages/svelte/src/lib/components/consent-button.svelte
+++ b/packages/svelte/src/lib/components/consent-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { buttonVariants } from '@c15t/ui/styles/primitives';
 import type { AllConsentNames } from '@c15t/core';
+import { buttonVariants } from '@c15t/ui/styles/primitives';
 import type { Snippet } from 'svelte';
 import type { HTMLButtonAttributes } from 'svelte/elements';
 import { getConsentContext, getThemeContext } from '../context.svelte';

--- a/packages/svelte/src/lib/components/consent-dialog.svelte
+++ b/packages/svelte/src/lib/components/consent-dialog.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
 import { getTextDirection, resolveTranslations } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType, Model } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { LegalLinks as LegalLinksType, Model } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { Dialog, Portal } from '../primitives';
 import { resolveComponentStyles } from '../utils';

--- a/packages/svelte/src/lib/components/consent-dialog.svelte
+++ b/packages/svelte/src/lib/components/consent-dialog.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
-import { getTextDirection, resolveTranslations } from '@c15t/ui/utils';
 import type { LegalLinks as LegalLinksType, Model } from '@c15t/core';
 import { defaultTranslationConfig } from '@c15t/core';
+import styles from '@c15t/ui/styles/components/consent-dialog.module.js';
+import { getTextDirection, resolveTranslations } from '@c15t/ui/utils';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { Dialog, Portal } from '../primitives';
 import { resolveComponentStyles } from '../utils';

--- a/packages/svelte/src/lib/components/consent-manager-provider.svelte
+++ b/packages/svelte/src/lib/components/consent-manager-provider.svelte
@@ -1,8 +1,4 @@
 <script lang="ts">
-import { createIAB, type IABHandle } from '@c15t/iab/v3';
-import { buildDefaultOptInPolicy, policyDefaults } from '@c15t/schema/types';
-import { generateThemeCSS } from '@c15t/ui/theme';
-import { deepMerge, setupColorScheme } from '@c15t/ui/utils';
 import {
 	type AllConsentNames,
 	type Callbacks,
@@ -34,6 +30,10 @@ import {
 	createWindowDebug,
 	resolveWindowDebugMode,
 } from '@c15t/core/v3/modules/window-debug';
+import { createIAB, type IABHandle } from '@c15t/iab/v3';
+import { buildDefaultOptInPolicy, policyDefaults } from '@c15t/schema/types';
+import { generateThemeCSS } from '@c15t/ui/theme';
+import { deepMerge, setupColorScheme } from '@c15t/ui/utils';
 import type { Snippet } from 'svelte';
 import { onDestroy, onMount, untrack } from 'svelte';
 import {

--- a/packages/svelte/src/lib/components/consent-manager-provider.svelte
+++ b/packages/svelte/src/lib/components/consent-manager-provider.svelte
@@ -10,7 +10,7 @@ import {
 	type I18nConfig,
 	type OfflinePolicyConfig,
 	type User,
-} from 'c15t';
+} from '@c15t/core';
 import {
 	type ConsentKernel,
 	type ConsentSnapshot,
@@ -25,15 +25,15 @@ import {
 	type KernelTransport,
 	type KernelUser,
 	type TranslationsResponse,
-} from 'c15t/v3';
-import { createIframeBlocker } from 'c15t/v3/modules/iframe-blocker';
-import { createNetworkBlocker } from 'c15t/v3/modules/network-blocker';
-import { createPersistence } from 'c15t/v3/modules/persistence';
-import { createScriptLoader } from 'c15t/v3/modules/script-loader';
+} from '@c15t/core/v3';
+import { createIframeBlocker } from '@c15t/core/v3/modules/iframe-blocker';
+import { createNetworkBlocker } from '@c15t/core/v3/modules/network-blocker';
+import { createPersistence } from '@c15t/core/v3/modules/persistence';
+import { createScriptLoader } from '@c15t/core/v3/modules/script-loader';
 import {
 	createWindowDebug,
 	resolveWindowDebugMode,
-} from 'c15t/v3/modules/window-debug';
+} from '@c15t/core/v3/modules/window-debug';
 import type { Snippet } from 'svelte';
 import { onDestroy, onMount, untrack } from 'svelte';
 import {

--- a/packages/svelte/src/lib/components/consent-widget.svelte
+++ b/packages/svelte/src/lib/components/consent-widget.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { AllConsentNames } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/consent-widget.module.js';
 import { switchVariants } from '@c15t/ui/styles/primitives';
 import {
@@ -11,8 +13,6 @@ import {
 	resolveTranslations,
 	shouldFillPolicyActions,
 } from '@c15t/ui/utils';
-import type { AllConsentNames } from '@c15t/core';
-import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { PreferenceItem, Switch } from '../primitives';
 import { resolveComponentStyles } from '../utils';

--- a/packages/svelte/src/lib/components/consent-widget.svelte
+++ b/packages/svelte/src/lib/components/consent-widget.svelte
@@ -11,8 +11,8 @@ import {
 	resolveTranslations,
 	shouldFillPolicyActions,
 } from '@c15t/ui/utils';
-import type { AllConsentNames } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { PreferenceItem, Switch } from '../primitives';
 import { resolveComponentStyles } from '../utils';

--- a/packages/svelte/src/lib/components/frame.svelte
+++ b/packages/svelte/src/lib/components/frame.svelte
@@ -2,8 +2,8 @@
 import styles from '@c15t/ui/styles/components/frame.module.js';
 import { buttonVariants } from '@c15t/ui/styles/primitives';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { AllConsentNames } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { AllConsentNames } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import type { Snippet } from 'svelte';
 import { onMount } from 'svelte';
 import { getConsentContext, getThemeContext } from '../context.svelte';

--- a/packages/svelte/src/lib/components/frame.svelte
+++ b/packages/svelte/src/lib/components/frame.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { AllConsentNames } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/frame.module.js';
 import { buttonVariants } from '@c15t/ui/styles/primitives';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { AllConsentNames } from '@c15t/core';
-import { defaultTranslationConfig } from '@c15t/core';
 import type { Snippet } from 'svelte';
 import { onMount } from 'svelte';
 import { getConsentContext, getThemeContext } from '../context.svelte';

--- a/packages/svelte/src/lib/components/iab-consent-banner.svelte
+++ b/packages/svelte/src/lib/components/iab-consent-banner.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import styles from '@c15t/ui/styles/components/iab-consent-banner.module.js';
 import { getTextDirection } from '@c15t/ui/utils';
-import type { Model } from 'c15t';
+import type { Model } from '@c15t/core';
 import { focusTrap } from '../actions/focus-trap';
 import { portal } from '../actions/portal';
 import { scrollLock } from '../actions/scroll-lock';

--- a/packages/svelte/src/lib/components/iab-consent-banner.svelte
+++ b/packages/svelte/src/lib/components/iab-consent-banner.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+import type { Model } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/iab-consent-banner.module.js';
 import { getTextDirection } from '@c15t/ui/utils';
-import type { Model } from '@c15t/core';
 import { focusTrap } from '../actions/focus-trap';
 import { portal } from '../actions/portal';
 import { scrollLock } from '../actions/scroll-lock';

--- a/packages/svelte/src/lib/components/iab-consent-dialog.svelte
+++ b/packages/svelte/src/lib/components/iab-consent-dialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+import { defaultTranslationConfig, type Model } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
 import { getTextDirection, resolveTranslations } from '@c15t/ui/utils';
-import { defaultTranslationConfig, type Model } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { getIABTranslations } from '../iab-translations';
 import { processGVLData, type VendorId } from '../iab-types';

--- a/packages/svelte/src/lib/components/iab-consent-dialog.svelte
+++ b/packages/svelte/src/lib/components/iab-consent-dialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
 import { getTextDirection, resolveTranslations } from '@c15t/ui/utils';
-import { defaultTranslationConfig, type Model } from 'c15t';
+import { defaultTranslationConfig, type Model } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { getIABTranslations } from '../iab-translations';
 import { processGVLData, type VendorId } from '../iab-types';

--- a/packages/svelte/src/lib/components/iab-vendor-list.svelte
+++ b/packages/svelte/src/lib/components/iab-vendor-list.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+import type { GlobalVendorList } from '@c15t/core';
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
 import { switchVariants } from '@c15t/ui/styles/primitives';
-import type { GlobalVendorList } from '@c15t/core';
 import { untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { IABTranslations } from '../iab-translations';

--- a/packages/svelte/src/lib/components/iab-vendor-list.svelte
+++ b/packages/svelte/src/lib/components/iab-vendor-list.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import styles from '@c15t/ui/styles/components/iab-consent-dialog.module.js';
 import { switchVariants } from '@c15t/ui/styles/primitives';
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 import { untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { IABTranslations } from '../iab-translations';

--- a/packages/svelte/src/lib/components/inline-legal-links.svelte
+++ b/packages/svelte/src/lib/components/inline-legal-links.svelte
@@ -2,8 +2,8 @@
 import legalLinkStyles from '@c15t/ui/styles/primitives/legal-links.module.js';
 import type { AllThemeKeys } from '@c15t/ui/theme';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
+import type { LegalLinks as LegalLinksType } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { resolveComponentStyles } from '../utils';
 

--- a/packages/svelte/src/lib/components/inline-legal-links.svelte
+++ b/packages/svelte/src/lib/components/inline-legal-links.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { LegalLinks as LegalLinksType } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import legalLinkStyles from '@c15t/ui/styles/primitives/legal-links.module.js';
 import type { AllThemeKeys } from '@c15t/ui/theme';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { LegalLinks as LegalLinksType } from '@c15t/core';
-import { defaultTranslationConfig } from '@c15t/core';
 import { getConsentContext, getThemeContext } from '../context.svelte';
 import { resolveComponentStyles } from '../utils';
 

--- a/packages/svelte/src/lib/components/policy-actions-renderer.svelte
+++ b/packages/svelte/src/lib/components/policy-actions-renderer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { PolicyUiActionDirection } from 'c15t';
+import type { PolicyUiActionDirection } from '@c15t/core';
 import type { Snippet } from 'svelte';
 
 let {

--- a/packages/svelte/src/lib/context.svelte.ts
+++ b/packages/svelte/src/lib/context.svelte.ts
@@ -1,4 +1,3 @@
-import type { Theme, UIOptions } from '@c15t/ui/theme';
 import {
 	type ActiveUI,
 	type AllConsentNames,
@@ -10,7 +9,7 @@ import {
 	type HasCondition,
 	type Model,
 	type TranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 import type {
 	ConsentKernel,
 	ConsentSnapshot,
@@ -18,7 +17,8 @@ import type {
 	KernelActiveUI,
 	KernelIABState,
 	PolicyUiSurfaceConfig,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
+import type { Theme, UIOptions } from '@c15t/ui/theme';
 import { getContext, setContext } from 'svelte';
 import type { ConsentManagerOptions } from './types';
 

--- a/packages/svelte/src/lib/headless.ts
+++ b/packages/svelte/src/lib/headless.ts
@@ -1,5 +1,5 @@
-export type { AllConsentNames } from 'c15t';
-export type { ConsentState, KernelActiveUI, KernelConfig } from 'c15t/v3';
+export type { AllConsentNames } from '@c15t/core';
+export type { ConsentState, KernelActiveUI, KernelConfig } from '@c15t/core/v3';
 export { focusTrap } from './actions/focus-trap';
 export { portal } from './actions/portal';
 export { scrollLock } from './actions/scroll-lock';

--- a/packages/svelte/src/lib/iab-translations.ts
+++ b/packages/svelte/src/lib/iab-translations.ts
@@ -1,6 +1,6 @@
+import type { TranslationConfig } from '@c15t/core';
+import { defaultTranslationConfig } from '@c15t/core';
 import { resolveTranslations } from '@c15t/ui/utils';
-import type { TranslationConfig } from 'c15t';
-import { defaultTranslationConfig } from 'c15t';
 
 /**
  * IAB translations interface.

--- a/packages/svelte/src/lib/iab-types.ts
+++ b/packages/svelte/src/lib/iab-types.ts
@@ -1,4 +1,4 @@
-import type { GlobalVendorList } from 'c15t';
+import type { GlobalVendorList } from '@c15t/core';
 
 export type VendorId = number | string;
 

--- a/packages/svelte/src/lib/index.ts
+++ b/packages/svelte/src/lib/index.ts
@@ -1,24 +1,10 @@
-export * from '@c15t/ui/primitives';
-export * from '@c15t/ui/styles/primitives';
-
-export type {
-	ColorTokens,
-	ComponentSlots,
-	MotionTokens,
-	RadiusTokens,
-	ShadowTokens,
-	SlotStyle,
-	SpacingTokens,
-	Theme,
-	TypographyTokens,
-} from '@c15t/ui/theme';
 export type {
 	AllConsentNames,
 	ConsentType,
 	I18nConfig,
 	LegalLinks,
 	Translations,
-} from 'c15t';
+} from '@c15t/core';
 export {
 	configureConsentManager,
 	defaultTranslationConfig,
@@ -26,7 +12,7 @@ export {
 	mergeTranslationConfigs,
 	policyPackPresets,
 	prepareTranslationConfig,
-} from 'c15t';
+} from '@c15t/core';
 export type {
 	ConsentKernel,
 	ConsentSnapshot,
@@ -52,7 +38,20 @@ export type {
 	SavePayload,
 	SaveResult,
 	TranslationsResponse,
-} from 'c15t/v3';
+} from '@c15t/core/v3';
+export * from '@c15t/ui/primitives';
+export * from '@c15t/ui/styles/primitives';
+export type {
+	ColorTokens,
+	ComponentSlots,
+	MotionTokens,
+	RadiusTokens,
+	ShadowTokens,
+	SlotStyle,
+	SpacingTokens,
+	Theme,
+	TypographyTokens,
+} from '@c15t/ui/theme';
 export { focusTrap } from './actions/focus-trap';
 export { portal } from './actions/portal';
 export { scrollLock } from './actions/scroll-lock';

--- a/packages/svelte/src/lib/server/index.ts
+++ b/packages/svelte/src/lib/server/index.ts
@@ -1,13 +1,13 @@
 import {
-	consentInputsToOverrides,
-	extractConsentRequestInputs,
-} from '@c15t/schema/types';
-import {
 	createHostedTransport,
 	type KernelConfig,
 	mergeInitResponseIntoKernelConfig,
-} from 'c15t/v3';
-import { readStoredConsentFromCookie } from 'c15t/v3/modules/persistence';
+} from '@c15t/core/v3';
+import { readStoredConsentFromCookie } from '@c15t/core/v3/modules/persistence';
+import {
+	consentInputsToOverrides,
+	extractConsentRequestInputs,
+} from '@c15t/schema/types';
 import { normalizeBackendURL } from './normalize-url';
 import type {
 	PrefetchInitialConsentOptions,
@@ -91,5 +91,5 @@ export async function prefetchInitialConsent(
 	}
 }
 
-export type { KernelConfig } from 'c15t/v3';
+export type { KernelConfig } from '@c15t/core/v3';
 export type { PrefetchInitialConsentOptions, ReadInitialConsentConfigOptions };

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -1,5 +1,3 @@
-import type { CreateIABOptions } from '@c15t/iab/v3';
-import type { Theme, UIOptions } from '@c15t/ui/theme';
 import type {
 	AllConsentNames,
 	Callbacks,
@@ -11,20 +9,22 @@ import type {
 	PolicyConfig,
 	StorageConfig,
 	User,
-} from 'c15t';
+} from '@c15t/core';
 import type {
 	KernelConfig,
 	KernelOverrides,
 	KernelTransport,
 	KernelUser,
-} from 'c15t/v3';
-import type { IframeBlockerOptions } from 'c15t/v3/modules/iframe-blocker';
-import type { NetworkBlockerRule } from 'c15t/v3/modules/network-blocker';
-import type { PersistenceOptions } from 'c15t/v3/modules/persistence';
+} from '@c15t/core/v3';
+import type { IframeBlockerOptions } from '@c15t/core/v3/modules/iframe-blocker';
+import type { NetworkBlockerRule } from '@c15t/core/v3/modules/network-blocker';
+import type { PersistenceOptions } from '@c15t/core/v3/modules/persistence';
 import type {
 	Script,
 	ScriptLoaderDebugEvent,
-} from 'c15t/v3/modules/script-loader';
+} from '@c15t/core/v3/modules/script-loader';
+import type { CreateIABOptions } from '@c15t/iab/v3';
+import type { Theme, UIOptions } from '@c15t/ui/theme';
 
 export type ProviderMode = 'hosted' | 'offline' | 'c15t';
 

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -8,9 +8,9 @@
 			"@c15t/iab/*": ["../iab/src/*"],
 			"@c15t/schema": ["../schema/dist-types/index.d.ts"],
 			"@c15t/schema/*": ["../schema/dist-types/*"],
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/v3": ["../core/src/v3/index.ts"],
-			"c15t/v3/modules/*": ["../core/src/v3/modules/*/index.ts"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/v3": ["../core/src/v3/index.ts"],
+			"@c15t/core/v3/modules/*": ["../core/src/v3/modules/*/index.ts"],
 			"~/*": ["../core/src/*", "./src/lib/*"]
 		}
 	},

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -13,35 +13,35 @@ export default mergeConfig(
 		resolve: {
 			alias: [
 				{
-					find: 'c15t/v3/modules/iframe-blocker',
+					find: '@c15t/core/v3/modules/iframe-blocker',
 					replacement: resolve(
 						__dirname,
 						'../core/src/v3/modules/iframe-blocker/index.ts'
 					),
 				},
 				{
-					find: 'c15t/v3/modules/network-blocker',
+					find: '@c15t/core/v3/modules/network-blocker',
 					replacement: resolve(
 						__dirname,
 						'../core/src/v3/modules/network-blocker/index.ts'
 					),
 				},
 				{
-					find: 'c15t/v3/modules/persistence',
+					find: '@c15t/core/v3/modules/persistence',
 					replacement: resolve(
 						__dirname,
 						'../core/src/v3/modules/persistence/index.ts'
 					),
 				},
 				{
-					find: 'c15t/v3/modules/script-loader',
+					find: '@c15t/core/v3/modules/script-loader',
 					replacement: resolve(
 						__dirname,
 						'../core/src/v3/modules/script-loader/index.ts'
 					),
 				},
 				{
-					find: 'c15t/v3/modules/window-debug',
+					find: '@c15t/core/v3/modules/window-debug',
 					replacement: resolve(
 						__dirname,
 						'../core/src/v3/modules/window-debug/index.ts'
@@ -64,7 +64,7 @@ export default mergeConfig(
 					replacement: resolve(__dirname, '../schema/src/index.ts'),
 				},
 				{
-					find: 'c15t/v3',
+					find: '@c15t/core/v3',
 					replacement: resolve(__dirname, '../core/src/v3/index.ts'),
 				},
 				{

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -140,8 +140,8 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
-		"@c15t/translations": "workspace:*",
-		"c15t": "workspace:*"
+		"@c15t/core": "workspace:*",
+		"@c15t/translations": "workspace:*"
 	},
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",

--- a/packages/ui/src/theme/options.ts
+++ b/packages/ui/src/theme/options.ts
@@ -12,7 +12,7 @@ import type {
 	StorageConfig,
 	TranslationConfig,
 	User,
-} from 'c15t';
+} from '@c15t/core';
 import type { UIOptions } from '../theme/types';
 
 /**

--- a/packages/ui/src/utils/policy-actions.ts
+++ b/packages/ui/src/utils/policy-actions.ts
@@ -4,7 +4,7 @@ export type {
 	PolicyUiActionGroup,
 	PolicyUiProfile,
 	PolicyUiSurfaceConfig,
-} from 'c15t';
+} from '@c15t/core';
 export {
 	flattenPolicyActionGroups,
 	hasPolicyHints,
@@ -15,4 +15,4 @@ export {
 	resolvePolicyPrimaryActions,
 	resolvePolicyUiProfile,
 	shouldFillPolicyActions,
-} from 'c15t';
+} from '@c15t/core';

--- a/packages/ui/src/utils/translations.ts
+++ b/packages/ui/src/utils/translations.ts
@@ -1,4 +1,4 @@
-import type { TranslationConfig, Translations } from 'c15t';
+import type { TranslationConfig, Translations } from '@c15t/core';
 
 /**
  * Resolves translations based on the provided configuration and default language.

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,8 +6,8 @@
 		"paths": {
 			"@c15t/translations": ["../translations/dist-types/index.d.ts"],
 			"@c15t/translations/*": ["../translations/dist-types/*"],
-			"c15t": ["../core/dist-types/index.d.ts"],
-			"c15t/*": ["../core/dist-types/*"],
+			"@c15t/core": ["../core/dist-types/index.d.ts"],
+			"@c15t/core/*": ["../core/dist-types/*"],
 			"~/*": ["./src/*"]
 		}
 	},

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -16,7 +16,7 @@ export default mergeConfig(
 					__dirname,
 					'../translations/src/index.ts'
 				),
-				c15t: resolve(__dirname, '../core/dist/index.js'),
+				'@c15t/core': resolve(__dirname, '../core/dist/index.js'),
 			},
 		},
 		test: {

--- a/packages/vue/build.config.ts
+++ b/packages/vue/build.config.ts
@@ -15,7 +15,7 @@ export default defineBuildConfig({
 		'vite',
 		'@c15t/schema',
 		'@c15t/ui',
-		'c15t',
+		'@c15t/core',
 		'@vueuse/core',
 		'reka-ui',
 		'defu',

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -55,10 +55,10 @@
 		"test": "vitest run"
 	},
 	"dependencies": {
+		"@c15t/core": "workspace:*",
 		"@c15t/schema": "workspace:*",
 		"@c15t/ui": "workspace:*",
 		"@vueuse/core": "^14.3.0",
-		"c15t": "workspace:*",
 		"defu": "^6.1.4",
 		"ufo": "^1.6.1",
 		"vue": "^3.5.39"

--- a/packages/vue/src/__tests__/conformance.test.ts
+++ b/packages/vue/src/__tests__/conformance.test.ts
@@ -17,20 +17,20 @@ import {
 	type SuiteApi,
 	type TestDriver,
 } from '@c15t/conformance';
-import type {
-	GlobalVendorList,
-	InitOutput,
-	TranslationsResponse,
-} from '@c15t/schema/types';
-import { flushPromises } from '@vue/test-utils';
 import {
 	type ConsentKernel,
 	type ConsentSnapshot,
 	createConsentKernel,
 	type KernelConfig,
 	type KernelTransport,
-} from 'c15t/v3';
-import { createPersistence } from 'c15t/v3/modules/persistence';
+} from '@c15t/core/v3';
+import { createPersistence } from '@c15t/core/v3/modules/persistence';
+import type {
+	GlobalVendorList,
+	InitOutput,
+	TranslationsResponse,
+} from '@c15t/schema/types';
+import { flushPromises } from '@vue/test-utils';
 import { describe, expect, test, vi } from 'vitest';
 import {
 	type App,

--- a/packages/vue/src/__tests__/kernel-runtime.test.ts
+++ b/packages/vue/src/__tests__/kernel-runtime.test.ts
@@ -1,6 +1,6 @@
+import { readStoredConsentFromCookie } from '@c15t/core/v3/modules/persistence';
 import type { InitOutput } from '@c15t/schema/types';
 import { flushPromises, mount } from '@vue/test-utils';
-import { readStoredConsentFromCookie } from 'c15t/v3/modules/persistence';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { createSSRApp, defineComponent } from 'vue';
 import { renderToString } from 'vue/server-renderer';

--- a/packages/vue/src/runtime/components/consent-manager.vue
+++ b/packages/vue/src/runtime/components/consent-manager.vue
@@ -9,7 +9,7 @@ import managerStyles from '@c15t/ui/styles/v3/consent-manager';
 import {
 	type CONSENT_CATEGORY,
 	getConsentAvailableCategories,
-} from 'c15t/v3/consent-record';
+} from '@c15t/core/v3/consent-record';
 import { computed, type HTMLAttributes, nextTick, ref, watch } from 'vue';
 import {
 	useConsentActiveUI,

--- a/packages/vue/src/runtime/components/consent-widget.vue
+++ b/packages/vue/src/runtime/components/consent-widget.vue
@@ -24,7 +24,7 @@ import { getTextDirection } from '@c15t/ui/utils/dom';
 import {
 	type CONSENT_CATEGORY,
 	getConsentAvailableCategories,
-} from 'c15t/v3/consent-record';
+} from '@c15t/core/v3/consent-record';
 import { computed, ref, useId, watch } from 'vue';
 import {
 	useConsentActiveUI,

--- a/packages/vue/src/runtime/composables/consent.ts
+++ b/packages/vue/src/runtime/composables/consent.ts
@@ -1,7 +1,7 @@
 import {
 	type CONSENT_CATEGORY,
 	getConsentAvailableCategories,
-} from 'c15t/v3/consent-record';
+} from '@c15t/core/v3/consent-record';
 import { computed } from 'vue';
 import { useConsentConfig } from './config';
 import { useConsentInit } from './init';

--- a/packages/vue/src/runtime/kernel.ts
+++ b/packages/vue/src/runtime/kernel.ts
@@ -1,9 +1,3 @@
-import type { ConsentActiveUI } from '@c15t/schema/config';
-import {
-	CONSENT_REQUEST_HEADER_NAMES,
-	extractConsentRequestInputs,
-	type InitOutput,
-} from '@c15t/schema/types';
 import {
 	type ConsentKernel,
 	type ConsentSnapshot,
@@ -15,24 +9,33 @@ import {
 	type KernelActiveUI,
 	type KernelConfig,
 	type KernelTransport,
-} from 'c15t/v3';
-import type { Consent } from 'c15t/v3/consent-record';
+} from '@c15t/core/v3';
+import type { Consent } from '@c15t/core/v3/consent-record';
 import {
 	createIframeBlocker,
 	type IframeBlockerOptions,
-} from 'c15t/v3/modules/iframe-blocker';
+} from '@c15t/core/v3/modules/iframe-blocker';
 import {
 	type BlockedRequestInfo,
 	createNetworkBlocker,
 	type NetworkBlockerRule,
-} from 'c15t/v3/modules/network-blocker';
+} from '@c15t/core/v3/modules/network-blocker';
 import {
 	createPersistence,
 	type StorageConfig,
 	type StoredPayload,
-} from 'c15t/v3/modules/persistence';
-import { createScriptLoader, type Script } from 'c15t/v3/modules/script-loader';
-import { createWindowDebug } from 'c15t/v3/modules/window-debug';
+} from '@c15t/core/v3/modules/persistence';
+import {
+	createScriptLoader,
+	type Script,
+} from '@c15t/core/v3/modules/script-loader';
+import { createWindowDebug } from '@c15t/core/v3/modules/window-debug';
+import type { ConsentActiveUI } from '@c15t/schema/config';
+import {
+	CONSENT_REQUEST_HEADER_NAMES,
+	extractConsentRequestInputs,
+	type InitOutput,
+} from '@c15t/schema/types';
 import { computed, type Ref, shallowRef } from 'vue';
 import type { ConsentConfig } from './config';
 import {

--- a/packages/vue/src/runtime/plugin.nuxt.ts
+++ b/packages/vue/src/runtime/plugin.nuxt.ts
@@ -1,5 +1,5 @@
+import { readStoredConsentFromCookie } from '@c15t/core/v3/modules/persistence';
 import type { InitOutput } from '@c15t/schema/types';
-import { readStoredConsentFromCookie } from 'c15t/v3/modules/persistence';
 import { defu } from 'defu';
 import { computed } from 'vue';
 import {

--- a/packages/vue/src/runtime/server/manifest-mode.ts
+++ b/packages/vue/src/runtime/server/manifest-mode.ts
@@ -1,3 +1,4 @@
+import { c15tVersionHeaders } from '@c15t/core/v3';
 import type {
 	ConsentManifest,
 	InitOutput,
@@ -8,7 +9,6 @@ import {
 	extractConsentRequestInputs,
 	resolveInitFromManifest,
 } from '@c15t/schema/types';
-import { c15tVersionHeaders } from 'c15t/v3';
 import type { ConsentConfig } from '../config';
 import { DEFAULT_MANIFEST_ROUTE, DEFAULT_NUXT_INIT_ROUTE } from '../manifest';
 

--- a/packages/vue/src/runtime/utils/symbols.ts
+++ b/packages/vue/src/runtime/utils/symbols.ts
@@ -1,7 +1,7 @@
+import type { ConsentKernel, ConsentSnapshot } from '@c15t/core/v3';
+import type { Consent } from '@c15t/core/v3/consent-record';
 import type { InitOutput } from '@c15t/schema';
 import type { ConsentActiveUI } from '@c15t/schema/config';
-import type { ConsentKernel, ConsentSnapshot } from 'c15t/v3';
-import type { Consent } from 'c15t/v3/consent-record';
 import type { InjectionKey, Ref } from 'vue';
 import type { VueConsentKernelContext } from '../kernel';
 

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -27,32 +27,32 @@ export default mergeConfig(
 				),
 				// Point c15t/v3 at source so v3 changes in core don't
 				// need a rebuild before these tests can run.
-				'c15t/v3/modules/script-loader': resolve(
+				'@c15t/core/v3/modules/script-loader': resolve(
 					__dirname,
 					'../core/src/v3/modules/script-loader/index.ts'
 				),
-				'c15t/v3/modules/network-blocker': resolve(
+				'@c15t/core/v3/modules/network-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/network-blocker/index.ts'
 				),
-				'c15t/v3/modules/iframe-blocker': resolve(
+				'@c15t/core/v3/modules/iframe-blocker': resolve(
 					__dirname,
 					'../core/src/v3/modules/iframe-blocker/index.ts'
 				),
-				'c15t/v3/modules/persistence': resolve(
+				'@c15t/core/v3/modules/persistence': resolve(
 					__dirname,
 					'../core/src/v3/modules/persistence/index.ts'
 				),
-				'c15t/v3/modules/window-debug': resolve(
+				'@c15t/core/v3/modules/window-debug': resolve(
 					__dirname,
 					'../core/src/v3/modules/window-debug/index.ts'
 				),
-				'c15t/v3/consent-record': resolve(
+				'@c15t/core/v3/consent-record': resolve(
 					__dirname,
 					'../core/src/v3/consent-record/index.ts'
 				),
-				'c15t/v3': resolve(__dirname, '../core/src/v3/index.ts'),
-				c15t: resolve(__dirname, '../core/src/index.ts'),
+				'@c15t/core/v3': resolve(__dirname, '../core/src/v3/index.ts'),
+				'@c15t/core': resolve(__dirname, '../core/src/index.ts'),
 				'@c15t/translations/all': resolve(
 					__dirname,
 					'../translations/src/all.ts'

--- a/scripts/generate-package-docs.ts
+++ b/scripts/generate-package-docs.ts
@@ -15,7 +15,7 @@ type PackageDocsConfig = {
 
 const PACKAGE_DOCS_CONFIGS: PackageDocsConfig[] = [
 	{
-		name: 'c15t',
+		name: '@c15t/core',
 		outDir: 'packages/core',
 		summary:
 			'Core JavaScript consent management docs for c15t, including client modes, script loading, callbacks, and integrations.',

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,7 @@
 			],
 			"env": ["WITH_RSDOCTOR"]
 		},
-		"c15t#build": {
+		"@c15t/core#build": {
 			"dependsOn": ["^build"],
 			"inputs": ["$TURBO_DEFAULT$", ".env*"],
 			"outputs": ["dist/**", "dist-types/**", "AGENTS.md", "docs/**"],
@@ -89,7 +89,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/backend#dev",
 				"@c15t/iab#dev",
 				"@c15t/logger#dev",
@@ -106,7 +106,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/nextjs#dev",
 				"@c15t/react#dev",
@@ -120,7 +120,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/schema#dev",
 				"@c15t/translations#dev",
@@ -132,7 +132,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/nextjs#dev",
 				"@c15t/react#dev",
@@ -146,7 +146,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/nextjs#dev",
 				"@c15t/react#dev",
@@ -160,7 +160,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/nextjs#dev",
 				"@c15t/react#dev",
@@ -174,7 +174,7 @@
 			"persistent": true,
 			"interruptible": true,
 			"with": [
-				"c15t#dev",
+				"@c15t/core#dev",
 				"@c15t/logger#dev",
 				"@c15t/nextjs#dev",
 				"@c15t/react#dev",


### PR DESCRIPTION
Renames the workspace package in `packages/core` from `c15t` to `@c15t/core`. The published `c15t` npm name lives on as the umbrella package introduced in the next PR of this stack, so the name continues without interruption — this layer is the internal rename only.

Refs #944.

## Scope

- Package manifest, every workspace dependency edge, and every import specifier (including `c15t/v3/*` in benchmarks, examples, and the conformance suite)
- `turbo.json` task keys (`c15t#build` → `@c15t/core#build`), `generate-package-docs` config, `.changeset/config.json` linked group, README regeneration
- Deliberately untouched: docs prose and code samples (users still install `c15t`), CLI constants naming the installable package, and runtime strings (`c15t` cookie, `c15t-ui-*` class prefixes, `/api/c15t/*` routes)

## Validation

Full build (38/38), check-types (60/60), script tests, and the full test suite. The only failures are 7 pre-existing a11y conformance failures in `@c15t/nextjs` that reproduce identically on `origin/v3`.

## Release note

`@c15t/core` is a new npm name — trusted publishing needs to be provisioned for it before the v3 release.