### PR TITLE
fix(backend): support native WebView app schemes in trustedOrigins

### DIFF
--- a/.changeset/tidy-jars-cheat.md
+++ b/.changeset/tidy-jars-cheat.md
@@ -4,7 +4,7 @@
 
 Support native WebView app schemes in `trustedOrigins`
 
-Origins such as `capacitor://localhost` (the default iOS Capacitor origin), `ionic://localhost`, and custom `iosScheme` values can now be used as trusted origins and are matched on scheme and host:
+Origins such as `capacitor://localhost` (the default iOS Capacitor origin), `ionic://localhost`, and custom `iosScheme` values can now be used as trusted origins, matched on both scheme and host:
 
 ```ts
 trustedOrigins: [
@@ -14,10 +14,4 @@ trustedOrigins: [
 ];
 ```
 
-Previously the CORS layer prefixed any entry lacking an `http(s)`/`ws(s)` scheme with `http://`, so `capacitor://localhost` parsed as the hostname `capacitor`. That collapsed every `capacitor://` origin onto a single host, and the two origin matchers disagreed about which requests to allow.
-
-This also closes a hole where trusting `capacitor://localhost` implicitly trusted every other host on that scheme, such as `capacitor://evil.com`.
-
-Only entries that explicitly name an app scheme change behaviour, and those did not work correctly before. Entries with no scheme or an `http(s)`/`ws(s)` scheme remain protocol-agnostic and match exactly as they did previously, so existing configurations are unaffected.
-
-If you set a custom `server.hostname` in your Capacitor config, list the origin your WebView actually sends (e.g. `capacitor://app.example.com`) rather than `capacitor://localhost` — the previous behaviour accepted either.
+Entries with no scheme or an `http(s)`/`ws(s)` scheme are unchanged. An entry naming an app scheme is now pinned to it, which narrows two cases that were broken before: `capacitor://localhost` no longer trusts `capacitor://evil.com`, and no longer matches `https://localhost`. List every origin you serve.

--- a/.changeset/tidy-jars-cheat.md
+++ b/.changeset/tidy-jars-cheat.md
@@ -1,0 +1,23 @@
+---
+'@c15t/backend': patch
+---
+
+Support native WebView app schemes in `trustedOrigins`
+
+Origins such as `capacitor://localhost` (the default iOS Capacitor origin), `ionic://localhost`, and custom `iosScheme` values can now be used as trusted origins and are matched on scheme and host:
+
+```ts
+trustedOrigins: [
+  'https://app.example.com', // your web app
+  'capacitor://localhost', // iOS
+  'http://localhost', // Android
+];
+```
+
+Previously the CORS layer prefixed any entry lacking an `http(s)`/`ws(s)` scheme with `http://`, so `capacitor://localhost` parsed as the hostname `capacitor`. That collapsed every `capacitor://` origin onto a single host, and the two origin matchers disagreed about which requests to allow.
+
+This also closes a hole where trusting `capacitor://localhost` implicitly trusted every other host on that scheme, such as `capacitor://evil.com`.
+
+Only entries that explicitly name an app scheme change behaviour, and those did not work correctly before. Entries with no scheme or an `http(s)`/`ws(s)` scheme remain protocol-agnostic and match exactly as they did previously, so existing configurations are unaffected.
+
+If you set a custom `server.hostname` in your Capacitor config, list the origin your WebView actually sends (e.g. `capacitor://app.example.com`) rather than `capacitor://localhost` — the previous behaviour accepted either.

--- a/docs/self-host/guides/framework-integration.mdx
+++ b/docs/self-host/guides/framework-integration.mdx
@@ -143,3 +143,36 @@ Features:
 - Wildcard subdomain matching with `*`
 - `localhost` is allowed in development
 - Preflight `OPTIONS` requests are handled automatically
