### PR TITLE
fix(backend): correct www handling in CORS origin matching

### DIFF
--- a/.changeset/olive-pugs-marry.md
+++ b/.changeset/olive-pugs-marry.md
@@ -1,0 +1,14 @@
+---
+'@c15t/backend': patch
+---
+
+Fix `www` handling in CORS origin matching
+
+Two trusted-origin configurations did not match the origins they should:
+
+- `*.example.com` rejected `https://www.example.com` while allowing every other subdomain. The incoming origin was `www`-stripped to the apex before matching, and a `*.` wildcard deliberately excludes the apex.
+- A schemeless `www.example.com` entry matched nothing at all — not the apex, not itself. Schemeless entries skip URL parsing, so `www.` survived normalization on the trusted side while being stripped from the origin. Entries written with a scheme (`https://www.example.com`) were unaffected.
+
+`www.` is no longer stripped from the incoming origin. Equivalence is applied to the trusted list instead, which now carries both the apex and `www.` form of every entry regardless of which was configured.
+
+This widens matching to origins that were previously rejected. Wildcards still exclude the apex (`*.example.com` does not match `example.com`), and unrelated hosts are unaffected — `example.com` still rejects `notexample.com`.

--- a/.changeset/olive-pugs-marry.md
+++ b/.changeset/olive-pugs-marry.md
@@ -4,11 +4,9 @@
 
 Fix `www` handling in CORS origin matching
 
-Two trusted-origin configurations did not match the origins they should:
+Two `trustedOrigins` configurations now match origins they previously rejected:
 
-- `*.example.com` rejected `https://www.example.com` while allowing every other subdomain. The incoming origin was `www`-stripped to the apex before matching, and a `*.` wildcard deliberately excludes the apex.
-- A schemeless `www.example.com` entry matched nothing at all — not the apex, not itself. Schemeless entries skip URL parsing, so `www.` survived normalization on the trusted side while being stripped from the origin. Entries written with a scheme (`https://www.example.com`) were unaffected.
+- `*.example.com` accepts `https://www.example.com`. Every other subdomain already worked.
+- A schemeless `www.example.com` entry accepts both `example.com` and `www.example.com`. It previously matched neither.
 
-`www.` is no longer stripped from the incoming origin. Equivalence is applied to the trusted list instead, which now carries both the apex and `www.` form of every entry regardless of which was configured.
-
-This widens matching to origins that were previously rejected. Wildcards still exclude the apex (`*.example.com` does not match `example.com`), and unrelated hosts are unaffected — `example.com` still rejects `notexample.com`.
+Wildcards still exclude the apex, unrelated hosts are unaffected, and entries written with a scheme are unchanged.

--- a/packages/backend/src/middleware/cors/cors.test.ts
+++ b/packages/backend/src/middleware/cors/cors.test.ts
@@ -86,6 +86,17 @@ describe('createCORSOptions (unit)', () => {
 			);
 		});
 
+		it('allows www from wildcard-only configuration', async () => {
+			// `www` is a subdomain like any other. It previously failed alone
+			// because the origin was www-stripped to the apex before matching,
+			// and the apex is deliberately outside a `*.` wildcard.
+			const config = createCORSOptions(['https://*.example.com']);
+
+			expect(await callOrigin(config.origin, 'https://www.example.com')).toBe(
+				'https://www.example.com'
+			);
+		});
+
 		it('rejects similar domains that are not subdomains', async () => {
 			const config = createCORSOptions(['https://*.example.com']);
 
@@ -135,6 +146,19 @@ describe('createCORSOptions (unit)', () => {
 			const config = createCORSOptions(['http://www.c15t.com']);
 			expect(await callOrigin(config.origin, 'http://c15t.com')).toBe(
 				'http://c15t.com'
+			);
+		});
+
+		it('allows both variants when a schemeless www entry is trusted', async () => {
+			// A schemeless entry skips URL parsing, so `www.` used to survive
+			// normalization on the trusted side while being stripped from the
+			// origin — leaving the entry matching neither form.
+			const config = createCORSOptions(['www.c15t.com']);
+			expect(await callOrigin(config.origin, 'http://c15t.com')).toBe(
+				'http://c15t.com'
+			);
+			expect(await callOrigin(config.origin, 'http://www.c15t.com')).toBe(
+				'http://www.c15t.com'
 			);
 		});
 	});

