### PR TITLE
fix(ui): ship default theme tokens in the published stylesheets

### DIFF
--- a/.changeset/ui-default-theme-tokens.md
+++ b/.changeset/ui-default-theme-tokens.md
@@ -1,0 +1,5 @@
+---
+'@c15t/ui': patch
+---
+
+Ship the default theme tokens in the published stylesheets. `styles.css`, `styles.tw3.css` and the IAB entrypoints now start with the `defaultTheme` tokens (`--c15t-surface`, `--c15t-radius-lg`, `--c15t-font-family`, ...) generated from the same `defaultTheme` the runtime exports, so an app that imports the stylesheet without passing a `theme` gets the default look instead of an unstyled banner — serif fallback font, square corners, transparent buttons. This matters most for server-rendered, zero-JS pages, which can never inject tokens client-side. A provider that does pass a `theme` still overrides them.

--- a/apps/parity-runner/src/diff-computed-style.test.ts
+++ b/apps/parity-runner/src/diff-computed-style.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'bun:test';
+
+import {
+	normalizeComputedStyleMap,
+	normalizeCssValue,
+} from './diff-computed-style';
+
+test('normalizeCssValue restores a missing leading zero', () => {
+	expect(normalizeCssValue('.5rem')).toBe('0.5rem');
+	expect(normalizeCssValue('cubic-bezier(.4, 0, .2, 1)')).toBe(
+		'cubic-bezier(0.4, 0, 0.2, 1)'
+	);
+	expect(normalizeCssValue('rgba(0, 0, 0, .08)')).toBe('rgba(0, 0, 0, 0.08)');
+});
+
+test('normalizeCssValue converts seconds to milliseconds', () => {
+	expect(normalizeCssValue('.15s')).toBe('150ms');
+	expect(normalizeCssValue('2s')).toBe('2000ms');
+	expect(normalizeCssValue('0.08s')).toBe('80ms');
+});
+
+test('normalizeCssValue leaves milliseconds alone', () => {
+	expect(normalizeCssValue('150ms')).toBe('150ms');
+	expect(normalizeCssValue('80ms cubic-bezier(0.4, 0, 0.2, 1)')).toBe(
+		'80ms cubic-bezier(0.4, 0, 0.2, 1)'
+	);
+});
+
+test('normalizeCssValue strips the CSS Modules hash from a scoped name', () => {
+	expect(normalizeCssValue('_enter_t5rx4_1')).toBe('enter');
+	expect(
+		normalizeCssValue('_enter_t5rx4_1 80ms cubic-bezier(.4, 0, .2, 1)')
+	).toBe('enter 80ms cubic-bezier(0.4, 0, 0.2, 1)');
+});
+
+test('normalizeCssValue folds the two spellings onto one another', () => {
+	const minified = normalizeCssValue(
+		'enter 80ms cubic-bezier(.4, 0, .2, 1), fade .15s linear'
+	);
+	const authored = normalizeCssValue(
+		'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1), _fade_t5rx4_2 150ms linear'
+	);
+	expect(minified).toBe(authored);
+});
+
+test('normalizeCssValue drops trailing zeros', () => {
+	expect(normalizeCssValue('1.50px')).toBe('1.5px');
+	expect(normalizeCssValue('2.0rem')).toBe('2rem');
+	expect(normalizeCssValue('10px')).toBe('10px');
+});
+
+test('normalizeCssValue leaves values it does not recognise alone', () => {
+	expect(normalizeCssValue('rgb(255, 255, 255)')).toBe('rgb(255, 255, 255)');
+	expect(normalizeCssValue('"Inter", system-ui, sans-serif')).toBe(
+		'"Inter", system-ui, sans-serif'
+	);
+	expect(normalizeCssValue('translate3d(0, 0, 0)')).toBe(
+		'translate3d(0, 0, 0)'
+	);
+	expect(normalizeCssValue('none')).toBe('none');
+});
+
+test('normalizeComputedStyleMap normalizes values, not keys', () => {
+	const normalized = normalizeComputedStyleMap({
+		'consent-banner-card': {
+			customProperties: { '--accordion-radius': '.5rem' },
+			properties: { 'border-radius': '.5rem', display: 'flex' },
+		},
+	});
+
+	expect(normalized).toEqual({
+		'consent-banner-card': {
+			customProperties: { '--accordion-radius': '0.5rem' },
+			properties: { 'border-radius': '0.5rem', display: 'flex' },
+		},
+	});
+});