+
+### Native WebViews (Capacitor, Cordova/Ionic)
+
+Entries without a scheme, or with `http(s)`, match either protocol. Native
+WebView shells serve the app from a custom scheme instead, so those origins must
+be listed in full:
+
+```ts
+c15tInstance({
+  trustedOrigins: [
+    'https://app.example.com', // your web app
+    'capacitor://localhost', // iOS (Capacitor default)
+    'http://localhost', // Android
+  ],
+  // ...
+});
+```
+
+An entry that names an app scheme is pinned to it: `capacitor://localhost` is a
+different origin from `https://localhost`, and it only matches that exact scheme
+and host — adding `capacitor://localhost` does not trust
+`capacitor://anything-else`.
+
+<Callout type="info">
+  iOS defaults to `capacitor://localhost`. Apps migrated from
+  `cordova-plugin-ionic-webview` use `ionic://localhost`, and a custom
+  [`iosScheme`](https://capacitorjs.com/docs/config#schema) produces
+  `yourscheme://localhost` — list whichever your app actually sends. A custom
+  `server.hostname` replaces the `localhost` half, giving
+  `capacitor://app.example.com`. Android serves from `http://` and needs no
+  special handling. When in doubt, read the `Origin` header off the failing
+  request rather than guessing.
+</Callout>

--- a/packages/backend/src/middleware/cors/app-scheme.test.ts
+++ b/packages/backend/src/middleware/cors/app-scheme.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { createCORSOptions } from './cors';
+import { isOriginTrusted } from './is-origin-trusted';
+
+/**
+ * Native WebView shells (Capacitor, Cordova/Ionic) serve the app from a custom
+ * scheme rather than http(s), so `capacitor://localhost` must be usable as a
+ * trusted origin without also trusting every other `capacitor://` host.
+ */
+const allowedOrigin = (
+	trustedOrigins: string[],
+	origin: string
+): string | null => {
+	const { origin: resolve } = createCORSOptions(trustedOrigins);
+	return typeof resolve === 'function' ? resolve(origin) : resolve;
+};
+
+describe('app-scheme trusted origins', () => {
+	describe('isOriginTrusted', () => {
+		it('trusts an app-scheme origin listed verbatim', () => {
+			expect(
+				isOriginTrusted('capacitor://localhost', ['capacitor://localhost'])
+			).toBe(true);
+			expect(isOriginTrusted('ionic://localhost', ['ionic://localhost'])).toBe(
+				true
+			);
+			expect(isOriginTrusted('myapp://localhost', ['myapp://localhost'])).toBe(
+				true
+			);
+		});
+
+		it('does not let one app-scheme entry trust other hosts', () => {
+			expect(
+				isOriginTrusted('capacitor://evil.com', ['capacitor://localhost'])
+			).toBe(false);
+		});
+
+		it('does not match across schemes', () => {
+			expect(
+				isOriginTrusted('ionic://localhost', ['capacitor://localhost'])
+			).toBe(false);
+			expect(
+				isOriginTrusted('https://localhost', ['capacitor://localhost'])
+			).toBe(false);
+		});
+
+		it('leaves entries without an app scheme protocol-agnostic', () => {
+			// Pre-existing behaviour: an entry that names no scheme matches any
+			// scheme on that host, app schemes included. Narrowing this would break
+			// deployments that list a bare host and serve a native WebView.
+			expect(isOriginTrusted('capacitor://localhost', ['localhost'])).toBe(
+				true
+			);
+			expect(
+				isOriginTrusted('capacitor://app.example.com', ['*.example.com'])
+			).toBe(true);
+		});
+
+		it('keeps web origins protocol-agnostic', () => {
+			expect(isOriginTrusted('https://example.com', ['example.com'])).toBe(
+				true
+			);
+			expect(
+				isOriginTrusted('http://example.com', ['https://example.com'])
+			).toBe(true);
+			expect(isOriginTrusted('wss://example.com', ['example.com'])).toBe(true);
+		});
+
+		it('still trusts the Android WebView origin', () => {
+			expect(isOriginTrusted('http://localhost', ['http://localhost'])).toBe(
+				true
+			);
+		});
+	});
+
+	describe('createCORSOptions', () => {
+		it('echoes an app-scheme origin that is trusted', () => {
+			expect(
+				allowedOrigin(['capacitor://localhost'], 'capacitor://localhost')
+			).toBe('capacitor://localhost');
+		});
+
+		it('rejects other hosts on the same app scheme', () => {
+			expect(
+				allowedOrigin(['capacitor://localhost'], 'capacitor://evil.com')
+			).toBeNull();
+		});
+
+		it('rejects other schemes on the same host', () => {
+			expect(
+				allowedOrigin(['capacitor://localhost'], 'ionic://localhost')
+			).toBeNull();
+			expect(
+				allowedOrigin(['capacitor://localhost'], 'https://localhost')
+			).toBeNull();
+		});
+
+		it('supports a Capacitor app alongside its web origins', () => {
+			const trusted = [
+				'https://app.example.com',
+				'capacitor://localhost',
+				'http://localhost',
+			];
+			expect(allowedOrigin(trusted, 'capacitor://localhost')).toBe(
+				'capacitor://localhost'
+			);
+			expect(allowedOrigin(trusted, 'https://app.example.com')).toBe(
+				'https://app.example.com'
+			);
+			expect(allowedOrigin(trusted, 'http://localhost')).toBe(
+				'http://localhost'
+			);
+		});
+
+		it('does not expand app schemes with a www variant', () => {
+			expect(
+				allowedOrigin(['capacitor://localhost'], 'capacitor://www.localhost')
+			).toBeNull();
+		});
+	});
+});

--- a/packages/backend/src/middleware/cors/app-scheme.test.ts
+++ b/packages/backend/src/middleware/cors/app-scheme.test.ts
@@ -44,6 +44,24 @@ describe('app-scheme trusted origins', () => {
 			).toBe(false);
 		});
 
