### PR TITLE
fix(core): restore enabled false behavior

### DIFF
--- a/.changeset/curly-snails-grant.md
+++ b/.changeset/curly-snails-grant.md
@@ -1,0 +1,5 @@
+---
+'c15t': patch
+---
+
+Restore the `enabled: false` behavior so all client-side consents are granted, initialization requests are skipped, and consent-gated scripts load immediately.

--- a/packages/core/src/__tests__/store-script-loader.test.ts
+++ b/packages/core/src/__tests__/store-script-loader.test.ts
@@ -177,6 +177,27 @@ describe('Store Script Loader Integration', () => {
 	}
 
 	describe('Script Management in Store', () => {
+		it('should load consent-gated scripts when disabled', () => {
+			const onBeforeLoad = vi.fn();
+			const store = createConsentManagerStore(mockConsentManager, {
+				enabled: false,
+				scripts: [
+					{
+						id: 'measurement-callback',
+						category: 'measurement',
+						callbackOnly: true,
+						onBeforeLoad,
+					},
+				],
+			});
+
+			expect(store.getState().has('measurement')).toBe(true);
+			expect(store.getState().isScriptLoaded('measurement-callback')).toBe(
+				true
+			);
+			expect(onBeforeLoad).toHaveBeenCalledOnce();
+		});
+
 		it('should add scripts to the store', () => {
 			const store = createTestStore();
 

--- a/packages/core/src/runtime/__tests__/index.test.ts
+++ b/packages/core/src/runtime/__tests__/index.test.ts
@@ -227,6 +227,7 @@ describe('runtime', () => {
 		expect(createConsentManagerStoreMock).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
+				enabled: false,
 				iab,
 				storageConfig,
 				initialTranslationConfig: {

--- a/packages/core/src/store/__tests__/consent-store.test.ts
+++ b/packages/core/src/store/__tests__/consent-store.test.ts
@@ -82,6 +82,33 @@ describe('Consent Store', () => {
 			expect(state.consents.experience).toBe(false);
 		});
 
+		it('should grant all consents without initializing when disabled', async () => {
+			const store = createConsentManagerStore(mockManager, {
+				enabled: false,
+			});
+			const state = store.getState();
+
+			expect(state.consents).toEqual({
+				necessary: true,
+				marketing: true,
+				measurement: true,
+				functionality: true,
+				experience: true,
+			});
+			expect(state.selectedConsents).toEqual(state.consents);
+			expect(state.hasConsented()).toBe(true);
+			expect(state.activeUI).toBe('none');
+			expect(state.isLoadingConsentInfo).toBe(false);
+			expect(mockManager.init).not.toHaveBeenCalled();
+
+			await expect(state.initConsentManager()).resolves.toBeUndefined();
+			await expect(
+				state.setOverrides({ country: 'US' })
+			).resolves.toBeUndefined();
+			expect(store.getState().overrides).toEqual({ country: 'US' });
+			expect(mockManager.init).not.toHaveBeenCalled();
+		});
+
 		it('should set namespace correctly', () => {
 			const store = createConsentManagerStore(mockManager, {
 				namespace: 'customStore',

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -174,7 +174,7 @@ export const createConsentManagerStore = (
 		initialConsentCategories,
 		initialTranslationConfig: legacyInitialTranslationConfig,
 		initialI18nConfig,
-		enabled: _unusedEnabled,
+		enabled = true,
 		debug: _unusedDebug,
 		// The rest are valid StoreConfig properties
 		...storeConfigOptions
@@ -192,6 +192,43 @@ export const createConsentManagerStore = (
 
 	// Load initial state from localStorage if available
 	const storedConsent = getStoredConsent(options.storageConfig);
+	const getInitialConsentState = (): Partial<ConsentStoreState> => {
+		if (!enabled) {
+			const grantedConsents = consentTypes.reduce((acc, consent) => {
+				acc[consent.name] = true;
+				return acc;
+			}, {} as ConsentState);
+
+			return {
+				consents: grantedConsents,
+				selectedConsents: grantedConsents,
+				consentInfo: { time: Date.now() },
+				activeUI: 'none',
+				isLoadingConsentInfo: false,
+			};
+		}
+
+		if (storedConsent) {
+			return {
+				consents: storedConsent.consents,
+				selectedConsents: storedConsent.consents,
+				consentInfo: storedConsent.consentInfo,
+				user: storedConsent.consentInfo?.externalId
+					? {
+							id: storedConsent.consentInfo.externalId,
+							identityProvider: storedConsent.consentInfo.identityProvider,
+						}
+					: undefined,
+				activeUI: 'none',
+				isLoadingConsentInfo: false,
+			};
+		}
+
+		return {
+			activeUI: 'none',
+			isLoadingConsentInfo: true,
+		};
+	};
 	const consentChangeListeners = new Set<Callback<OnConsentChangedPayload>>();
 	const inFlightConsentSaves = new Map<string, Promise<void>>();
 	const inFlightPolicyConsents = new Map<string, Promise<PostSubjectOutput>>();
@@ -206,24 +243,7 @@ export const createConsentManagerStore = (
 		...(initialConsentCategories && {
 			consentCategories: initialConsentCategories,
 		}),
-		...(storedConsent
-			? {
-					consents: storedConsent.consents,
-					selectedConsents: storedConsent.consents,
-					consentInfo: storedConsent.consentInfo,
-					user: storedConsent.consentInfo?.externalId
-						? {
-								id: storedConsent.consentInfo.externalId,
-								identityProvider: storedConsent.consentInfo.identityProvider,
-							}
-						: undefined,
-					activeUI: 'none' as const,
-					isLoadingConsentInfo: false,
-				}
-			: {
-					activeUI: 'none' as const,
-					isLoadingConsentInfo: true,
-				}),
+		...getInitialConsentState(),
 		setActiveUI: (ui, options = {}) => {
 			if (ui === 'none' || ui === 'dialog') {
 				set({ activeUI: ui });
@@ -394,8 +414,12 @@ export const createConsentManagerStore = (
 		},
 		setLocationInfo: (location) => set({ locationInfo: location }),
 
-		initConsentManager: (): Promise<ConsentBannerResponse | undefined> =>
-			initConsentManager({
+		initConsentManager: (): Promise<ConsentBannerResponse | undefined> => {
+			if (!enabled) {
+				return Promise.resolve(undefined);
+			}
+
+			return initConsentManager({
 				manager,
 				ssrData: options.ssrData,
 				backendURL: internalOptions.__internal?.backendURL,
@@ -404,7 +428,8 @@ export const createConsentManagerStore = (
 				iabConfig: iab as IABConfig | undefined,
 				get,
 				set,
-			}),
+			});
+		},
 
 		getDisplayedConsents: () => {
 			const { consentCategories, consentTypes } = get();
@@ -638,6 +663,9 @@ export const createConsentManagerStore = (
 			overrides: ConsentStoreState['overrides']
 		): Promise<ConsentBannerResponse | undefined> => {
 			set({ overrides: { ...get().overrides, ...overrides } });
+			if (!enabled) {
+				return undefined;
+			}
 
 			return await initConsentManager({
 				manager,
@@ -702,7 +730,11 @@ export const createConsentManagerStore = (
 			store.getState().identifyUser(options.user);
 		}
 
-		store.getState().initConsentManager();
+		if (enabled) {
+			store.getState().initConsentManager();
+		} else {
+			store.getState().updateScripts();
+		}
 	}
 
 	return store;

--- a/packages/react/src/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/providers/__tests__/provider-basic.test.tsx
@@ -9,6 +9,20 @@ import { clearConsentRuntimeCache } from '../consent-manager-provider';
 const mockFetch = vi.fn();
 window.fetch = mockFetch;
 
+const DisabledStateProbe = () => {
+	const { activeUI, has, hasConsented } = useConsentManager();
+
+	return (
+		<output data-testid="disabled-state">
+			{JSON.stringify({
+				measurement: has('measurement'),
+				hasConsented: hasConsented(),
+				activeUI,
+			})}
+		</output>
+	);
+};
+
 describe('ConsentManagerProvider Basic Request Behavior', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
@@ -64,6 +78,33 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 		expect(mockFetch).toHaveBeenCalledWith(
 			expect.stringContaining('/api/c15t/init'),
 			expect.any(Object)
+		);
+	});
+
+	it('should grant all consents without initializing when disabled', async () => {
+		const { getByTestId } = await render(
+			<ConsentManagerProvider
+				options={{
+					mode: 'hosted',
+					backendURL: '/api/c15t',
+					consentCategories: ['necessary', 'measurement', 'marketing'],
+					storageConfig: { storageKey: 'disabled-provider' },
+					enabled: false,
+				}}
+			>
+				<DisabledStateProbe />
+			</ConsentManagerProvider>
+		);
+
+		await vi.runAllTimersAsync();
+
+		expect(mockFetch).not.toHaveBeenCalled();
+		expect(getByTestId('disabled-state')).toHaveTextContent(
+			JSON.stringify({
+				measurement: true,
+				hasConsented: true,
+				activeUI: 'none',
+			})
 		);
 	});
 


### PR DESCRIPTION
## Summary

- restore the documented `enabled: false` behavior by granting all client-side consents
- skip mount, manual, and override-triggered initialization while disabled
- load configured consent-gated scripts immediately and add core/runtime/React regression coverage

## Testing

- `bun run --cwd packages/core test` (527 tests)
- `bun run --cwd packages/react test src/providers/__tests__/provider-basic.test.tsx` (7 tests)
- `bun turbo run check-types lint --filter=c15t`

Closes #1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling consent management with the `enabled: false` option.
  * When disabled, all consent categories are granted automatically, the consent UI is hidden, and initialization requests are skipped.
  * Consent-gated scripts load immediately, including callback-only scripts.

* **Bug Fixes**
  * Restored expected behavior for disabled consent management across store and provider integrations.

* **Tests**
  * Added coverage for disabled-state consent, script loading, provider behavior, and option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->