--- a/apps/parity-runner/src/diff-computed-style.test.ts
+++ b/apps/parity-runner/src/diff-computed-style.test.ts
@@ -38,7 +38,10 @@ test('normalizeCssValue folds the two spellings onto one another', () => {
 		'enter 80ms cubic-bezier(.4, 0, .2, 1), fade .15s linear'
 	);
 	const authored = normalizeCssValue(
-		'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1), _fade_t5rx4_2 150ms linear'
+		[
+			'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1),',
+			'_fade_t5rx4_2 150ms linear',
+		].join(' ')
 	);
 	expect(minified).toBe(authored);
 });
@@ -74,4 +77,33 @@ test('normalizeComputedStyleMap normalizes values, not keys', () => {
 			properties: { 'border-radius': '0.5rem', display: 'flex' },
 		},
 	});
+});
+
+test('normalizeCssValue leaves url() payloads alone', () => {
+	// `2s.svg` is a file name, not a duration: folding it would make this
+	// compare equal to a genuinely different `url(/assets/2000ms.svg)`.
+	expect(normalizeCssValue('url(/assets/2s.svg)')).toBe('url(/assets/2s.svg)');
+	expect(normalizeCssValue('url("/assets/.5x_a1b2c3_1.png")')).toBe(
+		'url("/assets/.5x_a1b2c3_1.png")'
+	);
+	expect(normalizeCssValue("url('/a/1.50s.woff2')")).toBe(
+		"url('/a/1.50s.woff2')"
+	);
+});
+
+test('normalizeCssValue leaves quoted strings alone', () => {
+	expect(normalizeCssValue('"2s.svg"')).toBe('"2s.svg"');
+	expect(normalizeCssValue("content: '.5 _x_a1b2c3_1'")).toBe(
+		"content: '.5 _x_a1b2c3_1'"
+	);
+});
+
+test('normalizeCssValue still folds the text around an opaque segment', () => {
+	expect(normalizeCssValue('url(/a/2s.svg) .15s _enter_t5rx4_1')).toBe(
+		'url(/a/2s.svg) 150ms enter'
+	);
+});
+
+test('normalizeCssValue does not read a path segment as a duration', () => {
+	expect(normalizeCssValue('2s/cover')).toBe('2s/cover');
 });

--- a/apps/parity-runner/src/diff-computed-style.ts
+++ b/apps/parity-runner/src/diff-computed-style.ts
@@ -7,6 +7,15 @@
  * via `diffComputedStyleMap` from `@c15t/conformance`.
  * Pass `*` as `elementSelector` to compare all descendants by DOM order.
  *
+ * Values are canonicalised before they leave this module, because each
+ * framework's Storybook reaches the same tokens by a different route and the
+ * browser hands back whatever text that route produced. Custom properties are
+ * the exposed case: `getComputedStyle` resolves a registered property but
+ * returns an unregistered `--*` as the author's literal token, so a stylesheet
+ * a bundler minified (`.5rem`, `.15s`) and one it did not (`0.5rem`, `150ms`)
+ * disagree on spelling while meaning the same thing. See
+ * {@link normalizeCssValue} for what is folded away.
+ *
  * The property list is duplicated here (and in `@c15t/conformance`'s
  * `computed-style.ts`) because Playwright can't import ESM into page context.
  * Keep these in sync.
@@ -59,12 +68,112 @@ const DEFAULT_PROPS = [
 	'direction',
 ] as const;
 
