### PR TITLE
test: make parity checks deterministic

### DIFF
--- a/internals/conformance/src/suite/persistence.ts
+++ b/internals/conformance/src/suite/persistence.ts
@@ -54,7 +54,10 @@ export function runPersistenceConformance(
 						persistence: true,
 					});
 					try {
-						api.expect(queryByTestId(first.root, BANNER_ROOT)).not.toBeNull();
+						const bannerVisible = await waitForCondition(
+							() => queryByTestId(first.root, BANNER_ROOT) !== null
+						);
+						api.expect(bannerVisible).toBe(true);
 						// Pre-consent under an opt-in policy: optional categories denied.
 						api.expect(readState(driver).consents?.marketing).toBe(false);
 
@@ -84,6 +87,10 @@ export function runPersistenceConformance(
 						persistence: true,
 					});
 					try {
+						const restored = await waitForCondition(
+							() => readState(driver).consents?.marketing === true
+						);
+						api.expect(restored).toBe(true);
 						api.expect(queryByTestId(second.root, BANNER_ROOT)).toBe(null);
 						const state = readState(driver);
 						api.expect(state.consents?.necessary).toBe(true);
@@ -111,7 +118,10 @@ export function runPersistenceConformance(
 					persistence: true,
 				});
 				try {
-					api.expect(queryByTestId(mounted.root, BANNER_ROOT)).not.toBeNull();
+					const bannerVisible = await waitForCondition(
+						() => queryByTestId(mounted.root, BANNER_ROOT) !== null
+					);
+					api.expect(bannerVisible).toBe(true);
 					api.expect(readState(driver).consents?.marketing).toBe(false);
 				} finally {
 					await mounted.unmount();

--- a/packages/react/src/v3/providers/__tests__/provider-basic.test.tsx
+++ b/packages/react/src/v3/providers/__tests__/provider-basic.test.tsx
@@ -13,10 +13,21 @@ import {
 const mockFetch = vi.fn();
 window.fetch = mockFetch;
 
+function clearConsentStorage(): void {
+	window.localStorage.clear();
+	for (const cookie of document.cookie.split(';')) {
+		const name = cookie.split('=')[0]?.trim();
+		if (name) {
+			document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+		}
+	}
+}
+
 describe('ConsentManagerProvider Basic Request Behavior', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 		clearConsentRuntimeCache();
+		clearConsentStorage();
 		// Set up fake timers for timer-related tests
 		vi.useFakeTimers();
 
@@ -44,6 +55,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 	afterEach(() => {
 		vi.clearAllMocks();
 		clearConsentRuntimeCache();
+		clearConsentStorage();
 		// Restore real timers after each test
 		vi.useRealTimers();
 	});
@@ -253,6 +265,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 			<ConsentManagerProvider
 				options={{
 					mode: 'offline',
+					reloadOnConsentRevoked: false,
 					callbacks: {
 						onConsentChanged: firstOnConsentChanged,
 					},
@@ -280,6 +293,7 @@ describe('ConsentManagerProvider Basic Request Behavior', () => {
 			<ConsentManagerProvider
 				options={{
 					mode: 'offline',
+					reloadOnConsentRevoked: false,
 					callbacks: {
 						onConsentChanged: secondOnConsentChanged,
 					},


### PR DESCRIPTION
Fix two nondeterministic CI failures exposed by the lint migration stack.

- compare expected Node CSS loader failures by error kind instead of whichever stylesheet a barrel reaches first
- warm the `bunx` executable cache before launching three concurrent Storybook servers
- fail the Storybook startup step when any server never becomes reachable
- add a focused regression test for CSS-import traversal order

Validation:
- `bun run --cwd packages/c15t test __tests__/facade-parity.test.ts`
- `bun run fmt:check`
- `bun run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved persistence checks to reliably validate banner visibility and restored marketing consent after remounting.
  * Enhanced provider test isolation by clearing stored consent data before and after tests.
  * Disabled consent-revocation reload behavior in callback-refresh test scenarios for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->