--- a/packages/backend/src/middleware/cors/cors.test.ts
+++ b/packages/backend/src/middleware/cors/cors.test.ts
@@ -97,6 +97,21 @@ describe('createCORSOptions (unit)', () => {
 			);
 		});
 
+		it('does not widen malformed wildcard entries', async () => {
+			// Deriving an apex by stripping `www.` would turn these into the
+			// allow-all `*` and the far broader `*.example.com` respectively.
+			const allowAll = createCORSOptions(['www.*']);
+			expect(await callOrigin(allowAll.origin, 'https://evil.com')).toBeNull();
+
+			const subdomains = createCORSOptions(['www.*.example.com']);
+			expect(
+				await callOrigin(subdomains.origin, 'https://evil.example.com')
+			).toBeNull();
+			expect(
+				await callOrigin(subdomains.origin, 'https://evil.com')
+			).toBeNull();
+		});
+
 		it('rejects similar domains that are not subdomains', async () => {
 			const config = createCORSOptions(['https://*.example.com']);
 

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -23,8 +23,8 @@ export interface CorsOptions {
 /** Regular expression to match www prefix in domain names */
 const WWW_REGEX = /^www\./;
 
-/** Regular expression to match protocol and www prefix in URLs */
-const PROTOCOL_WWW_REGEX = /^https?:\/\/(www\.)?/;
+/** Regular expression to match a protocol prefix in URLs */
+const PROTOCOL_REGEX = /^https?:\/\//;
 
 /**
  * Supported HTTP methods for CORS
@@ -89,17 +89,22 @@ function normalizeOrigin(origin: string): string {
 				? origin
 				: `http://${origin}`;
 		const url = new URL(originWithProtocol);
-		const hostname = url.hostname.replace(WWW_REGEX, '');
-		// Return without protocol to match both http and https
-		return `${hostname}${url.port ? `:${url.port}` : ''}`;
+		// Return without protocol to match both http and https. The `www.` prefix
+		// is preserved: stripping it here turned `www.example.com` into the apex
+		// `example.com`, which `*.example.com` deliberately excludes. Equivalence
+		// is applied to the trusted list instead, in `expandWithWWW`.
+		return `${url.hostname}${url.port ? `:${url.port}` : ''}`;
 	} catch {
-		// Fallback: remove www manually and protocol
-		return origin.replace(PROTOCOL_WWW_REGEX, '').replace(WWW_REGEX, '');
+		// Fallback: remove the protocol manually
+		return origin.replace(PROTOCOL_REGEX, '').toLowerCase();
 	}
 }
 
 /**
  * Expands a list of origins to include www variants
+ *
+ * Both forms are added regardless of which one was configured, so a
+ * `www.example.com` entry accepts the apex and vice versa.
  *
  * @param origins - Array of origin strings to expand
  * @returns Array of origins including www variants
@@ -117,10 +122,14 @@ function expandWithWWW(origins: string[]): string[] {
 		if (getAppScheme(normalized)) {
 			continue;
 		}
-		// Add www version if not already present
-		if (!normalized.includes('www.')) {
-			expanded.add(`www.${normalized}`);
+		// Wildcards already cover every subdomain, `www` included, and a
+		// `www.*.example.com` entry could never match anything.
+		if (normalized.startsWith('*.')) {
+			continue;
 		}
+		const apex = normalized.replace(WWW_REGEX, '');
+		expanded.add(apex);
+		expanded.add(`www.${apex}`);
 	}
 	return Array.from(expanded);
 }

--- a/packages/backend/src/middleware/cors/cors.ts
+++ b/packages/backend/src/middleware/cors/cors.ts
@@ -122,9 +122,11 @@ function expandWithWWW(origins: string[]): string[] {
 		if (getAppScheme(normalized)) {
 			continue;
 		}
-		// Wildcards already cover every subdomain, `www` included, and a
-		// `www.*.example.com` entry could never match anything.
-		if (normalized.startsWith('*.')) {
+		// Wildcards already cover every subdomain, `www` included. Any entry
+		// carrying a `*` is left verbatim: deriving an apex from one widens it,
+		// turning `www.*` into the allow-all `*` and `www.*.example.com` into
+		// `*.example.com`.
+		if (normalized.includes('*')) {
 			continue;
 		}
 		const apex = normalized.replace(WWW_REGEX, '');


### PR DESCRIPTION
> 📚 Stacked on #1012. Review that one first — this branch contains only the `www` fix.

## Overview

Two trusted-origin configurations silently failed to match the origins they should. Both are pre-existing and unrelated to #1012; I confirmed them against an unmodified `origin/canary` worktree.

| Trusted entry | Origin | Before | After |
|---|---|---|---|
| `*.example.com` | `https://www.example.com` | **null** | allowed |
| `*.example.com` | `https://api.example.com` | allowed | allowed |
| `*.example.com` | `https://example.com` (apex) | null | null |
| `www.example.com` | `https://example.com` | **null** | allowed |
| `www.example.com` | `https://www.example.com` | **null** | allowed |

So `*.example.com` allowed every subdomain *except* `www` — the one people hit first — and a schemeless `www.example.com` entry matched nothing at all, not even itself.

Both trace to one line: `normalizeOrigin` stripped `www.` off the **incoming origin**. That turned `www.example.com` into the apex `example.com`, which a `*.` wildcard deliberately excludes. And because the schemeless branch returns before that strip, a schemeless trusted entry kept a `www.` prefix the normalized origin could never carry.

## Related Issue

Fixes # (issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Implementation Details

### Key Changes

1. **`normalizeOrigin`** — no longer strips `www.`; returns `host[:port]` as-is. The catch-branch fallback strips only the protocol.
2. **`expandWithWWW`** — adds both the apex and the `www.` form of every entry, whichever was configured. Wildcard entries are skipped: they already cover every subdomain, and a `www.*.example.com` entry could never match anything.

### Technical Notes

Moving the equivalence entirely onto the trusted list is what makes both cases work from one change. The origin is now compared verbatim, so wildcard matching sees the real hostname.

`isOriginTrusted` already handled both cases correctly, so this also removes a disagreement between the two matchers.

## Testing

### Test Plan

- [x] Scenario 1: `www` from a wildcard-only config

  ```ts
  createCORSOptions(['https://*.example.com']).origin('https://www.example.com');
  ```

  ✓ Expected: echoes the origin (previously `null`)

- [x] Scenario 2: schemeless `www` entry accepts both forms

  ```ts
  createCORSOptions(['www.c15t.com']).origin('http://c15t.com');
  createCORSOptions(['www.c15t.com']).origin('http://www.c15t.com');
  ```

  ✓ Expected: both echo the origin (previously both `null`)

- [x] Scenario 3: malformed wildcards stay contained

  ```ts
  createCORSOptions(['www.*']).origin('https://evil.com');
  createCORSOptions(['www.*.example.com']).origin('https://evil.example.com');
  ```

  ✓ Expected: `null` for both

### Edge Cases

- [x] Security: this **widens** matching, so it got the most scrutiny. Wildcards still exclude the apex (`*.example.com` ✗ `example.com`), near-miss hosts are still rejected (`example.com` ✗ `notexample.com`, `*.example.com` ✗ `badexample.com`, `example.com.evil.com`), and only the `www.` label is treated as equivalent.
- [x] Malformed wildcards do not widen. Apex derivation is skipped for **any** entry containing `*`, not just those starting with `*.`. An earlier revision of this branch stripped `www.` from `www.*` and produced the allow-all `*`; both that and `www.*.example.com` → `*.example.com` now have regression tests.
- [x] Regression: the `localhost` special case (ports, `127.0.0.1`, `[::1]`), explicit-port scoping, and app-scheme matching from #1012 are all unchanged.

**Why existing tests missed this:** the wildcard suite configured apex *and* wildcard together, so `www` matched via the apex entry's expansion; and the `www` suite only used entries written with a scheme, which took the URL-parsing path where the strip was symmetric. Both gaps now have tests.

568 backend tests pass across 38 files, `check-types` clean, Biome clean.

## Checklist

### Required

- [ ] Issue is linked
- [x] Tests added/updated
- [ ] Documentation updated — no docs change; this restores the behaviour the docs already describe ("wildcard subdomain matching", "`www` variants are automatically allowed")
- [x] Tested locally
- [x] Code follows style guide
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

### Breaking Changes

None in the restrictive direction — no origin that was accepted before is rejected now. This does newly **accept** origins that were previously rejected, which is the fix itself, but worth a deliberate look if you rely on the old behaviour as a de-facto denylist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CORS origin matching for `www` subdomains in wildcard and schemeless configurations.
  * Trusted origins now correctly support both apex and `www` forms.
  * Prevented malformed wildcard entries from unintentionally broadening access.
  * Preserved expected behavior for wildcard apex exclusions and unrelated hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->