### PR TITLE
test(nextjs): fix accessibility conformance driver

### DIFF
--- a/packages/c15t/__tests__/facade-parity.test.ts
+++ b/packages/c15t/__tests__/facade-parity.test.ts
@@ -105,7 +105,6 @@ const EXPECTED_ESM_FAILURES = new Set<string>([
 	// The @c15t/nextjs ESM dist resolves `next/*` subpaths that only exist
 	// inside a bundler.
 	'./next',
-	'./next/v3/server',
 	'./next/v3/middleware',
 	// The vue plugin/runtime entries need a Nuxt/Vite context (`#imports`)
 	// or the `.vue` SFC pipeline.

--- a/packages/nextjs/src/__tests__/conformance.test.tsx
+++ b/packages/nextjs/src/__tests__/conformance.test.tsx
@@ -428,21 +428,31 @@ function StoreBridge({ bridge }: { bridge: SnapshotBridge }) {
 	return null;
 }
 
-function componentFor(component: MountableComponent): ReactElement {
-	switch (component) {
+function componentFor(opts: MountOptions): ReactElement {
+	const provided = (opts.providerOptions ?? {}) as ProviderOptions;
+	const trapFocus = provided.trapFocus ?? false;
+
+	switch (opts.component) {
 		case 'consent-banner':
 			return (
-				<ConsentBanner
-					disableAnimation
-					trapFocus={false}
-					hideBranding
-				/>
+				<>
+					<ConsentBanner
+						disableAnimation
+						trapFocus={trapFocus}
+						hideBranding
+					/>
+					<ConsentDialog
+						disableAnimation
+						trapFocus={trapFocus}
+						hideBranding
+					/>
+				</>
 			);
 		case 'consent-dialog':
 			return (
 				<ConsentDialog
 					disableAnimation
-					trapFocus={false}
+					trapFocus={trapFocus}
 					hideBranding
 				/>
 			);
@@ -450,7 +460,7 @@ function componentFor(component: MountableComponent): ReactElement {
 			return <ConsentWidget hideBranding />;
 		case 'iab-consent-banner':
 		case 'iab-consent-dialog':
-			throw new DriverNotImplementedError('nextjs', `mount(${component})`);
+			throw new DriverNotImplementedError('nextjs', `mount(${opts.component})`);
 	}
 }
 
@@ -460,7 +470,7 @@ function Harness({ opts }: { opts: MountOptions }) {
 			data-testid="nextjs-conformance-root"
 			dir={opts.locale === 'ar' ? 'rtl' : undefined}
 		>
-			{componentFor(opts.component)}
+			{componentFor(opts)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Overview

Repairs the Next.js conformance driver so accessibility cases exercise the same focus-trap inputs as the React driver. Banner mounts now include the dialog needed for the banner-to-dialog flow, and both components honor the requested `trapFocus` option.

This fixes seven pre-existing Next.js accessibility conformance failures exposed while validating the lint stack.

## Stack

This PR depends on #1047 and is part of stack #1039.

## Testing

- Next.js conformance: 41/41
- `bun run --cwd packages/nextjs check-types`
- `bun run lint` — passes with 434 rules
- `bun run fmt:check` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus-trapping behavior across consent banners and dialogs.
  * Updated consent banner test scenarios to include the associated consent dialog for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->