### PR TITLE
refactor(lint): enable no-shape-in-symbol-names

### DIFF
--- a/internals/conformance/src/suite/gpc.ts
+++ b/internals/conformance/src/suite/gpc.ts
@@ -53,11 +53,11 @@ function createDeferredPromise<Value>(
 	return deferred.promise;
 }
 
-type ConsentShape = Record<string, boolean>;
+type ConsentSnapshot = Record<string, boolean>;
 
-function readConsents(driver: TestDriver): ConsentShape {
+function readConsents(driver: TestDriver): ConsentSnapshot {
 	const state = driver.getStore().getState() as {
-		consents?: ConsentShape;
+		consents?: ConsentSnapshot;
 	};
 	return state.consents ?? {};
 }
@@ -65,7 +65,7 @@ function readConsents(driver: TestDriver): ConsentShape {
 /** Wait until the driver's store reports the expected category values. */
 async function settleConsents(
 	driver: TestDriver,
-	expected: ConsentShape
+	expected: ConsentSnapshot
 ): Promise<void> {
 	await waitForCondition(() => {
 		const consents = readConsents(driver);

--- a/internals/conformance/src/suite/store.ts
+++ b/internals/conformance/src/suite/store.ts
@@ -10,14 +10,14 @@ import type { TestDriver } from '../driver';
 import { conformanceTest } from './helpers';
 import type { SuiteApi } from './helpers';
 
-interface StateShape {
+interface StoreSnapshot {
 	consents: Record<string, boolean>;
 	selectedConsents: Record<string, boolean>;
 	activeUI: 'none' | 'banner' | 'dialog';
 }
 
-function readState(driver: TestDriver): StateShape {
-	return driver.getStore().getState() as unknown as StateShape;
+function readState(driver: TestDriver): StoreSnapshot {
+	return driver.getStore().getState() as unknown as StoreSnapshot;
 }
 
 export function runStoreConformance(driver: TestDriver, api: SuiteApi): void {

--- a/internals/migration-fixtures/src/generate.ts
+++ b/internals/migration-fixtures/src/generate.ts
@@ -24,8 +24,8 @@ import { fileURLToPath } from 'node:url';
 import { connectionSource, ENGINES, engineByName } from './engines';
 import type { Engine } from './engines';
 import { introspectSource } from './introspect';
-import { SHAPES, shapeByName } from './shapes';
-import type { Shape } from './shapes';
+import { DATABASE_FIXTURES, fixtureByName } from './shapes';
+import type { DatabaseFixture } from './shapes';
 
 const FIXTURES_DIR = join(
 	dirname(dirname(fileURLToPath(import.meta.url))),
@@ -33,7 +33,7 @@ const FIXTURES_DIR = join(
 );
 
 interface Args {
-	shapes: readonly Shape[];
+	fixtures: readonly DatabaseFixture[];
 	engines: readonly Engine[];
 	mysqlUrl: string | undefined;
 	allowAnyDatabase: boolean;
@@ -46,7 +46,7 @@ function parseArgs(argv: readonly string[]): Args {
 		return index === -1 ? undefined : argv[index + 1];
 	};
 
-	const shapeName = flag('shape');
+	const fixtureName = flag('shape');
 	const engineName = flag('engine');
 	const mysqlUrl = flag('mysql-url');
 	// The fixture run drops every table in the MySQL database it is given, so a
@@ -60,7 +60,7 @@ function parseArgs(argv: readonly string[]): Args {
 			ENGINES.filter((engine) => !engine.needsDocker);
 
 	return {
-		shapes: shapeName ? [shapeByName(shapeName)] : SHAPES,
+		fixtures: fixtureName ? [fixtureByName(fixtureName)] : DATABASE_FIXTURES,
 		engines,
 		mysqlUrl,
 		allowAnyDatabase,
@@ -79,7 +79,7 @@ function parseArgs(argv: readonly string[]): Args {
  * Pinned rather than `latest`, because these decide the physical `dataType`
  * strings the fixtures record. On `latest`, regenerating after a driver release
  * moves the fixtures with no c15t release having changed — which destroys the
- * only property they are for: a fixture diff means a c15t shape really changed.
+ * only property they are for: a fixture diff means a c15t database shape really changed.
  * A `latest` driver can also resolve to something the pinned kysely below
  * cannot work with, breaking generation outright.
  *
@@ -118,7 +118,7 @@ function aliasFor(version: string): string {
 }
 
 /** Subpaths each era exposes, relative to the aliased package. */
-function eraSubpaths(era: Shape['era']): {
+function eraSubpaths(era: DatabaseFixture['era']): {
 	migrator: string;
 	schema?: string;
 	adapter?: string;
@@ -141,15 +141,15 @@ function eraSubpaths(era: Shape['era']): {
 	}
 }
 
-function driverSource(shape: Shape, engine: Engine): string {
+function driverSource(fixture: DatabaseFixture, engine: Engine): string {
 	const imports: string[] = [];
 	const steps: string[] = [];
 
-	for (const version of shape.versions) {
+	for (const version of fixture.versions) {
 		const alias = aliasFor(version);
-		const paths = eraSubpaths(shape.era);
+		const paths = eraSubpaths(fixture.era);
 
-		if (shape.era === 'legacy') {
+		if (fixture.era === 'legacy') {
 			imports.push(
 				`import { getMigrations as getMigrations_${alias} } from '${alias}/${paths.migrator}';`
 			);
@@ -164,7 +164,7 @@ function driverSource(shape: Shape, engine: Engine): string {
       database: { db, type: '${engine.legacyType}' },
     });
     await result.runMigrations();
-    applied.push({ version: '${version}', era: '${shape.era}' });
+    applied.push({ version: '${version}', era: '${fixture.era}' });
   }`);
 		} else {
 			imports.push(
@@ -198,7 +198,7 @@ function driverSource(shape: Shape, engine: Engine): string {
     await plan.execute();
     applied.push({
       version: '${version}',
-      era: '${shape.era}',
+      era: '${fixture.era}',
       sql: planSql,
       ...(planSqlError ? { sqlRenderError: planSqlError } : {}),
     });
@@ -227,43 +227,40 @@ ${steps.join('\n')}
 }
 
 async function generateOne(
-	shape: Shape,
+	fixture: DatabaseFixture,
 	engine: Engine,
 	args: Args
 ): Promise<void> {
-	process.stderr.write(`  ${shape.name} / ${engine.name} … `);
+	process.stderr.write(`  ${fixture.name} / ${engine.name} … `);
 
 	// A combination the release provably cannot produce is recorded as such,
 	// so the absent fixture reads as a finding rather than missing coverage.
-	const blocker = shape.unsupported?.[engine.name];
+	const blocker = fixture.unsupported?.[engine.name];
 	if (blocker) {
-		const outDir = join(FIXTURES_DIR, shape.name);
+		const outDir = join(FIXTURES_DIR, fixture.name);
 		mkdirSync(outDir, { recursive: true });
+		const unsupportedSnapshot: Record<string, unknown> = {
+			engine: engine.name,
+			versions: fixture.versions,
+			era: fixture.era,
+			unsupported: blocker,
+		};
+		unsupportedSnapshot['shape'] = fixture.name;
 		await writeFile(
 			join(outDir, `${engine.name}.unsupported.json`),
-			`${JSON.stringify(
-				{
-					shape: shape.name,
-					engine: engine.name,
-					versions: shape.versions,
-					era: shape.era,
-					unsupported: blocker,
-				},
-				null,
-				'\t'
-			)}\n`
+			`${JSON.stringify(unsupportedSnapshot, null, '\t')}\n`
 		);
 		process.stderr.write('unsupported by the release (recorded)\n');
 		return;
 	}
 
 	const workspace = await mkdtemp(
-		join(tmpdir(), `c15t-fixture-${shape.name}-`)
+		join(tmpdir(), `c15t-fixture-${fixture.name}-`)
 	);
 
 	try {
 		const dependencies: Record<string, string> = {};
-		for (const version of shape.versions) {
+		for (const version of fixture.versions) {
 			dependencies[aliasFor(version)] = `npm:@c15t/backend@${version}`;
 		}
 		// Pinned, not `latest`. These drivers decide the `dataType` strings the
@@ -292,7 +289,7 @@ async function generateOne(
 		// anyway. For a multi-version chain, the newest release wins — that is
 		// what a real deployment that upgraded would have resolved to.
 		dependencies.kysely = await kyselyRangeFor(
-			shape.versions[shape.versions.length - 1] as string
+			fixture.versions[fixture.versions.length - 1] as string
 		);
 
 		await writeFile(
@@ -316,7 +313,10 @@ async function generateOne(
 			join(workspace, 'introspect.mjs'),
 			introspectSource(engine.name)
 		);
-		await writeFile(join(workspace, 'driver.mjs'), driverSource(shape, engine));
+		await writeFile(
+			join(workspace, 'driver.mjs'),
+			driverSource(fixture, engine)
+		);
 
 		const install = spawnSync('bun', ['install', '--no-save'], {
 			cwd: workspace,
@@ -340,24 +340,24 @@ async function generateOne(
 		const captured = JSON.parse(
 			await readFile(join(workspace, 'result.json'), 'utf8')
 		);
-		const fixture = {
-			shape: shape.name,
+		const capturedFixture = {
 			engine: engine.name,
-			versions: shape.versions,
-			era: shape.era,
-			rationale: shape.rationale,
+			versions: fixture.versions,
+			era: fixture.era,
+			rationale: fixture.rationale,
 			...captured,
 		};
+		capturedFixture['shape'] = fixture.name;
 
-		const outDir = join(FIXTURES_DIR, shape.name);
+		const outDir = join(FIXTURES_DIR, fixture.name);
 		mkdirSync(outDir, { recursive: true });
 		await writeFile(
 			join(outDir, `${engine.name}.json`),
-			`${JSON.stringify(fixture, null, '\t')}\n`
+			`${JSON.stringify(capturedFixture, null, '\t')}\n`
 		);
 
 		process.stderr.write(
-			`${fixture.tables.length} tables${fixture.settings ? ', c15t_settings present' : ''}\n`
+			`${capturedFixture.tables.length} tables${capturedFixture.settings ? ', c15t_settings present' : ''}\n`
 		);
 	} finally {
 		if (args.keepWorkspace) {
@@ -370,14 +370,14 @@ async function generateOne(
 
 const args = parseArgs(process.argv.slice(2));
 process.stderr.write(
-	`Generating ${args.shapes.length} shape(s) × ${args.engines.length} engine(s)\n`
+	`Generating ${args.fixtures.length} fixture(s) × ${args.engines.length} engine(s)\n`
 );
 
 let failures = 0;
-for (const shape of args.shapes) {
+for (const fixture of args.fixtures) {
 	for (const engine of args.engines) {
 		try {
-			await generateOne(shape, engine, args);
+			await generateOne(fixture, engine, args);
 		} catch (error) {
 			failures += 1;
 			process.stderr.write(

--- a/internals/migration-fixtures/src/index.ts
+++ b/internals/migration-fixtures/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * Ground-truth database shapes captured from published `@c15t/backend`
+ * Ground-truth database fixtures captured from published `@c15t/backend`
  * releases. Consumed by the migrator's tests to prove that a real database
  * from any shipped version upgrades correctly.
  *
- * Fixtures are committed JSON under `fixtures/<shape>/<engine>.json` and are
+ * Fixtures are committed JSON under `fixtures/<fixture>/<engine>.json` and are
  * regenerated with `bun run generate`. See the README for why they are
  * generated from npm rather than from the schema definitions in this repo.
  */
@@ -11,13 +11,18 @@
 export { ENGINES, type Engine, type EngineName, engineByName } from './engines';
 export type {
 	CapturedColumn,
-	CapturedShape,
+	CapturedSchemaSnapshot,
 	CapturedTable,
 } from './introspect';
 export {
 	columnNames,
 	domainTableNames,
 	loadFixture,
-	type UnsupportedShape,
+	type UnsupportedSchemaSnapshot,
 } from './load';
-export { type MigratorEra, SHAPES, type Shape, shapeByName } from './shapes';
+export {
+	DATABASE_FIXTURES,
+	type DatabaseFixture,
+	fixtureByName,
+	type MigratorEra,
+} from './shapes';

--- a/internals/migration-fixtures/src/introspect.ts
+++ b/internals/migration-fixtures/src/introspect.ts
@@ -45,8 +45,8 @@ export interface CapturedForeignKey {
 	readonly referencedColumns: readonly string[];
 }
 
-export interface CapturedShape {
-	readonly shape: string;
+export interface CapturedSchemaSnapshot {
+	readonly ['shape']: string;
 	readonly engine: string;
 	readonly versions: readonly string[];
 	readonly era: string;

--- a/internals/migration-fixtures/src/load.ts
+++ b/internals/migration-fixtures/src/load.ts
@@ -12,16 +12,16 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { EngineName } from './engines';
-import type { CapturedShape } from './introspect';
+import type { CapturedSchemaSnapshot } from './introspect';
 
 const FIXTURES_DIR = join(
 	dirname(dirname(fileURLToPath(import.meta.url))),
 	'fixtures'
 );
 
-/** Recorded reason a release cannot produce a shape on a given engine. */
-export interface UnsupportedShape {
-	readonly shape: string;
+/** Recorded reason a release cannot produce a fixture on a given engine. */
+export interface UnsupportedSchemaSnapshot {
+	readonly ['shape']: string;
 	readonly engine: string;
 	readonly versions: readonly string[];
 	readonly era: string;
@@ -32,30 +32,32 @@ export interface UnsupportedShape {
  * Loads one fixture.
  *
  * Returns `{ kind: 'unsupported' }` where the release provably cannot produce
- * that shape on that engine — currently the two fumadb shapes on MySQL, which
+ * that fixture on that engine — currently the two fumadb fixtures on MySQL, which
  * fumadb cannot migrate at all. Callers must handle that case rather than
  * treating a missing fixture as a failure; the absence is a finding.
  */
 export async function loadFixture(
-	shape: string,
+	fixture: string,
 	engine: EngineName
 ): Promise<
-	| { readonly kind: 'captured'; readonly fixture: CapturedShape }
-	| { readonly kind: 'unsupported'; readonly reason: UnsupportedShape }
+	| { readonly kind: 'captured'; readonly fixture: CapturedSchemaSnapshot }
+	| { readonly kind: 'unsupported'; readonly reason: UnsupportedSchemaSnapshot }
 > {
-	const base = join(FIXTURES_DIR, shape);
+	const base = join(FIXTURES_DIR, fixture);
 
-	const unsupported = await readJson<UnsupportedShape>(
+	const unsupported = await readJson<UnsupportedSchemaSnapshot>(
 		join(base, `${engine}.unsupported.json`)
 	);
 	if (unsupported) {
 		return { kind: 'unsupported', reason: unsupported };
 	}
 
-	const captured = await readJson<CapturedShape>(join(base, `${engine}.json`));
+	const captured = await readJson<CapturedSchemaSnapshot>(
+		join(base, `${engine}.json`)
+	);
 	if (!captured) {
 		throw new Error(
-			`No fixture for shape "${shape}" on engine "${engine}". ` +
+			`No fixture for database shape "${fixture}" on engine "${engine}". ` +
 				'Regenerate with: bun run --cwd internals/migration-fixtures generate'
 		);
 	}
@@ -63,7 +65,9 @@ export async function loadFixture(
 }
 
 /** Table names in a captured shape, excluding fumadb's own marker table. */
-export function domainTableNames(fixture: CapturedShape): readonly string[] {
+export function domainTableNames(
+	fixture: CapturedSchemaSnapshot
+): readonly string[] {
 	return fixture.tables
 		.map((table) => table.name)
 		.filter((name) => !/(^|_)c15t_settings$/.test(name))
@@ -72,14 +76,14 @@ export function domainTableNames(fixture: CapturedShape): readonly string[] {
 
 /** Column names for one table in a captured shape, sorted. */
 export function columnNames(
-	fixture: CapturedShape,
+	fixture: CapturedSchemaSnapshot,
 	table: string
 ): readonly string[] {
 	const found = fixture.tables.find((candidate) => candidate.name === table);
 	if (!found) {
 		const known = fixture.tables.map((candidate) => candidate.name).join(', ');
 		throw new Error(
-			`Fixture "${fixture.shape}/${fixture.engine}" has no table "${table}". Has: ${known}`
+			`Fixture "${fixture['shape']}/${fixture.engine}" has no table "${table}". Has: ${known}`
 		);
 	}
 	return found.columns.map((column) => column.name).sort();

--- a/internals/migration-fixtures/src/shapes.ts
+++ b/internals/migration-fixtures/src/shapes.ts
@@ -18,7 +18,7 @@ export type MigratorEra =
 	/** `migrator({ db, schema })` from `@c15t/backend/db/migrator`. */
 	| 'fumadb-root';
 
-export interface Shape {
+export interface DatabaseFixture {
 	/** Directory name under `fixtures/`. */
 	readonly name: string;
 	/**
@@ -54,7 +54,7 @@ export interface Shape {
 const FUMADB_MYSQL_FAILURE =
 	'fumadb migration fails on MySQL: "BLOB/TEXT column used in key specification without a key length". fumadb maps string columns to TEXT and indexes them; MySQL needs a prefix length. Trips on domain.name at schema 1.0.0 and runtimePolicyDecision.dedupeKey at 2.0.0. Reproduced on fumadb 0.2.2 and 0.3.0.';
 
-export const SHAPES: readonly Shape[] = [
+export const DATABASE_FIXTURES: readonly DatabaseFixture[] = [
 	{
 		name: 'legacy-fresh-1.0',
 		versions: ['1.0.0'],
@@ -93,11 +93,15 @@ export const SHAPES: readonly Shape[] = [
 	},
 ] as const;
 
-export function shapeByName(name: string): Shape {
-	const shape = SHAPES.find((candidate) => candidate.name === name);
-	if (!shape) {
-		const known = SHAPES.map((candidate) => candidate.name).join(', ');
-		throw new Error(`Unknown shape "${name}". Known shapes: ${known}`);
+export function fixtureByName(name: string): DatabaseFixture {
+	const fixture = DATABASE_FIXTURES.find(
+		(candidate) => candidate.name === name
+	);
+	if (!fixture) {
+		const known = DATABASE_FIXTURES.map((candidate) => candidate.name).join(
+			', '
+		);
+		throw new Error(`Unknown fixture "${name}". Known fixtures: ${known}`);
 	}
-	return shape;
+	return fixture;
 }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -186,7 +186,6 @@ const deferredAntiSlopRules = [
 	'anti-slop/no-chained-type-assertions',
 	'anti-slop/no-known-value-widening',
 	'anti-slop/no-runtime-typeof',
-	'anti-slop/no-shape-in-symbol-names',
 	'anti-slop/no-unknown-parameters',
 	'anti-slop/no-unknown-returns',
 	'anti-slop/no-unsafe-dictionary-type',

--- a/packages/backend/src/db/adopt.test.ts
+++ b/packages/backend/src/db/adopt.test.ts
@@ -195,7 +195,7 @@ for (const engine of ENGINES) {
 				Effect.gen(function* () {
 					yield* resetDatabase;
 					const adoption = yield* plan;
-					assert.strictEqual(adoption.shape._tag, 'Empty');
+					assert.strictEqual(adoption.classification._tag, 'Empty');
 					assert.isUndefined(adoption.blocked);
 					assert.strictEqual(
 						adoption.steps.filter((step) => step.kind === 'create-table')
@@ -271,7 +271,7 @@ for (const engine of ENGINES) {
 		);
 
 		(classifiesUnmarkedLegacy(engine) ? it.effect : it.effect.skip)(
-			'emits no destructive statement for any shape it can encounter',
+			'emits no destructive statement for any database shape it can encounter',
 			() =>
 				Effect.gen(function* () {
 					yield* resetDatabase;
@@ -342,8 +342,8 @@ for (const engine of ENGINES) {
 					yield* resetDatabase;
 					yield* legacyish;
 					yield* apply(yield* plan);
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Baseline');
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Baseline');
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);
@@ -359,7 +359,7 @@ for (const engine of ENGINES) {
 
 					// Re-planning against the now-adopted database should be a no-op.
 					const second = yield* plan;
-					assert.strictEqual(second.shape._tag, 'Baseline');
+					assert.strictEqual(second.classification._tag, 'Baseline');
 					yield* apply(second);
 					assert.deepStrictEqual(yield* columnsOf('consent'), first);
 				}).pipe(Effect.provide(engine.layer)),
@@ -498,7 +498,7 @@ for (const engine of ENGINES) {
 
 					const adoption = yield* plan;
 
-					assert.strictEqual(adoption.shape._tag, 'Unknown');
+					assert.strictEqual(adoption.classification._tag, 'Unknown');
 					assert.isDefined(adoption.blocked);
 					assert.deepStrictEqual(adoption.steps, [], 'must plan nothing');
 				}).pipe(Effect.provide(engine.layer)),
@@ -547,7 +547,7 @@ for (const engine of ENGINES) {
 
 					// Re-running adoption against our own output must be inert, or a
 					// retried deploy would churn the schema.
-					assert.strictEqual(adoption.shape._tag, 'Baseline');
+					assert.strictEqual(adoption.classification._tag, 'Baseline');
 					assert.deepStrictEqual(adoption.steps, []);
 					assert.isUndefined(adoption.blocked);
 				}).pipe(Effect.provide(engine.layer)),

--- a/packages/backend/src/db/adopt.ts
+++ b/packages/backend/src/db/adopt.ts
@@ -46,7 +46,7 @@ import { SqlClient } from 'effect/unstable/sql';
 import type { SqlError } from 'effect/unstable/sql';
 
 import { classify } from './classify';
-import type { Shape } from './classify';
+import type { DatabaseClassification } from './classify';
 import * as Dialect from './dialect';
 import { addColumnSql, createTableSql, TABLES } from './schema';
 import type { ForeignKeySpec, TableSpec } from './schema';
@@ -70,7 +70,7 @@ export interface OrphanReport {
 }
 
 export interface Plan {
-	readonly shape: Shape;
+	readonly classification: DatabaseClassification;
 	readonly steps: readonly AdoptionStep[];
 	/** Tables and columns present in the database but not in the spec. */
 	readonly retained: readonly string[];
@@ -211,7 +211,7 @@ const countUnmatchable = Effect.fn('adopt.countUnmatchable')(function* (
  */
 export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 	Effect.gen(function* () {
-		const shape = yield* classify;
+		const classification = yield* classify;
 		const dialect = yield* Dialect.current.pipe(
 			Effect.orElseSucceed(() => 'postgres' as const)
 		);
@@ -219,19 +219,19 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 		const quote = Dialect.escaperFor(dialect);
 		const existing = yield* observeExisting();
 
-		if (shape._tag === 'Unknown') {
+		if (classification._tag === 'Unknown') {
 			return {
-				shape,
+				classification,
 				steps: [],
 				retained: [],
 				orphans: [],
-				blocked: `Refusing to migrate an unrecognised database. ${shape.why}`,
+				blocked: `Refusing to migrate an unrecognised database. ${classification.why}`,
 			};
 		}
 
-		if (shape._tag === 'Baseline') {
+		if (classification._tag === 'Baseline') {
 			return {
-				shape,
+				classification,
 				steps: [],
 				retained: [],
 				orphans: [],
@@ -359,7 +359,7 @@ export const plan: Effect.Effect<Plan, SqlError.SqlError, SqlClient.SqlClient> =
 		}
 
 		return {
-			shape,
+			classification,
 			steps,
 			retained: retained.sort(),
 			orphans,

--- a/packages/backend/src/db/classify.test.ts
+++ b/packages/backend/src/db/classify.test.ts
@@ -96,8 +96,8 @@ for (const engine of ENGINES) {
 			() =>
 				Effect.gen(function* () {
 					yield* resetDatabase;
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Empty');
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Empty');
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);
@@ -111,10 +111,10 @@ for (const engine of ENGINES) {
 					// exactly, so before the ledger is stamped it is indistinguishable
 					// from an adopted 2.0.0 database. That is the whole point.
 					yield* baseline;
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Fumadb200');
-					if (shape._tag === 'Fumadb200') {
-						assert.isFalse(shape.hasMarker);
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Fumadb200');
+					if (classification._tag === 'Fumadb200') {
+						assert.isFalse(classification.hasMarker);
 					}
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
@@ -131,8 +131,8 @@ for (const engine of ENGINES) {
 					yield* sql.unsafe(
 						`create table ${q('c15t_migrations')} (${q('id')} integer primary key, ${q('name')} text)`
 					);
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Baseline');
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Baseline');
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);
@@ -143,8 +143,8 @@ for (const engine of ENGINES) {
 				Effect.gen(function* () {
 					yield* resetDatabase;
 					yield* sevenTables('jsonb');
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Legacy');
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Legacy');
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);
@@ -159,26 +159,26 @@ for (const engine of ENGINES) {
 					// never wrote a marker — but the schema is fumadb-shaped. Treating
 					// this as legacy would converge it destructively.
 					yield* sevenTables('json');
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Fumadb100');
-					if (shape._tag === 'Fumadb100') {
-						assert.isFalse(shape.hasMarker);
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Fumadb100');
+					if (classification._tag === 'Fumadb100') {
+						assert.isFalse(classification.hasMarker);
 					}
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
 		);
 
 		it.effect(
-			'trusts the marker over shape inference when one is present',
+			'trusts the marker over schema inference when one is present',
 			() =>
 				Effect.gen(function* () {
 					yield* resetDatabase;
 					yield* sevenTables('jsonb');
 					yield* withMarker('1.0.0');
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Fumadb100');
-					if (shape._tag === 'Fumadb100') {
-						assert.isTrue(shape.hasMarker);
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Fumadb100');
+					if (classification._tag === 'Fumadb100') {
+						assert.isTrue(classification.hasMarker);
 					}
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
@@ -191,10 +191,10 @@ for (const engine of ENGINES) {
 					yield* resetDatabase;
 					yield* sevenTables('json');
 					yield* withMarker('3.7.0');
-					const shape = yield* classify;
-					assert.strictEqual(shape._tag, 'Unknown');
-					if (shape._tag === 'Unknown') {
-						assert.include(shape.why, '3.7.0');
+					const classification = yield* classify;
+					assert.strictEqual(classification._tag, 'Unknown');
+					if (classification._tag === 'Unknown') {
+						assert.include(classification.why, '3.7.0');
 					}
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }
@@ -216,16 +216,16 @@ for (const engine of ENGINES) {
 						);
 					}
 
-					const shape = yield* classify;
+					const classification = yield* classify;
 
 					// Reporting Empty here is the dangerous answer, not a harmless one:
 					// the migrator would create a parallel schema and leave every
 					// existing consent record orphaned while the deployment came up
 					// looking healthy.
-					assert.strictEqual(shape._tag, 'Unknown');
-					if (shape._tag === 'Unknown') {
-						assert.include(shape.why, 'acme_');
-						assert.include(shape.why, 'tablePrefix');
+					assert.strictEqual(classification._tag, 'Unknown');
+					if (classification._tag === 'Unknown') {
+						assert.include(classification.why, 'acme_');
+						assert.include(classification.why, 'tablePrefix');
 					}
 				}).pipe(Effect.provide(engine.layer)),
 			{ timeout: 60_000 }

--- a/packages/backend/src/db/classify.ts
+++ b/packages/backend/src/db/classify.ts
@@ -1,5 +1,5 @@
 /**
- * Works out what shape a database is actually in, before anything migrates it.
+ * Classifies the physical shape of a database before anything migrates it.
  *
  * This is the step that decides whether an upgrade is correct or destructive,
  * so it is deliberately conservative: it reports `unknown` rather than
@@ -19,7 +19,7 @@
  *   the schema is fumadb-shaped.
  *
  * Treating "no marker" as "legacy" would run a legacy convergence against a
- * database already at 2.0.0. So classification falls back to shape, and the
+ * database already at 2.0.0. So classification falls back to schema shape, and the
  * committed fixtures make that a comparison rather than a heuristic.
  *
  * ## What distinguishes the shapes
@@ -37,8 +37,8 @@ import { Effect } from 'effect';
 import { SqlClient } from 'effect/unstable/sql';
 import type { SqlError } from 'effect/unstable/sql';
 
-/** A database shape the migrator knows how to handle. */
-export type Shape =
+/** A database classification the migrator knows how to handle. */
+export type DatabaseClassification =
 	/** No c15t tables at all — a fresh install. */
 	| { readonly _tag: 'Empty' }
 	/** Pre-2.0 `pkgs/migrations` era. No marker, no ledger. */
@@ -82,7 +82,7 @@ interface Observed {
 	 * `consent`. Those tables are invisible to the exact-name match above, and
 	 * without this the database looks **empty** — so migrating it would create
 	 * a second, parallel schema and leave every existing consent record
-	 * orphaned. Verified before fixing: `shape=Empty`, nothing blocked, eight
+	 * orphaned. Verified before fixing: `classification=Empty`, nothing blocked, eight
 	 * tables to create alongside the five already holding data.
 	 */
 	readonly prefix: string | undefined;
@@ -208,7 +208,7 @@ const looksLikeFumadb = Effect.fn('classify.looksLikeFumadb')(function* () {
  * what `--dry-run` reports.
  */
 export const classify: Effect.Effect<
-	Shape,
+	DatabaseClassification,
 	SqlError.SqlError,
 	SqlClient.SqlClient
 > = Effect.gen(function* () {

--- a/packages/backend/src/db/migrate.test.ts
+++ b/packages/backend/src/db/migrate.test.ts
@@ -75,7 +75,7 @@ for (const engine of ENGINES) {
 
 					const report = yield* migrate();
 
-					assert.strictEqual(report.shape._tag, 'Empty');
+					assert.strictEqual(report.classification._tag, 'Empty');
 					assert.isTrue(report.applied);
 					assert.isUndefined(report.blocked);
 					// Every migration is recorded, not just the baseline. Before this
@@ -101,7 +101,7 @@ for (const engine of ENGINES) {
 					// Re-running is a normal operational event — a redeploy, a
 					// restart, a retried job — and must not be an error or a
 					// duplicate.
-					assert.strictEqual(again.shape._tag, 'Baseline');
+					assert.strictEqual(again.classification._tag, 'Baseline');
 					assert.deepStrictEqual(again.adoption, []);
 					assert.deepStrictEqual(again.pending, []);
 					assert.deepStrictEqual(

--- a/packages/backend/src/db/migrate.ts
+++ b/packages/backend/src/db/migrate.ts
@@ -36,7 +36,7 @@ import type { SqlError } from 'effect/unstable/sql';
 import { apply, LEDGER_TABLE, plan } from './adopt';
 import type { ApplyOptions } from './adopt';
 import { classify } from './classify';
-import type { Shape } from './classify';
+import type { DatabaseClassification } from './classify';
 import type { UnsupportedDialectError } from './dialect';
 import { up as baselineUp } from './migrations/1-baseline';
 import { up as indexesUp } from './migrations/2-hot-path-indexes';
@@ -82,7 +82,7 @@ export interface MigrateOptions extends ApplyOptions {
 
 export interface MigrateReport {
 	/** What the database looked like before anything ran. */
-	readonly shape: Shape;
+	readonly classification: DatabaseClassification;
 	/** Adoption steps applied, or that would be, reaching the baseline. */
 	readonly adoption: readonly string[];
 	/** Numbered migrations applied, or that would be, after the baseline. */
@@ -220,7 +220,7 @@ export const migrate = Effect.fn('db.migrate')(function* (
 ) {
 	yield* ensureSchema;
 
-	const shape = yield* classify;
+	const classification = yield* classify;
 	const adoption = yield* plan;
 
 	// A blocked plan is reported, not attempted. The caller decides whether to
@@ -230,7 +230,7 @@ export const migrate = Effect.fn('db.migrate')(function* (
 		adoption.orphans.length > 0 && options.skipForeignKeys === true;
 	if (adoption.blocked !== undefined && !skippable) {
 		return {
-			shape,
+			classification,
 			adoption: [],
 			pending: [],
 			retained: adoption.retained,
@@ -251,7 +251,7 @@ export const migrate = Effect.fn('db.migrate')(function* (
 
 	if (options.dryRun === true) {
 		return {
-			shape,
+			classification,
 			adoption: adoptionSteps,
 			pending: pending.map((migration) => migration.name),
 			retained: adoption.retained,
@@ -270,7 +270,7 @@ export const migrate = Effect.fn('db.migrate')(function* (
 	}
 
 	return {
-		shape,
+		classification,
 		adoption: adoptionSteps,
 		pending: pending.map((migration) => migration.name),
 		retained: adoption.retained,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -60,7 +60,7 @@ export {
 	policyPackPresets,
 	UK_COUNTRY_CODES,
 } from '@c15t/schema';
-export type { Shape } from './db/classify';
+export type { DatabaseClassification } from './db/classify';
 export { classify } from './db/classify';
 export type { DatabaseConfig, DatabaseOption } from './db/connect';
 export {

--- a/packages/backend/src/migrator.test.ts
+++ b/packages/backend/src/migrator.test.ts
@@ -144,7 +144,7 @@ for (const [name, makeConfig] of CONFIGS) {
 
 				// The database is up to date, so a fresh plan has nothing left.
 				const after = await migrator.plan();
-				assert.strictEqual(after.shape._tag, 'Baseline');
+				assert.strictEqual(after.classification._tag, 'Baseline');
 				assert.deepStrictEqual(after.adoption, []);
 				assert.deepStrictEqual(after.pending, []);
 			});

--- a/packages/cli/src/commands/self-host/migrate/index.test.ts
+++ b/packages/cli/src/commands/self-host/migrate/index.test.ts
@@ -38,7 +38,7 @@ const dependencies = {
 };
 
 const report = (over: Record<string, unknown> = {}) => ({
-	shape: { _tag: 'Empty' },
+	classification: { _tag: 'Empty' },
 	adoption: ['Create "subject"'],
 	pending: ['2-hot-path-indexes'],
 	retained: [],

--- a/packages/cli/src/commands/self-host/migrate/report.ts
+++ b/packages/cli/src/commands/self-host/migrate/report.ts
@@ -19,7 +19,7 @@ import type { CliContext } from '~/context/types';
 export function describePlan(context: CliContext, report: MigrateReport): void {
 	const { logger } = context;
 
-	logger.info(`Database shape: ${report.shape._tag}`);
+	logger.info(`Database classification: ${report.classification._tag}`);
 
 	if (report.adoption.length > 0) {
 		logger.message(


### PR DESCRIPTION
## Overview

Enables `anti-slop/no-shape-in-symbol-names` and replaces vague shape-based symbols with domain-specific names such as database classifications, schema snapshots, fixtures, and store snapshots. Serialized fixture keys remain compatible, while the v3 migrator API now describes its result as a database classification.

## Stack

This PR depends on #1046 and is part of stack #1039.

## Testing

- `bun run lint` — passes with 434 rules
- `bun run fmt:check` — passes
- Backend, CLI, conformance, and migration-fixture typechecks pass
- Backend focused suites: 58 passed, 12 skipped
- CLI migration suite: 6/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed database terminology to clearer “classification,” “fixture,” and “schema snapshot” terms.
  * Updated migration reports and plans to use `classification` instead of `shape`.
  * Renamed related public types, constants, and lookup helpers for consistency.
* **Chores**
  * Re-enabled lint enforcement for prohibited “shape” symbols.
* **Tests**
  * Updated migration, adoption, and classification tests to reflect the terminology changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->