+		it('matches app-scheme hosts verbatim, without www equivalence', () => {
+			expect(
+				isOriginTrusted('capacitor://www.localhost', ['capacitor://localhost'])
+			).toBe(false);
+			expect(
+				isOriginTrusted('capacitor://localhost', ['capacitor://www.localhost'])
+			).toBe(false);
+		});
+
+		it('keeps www equivalence for web entries', () => {
+			expect(isOriginTrusted('https://www.example.com', ['example.com'])).toBe(
+				true
+			);
+			expect(isOriginTrusted('https://example.com', ['www.example.com'])).toBe(
+				true
+			);
+		});
+
 		it('leaves entries without an app scheme protocol-agnostic', () => {
 			// Pre-existing behaviour: an entry that names no scheme matches any
 			// scheme on that host, app schemes included. Narrowing this would break

--- a/packages/backend/src/middleware/cors/app-scheme.ts
+++ b/packages/backend/src/middleware/cors/app-scheme.ts
@@ -1,0 +1,79 @@
+/**
+ * Helpers for recognising non-web ("app") origin schemes such as the
+ * `capacitor://localhost` origin an iOS Capacitor WebView sends.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Schemes browsers treat as ordinary web origins.
+ *
+ * Trusted-origin entries using one of these (or no scheme at all) stay
+ * protocol-agnostic, which is the behaviour c15t has always had. Any other
+ * scheme is treated as an app scheme and must match exactly.
+ */
+const WEB_SCHEMES = new Set(['http:', 'https:', 'ws:', 'wss:']);
+
+/** Matches a URL scheme prefix (e.g. `https://`, `capacitor://`). */
+const SCHEME_REGEX = /^([a-z][a-z\d+.-]*):\/\//i;
+
+/**
+ * Extracts a non-web scheme from an origin or trusted-origin entry.
+ *
+ * Native WebView shells serve the app from a custom scheme rather than
+ * `http(s)`, so `capacitor://localhost` and `https://localhost` are distinct
+ * origins that must not be conflated. iOS Capacitor defaults to `capacitor:`,
+ * apps migrated from `cordova-plugin-ionic-webview` use `ionic:`, and
+ * `iosScheme` may set any custom value. Android serves from `http://localhost`
+ * and is therefore unaffected.
+ *
+ * @param value - An origin or trusted-origin entry
+ * @returns The lowercased scheme including the trailing colon (e.g.
+ * `capacitor:`), or `undefined` for web schemes and bare hostnames
+ *
+ * @example
+ * ```ts
+ * getAppScheme('capacitor://localhost'); // 'capacitor:'
+ * getAppScheme('https://example.com');   // undefined
+ * getAppScheme('example.com');           // undefined
+ * ```
+ *
+ * @internal
+ */
+export function getAppScheme(value: string): string | undefined {
+	const match = value.trim().match(SCHEME_REGEX);
+	if (!match?.[1]) {
+		return undefined;
+	}
+
+	const scheme = `${match[1].toLowerCase()}:`;
+	return WEB_SCHEMES.has(scheme) ? undefined : scheme;
+}
+
+/**
+ * Splits an app-scheme origin into its scheme and authority.
+ *
+ * `URL` reports `null` for the `origin` of a non-special scheme, so the
+ * authority is read from the raw string instead of a parsed URL.
+ *
+ * @param value - An origin or trusted-origin entry known to carry an app scheme
+ * @param scheme - The scheme returned by {@link getAppScheme}
+ * @returns The scheme and lowercased authority (host and optional port), or
+ * `null` when no authority is present
+ *
+ * @internal
+ */
+export function splitAppSchemeOrigin(
+	value: string,
+	scheme: string
+): { scheme: string; authority: string } | null {
+	const withoutScheme = value.trim().slice(scheme.length + 2);
+	// The authority ends at the first path, query, or fragment marker.
+	const authority = withoutScheme.split(/[/?#]/)[0]?.toLowerCase();
+
+	if (!authority) {
+		return null;
+	}
+
+	return { scheme, authority };
+}

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import { getAppScheme, splitAppSchemeOrigin } from './app-scheme';
 import { matchesWildcard } from './matches-wildcard';
 
 /**
@@ -53,10 +54,23 @@ const SUPPORTED_HEADERS = [
 /**
  * Normalizes an origin string by removing protocol and www prefix
  *
+ * App-scheme origins (e.g. `capacitor://localhost`) keep their scheme, because
+ * the scheme is what distinguishes them from the same host served over
+ * `http(s)`. Prefixing them with `http://` — as the generic path below does for
+ * bare hosts — would parse the scheme itself as the hostname and collapse every
+ * `capacitor://*` origin onto the single host `capacitor`.
+ *
  * @param origin - The origin URL to normalize
- * @returns Normalized origin string without protocol and www prefix
+ * @returns Normalized origin string without protocol and www prefix, or
+ * `scheme://authority` for app-scheme origins
  */
 function normalizeOrigin(origin: string): string {
+	const appScheme = getAppScheme(origin);
+	if (appScheme) {
+		const split = splitAppSchemeOrigin(origin, appScheme);
+		return split ? `${split.scheme}//${split.authority}` : origin.toLowerCase();
+	}
+
 	try {
 		// Handle bare domains like 'localhost' or 'example.com'
 		if (
@@ -99,6 +113,10 @@ function expandWithWWW(origins: string[]): string[] {
 		}
 		const normalized = normalizeOrigin(origin);
 		expanded.add(normalized);
+		// App-scheme origins are native WebView hosts, never www-prefixed domains
+		if (getAppScheme(normalized)) {
+			continue;
+		}
 		// Add www version if not already present
 		if (!normalized.includes('www.')) {
 			expanded.add(`www.${normalized}`);

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -187,11 +187,16 @@ export function isOriginTrusted(
 				return isMatch;
 			}
 
-			const normalizedOriginHostname = originHostname.replace(WWW_REGEX, '');
-			const normalizedTrustedHostname = normalizedDomain.hostname.replace(
-				WWW_REGEX,
-				''
-			);
+			// `www.` equivalence is a web-domain convention. App-scheme hosts are
+			// matched verbatim, so `capacitor://localhost` never trusts the distinct
+			// origin `capacitor://www.localhost`.
+			const stripWww = !normalizedDomain.scheme;
+			const normalizedOriginHostname = stripWww
+				? originHostname.replace(WWW_REGEX, '')
+				: originHostname;
+			const normalizedTrustedHostname = stripWww
+				? normalizedDomain.hostname.replace(WWW_REGEX, '')
+				: normalizedDomain.hostname;
 			const isMatch = normalizedOriginHostname === normalizedTrustedHostname;
 			logger?.debug(
 				`Exact match result: ${isMatch} ${normalizedOriginHostname} === ${normalizedTrustedHostname}`

--- a/packages/backend/src/middleware/cors/is-origin-trusted.ts
+++ b/packages/backend/src/middleware/cors/is-origin-trusted.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Logger } from '@c15t/logger';
+import { getAppScheme } from './app-scheme';
 import { matchesWildcard } from './matches-wildcard';
 
 /** Regular expression to match www prefix in domain names */
@@ -22,6 +23,11 @@ const DEFAULT_PORTS: Record<string, string> = {
 };
 
 interface NormalizedTrustedDomain {
+	/**
+	 * Non-web scheme the entry is pinned to (e.g. `capacitor:`), or `undefined`
+	 * when the entry is protocol-agnostic.
+	 */
+	scheme?: string;
 	hostname: string;
 	port?: string;
 }
@@ -62,6 +68,9 @@ function normalizeTrustedDomain(
 		const parsed = new URL(hasProtocol ? trimmed : `https://${authority}`);
 
 		return {
+			// Pin the entry to its scheme only when it is an app scheme, so
+			// existing http/https/bare-host entries stay protocol-agnostic.
+			scheme: getAppScheme(trimmed),
 			hostname: parsed.hostname.toLowerCase(),
 			// Read the port from the raw input rather than `parsed.port`, which
 			// drops scheme-default ports such as `:443` on https.
@@ -125,6 +134,9 @@ export function isOriginTrusted(
 		// Parse the origin URL to get host components
 		const url = new URL(origin);
 		const originHostname = url.hostname.toLowerCase();
+		// `undefined` for ordinary web origins; `capacitor:` and friends for
+		// native WebView origins, which only ever match a same-scheme entry.
+		const originScheme = getAppScheme(origin);
 		// Resolve the scheme default (e.g. 443 for https) so a trusted entry
 		// like `example.com:443` still matches `https://example.com`.
 		const originPort = url.port || DEFAULT_PORTS[url.protocol] || undefined;
@@ -146,6 +158,16 @@ export function isOriginTrusted(
 			logger?.debug(
 				`Checking against stripped domain: ${normalizedDomain.hostname}`
 			);
+
+			// An entry that names an app scheme is pinned to it: `capacitor://localhost`
+			// and `https://localhost` are different origins. Entries without one stay
+			// protocol-agnostic, matching any scheme exactly as they always have.
+			if (normalizedDomain.scheme && normalizedDomain.scheme !== originScheme) {
+				logger?.debug(
+					`Scheme mismatch: ${originScheme ?? '<web>'} !== ${normalizedDomain.scheme}`
+				);
+				return false;
+			}
 
 			if (normalizedDomain.port && normalizedDomain.port !== originPort) {
 				logger?.debug(


### PR DESCRIPTION
## Overview

Origins such as `capacitor://localhost` — the default origin an iOS Capacitor WebView sends — could not be used as trusted origins, so Capacitor/Ionic apps got a CORS error on every request. Android was unaffected because it serves from `http://localhost`.

`normalizeOrigin` prefixed any entry lacking an `http(s)`/`ws(s)` scheme with `http://`, so `capacitor://localhost` became `http://capacitor://localhost`, which `new URL()` parses with hostname **`capacitor`** and path `//localhost`. Two consequences:

1. Every `capacitor://` origin collapsed onto the single host `capacitor`, so a trusted `capacitor://localhost` **also trusted `capacitor://evil.com`**.
2. The two origin matchers disagreed — `isOriginTrusted` (edge `/init`) ignored schemes entirely while `createCORSOptions` (Hono path) collapsed them, so the same request could be allowed by one and denied by the other.

The fix adds a shared `app-scheme` helper used by both matchers, so they can't drift apart again.

## Related Issue

Fixes # (issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (improves existing functionality)
- [x] 📚 Documentation

## Implementation Details

### Key Changes

1. **`app-scheme.ts` (new)** — recognises non-web schemes and splits them into scheme + authority. `URL` reports `null` for the `origin` of a non-special scheme, so the authority is read from the raw string.
2. **`cors.ts`** — `normalizeOrigin` preserves app schemes instead of prefixing `http://`; `www.` expansion no longer applies to them.
3. **`is-origin-trusted.ts`** — an entry naming an app scheme is pinned to it; entries without one stay protocol-agnostic.

### Technical Notes

The pinning is deliberately one-directional. An entry that **names** an app scheme is pinned to it, but an entry **without** one keeps matching any scheme on that host, exactly as before:

```ts
isOriginTrusted('capacitor://localhost', ['localhost']); // true, unchanged
isOriginTrusted('capacitor://evil.com', ['capacitor://localhost']); // false, was true
```

Tightening the first case would have been the more "correct" model, but it would break deployments that list a bare host and serve a native WebView against edge `/init`. Preserving it keeps this a patch.

## Testing

### Test Plan

- [x] Scenario 1: A Capacitor app can be trusted alongside its web origins

  ```ts
  trustedOrigins: [
    'https://app.example.com',
    'capacitor://localhost', // iOS
    'http://localhost', // Android
  ];
  ```

  ✓ Expected: all three origins receive `access-control-allow-origin`

- [x] Scenario 2: An app-scheme entry does not trust other hosts on that scheme

  ```ts
  createCORSOptions(['capacitor://localhost']).origin('capacitor://evil.com');
  ```

  ✓ Expected: `null` (previously echoed the origin)

### Edge Cases

- [x] Security: closes cross-host trust on a shared app scheme. `capacitor://localhost` no longer implies `capacitor://evil.com`.
- [x] Error handling: unparseable entries still fall through the existing `try`/`catch` and are skipped rather than throwing.
- [x] Performance: matching stays a string comparison per entry; no added parsing on the hot path for web origins.

Verified locally: **563 backend tests pass across 38 files** (45 in the CORS suite, 15 of them new), `check-types` clean, Biome clean, docs lint clean.

## Checklist

### Required

- [ ] Issue is linked
- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes

Not breaking for any correct configuration — entries with no scheme or an `http(s)`/`ws(s)` scheme match exactly as they did before. Two narrowings apply only to entries that explicitly name an app scheme, which did not work correctly beforehand:

- `capacitor://localhost` no longer trusts `capacitor://evil.com` (the security fix)
- `capacitor://localhost` no longer trusts `https://localhost`

One way an existing deployment could notice: if you set a custom `server.hostname` in your Capacitor config, your WebView sends `capacitor://app.example.com`, and the old collapse bug accepted a mismatched `capacitor://localhost` entry. List the origin your app actually sends.

```ts
// Before — accepted by accident when server.hostname was customised
trustedOrigins: ['capacitor://localhost'];

// After — list the origin the WebView actually sends
trustedOrigins: ['capacitor://app.example.com'];
```

---

⚠️ **This does not fully unblock the reported issue.** The customer's stated blocker is that the hosted console refuses to accept `capacitor://localhost` under Trusted Origins. There is no trusted-origin format validation anywhere in this repo — `packages/schema` has no origin schema, the backend accepts `trustedOrigins: string[]` unvalidated, and the CLI forwards the array to the control plane without checking it. That rejection lives in the console/control-plane service. This PR makes the backend correct once the value can be saved; the console-side validation needs a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for native WebView application schemes in trusted CORS origins, including Capacitor, Ionic, Cordova, and custom iOS schemes.
  * Enforced exact scheme-and-host matching to prevent unintended cross-host trust.
  * Preserved existing behavior for web, socket, and unschemed origins.
* **Documentation**
  * Added guidance for configuring native WebView origins, platform defaults, and custom hostnames.
* **Bug Fixes**
  * Corrected origin parsing and validation for custom application schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->