-export const captureComputedStyleMap = function captureComputedStyleMap(
+/**
+ * A CSS Modules scoped identifier, as Vite's default
+ * `[local]_[hash:base64:5]_[index]` generator spells it: `_enter_t5rx4_1`.
+ * The React Storybook compiles its keyframes through CSS Modules, the others
+ * link the built stylesheet, so the same animation arrives under two names.
+ */
+const CSS_MODULES_SCOPED_NAME =
+	/_(?<localName>[a-zA-Z][\w-]*?)_[a-z0-9]{4,8}_\d+\b/gu;
+
+/** A seconds literal, excluding the `s` that ends `ms`. */
+const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![a-z%-])/gu;
+
+/** A decimal written without its leading zero: `.5rem`, `cubic-bezier(.4`. */
+const BARE_DECIMAL = /(?<before>^|[^\w.])\.(?<digit>\d)/gu;
+
+/** Trailing zeros that carry no value: `1.50px`, `2.0s`. */
+const TRAILING_ZEROS = /(?<whole>\d+)\.(?<fraction>\d*[1-9])?0+(?![\d.])/gu;
+
+/**
+ * Rounds to 6 decimal places, so `0.15 * 1000` reads as `150` rather than
+ * `150.00000000000003`.
+ */
+const roundMilliseconds = function roundMilliseconds(seconds: number): number {
+	return Math.round(seconds * 1e9) / 1e6;
+};
+
+/**
+ * Canonicalises one computed CSS value so two spellings of the same value
+ * compare equal.
+ *
+ * Three rewrites, each folding away a difference in how the value was
+ * serialised rather than a difference in what it means:
+ *
+ * - **Scoped names** — `_enter_t5rx4_1` becomes `enter`, so a keyframe
+ *   compiled through CSS Modules matches the same keyframe linked from a
+ *   plain stylesheet.
+ * - **Times** — seconds become milliseconds, so `.15s` matches `150ms`.
+ * - **Numbers** — a missing leading zero is restored and trailing zeros are
+ *   dropped, so `.5rem` matches `0.5rem` and `cubic-bezier(.4, 0, .2, 1)`
+ *   matches `cubic-bezier(0.4, 0, 0.2, 1)`.
+ *
+ * Anything else is left alone. Two values that still differ after this differ
+ * for a reason the gate should report.
+ *
+ * @param value - A computed property or custom property value.
+ * @returns The canonical spelling of that value.
+ *
+ * @example
+ * ```ts
+ * normalizeCssValue('_enter_t5rx4_1 80ms cubic-bezier(.4, 0, .2, 1)');
+ * // 'enter 80ms cubic-bezier(0.4, 0, 0.2, 1)'
+ * ```
+ */
+export const normalizeCssValue = function normalizeCssValue(
+	value: string
+): string {
+	return value
+		.replace(CSS_MODULES_SCOPED_NAME, '$<localName>')
+		.replace(
+			SECONDS_LITERAL,
+			(_match, seconds: string) => `${roundMilliseconds(Number(seconds))}ms`
+		)
+		.replace(BARE_DECIMAL, '$<before>0.$<digit>')
+		.replace(TRAILING_ZEROS, (_match, whole: string, fraction?: string) =>
+			fraction ? `${whole}.${fraction}` : whole
+		);
+};
+
+/**
+ * Applies {@link normalizeCssValue} to every value in a captured snapshot map,
+ * leaving the element ids and property names untouched.
+ *
+ * @param snapshots - The map `captureComputedStyleMap` collected in the page.
+ * @returns The same map with canonical values.
+ */
+export const normalizeComputedStyleMap = function normalizeComputedStyleMap<
+	MapType extends Record<string, ComputedStyleSnapshot>,
+>(snapshots: MapType): Record<string, ComputedStyleSnapshot> {
+	const normalizeEntries = function normalizeEntries(
+		values: Record<string, string>
+	): Record<string, string> {
+		return Object.fromEntries(
+			Object.entries(values).map(([name, value]) => [
+				name,
+				normalizeCssValue(value),
+			])
+		);
+	};
+
+	return Object.fromEntries(
+		Object.entries(snapshots).map(([id, snapshot]) => [
+			id,
+			{
+				customProperties: normalizeEntries(snapshot.customProperties),
+				properties: normalizeEntries(snapshot.properties),
+			},
+		])
+	);
+};
+
+export const captureComputedStyleMap = async function captureComputedStyleMap(
 	page: Page,
 	selector: string,
 	elementSelector = '[data-testid]'
 ): Promise<Record<string, ComputedStyleSnapshot>> {
-	return page.evaluate(
+	const captured = await page.evaluate(
 		(args: { sel: string; props: readonly string[]; elements: string }) => {
 			const root = document.querySelector(args.sel);
 			if (!root) {
@@ -121,4 +230,6 @@ export const captureComputedStyleMap = function captureComputedStyleMap(
 		},
 		{ elements: elementSelector, props: DEFAULT_PROPS, sel: selector }
 	);
+
+	return normalizeComputedStyleMap(captured);
 };

--- a/apps/parity-runner/src/diff-computed-style.ts
+++ b/apps/parity-runner/src/diff-computed-style.ts
@@ -77,14 +77,27 @@ const DEFAULT_PROPS = [
 const CSS_MODULES_SCOPED_NAME =
 	/_(?<localName>[a-zA-Z][\w-]*?)_[a-z0-9]{4,8}_\d+\b/gu;
 
-/** A seconds literal, excluding the `s` that ends `ms`. */
-const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![a-z%-])/gu;
+/**
+ * A seconds literal, excluding the `s` that ends `ms`.
+ *
+ * The lookahead has to reject `.` and `/` as well as letters: without it
+ * `2s.svg` inside a path reads as a time and comes back as `2000ms.svg`.
+ */
+const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![\w.%/-])/gu;
 
 /** A decimal written without its leading zero: `.5rem`, `cubic-bezier(.4`. */
 const BARE_DECIMAL = /(?<before>^|[^\w.])\.(?<digit>\d)/gu;
 
 /** Trailing zeros that carry no value: `1.50px`, `2.0s`. */
 const TRAILING_ZEROS = /(?<whole>\d+)\.(?<fraction>\d*[1-9])?0+(?![\d.])/gu;
+
+/**
+ * Text a rewrite must not enter: a `url()` and a quoted string are opaque
+ * payloads, not CSS values. `url(/assets/2s.svg)` is not a two-second
+ * anything, and folding it would make it compare equal to a genuinely
+ * different `url(/assets/2000ms.svg)`.
+ */
+const OPAQUE_SEGMENT = /url\((?:[^)'"]|"[^"]*"|'[^']*')*\)|"[^"]*"|'[^']*'/gu;
 
 /**
  * Rounds to 6 decimal places, so `0.15 * 1000` reads as `150` rather than
@@ -109,6 +122,10 @@ const roundMilliseconds = function roundMilliseconds(seconds: number): number {
  *   dropped, so `.5rem` matches `0.5rem` and `cubic-bezier(.4, 0, .2, 1)`
  *   matches `cubic-bezier(0.4, 0, 0.2, 1)`.
  *
+ * `url()` payloads and quoted strings are left untouched: they carry file
+ * names and content, not CSS values, and rewriting them would fold two
+ * genuinely different assets onto one another.
+ *
  * Anything else is left alone. Two values that still differ after this differ
  * for a reason the gate should report.
  *
@@ -121,10 +138,8 @@ const roundMilliseconds = function roundMilliseconds(seconds: number): number {
  * // 'enter 80ms cubic-bezier(0.4, 0, 0.2, 1)'
  * ```
  */
-export const normalizeCssValue = function normalizeCssValue(
-	value: string
-): string {
-	return value
+const rewriteCssText = function rewriteCssText(text: string): string {
+	return text
 		.replace(CSS_MODULES_SCOPED_NAME, '$<localName>')
 		.replace(
 			SECONDS_LITERAL,
@@ -134,6 +149,19 @@ export const normalizeCssValue = function normalizeCssValue(
 		.replace(TRAILING_ZEROS, (_match, whole: string, fraction?: string) =>
 			fraction ? `${whole}.${fraction}` : whole
 		);
+};
+
+export const normalizeCssValue = function normalizeCssValue(
+	value: string
+): string {
+	let out = '';
+	let cursor = 0;
+	for (const match of value.matchAll(OPAQUE_SEGMENT)) {
+		const start = match.index;
+		out += rewriteCssText(value.slice(cursor, start)) + match[0];
+		cursor = start + match[0].length;
+	}
+	return out + rewriteCssText(value.slice(cursor));
 };
 
 /**

--- a/apps/storybook-svelte/.storybook/preview.ts
+++ b/apps/storybook-svelte/.storybook/preview.ts
@@ -1,16 +1,12 @@
 import type { Preview } from '@storybook/svelte-vite';
 
+// The stylesheets ship the `defaultTheme` tokens themselves, so the canvas
+// only has to opt into them — no `generateThemeCSS(defaultTheme)` injection.
 import '../../../packages/svelte/src/styles.css';
 import '../../../packages/svelte/src/iab/styles.css';
-import {
-	defaultTheme,
-	generateThemeCSS,
-} from '../../../packages/ui/src/theme/utils';
 
-const storybookThemeStyleId = 'c15t-storybook-theme';
 const storybookCanvasStyleId = 'c15t-storybook-canvas';
 
-const themeCSS = generateThemeCSS(defaultTheme);
 const canvasCSS = `
 	:root {
 		color: var(--c15t-text);
@@ -43,7 +39,6 @@ const ensureGlobalStyle = function ensureGlobalStyle(
 	document.head.appendChild(style);
 };
 
-ensureGlobalStyle(storybookThemeStyleId, themeCSS);
 ensureGlobalStyle(storybookCanvasStyleId, canvasCSS);
 
 const preview: Preview = {

--- a/packages/ui/scripts/generate-css-entrypoints.ts
+++ b/packages/ui/scripts/generate-css-entrypoints.ts
@@ -262,9 +262,12 @@ const collectCssParts = function collectCssParts(
  * stylesheet into a cascade layer (`@import ... layer(c15t)`), since unlayered
  * declarations outrank every layer.
  */
-const DEFAULT_THEME_CSS = `/* default theme tokens (generated from defaultTheme) */\n${generateThemeCSS(
-	defaultTheme
-)}`;
+const DEFAULT_THEME_BANNER =
+	'/* default theme tokens (generated from defaultTheme) */';
+const DEFAULT_THEME_CSS = [
+	DEFAULT_THEME_BANNER,
+	generateThemeCSS(defaultTheme),
+].join('\n');
 
 /**
  * Generate layered CSS: component rules wrapped in @layer components.

--- a/packages/ui/scripts/generate-css-entrypoints.ts
+++ b/packages/ui/scripts/generate-css-entrypoints.ts
@@ -5,6 +5,10 @@
  * 2. Generates aggregated CSS entrypoints from `dist/styles/primitives` and
  *    the flat component CSS in `dist/styles/components` (produced by
  *    `generate-style-artifacts.ts`, which must run first):
+ *    - the `defaultTheme` base tokens (`--c15t-surface`, `--c15t-radius-lg`,
+ *      `--c15t-font-family`, ...) are emitted first and unlayered, so an app
+ *      that imports the stylesheet without passing a `theme` still renders the
+ *      styled UI instead of falling back to browser defaults
  *    - :root custom properties and @keyframes stay unlayered
  *    - `styles.css` / `iab/styles.css` wrap component rules in `@layer components`
  *      for Tailwind 4 and native CSS layer consumers
@@ -20,6 +24,8 @@ import {
 	writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+
+import { defaultTheme, generateThemeCSS } from '../src/theme/utils';
 
 const DIST_DIR = join(import.meta.dirname, '..', 'dist');
 const PRIMITIVES_DIR = join(DIST_DIR, 'styles', 'primitives');
@@ -239,6 +245,28 @@ const collectCssParts = function collectCssParts(
 };
 
 /**
+ * The `defaultTheme` base tokens, rendered by the same `generateThemeCSS` a
+ * host calls when it passes `theme`. Every component stylesheet resolves its
+ * colours, radii, fonts and motion through these, mostly without `var()`
+ * fallbacks, so a stylesheet that ships without them renders unstyled in any
+ * app that does not pass a `theme` — including server-rendered, zero-JS pages
+ * that can never inject them.
+ *
+ * `defaultTheme` stays the single source of truth: this is generated at build
+ * time from the same object the runtime exports, so CSS and JS cannot drift.
+ *
+ * Emitted first and **unlayered** in every entrypoint. A provider's injected
+ * `<style id="c15t-theme">` still wins: it carries the same selectors and the
+ * same specificity, and lands later in the cascade — later in `<head>` when
+ * the defaults are unlayered too, and unconditionally when a host imports the
+ * stylesheet into a cascade layer (`@import ... layer(c15t)`), since unlayered
+ * declarations outrank every layer.
+ */
+const DEFAULT_THEME_CSS = `/* default theme tokens (generated from defaultTheme) */\n${generateThemeCSS(
+	defaultTheme
+)}`;
+
+/**
  * Generate layered CSS: component rules wrapped in @layer components.
  * Use with Tailwind 4 — import Tailwind normally; c15t joins the components layer automatically.
  */
@@ -246,7 +274,7 @@ const buildLayeredCss = function buildLayeredCss(
 	rootParts: string[],
 	ruleParts: string[]
 ): string {
-	const parts: string[] = [];
+	const parts: string[] = [DEFAULT_THEME_CSS];
 	if (rootParts.length) {
 		parts.push(rootParts.join('\n\n'));
 	}
@@ -267,7 +295,7 @@ const buildFlatCss = function buildFlatCss(
 	rootParts: string[],
 	ruleParts: string[]
 ): string {
-	const parts: string[] = [];
+	const parts: string[] = [DEFAULT_THEME_CSS];
 	if (rootParts.length) {
 		parts.push(rootParts.join('\n\n'));
 	}

--- a/packages/ui/src/styles/__tests__/default-tokens.test.ts
+++ b/packages/ui/src/styles/__tests__/default-tokens.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Guards the default theme tokens that `generate-css-entrypoints.ts` bakes
+ * into every published stylesheet.
+ *
+ * Without them every component rule resolves `var(--c15t-surface)`,
+ * `var(--c15t-radius-lg)` and friends against nothing, and an app that imports
+ * the stylesheet without passing a `theme` renders the banner unstyled.
+ *
+ * These read the built artifacts, so `bun run --cwd packages/ui build` (or
+ * `turbo run build --filter=@c15t/ui`, which `test` depends on) must have run.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { defaultTheme, generateThemeCSS, themeToVars } from '../../theme/utils';
+
+const DIST_DIR = join(__dirname, '..', '..', '..', 'dist');
+
+const ENTRYPOINTS = [
+	'styles.css',
+	'styles.tw3.css',
+	join('iab', 'styles.css'),
+	join('iab', 'styles.tw3.css'),
+];
+
+const readEntrypoint = function readEntrypoint(relativePath: string): string {
+	const path = join(DIST_DIR, relativePath);
+
+	if (!existsSync(path)) {
+		throw new Error(
+			`Missing ${path}. Build @c15t/ui first: bun run --cwd packages/ui build`
+		);
+	}
+
+	return readFileSync(path, 'utf8');
+};
+
+/**
+ * Slice out one `selector { ... }` block by brace matching, so nested blocks
+ * inside the stylesheet do not truncate it early.
+ */
+const readBlock = function readBlock(
+	css: string,
+	selector: string
+): string | null {
+	const start = css.indexOf(`${selector} {`);
+
+	if (start === -1) {
+		return null;
+	}
+
+	const bodyStart = css.indexOf('{', start) + 1;
+	let depth = 1;
+
+	for (let index = bodyStart; index < css.length; index += 1) {
+		const char = css[index];
+
+		if (char === '{') {
+			depth += 1;
+		} else if (char === '}') {
+			depth -= 1;
+
+			if (depth === 0) {
+				return css.slice(bodyStart, index);
+			}
+		}
+	}
+
+	return null;
+};
+
+const LIGHT_SELECTOR = ':root, .c15t-theme-root';
+const DARK_SELECTOR =
+	':root.dark, .dark .c15t-theme-root, :root.c15t-dark, .c15t-dark .c15t-theme-root';
+
+describe.each(ENTRYPOINTS)('%s', (entrypoint) => {
+	const css = readEntrypoint(entrypoint);
+
+	test('defines every light token themeToVars(defaultTheme) emits', () => {
+		const block = readBlock(css, LIGHT_SELECTOR);
+		expect(block).not.toBeNull();
+
+		for (const [name, value] of Object.entries(
+			themeToVars(defaultTheme, false)
+		)) {
+			expect(block).toContain(`${name}: ${value};`);
+		}
+	});
+
+	test('defines every dark token themeToVars(defaultTheme, true) emits', () => {
+		const block = readBlock(css, DARK_SELECTOR);
+		expect(block).not.toBeNull();
+
+		for (const [name, value] of Object.entries(
+			themeToVars(defaultTheme, true)
+		)) {
+			expect(block).toContain(`${name}: ${value};`);
+		}
+	});
+
+	test('emits the tokens first, so they read as the file preamble', () => {
+		expect(css.startsWith('/* default theme tokens')).toBe(true);
+	});
+
+	test('matches what a host passing theme: defaultTheme would inject', () => {
+		// Byte-for-byte parity with `generateThemeCSS(defaultTheme)` is what
+		// keeps CSS and JS from drifting, and what makes the defaults behave
+		// exactly like a provider-injected theme.
+		expect(css).toContain(generateThemeCSS(defaultTheme));
+	});
+
+	test('emits the tokens unlayered', () => {
+		// A provider's injected `<style id="c15t-theme">` is unlayered. Unlayered
+		// declarations outrank every cascade layer, so keeping the defaults
+		// unlayered too is what leaves source order — and therefore the injected
+		// override — in charge. If a host imports this stylesheet into a layer
+		// (`@import ... layer(c15t)`, as examples/sveltekit-demo does), the
+		// override wins by layer precedence instead.
+		const layerStart = css.indexOf('@layer');
+		const tokensEnd = css.indexOf('}', css.indexOf(LIGHT_SELECTOR));
+
+		if (layerStart !== -1) {
+			expect(tokensEnd).toBeLessThan(layerStart);
+		}
+	});
+});
+
+describe('an app that imports the stylesheet without a theme', () => {
+	beforeEach(() => {
+		document.head.innerHTML = '';
+		document.documentElement.className = '';
+	});
+
+	/**
+	 * jsdom's CSS parser rejects the whole stylesheet — it does not understand
+	 * `@layer`, `color-mix()` or range media queries — and a rejected sheet
+	 * contributes nothing to the cascade. Mount the real artifact's token
+	 * preamble instead: still the shipped bytes, minus the component rules
+	 * jsdom could not apply anyway.
+	 */
+	const mountStylesheet = function mountStylesheet() {
+		const css = readEntrypoint('styles.css');
+		const componentsStart = css.indexOf('/* primitives/');
+		expect(componentsStart).toBeGreaterThan(0);
+
+		const style = document.createElement('style');
+		style.textContent = css.slice(0, componentsStart);
+		document.head.appendChild(style);
+	};
+
+	test('resolves the base tokens on :root', () => {
+		mountStylesheet();
+
+		const computed = getComputedStyle(document.documentElement);
+
+		expect(computed.getPropertyValue('--c15t-surface')).toBe(
+			defaultTheme.colors.surface
+		);
+		expect(computed.getPropertyValue('--c15t-radius-lg')).toBe(
+			defaultTheme.radius.lg
+		);
+		expect(computed.getPropertyValue('--c15t-font-family')).toBe(
+			defaultTheme.typography.fontFamily
+		);
+	});
+
+	test('lets a provider-injected <style id="c15t-theme"> override them', () => {
+		mountStylesheet();
+
+		const injected = document.createElement('style');
+		injected.id = 'c15t-theme';
+		injected.textContent = `${LIGHT_SELECTOR} { --c15t-surface: rebeccapurple; }`;
+		document.head.appendChild(injected);
+
+		expect(
+			getComputedStyle(document.documentElement).getPropertyValue(
+				'--c15t-surface'
+			)
+		).toBe('rebeccapurple');
+	});
+});

--- a/packages/ui/src/styles/__tests__/default-tokens.test.ts
+++ b/packages/ui/src/styles/__tests__/default-tokens.test.ts
@@ -72,8 +72,12 @@ const readBlock = function readBlock(
 };
 
 const LIGHT_SELECTOR = ':root, .c15t-theme-root';
-const DARK_SELECTOR =
-	':root.dark, .dark .c15t-theme-root, :root.c15t-dark, .c15t-dark .c15t-theme-root';
+const DARK_SELECTOR = [
+	':root.dark',
+	'.dark .c15t-theme-root',
+	':root.c15t-dark',
+	'.c15t-dark .c15t-theme-root',
+].join(', ');
 
 describe.each(ENTRYPOINTS)('%s', (entrypoint) => {
 	const css = readEntrypoint(entrypoint);


### PR DESCRIPTION
## Summary

Apps that import `@c15t/ui/styles.css` (directly or through `@c15t/react/styles.css`, `@c15t/svelte/styles.css`) without passing a `theme` render the banner and dialog unstyled: serif fallback font, square corners, transparent buttons. Every component stylesheet resolves colours, radii, fonts and motion through base tokens such as `--c15t-surface` and `--c15t-radius-lg`, and nothing in the published stylesheets defined them. They only existed when a provider injected `generateThemeCSS(theme)`, which React and Svelte do only when a `theme` is passed, when Nuxt wrote the schema defaults to `:root`, or when Storybook injected them by hand.

This ships the defaults in the stylesheet so the default look needs no runtime injection, which also makes zero-JS server-rendered markup (the Astro banner) styled on first paint.

## Change

- `packages/ui/scripts/generate-css-entrypoints.ts` prepends `generateThemeCSS(defaultTheme)` to `styles.css`, `styles.tw3.css` and both IAB entrypoints. The block is byte-identical to what a provider injects, so the JS `defaultTheme` stays the single source of truth and the two cannot drift.
- Selectors match `generateThemeCSS` exactly (`:root, .c15t-theme-root` for light; `.dark` and `.c15t-dark` variants for dark), so a provider's later `<style id="c15t-theme">` override ties on specificity and wins on cascade order. Verified in all three arrangements: defaults inside `@layer c15t`, defaults unlayered in `<head>`, and React's body-mounted override.
- The redundant injection in `apps/storybook-svelte/.storybook/preview.ts` is removed.
- No `prefers-color-scheme` block: `generateThemeCSS` has none and `setupColorScheme` drives dark mode by toggling `c15t-dark` on `<html>`, so behaviour matches `theme: defaultTheme`.

## Tests

22 new tests in `packages/ui/src/styles/__tests__/default-tokens.test.ts`: every token `themeToVars(defaultTheme)` emits is defined in the light and dark blocks of all four files, the block is the file preamble and precedes any `@layer`, it equals `generateThemeCSS(defaultTheme)` verbatim, and a jsdom check that the tokens resolve through `getComputedStyle` and that a later provider style overrides them.

Verified: ui build and 358 tests, svelte 195, react 422, check-types, repo lint, storybook-svelte build. Screenshots of the SvelteKit bench and the Astro demo before and after in light and dark confirm the rounded card, system font and correct dark palette.

## Notes

Standalone fix off `v3`; the SvelteKit and Astro stack (#1068, #1069) will rebase onto it once merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Published UI stylesheets now include default light and dark theme tokens, so components are styled correctly even without a custom theme.
  - Custom provider themes continue to override the default tokens.

- **Bug Fixes**
  - Improved style comparisons across different CSS formatting and module-scoping conventions, helping visual parity checks recognize equivalent styles consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->