### PR TITLE
refactor(lint): enable no-conditional-empty-object-spread

### DIFF
--- a/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/nextjs-browser-bench/scripts/run-bench.ts
@@ -480,18 +480,20 @@ function isManifestScenario(scenario: string): boolean {
 async function run() {
 	await ensureBuild();
 
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		C15T_BENCH_INIT_LATENCY_MS: `${initLatencyMs}`,
+	};
+	if (coldManifestMode) {
+		env.C15T_BENCH_COLD_MANIFEST_TOKEN = String(Date.now());
+	}
+
 	const server = spawn(
 		'bun',
 		['run', 'start', '--', '-H', HOST, '-p', `${PORT}`],
 		{
 			cwd: appDir,
-			env: {
-				...process.env,
-				C15T_BENCH_INIT_LATENCY_MS: `${initLatencyMs}`,
-				...(coldManifestMode
-					? { C15T_BENCH_COLD_MANIFEST_TOKEN: String(Date.now()) }
-					: {}),
-			},
+			env,
 			stdio: ['ignore', 'pipe', 'pipe'],
 		}
 	);

--- a/benchmarks/nuxt-browser-bench/nuxt.config.ts
+++ b/benchmarks/nuxt-browser-bench/nuxt.config.ts
@@ -16,28 +16,9 @@ function getBenchManifestURL() {
  * page's own floor. Two-build pattern, same as the CSS experiment.
  */
 const baselineBuild = process.env.C15T_BENCH_BASELINE === '1';
-
-export default defineNuxtConfig({
+const config = {
 	compatibilityDate: '2026-07-04',
 	modules: baselineBuild ? [] : ['@c15t/vue'],
-	...(baselineBuild
-		? {}
-		: {
-				c15t: {
-					backendURL: '/api/bench-consent',
-					manifest: true,
-					manifestURL: getBenchManifestURL(),
-					consentCategories: [
-						'necessary',
-						'functionality',
-						'experience',
-						'measurement',
-						'marketing',
-					],
-					disableAnimation: true,
-					trapFocus: false,
-				},
-			}),
 	runtimeConfig: {
 		public: {
 			c15t: {
@@ -46,19 +27,6 @@ export default defineNuxtConfig({
 			benchBaseline: baselineBuild,
 		},
 	},
-	...(baselineBuild
-		? {
-				ignore: [
-					'app/pages/ssr.vue',
-					'app/pages/ssr-manifest.vue',
-					'app/pages/client.vue',
-					'app/pages/client-manifest.vue',
-					'app/pages/repeat-visitor.vue',
-					'app/components/**',
-					'app/plugins/**',
-				],
-			}
-		: {}),
 	routeRules: {
 		'/client': { ssr: false },
 		'/client-manifest': { ssr: false },
@@ -88,4 +56,37 @@ export default defineNuxtConfig({
 	typescript: {
 		strict: true,
 	},
-});
+};
+
+if (baselineBuild) {
+	Object.assign(config, {
+		ignore: [
+			'app/pages/ssr.vue',
+			'app/pages/ssr-manifest.vue',
+			'app/pages/client.vue',
+			'app/pages/client-manifest.vue',
+			'app/pages/repeat-visitor.vue',
+			'app/components/**',
+			'app/plugins/**',
+		],
+	});
+} else {
+	Object.assign(config, {
+		c15t: {
+			backendURL: '/api/bench-consent',
+			manifest: true,
+			manifestURL: getBenchManifestURL(),
+			consentCategories: [
+				'necessary',
+				'functionality',
+				'experience',
+				'measurement',
+				'marketing',
+			],
+			disableAnimation: true,
+			trapFocus: false,
+		},
+	});
+}
+
+export default defineNuxtConfig(config);

--- a/benchmarks/nuxt-browser-bench/scripts/run-bench.ts
+++ b/benchmarks/nuxt-browser-bench/scripts/run-bench.ts
@@ -514,19 +514,21 @@ function isManifestScenario(scenario: string): boolean {
 async function run() {
 	await ensureBuild();
 
+	const env = {
+		...process.env,
+		C15T_BENCH_INIT_LATENCY_MS: `${initLatencyMs}`,
+		HOST,
+		PORT: `${PORT}`,
+		NITRO_HOST: HOST,
+		NITRO_PORT: `${PORT}`,
+	};
+	if (coldManifestMode) {
+		env.C15T_BENCH_COLD_MANIFEST_TOKEN = String(Date.now());
+	}
+
 	const server = spawn('node', ['.output/server/index.mjs'], {
 		cwd: appDir,
-		env: {
-			...process.env,
-			C15T_BENCH_INIT_LATENCY_MS: `${initLatencyMs}`,
-			...(coldManifestMode
-				? { C15T_BENCH_COLD_MANIFEST_TOKEN: String(Date.now()) }
-				: {}),
-			HOST,
-			PORT: `${PORT}`,
-			NITRO_HOST: HOST,
-			NITRO_PORT: `${PORT}`,
-		},
+		env,
 		stdio: ['ignore', 'pipe', 'pipe'],
 	});
 

--- a/benchmarks/react-browser-bench/next.config.ts
+++ b/benchmarks/react-browser-bench/next.config.ts
@@ -33,32 +33,31 @@ const transpilePackages = [
 	'@c15t/core',
 ];
 
+const turbopackResolveAlias: Record<string, string> = {
+	'bench-css-entry': cssEntryRel,
+};
+if (useStylesCss) {
+	turbopackResolveAlias['@c15t/ui/styles/components/consent-banner.module.js'] =
+		bannerShimRel;
+}
+
 const config: NextConfig = {
 	transpilePackages,
 	turbopack: {
 		root: monorepoRoot,
-		resolveAlias: {
-			'bench-css-entry': cssEntryRel,
-			...(useStylesCss
-				? {
-						'@c15t/ui/styles/components/consent-banner.module.js':
-							bannerShimRel,
-					}
-				: {}),
-		},
+		resolveAlias: turbopackResolveAlias,
 	},
 	webpack: (webpackConfig) => {
 		webpackConfig.resolve = webpackConfig.resolve ?? {};
-		webpackConfig.resolve.alias = {
+		const resolveAlias = {
 			...webpackConfig.resolve.alias,
 			'bench-css-entry$': cssEntryAbs,
-			...(useStylesCss
-				? {
-						'@c15t/ui/styles/components/consent-banner.module.js$':
-							bannerShimAbs,
-					}
-				: {}),
 		};
+		if (useStylesCss) {
+			resolveAlias['@c15t/ui/styles/components/consent-banner.module.js$'] =
+				bannerShimAbs;
+		}
+		webpackConfig.resolve.alias = resolveAlias;
 		return webpackConfig;
 	},
 };

--- a/examples/demo/components/consent-manager/provider.tsx
+++ b/examples/demo/components/consent-manager/provider.tsx
@@ -37,10 +37,15 @@ function resolveGeoOverrides(
 		return undefined;
 	}
 
-	return {
-		...(queryCountry ? { country: queryCountry.toUpperCase() } : {}),
-		...(queryRegion ? { region: queryRegion.toUpperCase() } : {}),
-	};
+	const overrides: { country?: string; region?: string } = {};
+	if (queryCountry) {
+		overrides.country = queryCountry.toUpperCase();
+	}
+	if (queryRegion) {
+		overrides.region = queryRegion.toUpperCase();
+	}
+
+	return overrides;
 }
 
 /**

--- a/examples/demo/components/demo/consent-demo.tsx
+++ b/examples/demo/components/demo/consent-demo.tsx
@@ -149,13 +149,16 @@ export function ConsentDemo({ backend = 'hosted' }: ConsentDemoProps) {
 		[]
 	);
 
-	const overrides = useMemo(
-		() => ({
-			...(params.country ? { country: params.country } : {}),
-			...(params.region ? { region: params.region } : {}),
-		}),
-		[params.country, params.region]
-	);
+	const overrides = useMemo(() => {
+		const nextOverrides: { country?: string; region?: string } = {};
+		if (params.country) {
+			nextOverrides.country = params.country;
+		}
+		if (params.region) {
+			nextOverrides.region = params.region;
+		}
+		return nextOverrides;
+	}, [params.country, params.region]);
 
 	// Remount the provider whenever the simulated environment changes so the
 	// consent manager re-initializes from scratch.
@@ -192,14 +195,21 @@ export function ConsentDemo({ backend = 'hosted' }: ConsentDemoProps) {
 
 	const providerOptions =
 		params.mode === 'hosted'
-			? {
-					mode: 'c15t' as const,
-					backendURL: isSelfHost ? '/api/self-host' : HOSTED_BACKEND_URL,
-					...(isSelfHost
-						? { headers: { [DEMO_SCENARIO_HEADER]: params.scenarioId } }
-						: {}),
-					...sharedOptions,
-				}
+			? (() => {
+					const hostedOptions = {
+						mode: 'c15t' as const,
+						backendURL: isSelfHost ? '/api/self-host' : HOSTED_BACKEND_URL,
+					};
+					if (isSelfHost) {
+						Object.assign(hostedOptions, {
+							headers: { [DEMO_SCENARIO_HEADER]: params.scenarioId },
+						});
+					}
+					return {
+						...hostedOptions,
+						...sharedOptions,
+					};
+				})()
 			: {
 					mode: 'offline' as const,
 					offlinePolicy: {

--- a/examples/demo/components/policy/policy-demo.tsx
+++ b/examples/demo/components/policy/policy-demo.tsx
@@ -735,13 +735,16 @@ export function PolicyDemo() {
 		navigate(preset.id, demoMode, preset.country, preset.region ?? '');
 	};
 
-	const overrides = useMemo(
-		() => ({
-			...(normalizedCountry ? { country: normalizedCountry } : {}),
-			...(normalizedRegion ? { region: normalizedRegion } : {}),
-		}),
-		[normalizedCountry, normalizedRegion]
-	);
+	const overrides = useMemo(() => {
+		const nextOverrides: { country?: string; region?: string } = {};
+		if (normalizedCountry) {
+			nextOverrides.country = normalizedCountry;
+		}
+		if (normalizedRegion) {
+			nextOverrides.region = normalizedRegion;
+		}
+		return nextOverrides;
+	}, [normalizedCountry, normalizedRegion]);
 
 	const categories: (
 		| 'necessary'

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -184,7 +184,6 @@ const deferredRules = [
 // Three anti-slop rules are already clean and stay enabled through the preset.
 const deferredAntiSlopRules = [
 	'anti-slop/no-chained-type-assertions',
-	'anti-slop/no-conditional-empty-object-spread',
 	'anti-slop/no-known-value-widening',
 	'anti-slop/no-module-mocking',
 	'anti-slop/no-runtime-typeof',

--- a/packages/backend/src/http/app.test.ts
+++ b/packages/backend/src/http/app.test.ts
@@ -493,10 +493,15 @@ for (const engine of ENGINES) {
 		const put = (body: unknown, auth = true) =>
 			app.request('/legal-documents/privacy_policy/current', {
 				method: 'PUT',
-				headers: {
-					'Content-Type': 'application/json',
-					...(auth ? { Authorization: `Bearer ${API_KEY}` } : {}),
-				},
+				headers: (() => {
+					const headers: Record<string, string> = {
+						'Content-Type': 'application/json',
+					};
+					if (auth) {
+						headers.Authorization = `Bearer ${API_KEY}`;
+					}
+					return headers;
+				})(),
 				body: JSON.stringify(body),
 			});
 

--- a/packages/backend/src/observability/evlog.ts
+++ b/packages/backend/src/observability/evlog.ts
@@ -208,12 +208,17 @@ export function middleware(
 
 	const rates = ratesFor(level);
 	if (rates !== undefined || options?.service !== undefined) {
-		initLogger({
-			...(options?.service === undefined
-				? {}
-				: { env: { service: options.service } }),
-			...(rates === undefined ? {} : { sampling: { rates } }),
-		});
+		const loggerOptions: {
+			env?: { service: string };
+			sampling?: { rates: ReturnType<typeof ratesFor> };
+		} = {};
+		if (options?.service !== undefined) {
+			loggerOptions.env = { service: options.service };
+		}
+		if (rates !== undefined) {
+			loggerOptions.sampling = { rates };
+		}
+		initLogger(loggerOptions);
 	}
 
 	return evlog(resolveOptions(options ?? {}));

--- a/packages/cli/src/machines/generate/runner.ts
+++ b/packages/cli/src/machines/generate/runner.ts
@@ -174,10 +174,13 @@ export async function runGenerateMachine(
 	}
 
 	// Create the actor
-	const actor = createActor(generateMachine, {
+	const actorOptions = {
 		input: { cliContext, modeArg },
-		...(snapshot ? { snapshot: snapshot as never } : {}),
-	});
+	};
+	if (snapshot) {
+		Object.assign(actorOptions, { snapshot });
+	}
+	const actor = createActor(generateMachine, actorOptions);
 
 	// Set up subscribers
 	const subscribers: ((snapshot: unknown) => void)[] = [];

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -379,12 +379,18 @@ export class Telemetry {
 		const writeKey = process.env[ENV_VARS.TELEMETRY_WRITE_KEY];
 		const orgId = process.env[ENV_VARS.TELEMETRY_ORG_ID];
 
-		return {
+		const headers: Record<string, string> = {
 			'Content-Type': 'application/json',
-			...(writeKey ? { Authorization: `Bearer ${writeKey}` } : {}),
-			...(orgId ? { 'X-Axiom-Org-Id': orgId } : {}),
-			...overrides,
 		};
+		if (writeKey) {
+			headers.Authorization = `Bearer ${writeKey}`;
+		}
+		if (orgId) {
+			headers['X-Axiom-Org-Id'] = orgId;
+		}
+		Object.assign(headers, overrides);
+
+		return headers;
 	}
 
 	private async flushAll(): Promise<void> {

--- a/packages/core/src/client/hosted/pending-submissions.ts
+++ b/packages/core/src/client/hosted/pending-submissions.ts
@@ -100,16 +100,16 @@ export async function processPendingConsentSubmissions(
 						externalId: submission.externalSubjectId,
 						identityProvider: submission.identityProvider,
 					});
-				const sanitizedSubmission: SetConsentRequestBody = {
-					...submission,
-					...(externalSubjectId ? { externalSubjectId } : {}),
-					...(identityProvider ? { identityProvider } : {}),
-				};
+				const sanitizedSubmission: SetConsentRequestBody = { ...submission };
 
-				if (!externalSubjectId) {
+				if (externalSubjectId) {
+					sanitizedSubmission.externalSubjectId = externalSubjectId;
+				} else {
 					delete sanitizedSubmission.externalSubjectId;
 				}
-				if (!identityProvider) {
+				if (identityProvider) {
+					sanitizedSubmission.identityProvider = identityProvider;
+				} else {
 					delete sanitizedSubmission.identityProvider;
 				}
 

--- a/packages/core/src/libs/init-consent-manager/index.ts
+++ b/packages/core/src/libs/init-consent-manager/index.ts
@@ -7,6 +7,7 @@
  * @packageDocumentation
  */
 
+import type { SetConsentRequestBody } from '../../client/client-interface';
 import type { ResponseContext } from '../../client/types';
 import type { InitDataSource, SSRInitialData } from '../../store/type';
 import {
@@ -360,23 +361,29 @@ function processPendingConsentSync(
 				identityProvider: data.identityProvider,
 			});
 
+		const consentBody: SetConsentRequestBody = {
+			type: 'cookie_banner',
+			domain: data.domain,
+			preferences: data.preferences,
+			subjectId: data.subjectId,
+			jurisdiction: data.jurisdiction,
+			jurisdictionModel: data.jurisdictionModel ?? undefined,
+			givenAt: data.givenAt,
+			uiSource: data.uiSource ?? 'api',
+			policySnapshotToken: data.policySnapshotToken,
+		};
+		if (externalSubjectId) {
+			consentBody.externalSubjectId = externalSubjectId;
+		}
+		if (identityProvider) {
+			consentBody.identityProvider = identityProvider;
+		}
+
 		// Fire API call (non-blocking)
 		void (async () => {
 			try {
 				const result = await manager.setConsent({
-					body: {
-						type: 'cookie_banner',
-						domain: data.domain,
-						preferences: data.preferences,
-						subjectId: data.subjectId,
-						jurisdiction: data.jurisdiction,
-						jurisdictionModel: data.jurisdictionModel ?? undefined,
-						givenAt: data.givenAt,
-						uiSource: data.uiSource ?? 'api',
-						policySnapshotToken: data.policySnapshotToken,
-						...(externalSubjectId ? { externalSubjectId } : {}),
-						...(identityProvider ? { identityProvider } : {}),
-					},
+					body: consentBody,
 				});
 				if (!result.ok) {
 					const errorMsg =

--- a/packages/core/src/libs/sanitize-subject-identifiers.ts
+++ b/packages/core/src/libs/sanitize-subject-identifiers.ts
@@ -37,9 +37,14 @@ export function sanitizeSubjectIdentifiers(
 ): SanitizedSubjectIdentifiers {
 	const externalId = sanitizeIdentifier(identifiers.externalId);
 	const identityProvider = sanitizeIdentifier(identifiers.identityProvider);
+	const sanitized: SanitizedSubjectIdentifiers = {};
 
-	return {
-		...(externalId ? { externalId } : {}),
-		...(identityProvider ? { identityProvider } : {}),
-	};
+	if (externalId) {
+		sanitized.externalId = externalId;
+	}
+	if (identityProvider) {
+		sanitized.identityProvider = identityProvider;
+	}
+
+	return sanitized;
 }

--- a/packages/core/src/libs/save-consents.ts
+++ b/packages/core/src/libs/save-consents.ts
@@ -3,7 +3,10 @@ import type { StoreApi } from 'zustand';
 
 import type { ConsentStoreState } from '~/store/type';
 
-import type { ConsentManagerInterface } from '../client/client-interface';
+import type {
+	ConsentManagerInterface,
+	SetConsentRequestBody,
+} from '../client/client-interface';
 import type {
 	ConsentInfo,
 	ConsentState,
@@ -289,9 +292,13 @@ export async function saveConsents({
 		time: givenAt,
 		subjectId,
 		materialPolicyFingerprint,
-		...(externalId ? { externalId } : {}),
-		...(identityProvider ? { identityProvider } : {}),
 	};
+	if (externalId) {
+		nextConsentInfo.externalId = externalId;
+	}
+	if (identityProvider) {
+		nextConsentInfo.identityProvider = identityProvider;
+	}
 
 	// Check if we need to reload the page due to consent revocation
 	const needsReload = shouldReloadOnConsentChange(
@@ -334,9 +341,13 @@ export async function saveConsents({
 			domain: window.location.hostname,
 			uiSource: options?.uiSource ?? 'api',
 			policySnapshotToken: lastBannerFetchData?.policySnapshotToken,
-			...(externalId ? { externalId } : {}),
-			...(identityProvider ? { identityProvider } : {}),
 		};
+		if (externalId) {
+			pendingSync.externalId = externalId;
+		}
+		if (identityProvider) {
+			pendingSync.identityProvider = identityProvider;
+		}
 
 		try {
 			localStorage.setItem(
@@ -380,21 +391,27 @@ export async function saveConsents({
 	}
 
 	// Send consent to API in the background - the UI is already updated
+	const consentBody: SetConsentRequestBody = {
+		type: 'cookie_banner' as const,
+		domain: typeof window !== 'undefined' ? window.location.hostname : '',
+		preferences: requestPreferences,
+		subjectId,
+		jurisdiction: locationInfo?.jurisdiction ?? undefined,
+		jurisdictionModel: model ?? undefined,
+		givenAt,
+		uiSource: options?.uiSource ?? 'api',
+		consentAction: type,
+		policySnapshotToken: lastBannerFetchData?.policySnapshotToken,
+	};
+	if (externalId) {
+		consentBody.externalSubjectId = externalId;
+	}
+	if (identityProvider) {
+		consentBody.identityProvider = identityProvider;
+	}
+
 	const consent = await manager.setConsent({
-		body: {
-			type: 'cookie_banner',
-			domain: typeof window !== 'undefined' ? window.location.hostname : '',
-			preferences: requestPreferences,
-			subjectId,
-			jurisdiction: locationInfo?.jurisdiction ?? undefined,
-			jurisdictionModel: model ?? undefined,
-			givenAt,
-			uiSource: options?.uiSource ?? 'api',
-			consentAction: type,
-			policySnapshotToken: lastBannerFetchData?.policySnapshotToken,
-			...(externalId ? { externalSubjectId: externalId } : {}),
-			...(identityProvider ? { identityProvider } : {}),
-		},
+		body: consentBody,
 	});
 
 	// Handle error case if the API request fails

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -264,6 +264,11 @@ export function getOrCreateConsentRuntime(
 					})
 				: undefined;
 		const resolvedSSRData = explicitSSRData ?? autoPrefetchedSSRData;
+		const meta = { ...(userConfig?.meta ?? {}) };
+		if (normalizedMode === 'hosted') {
+			meta.backendURL = resolvedBackendURL;
+			meta.requestCredentials = 'include';
+		}
 
 		consentStore = createConsentManagerStore(consentManager, {
 			config: {
@@ -271,15 +276,7 @@ export function getOrCreateConsentRuntime(
 				pkg: pkgInfo?.pkg || 'c15t',
 				version: pkgInfo?.version || version,
 				mode: normalizedMode,
-				meta: {
-					...(userConfig?.meta ?? {}),
-					...(normalizedMode === 'hosted'
-						? {
-								backendURL: resolvedBackendURL,
-								requestCredentials: 'include',
-							}
-						: {}),
-				},
+				meta,
 			},
 			...cleanStoreOptionOverrides,
 			...storeWithoutTranslationInputs,

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { isLegalDocumentType } from '@c15t/schema/types';
-import type { PostSubjectOutput } from '@c15t/schema/types';
+import type { PostSubjectInput, PostSubjectOutput } from '@c15t/schema/types';
 import { resolveTranslationInput } from '@c15t/translations';
 import { createStore } from 'zustand/vanilla';
 
@@ -548,19 +548,29 @@ export const createConsentManagerStore = (
 
 				const givenAt = input.givenAt ?? Date.now();
 
+				const consentBody: PostSubjectInput = {
+					type: input.type,
+					subjectId,
+					domain,
+					givenAt,
+					uiSource: input.uiSource ?? 'api',
+					...legalDocumentFields,
+				};
+				if (input.metadata) {
+					consentBody.metadata = input.metadata;
+				}
+				if (input.preferences) {
+					consentBody.preferences = input.preferences;
+				}
+				if (externalId) {
+					consentBody.externalSubjectId = externalId;
+				}
+				if (identityProvider) {
+					consentBody.identityProvider = identityProvider;
+				}
+
 				const response = await manager.setConsent({
-					body: {
-						type: input.type,
-						subjectId,
-						domain,
-						givenAt,
-						uiSource: input.uiSource ?? 'api',
-						...legalDocumentFields,
-						...(input.metadata ? { metadata: input.metadata } : {}),
-						...(input.preferences ? { preferences: input.preferences } : {}),
-						...(externalId ? { externalSubjectId: externalId } : {}),
-						...(identityProvider ? { identityProvider } : {}),
-					},
+					body: consentBody,
 				});
 
 				if (!response.ok || !response.data) {
@@ -590,25 +600,29 @@ export const createConsentManagerStore = (
 
 				const latestState = get();
 				const latestInfo = latestState.consentInfo;
-				const nextConsentInfo = {
+				const nextConsentInfo: ConsentInfo = {
 					...latestInfo,
 					time: consent.givenAt.getTime(),
 					subjectId,
-					...(externalId ? { externalId } : {}),
-					...(identityProvider ? { identityProvider } : {}),
 				};
+				if (externalId) {
+					nextConsentInfo.externalId = externalId;
+				}
+				if (identityProvider) {
+					nextConsentInfo.identityProvider = identityProvider;
+				}
 
-				set({
+				const statePatch: Partial<ConsentStoreState> = {
 					consentInfo: nextConsentInfo,
-					...(externalId
-						? {
-								user: {
-									id: externalId,
-									identityProvider,
-								},
-							}
-						: {}),
-				});
+				};
+				if (externalId) {
+					statePatch.user = {
+						id: externalId,
+						identityProvider,
+					};
+				}
+
+				set(statePatch);
 
 				saveConsentToStorage(
 					{

--- a/packages/core/src/v3/libs/sanitize-subject-identifiers.ts
+++ b/packages/core/src/v3/libs/sanitize-subject-identifiers.ts
@@ -37,9 +37,14 @@ export function sanitizeSubjectIdentifiers(
 ): SanitizedSubjectIdentifiers {
 	const externalId = sanitizeIdentifier(identifiers.externalId);
 	const identityProvider = sanitizeIdentifier(identifiers.identityProvider);
+	const sanitized: SanitizedSubjectIdentifiers = {};
 
-	return {
-		...(externalId ? { externalId } : {}),
-		...(identityProvider ? { identityProvider } : {}),
-	};
+	if (externalId) {
+		sanitized.externalId = externalId;
+	}
+	if (identityProvider) {
+		sanitized.identityProvider = identityProvider;
+	}
+
+	return sanitized;
 }

--- a/packages/dev-tools/src/core/devtools.ts
+++ b/packages/dev-tools/src/core/devtools.ts
@@ -711,22 +711,26 @@ export function createDevToolsPanel(options: {
 		},
 	});
 
+	const containerStyle: Partial<CSSStyleDeclaration> = {
+		display: 'flex',
+		flexDirection: 'column',
+		height: '100%',
+		boxSizing: 'border-box',
+		gap: '0.75rem',
+		padding: '0.75rem',
+		fontFamily: 'inherit',
+		fontSize: 'var(--c15t-devtools-font-size-sm)',
+		color: isEmbedded ? 'var(--c15t-text, #eef2ff)' : 'inherit',
+		backgroundColor: 'transparent',
+		colorScheme: isEmbedded ? 'dark' : undefined,
+	};
+	if (isEmbedded) {
+		Object.assign(containerStyle, EMBEDDED_THEME_VARIABLES);
+	}
+
 	// Create container
 	const container = div({
-		style: {
-			display: 'flex',
-			flexDirection: 'column',
-			height: '100%',
-			boxSizing: 'border-box',
-			gap: '0.75rem',
-			padding: '0.75rem',
-			fontFamily: 'inherit',
-			fontSize: 'var(--c15t-devtools-font-size-sm)',
-			color: isEmbedded ? 'var(--c15t-text, #eef2ff)' : 'inherit',
-			backgroundColor: 'transparent',
-			colorScheme: isEmbedded ? 'dark' : undefined,
-			...(isEmbedded ? EMBEDDED_THEME_VARIABLES : {}),
-		},
+		style: containerStyle,
 	});
 
 	// Create content area (before tabs so we can pass render function)

--- a/packages/nextjs/src/__tests__/conformance.test.tsx
+++ b/packages/nextjs/src/__tests__/conformance.test.tsx
@@ -243,16 +243,18 @@ function buildPolicy(
 		| { activeUI?: 'none' | 'banner' | 'dialog' }
 		| undefined;
 	const mode = state?.activeUI ?? activeUIForComponent(opts.component);
+	const consent: ResolvedPolicy['consent'] = {
+		categories: consentCategoriesFor(options),
+		scopeMode: 'permissive',
+	};
+	if (opts.policy?.respectGpc !== undefined) {
+		consent.gpc = opts.policy.respectGpc;
+	}
+
 	return {
 		id: 'nextjs_conformance_policy',
 		model: opts.policy?.model ?? 'opt-in',
-		consent: {
-			categories: consentCategoriesFor(options),
-			scopeMode: 'permissive',
-			...(opts.policy?.respectGpc === undefined
-				? {}
-				: { gpc: opts.policy.respectGpc }),
-		},
+		consent,
 		ui: {
 			mode,
 			banner: {
@@ -293,17 +295,15 @@ function buildBoundaryProps(opts: MountOptions): {
 		initialHasConsented:
 			state?.hasConsented ?? provided.prefetch?.initialHasConsented,
 		initialTranslations: resolveTranslations(provided, opts.locale),
-		// GPC arrives in the serializable server config — exactly the field
-		// the nextjs server plumbing derives from the `sec-gpc` header.
-		...(opts.gpc === undefined
-			? {}
-			: {
-					initialOverrides: {
-						...(provided.prefetch?.initialOverrides ?? {}),
-						gpc: opts.gpc,
-					},
-				}),
 	};
+	// GPC arrives in the serializable server config — exactly the field
+	// the nextjs server plumbing derives from the `sec-gpc` header.
+	if (opts.gpc !== undefined) {
+		basePrefetch.initialOverrides = {
+			...(provided.prefetch?.initialOverrides ?? {}),
+			gpc: opts.gpc,
+		};
+	}
 	const config: KernelConfig =
 		initMode === 'authoritative'
 			? {

--- a/packages/node-sdk/src/testing.ts
+++ b/packages/node-sdk/src/testing.ts
@@ -181,13 +181,14 @@ export function createMockClient(overrides: MockClientOverrides = {}) {
 		checkConsent: (query: unknown) => Promise.resolve(checkConsent(query)),
 		createSubject: (input: unknown) => Promise.resolve(createSubject(input)),
 		getSubject: (id: string) => Promise.resolve(getSubject(id)),
-		patchSubject: (id: string, input: unknown) =>
-			Promise.resolve(
-				patchSubject({
-					id,
-					...(typeof input === 'object' && input !== null ? input : {}),
-				})
-			),
+		patchSubject: (id: string, input: unknown) => {
+			const patchInput = { id };
+			if (typeof input === 'object' && input !== null) {
+				Object.assign(patchInput, input);
+			}
+
+			return Promise.resolve(patchSubject(patchInput));
+		},
 		listSubjects: (query?: unknown) => Promise.resolve(listSubjects(query)),
 
 		// Namespaced methods
@@ -197,13 +198,14 @@ export function createMockClient(overrides: MockClientOverrides = {}) {
 		subjects: {
 			create: (input: unknown) => Promise.resolve(createSubject(input)),
 			get: (id: string) => Promise.resolve(getSubject(id)),
-			patch: (id: string, input: unknown) =>
-				Promise.resolve(
-					patchSubject({
-						id,
-						...(typeof input === 'object' && input !== null ? input : {}),
-					})
-				),
+			patch: (id: string, input: unknown) => {
+				const patchInput = { id };
+				if (typeof input === 'object' && input !== null) {
+					Object.assign(patchInput, input);
+				}
+
+				return Promise.resolve(patchSubject(patchInput));
+			},
 			list: (query?: unknown) => Promise.resolve(listSubjects(query)),
 		},
 		meta: {

--- a/packages/react/src/__tests__/conformance.test.tsx
+++ b/packages/react/src/__tests__/conformance.test.tsx
@@ -90,7 +90,7 @@ function renderFor(component: MountableComponent): ReactElement {
  * the real lifecycle instead of the driver's forced `setActiveUI`.
  */
 function buildOfflinePolicy(opts: MountOptions) {
-	return {
+	const offlinePolicy = {
 		policy: {
 			id: 'react_v2_conformance_policy',
 			model: opts.policy?.model ?? 'opt-in',
@@ -103,15 +103,17 @@ function buildOfflinePolicy(opts: MountOptions) {
 					'marketing',
 				],
 				scopeMode: 'permissive',
-				...(opts.policy?.respectGpc === undefined
-					? {}
-					: { gpc: opts.policy.respectGpc }),
 			},
 			ui: {
 				mode: 'banner',
 			},
 		},
 	} as NonNullable<ConsentManagerOptions['offlinePolicy']>;
+	if (opts.policy?.respectGpc !== undefined) {
+		offlinePolicy.policy.consent.gpc = opts.policy.respectGpc;
+	}
+
+	return offlinePolicy;
 }
 
 function usesPolicyLifecycle(opts: MountOptions): boolean {
@@ -127,25 +129,25 @@ function buildProviderOptions(opts: MountOptions): ConsentManagerOptions {
 	}
 	const provided = (opts.providerOptions ??
 		{}) as Partial<ConsentManagerOptions>;
-	return {
+	const options = {
 		mode: 'offline',
-		...(usesPolicyLifecycle(opts)
-			? {
-					offlinePolicy: buildOfflinePolicy(opts),
-					// v2 defaults `consentCategories` to `['necessary']`; real apps
-					// configure the categories they use, and `saveConsents('all')`
-					// only grants configured categories.
-					consentCategories: [
-						'necessary',
-						'functionality',
-						'experience',
-						'measurement',
-						'marketing',
-					] as ConsentManagerOptions['consentCategories'],
-				}
-			: {}),
-		...provided,
 	} as ConsentManagerOptions;
+	if (usesPolicyLifecycle(opts)) {
+		options.offlinePolicy = buildOfflinePolicy(opts);
+		// v2 defaults `consentCategories` to `['necessary']`; real apps
+		// configure the categories they use, and `saveConsents('all')`
+		// only grants configured categories.
+		options.consentCategories = [
+			'necessary',
+			'functionality',
+			'experience',
+			'measurement',
+			'marketing',
+		] as ConsentManagerOptions['consentCategories'];
+	}
+	Object.assign(options, provided);
+
+	return options;
 }
 
 /**

--- a/packages/react/src/__tests__/conformance.v3.test.tsx
+++ b/packages/react/src/__tests__/conformance.v3.test.tsx
@@ -229,16 +229,18 @@ function buildPolicy(
 		| { activeUI?: 'none' | 'banner' | 'dialog' }
 		| undefined;
 	const mode = state?.activeUI ?? activeUIForComponent(opts.component);
+	const consent: ResolvedPolicy['consent'] = {
+		categories: consentCategoriesFor(options),
+		scopeMode: 'permissive',
+	};
+	if (opts.policy?.respectGpc !== undefined) {
+		consent.gpc = opts.policy.respectGpc;
+	}
+
 	return {
 		id: 'react_v3_conformance_policy',
 		model: opts.policy?.model ?? 'opt-in',
-		consent: {
-			categories: consentCategoriesFor(options),
-			scopeMode: 'permissive',
-			...(opts.policy?.respectGpc === undefined
-				? {}
-				: { gpc: opts.policy.respectGpc }),
-		},
+		consent,
 		ui: {
 			mode,
 			banner: {
@@ -329,18 +331,22 @@ function buildProviderOptions(opts: MountOptions): ConsentProviderOptions {
 				}
 			: basePrefetch;
 
-	return {
+	const options: ProviderOptions = {
 		...provided,
 		mode: 'offline',
 		persistence: opts.persistence ?? false,
 		disableAnimation: true,
 		trapFocus: false,
 		consentCategories: consentCategoriesFor(provided),
-		// GPC uses the provider's public `overrides` input — the same channel
-		// a real app (or the nextjs server plumbing) delivers the signal on.
-		...(opts.gpc === undefined ? {} : { overrides: { gpc: opts.gpc } }),
 		prefetch,
 	};
+	// GPC uses the provider's public `overrides` input — the same channel
+	// a real app (or the nextjs server plumbing) delivers the signal on.
+	if (opts.gpc !== undefined) {
+		options.overrides = { gpc: opts.gpc };
+	}
+
+	return options;
 }
 
 function createPendingInit() {
@@ -494,10 +500,10 @@ const driver: TestDriver = {
 	framework: 'react',
 	async mount(opts: MountOptions): Promise<MountResult> {
 		const lifecycle = lifecycleTransportFor(opts);
-		const options = {
-			...buildProviderOptions(opts),
-			...(lifecycle.transport ? { transport: lifecycle.transport } : {}),
-		};
+		const options = buildProviderOptions(opts);
+		if (lifecycle.transport) {
+			options.transport = lifecycle.transport;
+		}
 		let mountedKernel: ConsentKernel | null = null;
 		let resolveSettled: () => void = () => {};
 		const settled = createVoidDeferredPromise((resolve) => {

--- a/packages/schema/src/shared/policy-pack-defaults.ts
+++ b/packages/schema/src/shared/policy-pack-defaults.ts
@@ -57,11 +57,16 @@ function europePolicy(mode: EuropePolicyMode): PolicyConfig {
 			policyMatchers.iab(),
 			policyMatchers.fallback()
 		),
-		consent: {
-			model: mode,
-			expiryDays: 365,
-			...(isIab ? { categories: ['*'] } : {}),
-		},
+		consent: (() => {
+			const consent: PolicyConfig['consent'] = {
+				model: mode,
+				expiryDays: 365,
+			};
+			if (isIab) {
+				consent.categories = ['*'];
+			}
+			return consent;
+		})(),
 		proof: {
 			storeIp: true,
 			storeUserAgent: true,

--- a/packages/scripts/src/vendors/functional/crisp.ts
+++ b/packages/scripts/src/vendors/functional/crisp.ts
@@ -92,15 +92,18 @@ function createCrispManifest(options: CrispOptions): VendorManifest {
 	];
 
 	if (options.locale !== undefined || options.sessionMerge !== undefined) {
+		const value: { locale?: string; session_merge?: string } = {};
+		if (options.locale !== undefined) {
+			value.locale = '{{locale}}';
+		}
+		if (options.sessionMerge !== undefined) {
+			value.session_merge = '{{sessionMerge}}';
+		}
+
 		install.push({
 			type: 'setGlobal',
 			name: 'CRISP_RUNTIME_CONFIG',
-			value: {
-				...(options.locale !== undefined ? { locale: '{{locale}}' } : {}),
-				...(options.sessionMerge !== undefined
-					? { session_merge: '{{sessionMerge}}' }
-					: {}),
-			},
+			value,
 			ifUndefined: false,
 		});
 	}

--- a/packages/svelte/src/__tests__/conformance.test.ts
+++ b/packages/svelte/src/__tests__/conformance.test.ts
@@ -114,18 +114,20 @@ function buildPolicy(
 		| { activeUI?: 'none' | 'banner' | 'dialog' }
 		| undefined;
 	const mode = state?.activeUI ?? activeUIForComponent(opts.component);
+	const consent: ResolvedPolicy['consent'] = {
+		categories: consentCategoriesFor(options),
+		scopeMode: 'permissive',
+	};
+	if (opts.policy?.respectGpc !== undefined) {
+		consent.gpc = opts.policy.respectGpc;
+	}
+
 	return {
 		id: 'svelte_conformance_policy',
 		model: isIabComponent(opts.component)
 			? 'iab'
 			: (opts.policy?.model ?? 'opt-in'),
-		consent: {
-			categories: consentCategoriesFor(options),
-			scopeMode: 'permissive',
-			...(opts.policy?.respectGpc === undefined
-				? {}
-				: { gpc: opts.policy.respectGpc }),
-		},
+		consent,
 		ui: {
 			mode,
 			banner: {
@@ -181,31 +183,33 @@ function buildProviderOptions(opts: MountOptions): ProviderOptions {
 		initialPolicySnapshotToken: 'svelte_conformance_token',
 	};
 
-	return {
+	const options = {
 		...provided,
 		mode: provided.mode ?? 'offline',
 		persistence: opts.persistence ?? provided.persistence ?? false,
 		disableAnimation: provided.disableAnimation ?? true,
 		trapFocus: provided.trapFocus ?? false,
 		consentCategories: consentCategoriesFor(provided),
-		// GPC flows through the public `overrides` option — the same input an
-		// embedding app uses — which the provider merges into the kernel's
-		// `initialOverrides` (consent-manager-provider.svelte).
-		...(opts.gpc === undefined ? {} : { overrides: { gpc: opts.gpc } }),
-		// Real IAB wiring: the provider normalizes this into `createIAB`,
-		// which seeds the kernel's IAB slice (enabled + GVL + CMP id).
-		...(isIabComponent(opts.component)
-			? {
-					iab: {
-						enabled: true,
-						cmpId: IAB_FIXTURE_CMP_ID,
-						cmpVersion: IAB_FIXTURE_CMP_VERSION,
-						gvl: MINIMAL_GVL as unknown as GlobalVendorList,
-					},
-				}
-			: {}),
 		prefetch,
 	} as ProviderOptions;
+	// GPC flows through the public `overrides` option — the same input an
+	// embedding app uses — which the provider merges into the kernel's
+	// `initialOverrides` (consent-manager-provider.svelte).
+	if (opts.gpc !== undefined) {
+		options.overrides = { gpc: opts.gpc };
+	}
+	// Real IAB wiring: the provider normalizes this into `createIAB`,
+	// which seeds the kernel's IAB slice (enabled + GVL + CMP id).
+	if (isIabComponent(opts.component)) {
+		options.iab = {
+			enabled: true,
+			cmpId: IAB_FIXTURE_CMP_ID,
+			cmpVersion: IAB_FIXTURE_CMP_VERSION,
+			gvl: MINIMAL_GVL as unknown as GlobalVendorList,
+		};
+	}
+
+	return options;
 }
 
 function activeUIForStore(activeUI: KernelActiveUI): StoreState['activeUI'] {

--- a/packages/translations/src/utils.ts
+++ b/packages/translations/src/utils.ts
@@ -265,12 +265,12 @@ export function resolveTranslationInput(
 		return undefined;
 	}
 
-	return toTranslationConfig(
-		normalizeI18nConfig({
-			...(legacyConfig ?? {}),
-			...(i18nConfig ? { i18n: i18nConfig } : {}),
-		})
-	);
+	const config: TranslationInputConfig = { ...(legacyConfig ?? {}) };
+	if (i18nConfig) {
+		config.i18n = i18nConfig;
+	}
+
+	return toTranslationConfig(normalizeI18nConfig(config));
 }
 
 /**

--- a/packages/vue/src/__tests__/conformance.test.ts
+++ b/packages/vue/src/__tests__/conformance.test.ts
@@ -224,6 +224,13 @@ function buildInitOutput(
 		options.consentCategories?.length === 0
 			? [...DEFAULT_CONSENT_CATEGORIES]
 			: [...(options.consentCategories ?? DEFAULT_CONSENT_CATEGORIES)];
+	const consent: NonNullable<NonNullable<InitOutput['policy']>['consent']> = {
+		categories: consentCategories,
+		scopeMode: 'permissive',
+	};
+	if (opts.policy?.respectGpc !== undefined) {
+		consent.gpc = opts.policy.respectGpc;
+	}
 
 	return {
 		jurisdiction: 'GDPR',
@@ -236,13 +243,7 @@ function buildInitOutput(
 		policy: {
 			id: 'vue_conformance_policy',
 			model: policyModelFor(opts),
-			consent: {
-				categories: consentCategories,
-				scopeMode: 'permissive',
-				...(opts.policy?.respectGpc === undefined
-					? {}
-					: { gpc: opts.policy.respectGpc }),
-			},
+			consent,
 			ui: {
 				mode: 'banner',
 				banner: {
@@ -283,18 +284,18 @@ function buildKernelConfig(
 		initialConsents: state?.consents,
 		initialHasConsented: state?.hasConsented,
 		initialTranslations: resolveTranslations(options, opts.locale),
-		...(opts.gpc === undefined ? {} : { initialOverrides: { gpc: opts.gpc } }),
-		...(isIabComponent(opts.component)
-			? {
-					initialIab: {
-						enabled: true,
-						gvl: MINIMAL_GVL as unknown as GlobalVendorList,
-						cmpId: IAB_FIXTURE_CMP_ID,
-					},
-				}
-			: {}),
 		transport,
 	};
+	if (opts.gpc !== undefined) {
+		base.initialOverrides = { gpc: opts.gpc };
+	}
+	if (isIabComponent(opts.component)) {
+		base.initialIab = {
+			enabled: true,
+			gvl: MINIMAL_GVL as unknown as GlobalVendorList,
+			cmpId: IAB_FIXTURE_CMP_ID,
+		};
+	}
 	if (initMode === 'authoritative') {
 		return {
 			...base,

--- a/packages/vue/src/runtime/kernel.ts
+++ b/packages/vue/src/runtime/kernel.ts
@@ -216,12 +216,13 @@ function getManifestInputs(
 	headers: Record<string, string>
 ) {
 	if (isClientManifestModeEnabled(config)) {
-		const inputs = extractConsentRequestInputs({
-			...headers,
-			...(getBrowserLanguage()
-				? { 'accept-language': getBrowserLanguage() }
-				: {}),
-		});
+		const contextualHeaders = { ...headers };
+		const browserLanguage = getBrowserLanguage();
+		if (browserLanguage) {
+			contextualHeaders['accept-language'] = browserLanguage;
+		}
+
+		const inputs = extractConsentRequestInputs(contextualHeaders);
 		return {
 			country: null,
 			region: null,
@@ -253,21 +254,21 @@ function createVueHostedTransport(
 
 	return {
 		async init(ctx) {
-			const contextualHeaders = pickAllowedInitHeaders({
-				...headers,
-				...(ctx.overrides.language
-					? { 'accept-language': ctx.overrides.language }
-					: {}),
-				...(ctx.overrides.gpc === undefined
-					? {}
-					: { 'sec-gpc': ctx.overrides.gpc ? '1' : '0' }),
-				...(ctx.overrides.country
-					? { 'x-c15t-country': ctx.overrides.country }
-					: {}),
-				...(ctx.overrides.region
-					? { 'x-c15t-region': ctx.overrides.region }
-					: {}),
-			});
+			const initHeaders = { ...headers };
+			if (ctx.overrides.language) {
+				initHeaders['accept-language'] = ctx.overrides.language;
+			}
+			if (ctx.overrides.gpc !== undefined) {
+				initHeaders['sec-gpc'] = ctx.overrides.gpc ? '1' : '0';
+			}
+			if (ctx.overrides.country) {
+				initHeaders['x-c15t-country'] = ctx.overrides.country;
+			}
+			if (ctx.overrides.region) {
+				initHeaders['x-c15t-region'] = ctx.overrides.region;
+			}
+
+			const contextualHeaders = pickAllowedInitHeaders(initHeaders);
 			return (
 				createHostedTransport({
 					backendURL,
@@ -389,10 +390,14 @@ async function refreshClientGeo(
 		if (!(country || region)) {
 			return;
 		}
-		context.kernel.set.overrides({
-			...(country ? { country } : {}),
-			...(region ? { region } : {}),
-		});
+		const overrides: { country?: string; region?: string } = {};
+		if (country) {
+			overrides.country = country;
+		}
+		if (region) {
+			overrides.region = region;
+		}
+		context.kernel.set.overrides(overrides);
 		await context.kernel.commands.init();
 	} catch {
 		// Keep the strict unknown-geo manifest result when the optional geo


### PR DESCRIPTION
## Overview

Enables `anti-slop/no-conditional-empty-object-spread` and replaces conditional empty-object spreads with explicit object construction and optional field assignment. This keeps request and configuration shapes visible to TypeScript without changing runtime behavior.

## Stack

This PR depends on #1044 and is part of stack #1039.

## Testing

- `bun run lint` — passes with 432 rules
- `bun run fmt:check` — passes
- Affected Core, CLI, React, and Vue typechecks pass
- Core focused tests: 138/138
- React conformance: 82/82
- Svelte conformance: 41/41
- Vue conformance: 41/41

The isolated backend HTTP test starts but does not exit or emit results; it was stopped after the focused package suites completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in configuration, request payload, header, and override construction across benchmark tools, SDKs, consent flows, and framework integrations.
  * Preserved existing consent, policy, localization, telemetry, and hosted-mode behavior.
* **Tests**
  * Updated conformance and backend test setup to use clearer, consistent construction patterns.
* **Chores**
  * Strengthened linting by enforcing the rule against conditional empty-object spreads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->