### PR TITLE
refactor(cli): type generated package manifests

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -207,7 +207,6 @@ const deferredAntiSlopRules = [
 	'anti-slop/no-conditional-empty-object-spread',
 	'anti-slop/no-known-value-widening',
 	'anti-slop/no-module-mocking',
-	'anti-slop/no-object-parameters',
 	'anti-slop/no-runtime-typeof',
 	'anti-slop/no-shape-in-symbol-names',
 	'anti-slop/no-unknown-parameters',

--- a/packages/cli/src/machines/generate/actors/dependencies.test.ts
+++ b/packages/cli/src/machines/generate/actors/dependencies.test.ts
@@ -6,7 +6,11 @@ import { checkInstalledDependencies } from './dependencies';
 
 const tempDirs: string[] = [];
 
-async function createProject(manifest: object): Promise<string> {
+interface ProjectManifest {
+	dependencies?: Record<string, string>;
+}
+
+async function createProject(manifest: ProjectManifest): Promise<string> {
 	const root = await mkdtemp(join(tmpdir(), 'c15t-check-deps-'));
 	tempDirs.push(root);
 	await writeFile(


### PR DESCRIPTION
## Overview

Enables anti-slop `no-object-parameters` on top of #1036 and fixes its single violation.

## Changes

- Adds a `ProjectManifest` interface to the CLI test helper.
- Uses that type for generated package manifests instead of an anonymous object parameter.
- Enables `anti-slop/no-object-parameters` repository-wide.

This is isolated from the anti-slop baseline so the rule activation and its only required fix can be reviewed together.

## Verification

- `bun run lint`
- CLI targeted suite — 5 tests passed
- `bun run check-types` — 61 tasks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated linting configuration to apply object-parameter checks.
  - Improved type safety in project dependency test setup.

- **Tests**
  - Refined test fixtures to explicitly model optional project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->