### PR TITLE
feat(astro): React and Vue dialog islands, colour scheme, manifest cache on the server path

### DIFF
--- a/.changeset/astro-framework-islands.md
+++ b/.changeset/astro-framework-islands.md
@@ -1,0 +1,35 @@
+---
+'@c15t/astro': minor
+'@c15t/vue': patch
+---
+
+`@c15t/astro` can render its dialogs with React or Vue instead of Svelte.
+
+A site that already ships React or Vue should reuse that runtime for the
+consent dialog rather than downloading Svelte alongside it. Set `ui: 'react'`
+or `ui: 'vue'` and install the matching Astro integration; `'svelte'` stays
+the default because it is the smallest of the three.
+
+The choice is never inferred. Reading it off whichever integration happens to
+be installed would change what every visitor downloads without anyone asking
+for it, so an installed `@astrojs/react` or `@astrojs/vue` gets a one-line
+suggestion at build time and nothing more. `astro:config:done` fails with the
+list of packages to install when the selected `ui` has no matching Astro
+integration.
+
+Only the selected framework reaches the build. The adapter registry ships
+empty and the integration writes the one adapter and the one island specifier
+into the page script it injects, both behind `import()`, so a Svelte site's
+build never resolves `@c15t/react` or `vue` and a React site's never resolves
+Svelte. Measured on `examples/astro-demo`, the on-demand dialog graph is 74.6
+KB gzipped for `svelte`, 115.7 KB for `react` and 139.7 KB for `vue`, and each
+build contains exactly one framework runtime.
+
+`react`, `react-dom`, `vue`, `@c15t/react` and `@c15t/vue` are optional peer
+dependencies. `requireSvelte` is now `requireUIIntegration`, which checks
+whichever framework `ui` names.
+
+`@c15t/vue`'s Vite plugin now answers `#c15t/composables` from `resolveId` as
+well as `resolve.alias`. A host that declares its own aliases in array form —
+Astro does — replaced the object the plugin contributed instead of merging
+with it, and the specifier reached Rollup unresolved.

--- a/.changeset/astro-framework-islands.md
+++ b/.changeset/astro-framework-islands.md
@@ -22,12 +22,18 @@ empty and the integration writes the one adapter and the one island specifier
 into the page script it injects, both behind `import()`, so a Svelte site's
 build never resolves `@c15t/react` or `vue` and a React site's never resolves
 Svelte. Measured on `examples/astro-demo`, the on-demand dialog graph is 74.6
-KB gzipped for `svelte`, 115.7 KB for `react` and 139.7 KB for `vue`, and each
+KB gzipped for `svelte`, 115.9 KB for `react` and 139.7 KB for `vue`, and each
 build contains exactly one framework runtime.
 
 `react`, `react-dom`, `vue`, `@c15t/react` and `@c15t/vue` are optional peer
 dependencies. `requireSvelte` is now `requireUIIntegration`, which checks
 whichever framework `ui` names.
+
+Offline sites now resolve a policy narrowed to the configured
+`consentCategories` on the server as well as in the browser. The React dialog
+reads its toggle list off the resolved policy, so a wide policy showed
+categories the site never configured while the Svelte and Vue surfaces —
+which filter by option — did not.
 
 `@c15t/vue`'s Vite plugin now answers `#c15t/composables` from `resolveId` as
 well as `resolve.alias`. A host that declares its own aliases in array form —

--- a/.changeset/external-runtime-providers.md
+++ b/.changeset/external-runtime-providers.md
@@ -1,0 +1,32 @@
+---
+'@c15t/react': minor
+'@c15t/vue': minor
+---
+
+`ConsentProvider` and the `c15tVue` plugin can render a consent runtime they
+do not own.
+
+Hosts without a single component tree — an Astro page whose islands cannot see
+each other, a SvelteKit root layout — create one runtime with
+`createConsentRuntime()` and hand it to whatever renders. `@c15t/svelte`'s
+provider already took a `runtime` prop; React and Vue now match.
+
+```tsx
+<ConsentProvider runtime={runtime} options={{ theme }}>
+  <ConsentDialog />
+</ConsentProvider>
+```
+
+```ts
+createApp(Dialog).use(c15tVue, { runtime }).mount(target);
+```
+
+A borrowed runtime is borrowed, not adopted: neither provider starts or
+disposes it, and neither mounts the modules it already owns — no second
+`init()`, no second persistence handle, no second `window.c15t`. In React the
+IAB bridge republishes `runtime.iab` rather than calling `createIAB()` again,
+which avoids a second `__tcfapi` on the page and keeps the TCF encoder out of
+the preference-centre chunk.
+
+Passing no `runtime` behaves exactly as before, and the Nuxt module is
+untouched.

--- a/.changeset/wide-pillows-argue.md
+++ b/.changeset/wide-pillows-argue.md
@@ -14,8 +14,9 @@ framework — reads that one runtime.
 - The banner is a server-rendered `.astro` component with zero framework
   JavaScript, the same DOM and `data-testid`s as the Svelte and React banners,
   and no markup at all for a visitor who has already consented.
-- The preference centre and IAB dialogs are Svelte islands mounted on first
-  open with Svelte 5's `mount()`, behind a swappable adapter seam.
+- The preference centre and IAB dialogs are islands mounted on first open,
+  behind a swappable adapter seam. `ui` picks the framework: `'svelte'`
+  (default, smallest), `'react'` or `'vue'`.
 - Middleware reads the consent cookie plus geo and GPC headers through the
   shared `@c15t/schema` helpers and resolves the decision server-side, so the
   browser boots from an inlined config with no `/init` roundtrip per page.
@@ -27,5 +28,5 @@ framework — reads that one runtime.
 The runtime is `createConsentRuntime` from `@c15t/core/runtime` and the
 injected routes use the shared manifest cache in `@c15t/core/server`, so the
 Astro, SvelteKit, Next.js and Nuxt layers cannot drift on lifecycle or cache
-semantics. The dialog island renders `<ConsentManagerProvider runtime={...}>`
-against the page runtime rather than building a kernel of its own.
+semantics. Whichever framework renders the island, its provider is handed the
+page runtime rather than building a kernel of its own.

--- a/bun.lock
+++ b/bun.lock
@@ -439,7 +439,14 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
+        "@astrojs/react": "^4.4.0",
+        "@astrojs/vue": "^5.1.0",
+        "@c15t/react": "workspace:*",
+        "@c15t/vue": "workspace:*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "6.0.3",
+        "vue": "^3.5.0",
       },
     },
     "examples/demo": {
@@ -754,19 +761,34 @@
         "@c15t/ui": "workspace:*",
       },
       "devDependencies": {
+        "@c15t/react": "workspace:*",
         "@c15t/typescript-config": "workspace:*",
         "@c15t/vitest-config": "workspace:*",
+        "@c15t/vue": "workspace:*",
         "astro": "^5.16.0",
         "jsdom": "^25.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "svelte": "^5.0.0",
         "typescript": "6.0.3",
+        "vue": "^3.5.0",
       },
       "peerDependencies": {
+        "@c15t/react": "workspace:^",
+        "@c15t/vue": "workspace:^",
         "astro": "^5.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "svelte": "^5.0.0",
+        "vue": "^3.5.0",
       },
       "optionalPeers": [
+        "@c15t/react",
+        "@c15t/vue",
+        "react",
+        "react-dom",
         "svelte",
+        "vue",
       ],
     },
     "packages/backend": {
@@ -1217,6 +1239,8 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@antfu/utils": ["@antfu/utils@0.7.10", "", {}, "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
@@ -1259,9 +1283,13 @@
 
     "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
 
+    "@astrojs/react": ["@astrojs/react@4.4.2", "", { "dependencies": { "@vitejs/plugin-react": "^4.7.0", "ultrahtml": "^1.6.0", "vite": "^6.4.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ=="],
+
     "@astrojs/svelte": ["@astrojs/svelte@7.2.5", "", { "dependencies": { "@sveltejs/vite-plugin-svelte": "^5.1.1", "svelte2tsx": "^0.7.46", "vite": "^6.4.1" }, "peerDependencies": { "astro": "^5.0.0", "svelte": "^5.1.16", "typescript": "^5.3.3" } }, "sha512-Tl5aF/dYbzzd7sLpxMBX6pRz3yJ1B4pilt9G3GJbj0I0/doJHIEmerNQsnlxX0/InNKUhMXXN8wyyet9VhA+Zw=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
+
+    "@astrojs/vue": ["@astrojs/vue@5.1.4", "", { "dependencies": { "@vitejs/plugin-vue": "5.2.4", "@vitejs/plugin-vue-jsx": "^4.2.0", "@vue/compiler-sfc": "^3.5.26", "vite": "^6.4.1", "vite-plugin-vue-devtools": "^7.7.9" }, "peerDependencies": { "astro": "^5.0.0", "vue": "^3.2.30" } }, "sha512-srE+3tgSnGG4FVr7Bs9JAgLcUAg1mtGrbBFdwlj++Y05Awwlc967WCcmOK6rnxQ6q5PcK5+WL2x2tKoWh5SN7A=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
@@ -1305,6 +1333,8 @@
 
     "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
+    "@babel/plugin-proposal-decorators": ["@babel/plugin-proposal-decorators@7.29.7", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.29.7", "@babel/helper-plugin-utils": "^7.29.7", "@babel/plugin-syntax-decorators": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg=="],
+
     "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
 
     "@babel/plugin-syntax-bigint": ["@babel/plugin-syntax-bigint@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg=="],
@@ -1312,6 +1342,8 @@
     "@babel/plugin-syntax-class-properties": ["@babel/plugin-syntax-class-properties@7.12.13", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.12.13" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA=="],
 
     "@babel/plugin-syntax-class-static-block": ["@babel/plugin-syntax-class-static-block@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw=="],
+
+    "@babel/plugin-syntax-decorators": ["@babel/plugin-syntax-decorators@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg=="],
 
     "@babel/plugin-syntax-import-attributes": ["@babel/plugin-syntax-import-attributes@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw=="],
 
@@ -2965,7 +2997,7 @@
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.7", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.2.25" } }, "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg=="],
 
-    "@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@5.1.6", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-syntax-typescript": "^7.29.7", "@babel/plugin-transform-typescript": "^7.29.7", "@rolldown/pluginutils": "^1.0.1", "@vue/babel-plugin-jsx": "^2.0.1" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.0.0" } }, "sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA=="],
+    "@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@4.2.0", "", { "dependencies": { "@babel/core": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1", "@rolldown/pluginutils": "^1.0.0-beta.9", "@vue/babel-plugin-jsx": "^1.4.0" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.0.0" } }, "sha512-DSTrmrdLp+0LDNF77fqrKfx7X0ErRbOcUAgJL/HbSesqQwoUvUQ4uYQqaex+rovqgGcoPqVk+AwUh3v9CuiYIw=="],
 
     "@vitest/browser": ["@vitest/browser@4.1.9", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg=="],
 
@@ -3009,11 +3041,11 @@
 
     "@vue-macros/common": ["@vue-macros/common@3.1.2", "", { "dependencies": { "@vue/compiler-sfc": "^3.5.22", "ast-kit": "^2.1.2", "local-pkg": "^1.1.2", "magic-string-ast": "^1.0.2", "unplugin-utils": "^0.3.0" }, "peerDependencies": { "vue": "^2.7.0 || ^3.2.25" }, "optionalPeers": ["vue"] }, "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng=="],
 
-    "@vue/babel-helper-vue-transform-on": ["@vue/babel-helper-vue-transform-on@2.0.1", "", {}, "sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA=="],
+    "@vue/babel-helper-vue-transform-on": ["@vue/babel-helper-vue-transform-on@1.5.0", "", {}, "sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA=="],
 
-    "@vue/babel-plugin-jsx": ["@vue/babel-plugin-jsx@2.0.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@vue/babel-helper-vue-transform-on": "2.0.1", "@vue/babel-plugin-resolve-type": "2.0.1", "@vue/shared": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" }, "optionalPeers": ["@babel/core"] }, "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA=="],
+    "@vue/babel-plugin-jsx": ["@vue/babel-plugin-jsx@1.5.0", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.2", "@vue/babel-helper-vue-transform-on": "1.5.0", "@vue/babel-plugin-resolve-type": "1.5.0", "@vue/shared": "^3.5.18" }, "peerDependencies": { "@babel/core": "^7.0.0-0" }, "optionalPeers": ["@babel/core"] }, "sha512-mneBhw1oOqCd2247O0Yw/mRwC9jIGACAJUlawkmMBiNmL4dGA2eMzuNZVNqOUfYTa6vqmND4CtOPzmEEEqLKFw=="],
 
-    "@vue/babel-plugin-resolve-type": ["@vue/babel-plugin-resolve-type@2.0.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/parser": "^7.28.4", "@vue/compiler-sfc": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ=="],
+    "@vue/babel-plugin-resolve-type": ["@vue/babel-plugin-resolve-type@1.5.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/parser": "^7.28.0", "@vue/compiler-sfc": "^3.5.18" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Wm/60o+53JwJODm4Knz47dxJnLDJ9FnKnGZJbUUf8nQRAtt6P+undLUAVU3Ha33LxOJe6IPoifRQ6F/0RrU31w=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.40", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/shared": "3.5.40", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ=="],
 
@@ -3031,7 +3063,7 @@
 
     "@vue/devtools-kit": ["@vue/devtools-kit@8.1.3", "", { "dependencies": { "@vue/devtools-shared": "^8.1.3", "birpc": "^2.6.1", "hookable": "^5.5.3", "perfect-debounce": "^2.0.0" } }, "sha512-cRn7GXiCQkMYU2Z3h3pM4YO/ndbx9FY1yLDAqIqPLcmIq4H6zAOJHein6tvZU3AfPwgrodqLiPBEF+YQaS8AxA=="],
 
-    "@vue/devtools-shared": ["@vue/devtools-shared@8.1.3", "", {}, "sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA=="],
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.10", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ=="],
 
     "@vue/language-core": ["@vue/language-core@3.3.6", "", { "dependencies": { "@volar/language-core": "2.4.28", "@vue/compiler-dom": "^3.5.0", "@vue/shared": "^3.5.0", "alien-signals": "^3.2.0", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1", "picomatch": "^4.0.4" } }, "sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q=="],
 
@@ -3386,6 +3418,8 @@
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "copy-anything": ["copy-anything@4.1.0", "", {}, "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q=="],
 
     "core-js": ["core-js@3.47.0", "", {}, "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg=="],
 
@@ -4187,6 +4221,8 @@
 
     "knitwork": ["knitwork@1.3.0", "", {}, "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw=="],
 
+    "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
@@ -4472,6 +4508,8 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
     "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
@@ -5241,6 +5279,8 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
 
+    "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
+
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
@@ -5306,6 +5346,8 @@
     "stylehacks": ["stylehacks@8.0.1", "", { "dependencies": { "browserslist": "^4.28.2", "postcss-selector-parser": "^7.1.2" }, "peerDependencies": { "postcss": "^8.5.15" } }, "sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -5595,6 +5637,10 @@
 
     "vite-plugin-solid": ["vite-plugin-solid@2.11.11", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-YMZCXsLw9kyuvQFEdwLP27fuTQJLmjNoHy90AOJnbRuJ6DwShUxKFo38gdFrWn9v11hnGicKCZEaeI/TFs6JKw=="],
 
+    "vite-plugin-vue-devtools": ["vite-plugin-vue-devtools@7.7.10", "", { "dependencies": { "@vue/devtools-core": "^7.7.10", "@vue/devtools-kit": "^7.7.10", "@vue/devtools-shared": "^7.7.10", "execa": "^9.5.2", "sirv": "^3.0.1", "vite-plugin-inspect": "0.8.9", "vite-plugin-vue-inspector": "^5.3.1" }, "peerDependencies": { "vite": "^3.1.0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0" } }, "sha512-aHkUvDKxUdmSnuolEc8DkOrSjMpKO4Bb/BG01x2pBv6xTv487No9Tr7BMAsH2XWwMd+LtlUeCamhEZyEu9vxKQ=="],
+
+    "vite-plugin-vue-inspector": ["vite-plugin-vue-inspector@5.4.0", "", { "dependencies": { "@babel/core": "^7.23.0", "@babel/plugin-proposal-decorators": "^7.23.0", "@babel/plugin-syntax-import-attributes": "^7.22.5", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-transform-typescript": "^7.22.15", "@vue/babel-plugin-jsx": "^1.1.5", "@vue/compiler-dom": "^3.3.4", "kolorist": "^1.8.0", "magic-string": "^0.30.4" }, "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-Iq/024CydcE46FZqWPU4t4lw4uYOdLnFSO1RNxJVt2qY9zxIjmnkBqhHnYaReWM82kmNnaXs7OkfgRrV2GEjyw=="],
+
     "vite-plugin-vue-tracer": ["vite-plugin-vue-tracer@1.4.0", "", { "dependencies": { "estree-walker": "^3.0.3", "exsolve": "^1.0.8", "magic-string": "^0.30.21", "pathe": "^2.0.3", "source-map-js": "^1.2.1" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "vue": "^3.5.0" } }, "sha512-0tQCjCqZWVSK6UeRW9S4ABbf47lKQ68zvrT2FNvZmiL+alDydCVyH/T3Jlfbdc3T3C2Iuyyl5aVsMbF8IQIoxA=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
@@ -5791,9 +5837,17 @@
 
     "@astrojs/language-server/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "@astrojs/react/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@astrojs/react/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@5.1.1", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1", "debug": "^4.4.1", "deepmerge": "^4.3.1", "kleur": "^4.1.5", "magic-string": "^0.30.17", "vitefu": "^1.0.6" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ=="],
 
     "@astrojs/svelte/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
+
+    "@astrojs/vue/@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "@astrojs/vue/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "@astrojs/yaml2ts/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
@@ -5844,6 +5898,10 @@
     "@babel/helpers/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@babel/plugin-proposal-decorators/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
+
+    "@babel/plugin-syntax-decorators/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
     "@babel/plugin-syntax-typescript/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
@@ -6235,6 +6293,8 @@
 
     "@nuxt/vite-builder/@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.8", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.2.25" } }, "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew=="],
 
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx": ["@vitejs/plugin-vue-jsx@5.1.6", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-syntax-typescript": "^7.29.7", "@babel/plugin-transform-typescript": "^7.29.7", "@rolldown/pluginutils": "^1.0.1", "@vue/babel-plugin-jsx": "^2.0.1" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.0.0" } }, "sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA=="],
+
     "@nuxt/vite-builder/autoprefixer": ["autoprefixer@10.5.4", "", { "dependencies": { "browserslist": "^4.28.6", "caniuse-lite": "^1.0.30001806", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA=="],
 
     "@nuxt/vite-builder/exsolve": ["exsolve@1.1.1", "", {}, "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g=="],
@@ -6505,21 +6565,23 @@
 
     "@vue-macros/common/@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/compiler-core": "3.5.38", "@vue/compiler-dom": "3.5.38", "@vue/compiler-ssr": "3.5.38", "@vue/shared": "3.5.38", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.15", "source-map-js": "^1.2.1" } }, "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg=="],
 
-    "@vue/babel-plugin-jsx/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+    "@vue/babel-plugin-jsx/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
-    "@vue/babel-plugin-jsx/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+    "@vue/babel-plugin-jsx/@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@vue/babel-plugin-jsx/@vue/shared": ["@vue/shared@3.5.38", "", {}, "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug=="],
+    "@vue/babel-plugin-resolve-type/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@vue/babel-plugin-resolve-type/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+    "@vue/babel-plugin-resolve-type/@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.29.7", "", {}, "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw=="],
 
     "@vue/babel-plugin-resolve-type/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
-
-    "@vue/babel-plugin-resolve-type/@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/compiler-core": "3.5.38", "@vue/compiler-dom": "3.5.38", "@vue/compiler-ssr": "3.5.38", "@vue/shared": "3.5.38", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.15", "source-map-js": "^1.2.1" } }, "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg=="],
 
     "@vue/compiler-core/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@vue/compiler-sfc/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@vue/devtools-core/@vue/devtools-shared": ["@vue/devtools-shared@8.1.3", "", {}, "sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA=="],
+
+    "@vue/devtools-kit/@vue/devtools-shared": ["@vue/devtools-shared@8.1.3", "", {}, "sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA=="],
 
     "@vue/devtools-kit/birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
@@ -7337,6 +7399,14 @@
 
     "vite-plugin-checker/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "vite-plugin-vue-devtools/@vue/devtools-core": ["@vue/devtools-core@7.7.10", "", { "dependencies": { "@vue/devtools-kit": "^7.7.10", "@vue/devtools-shared": "^7.7.10", "mitt": "^3.0.1", "nanoid": "^5.1.0", "pathe": "^2.0.3", "vite-hot-client": "^2.0.4" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-rpsAY7HuxYUz6G7R0zBGoOgYsn/r3iU0LixLOGNJ3o5if6tkPDGIGV+6CIJbDNbeueP2HsGDCOQ5ni6Wr36xEQ=="],
+
+    "vite-plugin-vue-devtools/@vue/devtools-kit": ["@vue/devtools-kit@7.7.10", "", { "dependencies": { "@vue/devtools-shared": "^7.7.10", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw=="],
+
+    "vite-plugin-vue-devtools/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "vite-plugin-vue-devtools/vite-plugin-inspect": ["vite-plugin-inspect@0.8.9", "", { "dependencies": { "@antfu/utils": "^0.7.10", "@rollup/pluginutils": "^5.1.3", "debug": "^4.3.7", "error-stack-parser-es": "^0.1.5", "fs-extra": "^11.2.0", "open": "^10.1.0", "perfect-debounce": "^1.0.0", "picocolors": "^1.1.1", "sirv": "^3.0.0" }, "peerDependencies": { "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.1" } }, "sha512-22/8qn+LYonzibb1VeFZmISdVao5kC22jmEKm24vfFE8siEn47EpVcCLYMv6iKOYMJfjSvSJfueOwcFCkUnV3A=="],
+
     "vite-plugin-vue-tracer/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "vitest/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -7427,6 +7497,18 @@
 
     "@astrojs/language-server/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "@astrojs/react/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@astrojs/react/@vitejs/plugin-react/react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "@astrojs/react/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@astrojs/react/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@astrojs/react/vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "@astrojs/react/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
 
     "@astrojs/svelte/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
@@ -7436,6 +7518,14 @@
     "@astrojs/svelte/vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "@astrojs/svelte/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "@astrojs/vue/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@astrojs/vue/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@astrojs/vue/vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "@astrojs/vue/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
@@ -8145,6 +8235,8 @@
 
     "@nuxt/kit/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx": ["@vue/babel-plugin-jsx@2.0.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@vue/babel-helper-vue-transform-on": "2.0.1", "@vue/babel-plugin-resolve-type": "2.0.1", "@vue/shared": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" }, "optionalPeers": ["@babel/core"] }, "sha512-a8CaLQjD/s4PVdhrLD/zT574ZNPnZBOY+IhdtKWRB4HRZ0I2tXBi5ne7d9eCfaYwp5gU5+4KIyFTV1W1YL9xZA=="],
+
     "@nuxt/vite-builder/autoprefixer/browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
 
     "@nuxt/vite-builder/autoprefixer/caniuse-lite": ["caniuse-lite@1.0.30001806", "", {}, "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw=="],
@@ -8501,31 +8593,13 @@
 
     "@vue-macros/common/@vue/compiler-sfc/@vue/shared": ["@vue/shared@3.5.38", "", {}, "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug=="],
 
-    "@vue/babel-plugin-jsx/@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@vue/babel-plugin-jsx/@babel/template/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
-    "@vue/babel-plugin-jsx/@babel/template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@vue/babel-plugin-resolve-type/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@vue/babel-plugin-jsx/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@vue/babel-plugin-resolve-type/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-core": ["@vue/compiler-core@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/shared": "3.5.38", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ=="],
-
-    "@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-dom": ["@vue/compiler-dom@3.5.38", "", { "dependencies": { "@vue/compiler-core": "3.5.38", "@vue/shared": "3.5.38" } }, "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw=="],
-
-    "@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.38", "", { "dependencies": { "@vue/compiler-dom": "3.5.38", "@vue/shared": "3.5.38" } }, "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA=="],
-
-    "@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/shared": ["@vue/shared@3.5.38", "", {}, "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug=="],
 
     "@vue/language-core/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/shared": "3.5.38", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ=="],
 
@@ -9455,6 +9529,20 @@
 
     "vite-plugin-checker/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "vite-plugin-vue-devtools/@vue/devtools-core/nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+
+    "vite-plugin-vue-devtools/@vue/devtools-kit/birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
+    "vite-plugin-vue-devtools/@vue/devtools-kit/hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "vite-plugin-vue-devtools/@vue/devtools-kit/perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
+    "vite-plugin-vue-devtools/vite-plugin-inspect/error-stack-parser-es": ["error-stack-parser-es@0.1.5", "", {}, "sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg=="],
+
+    "vite-plugin-vue-devtools/vite-plugin-inspect/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "vite-plugin-vue-devtools/vite-plugin-inspect/perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
     "vite-plugin-vue-tracer/estree-walker/@types/estree": ["@types/estree@1.0.5", "", {}, "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="],
 
     "vscode-languageserver/vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
@@ -9523,6 +9611,58 @@
 
     "@astrojs/check/yargs/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "@astrojs/react/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@astrojs/react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
     "@astrojs/svelte/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@astrojs/svelte/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -9574,6 +9714,58 @@
     "@astrojs/svelte/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@astrojs/svelte/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@astrojs/vue/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@babel/helper-create-class-features-plugin/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -10439,6 +10631,16 @@
 
     "@nuxt/devtools/execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-helper-vue-transform-on": ["@vue/babel-helper-vue-transform-on@2.0.1", "", {}, "sha512-uZ66EaFbnnZSYqYEyplWvn46GhZ1KuYSThdT68p+am7MgBNbQ3hphTL9L+xSIsWkdktwhPYLwPgVWqo96jDdRA=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type": ["@vue/babel-plugin-resolve-type@2.0.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/helper-module-imports": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/parser": "^7.28.4", "@vue/compiler-sfc": "^3.5.22" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ybwgIuRGRRBhOU37GImDoWQoz+TlSqap65qVI6iwg/J7FfLTLmMf97TS7xQH9I7Qtr/gp161kYVdhr1ZMraSYQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/shared": ["@vue/shared@3.5.38", "", {}, "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug=="],
+
     "@nuxt/vite-builder/autoprefixer/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.11.6", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw=="],
 
     "@nuxt/vite-builder/autoprefixer/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.396", "", {}, "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ=="],
@@ -10989,21 +11191,7 @@
 
     "@vercel/nft/glob/path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
-    "@vue/babel-plugin-jsx/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@vue/babel-plugin-jsx/@babel/template/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@vue/babel-plugin-jsx/@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@vue/babel-plugin-jsx/@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
     "@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
-    "@vue/babel-plugin-jsx/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@vue/language-core/@vue/compiler-dom/@vue/compiler-core/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
@@ -11337,6 +11525,8 @@
 
     "vite-node/vite/tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "vite-plugin-vue-devtools/vite-plugin-inspect/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
     "vue-component-meta/@volar/typescript/@volar/language-core/@volar/source-map": ["@volar/source-map@2.4.15", "", {}, "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg=="],
 
     "vue-component-meta/@vue/language-core/@volar/language-core/@volar/source-map": ["@volar/source-map@2.4.15", "", {}, "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg=="],
@@ -11472,6 +11662,26 @@
     "@npmcli/package-json/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@npmcli/package-json/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/compiler-core": "3.5.38", "@vue/compiler-dom": "3.5.38", "@vue/compiler-ssr": "3.5.38", "@vue/shared": "3.5.38", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.15", "source-map-js": "^1.2.1" } }, "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg=="],
 
     "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-darwin-arm64": ["@rspack/binding-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WRVMGOmVSLeQfu6uNuBjXyNhgs2j/1GWZhSL+vhieZGLwpSggBAZZpiRWd1jhFzQpRitQyWZYD+3XgoX5tiaPg=="],
 
@@ -11806,6 +12016,32 @@
     "@npmcli/package-json/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@npmcli/package-json/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/template/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@babel/traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-core": ["@vue/compiler-core@3.5.38", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/shared": "3.5.38", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-dom": ["@vue/compiler-dom@3.5.38", "", { "dependencies": { "@vue/compiler-core": "3.5.38", "@vue/shared": "3.5.38" } }, "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw=="],
+
+    "@nuxt/vite-builder/@vitejs/plugin-vue-jsx/@vue/babel-plugin-jsx/@vue/babel-plugin-resolve-type/@vue/compiler-sfc/@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.38", "", { "dependencies": { "@vue/compiler-dom": "3.5.38", "@vue/shared": "3.5.38" } }, "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA=="],
 
     "@rslib/core/@rsbuild/core/@rspack/core/@rspack/binding/@rspack/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 

--- a/examples/astro-demo/README.md
+++ b/examples/astro-demo/README.md
@@ -34,6 +34,21 @@ Then open http://localhost:4321.
   curl -H 'accept-language: de-DE,de;q=0.9' http://localhost:4321/
   ```
 
+## Switching the dialog framework
+
+`ui` picks which framework renders the on-demand dialogs. Real sites hardcode
+one; the demo reads `C15T_UI` so the three builds can be compared:
+
+```bash
+C15T_UI=react bun run --cwd examples/astro-demo build
+C15T_UI=vue   bun run --cwd examples/astro-demo dev
+```
+
+Only the selected framework's Astro integration is registered, so a build
+contains exactly one framework runtime — the Svelte chunk is absent from the
+React and Vue builds and vice versa. `vite.build.manifest` is on so the
+dialog chunk graph can be walked from `dist/client/.vite/manifest.json`.
+
 ## Configuration
 
 `astro.config.mjs` uses `offline()`, so the demo needs no backend. Swap in

--- a/examples/astro-demo/astro.config.mjs
+++ b/examples/astro-demo/astro.config.mjs
@@ -1,7 +1,25 @@
 import node from '@astrojs/node';
+import react from '@astrojs/react';
 import svelte from '@astrojs/svelte';
+import vue from '@astrojs/vue';
 import c15t, { offline } from '@c15t/astro';
 import { defineConfig } from 'astro/config';
+
+// Which framework renders the on-demand dialog islands. Real sites hardcode
+// one; the demo takes it from the environment so the three builds can be
+// compared side by side:
+//
+//   C15T_UI=react bun run --cwd examples/astro-demo build
+const ui = process.env.C15T_UI ?? 'svelte';
+
+// Only the selected framework's Astro integration is listed. Loading all
+// three would let a stray chunk from the others reach the page and make the
+// bundle comparison meaningless.
+const uiIntegrations = {
+	react: react(),
+	svelte: svelte(),
+	vue: vue(),
+};
 
 // Server output so the middleware sees a real request per visitor: geo
 // headers, the GPC signal and the consent cookie all have to be read
@@ -9,7 +27,7 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
 	adapter: node({ mode: 'standalone' }),
 	integrations: [
-		svelte(),
+		uiIntegrations[ui],
 		c15t({
 			consentCategories: [
 				'necessary',
@@ -33,7 +51,10 @@ export default defineConfig({
 						"window.__demoAnalyticsLoaded = true; document.querySelector('[data-testid=\"script-status\"]')?.setAttribute('data-loaded', 'true');",
 				},
 			],
+			ui,
 		}),
 	],
 	output: 'server',
+	// The bundle comparison reads this to walk the dialog chunk graph.
+	vite: { build: { manifest: true } },
 });

--- a/examples/astro-demo/package.json
+++ b/examples/astro-demo/package.json
@@ -21,6 +21,13 @@
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.4",
-		"typescript": "6.0.3"
+		"@astrojs/react": "^4.4.0",
+		"@astrojs/vue": "^5.1.0",
+		"@c15t/react": "workspace:*",
+		"@c15t/vue": "workspace:*",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"typescript": "6.0.3",
+		"vue": "^3.5.0"
 	}
 }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@c15t/astro",
 	"version": "0.1.0",
-	"description": "Astro consent management: server-rendered cookie banner, Svelte preference-centre islands, geo-aware middleware, and consent-gated script loading.",
+	"description": "Astro consent management: server-rendered cookie banner, on-demand Svelte, React or Vue preference-centre islands, geo-aware middleware, and consent-gated script loading.",
 	"keywords": [
 		"astro",
 		"astro-integration",
@@ -16,10 +16,12 @@
 		"islands",
 		"lgpd",
 		"privacy",
+		"react",
 		"ssr",
 		"svelte",
 		"tcf",
-		"typescript"
+		"typescript",
+		"vue"
 	],
 	"homepage": "https://c15t.com/docs/frameworks/astro/quickstart",
 	"bugs": {
@@ -68,6 +70,21 @@
 			"import": "./dist/api/index.js",
 			"default": "./dist/api/index.js"
 		},
+		"./ui/svelte": {
+			"types": "./dist-types/ui/svelte.d.ts",
+			"import": "./dist/ui/svelte.js",
+			"default": "./dist/ui/svelte.js"
+		},
+		"./ui/react": {
+			"types": "./dist-types/ui/react.d.ts",
+			"import": "./dist/ui/react.js",
+			"default": "./dist/ui/react.js"
+		},
+		"./ui/vue": {
+			"types": "./dist-types/ui/vue.d.ts",
+			"import": "./dist/ui/vue.js",
+			"default": "./dist/ui/vue.js"
+		},
 		"./components/*": "./src/components/*",
 		"./islands/*": {
 			"svelte": "./src/components/islands/*",
@@ -108,19 +125,44 @@
 		"@c15t/ui": "workspace:*"
 	},
 	"devDependencies": {
+		"@c15t/react": "workspace:*",
 		"@c15t/typescript-config": "workspace:*",
 		"@c15t/vitest-config": "workspace:*",
+		"@c15t/vue": "workspace:*",
 		"astro": "^5.16.0",
 		"jsdom": "^25.0.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
 		"svelte": "^5.0.0",
-		"typescript": "6.0.3"
+		"typescript": "6.0.3",
+		"vue": "^3.5.0"
 	},
 	"peerDependencies": {
+		"@c15t/react": "workspace:^",
+		"@c15t/vue": "workspace:^",
 		"astro": "^5.0.0",
-		"svelte": "^5.0.0"
+		"react": "^18.0.0 || ^19.0.0",
+		"react-dom": "^18.0.0 || ^19.0.0",
+		"svelte": "^5.0.0",
+		"vue": "^3.5.0"
 	},
 	"peerDependenciesMeta": {
+		"@c15t/react": {
+			"optional": true
+		},
+		"@c15t/vue": {
+			"optional": true
+		},
+		"react": {
+			"optional": true
+		},
+		"react-dom": {
+			"optional": true
+		},
 		"svelte": {
+			"optional": true
+		},
+		"vue": {
 			"optional": true
 		}
 	}

--- a/packages/astro/src/__tests__/adapter.test.ts
+++ b/packages/astro/src/__tests__/adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	loadDialogAdapter,
@@ -9,16 +9,20 @@ import {
 import type { ConsentDialogAdapter } from '../ui/adapter';
 
 describe('dialog adapter registry', () => {
-	it('ships svelte as the built-in adapter', async () => {
-		const adapter = await loadDialogAdapter('svelte');
-		expect(adapter.name).toBe('svelte');
+	it('starts empty so no build resolves a framework it did not pick', async () => {
+		await expect(loadDialogAdapter('svelte')).rejects.toThrowError(
+			/no dialog adapter registered for ui: "svelte"/u
+		);
 	});
 
-	it('lets another framework replace it', async () => {
-		const custom = { mount: vi.fn(), name: 'svelte' } as ConsentDialogAdapter;
-		registerDialogAdapter('svelte', () => Promise.resolve(custom));
-		expect(await loadDialogAdapter('svelte')).toBe(custom);
-	});
+	it.each(['svelte', 'react', 'vue'] as const)(
+		'accepts the %s adapter the integration registers',
+		async (name) => {
+			const adapter = { mount: vi.fn(), name } as ConsentDialogAdapter;
+			registerDialogAdapter(name, () => Promise.resolve(adapter));
+			expect(await loadDialogAdapter(name)).toBe(adapter);
+		}
+	);
 
 	it('runs a registered loader at most once', async () => {
 		const custom = { mount: vi.fn(), name: 'svelte' } as ConsentDialogAdapter;
@@ -61,23 +65,39 @@ describe('dialog adapter registry', () => {
 	});
 
 	it('names the ui option in the error for an unknown adapter', async () => {
-		await expect(loadDialogAdapter('react' as never)).rejects.toThrowError(
-			/no dialog adapter registered for ui: "react"/u
+		await expect(loadDialogAdapter('solid' as never)).rejects.toThrowError(
+			/no dialog adapter registered for ui: "solid"/u
 		);
 	});
 });
 
 describe('dialog surface registry', () => {
-	it('tells you which component registers the island', () => {
-		// A page with only <ConsentDialogTrigger> and no <ConsentDialog />.
-		expect(() => requireDialogSurface('vue' as never)).toThrowError(
-			/Render <ConsentDialog \/>/u
+	it('points at the integration when nothing registered a surface', () => {
+		expect(() => requireDialogSurface('solid' as never)).toThrowError(
+			/c15t\(\) is missing from astro.config/u
 		);
 	});
 
 	it('returns the registered loader', () => {
 		const load = vi.fn(() => Promise.resolve({ default: {} }));
-		registerDialogSurface('svelte', load);
-		expect(requireDialogSurface('svelte')).toBe(load);
+		registerDialogSurface('react', load);
+		expect(requireDialogSurface('react')).toBe(load);
+	});
+});
+
+describe('the shipped adapters', () => {
+	beforeEach(() => {
+		registerDialogSurface('svelte', () => Promise.resolve({ default: {} }));
+		registerDialogSurface('react', () => Promise.resolve({ default: {} }));
+		registerDialogSurface('vue', () => Promise.resolve({ default: {} }));
+	});
+
+	it.each([
+		['svelte', () => import('../ui/svelte'), 'svelteDialogAdapter'],
+		['react', () => import('../ui/react'), 'reactDialogAdapter'],
+		['vue', () => import('../ui/vue'), 'vueDialogAdapter'],
+	] as const)('names itself %s', async (name, load, exportName) => {
+		const module = (await load()) as Record<string, ConsentDialogAdapter>;
+		expect(module[exportName]?.name).toBe(name);
 	});
 });

--- a/packages/astro/src/__tests__/adapter.test.ts
+++ b/packages/astro/src/__tests__/adapter.test.ts
@@ -5,8 +5,13 @@ import {
 	registerDialogAdapter,
 	registerDialogSurface,
 	requireDialogSurface,
+	resetDialogRegistriesForTest,
 } from '../ui/adapter';
 import type { ConsentDialogAdapter } from '../ui/adapter';
+
+beforeEach(() => {
+	resetDialogRegistriesForTest();
+});
 
 describe('dialog adapter registry', () => {
 	it('starts empty so no build resolves a framework it did not pick', async () => {

--- a/packages/astro/src/__tests__/color-scheme.dom.test.ts
+++ b/packages/astro/src/__tests__/color-scheme.dom.test.ts
@@ -108,22 +108,21 @@ describe('boot applies the colour scheme', () => {
 describe('a webview with no matchMedia', () => {
 	it('still honours a pinned scheme instead of throwing', () => {
 		vi.stubGlobal('matchMedia', undefined);
-		// oxlint-disable-next-line no-explicit-any -- Removing a DOM global.
-		(window as any).matchMedia = undefined;
+		Reflect.set(window, 'matchMedia', undefined);
 
 		expect(() => start('dark')).not.toThrow();
 		expect(isDark()).toBe(true);
 	});
 
-	it('leaves system at the stylesheet default rather than guessing', () => {
+	it('falls system back to light rather than keeping a stale dark', () => {
 		document.documentElement.classList.add('c15t-dark');
 		vi.stubGlobal('matchMedia', undefined);
-		// oxlint-disable-next-line no-explicit-any -- Removing a DOM global.
-		(window as any).matchMedia = undefined;
+		Reflect.set(window, 'matchMedia', undefined);
 
 		expect(() => start('system')).not.toThrow();
-		// Untouched: with nothing to read, changing it would be a guess.
-		expect(isDark()).toBe(true);
+		// The documented fallback for `system` is light, and a swapped-in
+		// dark shell would otherwise stay dark for the rest of the visit.
+		expect(isDark()).toBe(false);
 	});
 });
 

--- a/packages/astro/src/__tests__/color-scheme.dom.test.ts
+++ b/packages/astro/src/__tests__/color-scheme.dom.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The client boot's half of the colour scheme.
+ *
+ * The inline `<head>` script gets the first paint right; `boot()` has to
+ * keep it right afterwards — and, because ClientRouter replaces `<html>`'s
+ * attributes on every navigation, re-apply it without leaking the previous
+ * media-query listener.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { boot } from '../client';
+import type { AstroConsentClient } from '../client';
+import { resolveOptions } from '../integration';
+import { offlineMode } from '../mode';
+import type { C15tAstroOptions, C15tColorScheme } from '../types';
+
+interface MediaQueryStub {
+	matches: boolean;
+	listeners: Set<(event: MediaQueryListEvent) => void>;
+	addEventListener: ReturnType<typeof vi.fn>;
+	removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+let media: MediaQueryStub;
+let client: AstroConsentClient | null = null;
+
+const stubMatchMedia = function stubMatchMedia(matches: boolean): void {
+	const listeners = new Set<(event: MediaQueryListEvent) => void>();
+	media = {
+		addEventListener: vi.fn((_type: string, listener: () => void) => {
+			listeners.add(listener);
+		}),
+		listeners,
+		matches,
+		removeEventListener: vi.fn((_type: string, listener: () => void) => {
+			listeners.delete(listener);
+		}),
+	};
+	vi.stubGlobal(
+		'matchMedia',
+		vi.fn(() => media)
+	);
+	window.matchMedia = globalThis.matchMedia;
+};
+
+const start = function start(
+	colorScheme?: C15tColorScheme
+): AstroConsentClient {
+	const options: C15tAstroOptions = { mode: offlineMode() };
+	if (colorScheme) {
+		options.colorScheme = colorScheme;
+	}
+	client = boot(resolveOptions(options));
+	return client;
+};
+
+beforeEach(() => {
+	stubMatchMedia(false);
+	document.documentElement.className = '';
+	const globals = window as unknown as Record<string, unknown>;
+	globals.__c15tAstro = undefined;
+	globals.__c15tAstroColorScheme = undefined;
+	globals.__c15tAstroConfig = undefined;
+	globals.__c15tAstroActions = undefined;
+});
+
+afterEach(() => {
+	client?.dispose();
+	client = null;
+	vi.unstubAllGlobals();
+});
+
+const isDark = () => document.documentElement.classList.contains('c15t-dark');
+
+describe('boot applies the colour scheme', () => {
+	it('pins dark', () => {
+		start('dark');
+		expect(isDark()).toBe(true);
+	});
+
+	it('pins light even when the system is dark', () => {
+		stubMatchMedia(true);
+		document.documentElement.classList.add('c15t-dark');
+		start('light');
+		expect(isDark()).toBe(false);
+	});
+
+	it('follows the system by default', () => {
+		stubMatchMedia(true);
+		start();
+		expect(isDark()).toBe(true);
+	});
+
+	it('keeps following the system as the visitor changes it', () => {
+		stubMatchMedia(false);
+		start();
+		expect(isDark()).toBe(false);
+
+		media.matches = true;
+		for (const listener of media.listeners) {
+			listener({ matches: true } as MediaQueryListEvent);
+		}
+		expect(isDark()).toBe(true);
+	});
+});
+
+describe('a webview with no matchMedia', () => {
+	it('still honours a pinned scheme instead of throwing', () => {
+		vi.stubGlobal('matchMedia', undefined);
+		// oxlint-disable-next-line no-explicit-any -- Removing a DOM global.
+		(window as any).matchMedia = undefined;
+
+		expect(() => start('dark')).not.toThrow();
+		expect(isDark()).toBe(true);
+	});
+
+	it('leaves system at the stylesheet default rather than guessing', () => {
+		document.documentElement.classList.add('c15t-dark');
+		vi.stubGlobal('matchMedia', undefined);
+		// oxlint-disable-next-line no-explicit-any -- Removing a DOM global.
+		(window as any).matchMedia = undefined;
+
+		expect(() => start('system')).not.toThrow();
+		// Untouched: with nothing to read, changing it would be a guess.
+		expect(isDark()).toBe(true);
+	});
+});
+
+describe('ClientRouter navigation', () => {
+	it('re-applies against the swapped document without leaking a listener', () => {
+		stubMatchMedia(true);
+		start();
+		expect(isDark()).toBe(true);
+		expect(media.listeners.size).toBe(1);
+
+		// The swap replaces `<html>`'s attributes, taking the class with it.
+		document.documentElement.className = '';
+		document.dispatchEvent(new Event('astro:after-swap'));
+
+		expect(isDark()).toBe(true);
+		expect(media.listeners.size).toBe(1);
+		expect(media.removeEventListener).toHaveBeenCalled();
+	});
+});
+
+describe('dispose', () => {
+	it('drops the media-query listener', () => {
+		stubMatchMedia(true);
+		start();
+		expect(media.listeners.size).toBe(1);
+
+		client?.dispose();
+		client = null;
+
+		expect(media.listeners.size).toBe(0);
+		expect(
+			(window as unknown as Record<string, unknown>).__c15tAstroColorScheme
+		).toBeUndefined();
+	});
+});

--- a/packages/astro/src/__tests__/color-scheme.test.ts
+++ b/packages/astro/src/__tests__/color-scheme.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Colour-scheme plumbing.
+ *
+ * `c15t-dark` on `<html>` is the only thing that makes the surfaces dark —
+ * the stylesheet carries no `prefers-color-scheme` block — so these cover
+ * the two places that set it: the resolved option that reaches the browser,
+ * and the inline script that runs before the first paint.
+ */
+
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import ConsentBanner from '../components/consent-banner.astro';
+import ConsentScript from '../components/consent-script.astro';
+import { c15t, resolveOptions } from '../integration';
+import { offlineMode } from '../mode';
+import { buildColorSchemeScript, resolveConsentContext } from '../server';
+import type { C15tAstroOptions, C15tLocals } from '../types';
+
+let container: AstroContainer;
+
+beforeAll(async () => {
+	container = await AstroContainer.create();
+});
+
+const buildLocals = async function buildLocals(
+	options: C15tAstroOptions = { mode: offlineMode() }
+): Promise<C15tLocals> {
+	return await resolveConsentContext({
+		headers: new Headers(),
+		options: resolveOptions(options),
+	});
+};
+
+const serializedOptions = async function serializedOptions(
+	options: C15tAstroOptions
+) {
+	const integration = c15t(options);
+	const updateConfig = vi.fn();
+	await integration.hooks['astro:config:setup']?.({
+		addMiddleware: vi.fn(),
+		injectRoute: vi.fn(),
+		injectScript: vi.fn(),
+		updateConfig,
+	} as unknown as Parameters<
+		NonNullable<(typeof integration)['hooks']['astro:config:setup']>
+	>[0]);
+	const [config] = updateConfig.mock.calls[0] as [
+		{
+			vite: {
+				plugins: {
+					resolveId: (id: string) => string;
+					load: (id: string) => string;
+				}[];
+			};
+		},
+	];
+	const [plugin] = config.vite.plugins;
+	const loaded = plugin?.load(
+		plugin.resolveId('virtual:c15t/options') as string
+	) as string;
+	return JSON.parse(loaded.replace(/^export default /u, '').replace(/;$/u, ''));
+};
+
+describe('the colorScheme option', () => {
+	it('defaults to system', () => {
+		expect(resolveOptions({ mode: offlineMode() }).colorScheme).toBe('system');
+	});
+
+	it.each(['light', 'dark', 'system'] as const)('keeps %s', (colorScheme) => {
+		expect(
+			resolveOptions({ colorScheme, mode: offlineMode() }).colorScheme
+		).toBe(colorScheme);
+	});
+
+	it('reaches the browser through the virtual options module', async () => {
+		expect(
+			(await serializedOptions({ colorScheme: 'dark', mode: offlineMode() }))
+				.colorScheme
+		).toBe('dark');
+		expect((await serializedOptions({ mode: offlineMode() })).colorScheme).toBe(
+			'system'
+		);
+	});
+});
+
+describe('buildColorSchemeScript', () => {
+	it('emits nothing for light, because light is the absence of the class', () => {
+		expect(buildColorSchemeScript('light')).toBe('');
+	});
+
+	it('sets the class unconditionally for dark', () => {
+		expect(buildColorSchemeScript('dark')).toContain(
+			"classList.add('c15t-dark')"
+		);
+		expect(buildColorSchemeScript('dark')).not.toContain('matchMedia');
+	});
+
+	it('reads prefers-color-scheme for system', () => {
+		const script = buildColorSchemeScript('system');
+		expect(script).toContain('(prefers-color-scheme:dark)');
+		expect(script).toContain("'c15t-dark'");
+	});
+
+	it('survives a webview with no matchMedia', () => {
+		// A throw in a parser-blocking head script takes the rest of the
+		// document with it.
+		expect(buildColorSchemeScript('system')).toMatch(/^try\{.*\}catch/su);
+	});
+
+	it.each(['light', 'dark', 'system'] as const)(
+		'keeps %s under the inline budget and free of framework code',
+		(colorScheme) => {
+			const script = buildColorSchemeScript(colorScheme);
+			expect(new TextEncoder().encode(script).length).toBeLessThan(300);
+			expect(script).not.toMatch(/\bimport\b|\brequire\b|\bexport\b/u);
+		}
+	);
+});
+
+describe('<ConsentScript />', () => {
+	const render = async function render(locals: C15tLocals): Promise<string> {
+		return await container.renderToString(ConsentScript, {
+			locals: { c15t: locals },
+		});
+	};
+
+	it('runs the colour-scheme script before the config script', async () => {
+		const html = await render(await buildLocals());
+		const colorScheme = html.indexOf('prefers-color-scheme');
+		const config = html.indexOf('__c15tAstroConfig');
+		expect(colorScheme).toBeGreaterThan(-1);
+		expect(config).toBeGreaterThan(colorScheme);
+	});
+
+	it('emits the dark variant when the site pinned dark', async () => {
+		const html = await render(
+			await buildLocals({ colorScheme: 'dark', mode: offlineMode() })
+		);
+		expect(html).toContain("classList.add('c15t-dark')");
+		expect(html).not.toContain('prefers-color-scheme');
+	});
+
+	it('emits no colour-scheme script for light', async () => {
+		const html = await render(
+			await buildLocals({ colorScheme: 'light', mode: offlineMode() })
+		);
+		expect(html).not.toContain('c15t-dark');
+		expect(html).toContain('__c15tAstroConfig');
+	});
+
+	it('emits once per request, even alongside a banner', async () => {
+		// One `locals` object for both renders: that identity is what the
+		// emission guard keys off, and Astro hands the same one to every
+		// component in a request.
+		const locals = { c15t: await buildLocals() };
+		const head = await container.renderToString(ConsentScript, { locals });
+		const banner = await container.renderToString(ConsentBanner, {
+			locals,
+			props: {},
+		});
+		expect(head).toContain('prefers-color-scheme');
+		expect(banner).not.toContain('prefers-color-scheme');
+	});
+});
+
+describe('<ConsentBanner /> without a <ConsentScript /> in head', () => {
+	it('emits the colour-scheme script before its own markup', async () => {
+		const html = await container.renderToString(ConsentBanner, {
+			locals: { c15t: await buildLocals() },
+			props: {},
+		});
+		const script = html.indexOf('prefers-color-scheme');
+		const root = html.indexOf('consent-banner-root');
+		expect(script).toBeGreaterThan(-1);
+		expect(root).toBeGreaterThan(script);
+	});
+});

--- a/packages/astro/src/__tests__/integration.test.ts
+++ b/packages/astro/src/__tests__/integration.test.ts
@@ -99,8 +99,23 @@ describe('resolveOptions', () => {
 			mode: offlineMode(),
 			requireUIIntegration: false,
 		});
-		expect(resolved).not.toHaveProperty('middleware');
 		expect(resolved).not.toHaveProperty('requireUIIntegration');
+	});
+
+	it('normalizes the middleware option', () => {
+		expect(resolveOptions({ mode: offlineMode() }).middleware).toEqual({
+			enabled: true,
+			skip: [],
+		});
+		expect(
+			resolveOptions({ middleware: false, mode: offlineMode() }).middleware
+		).toEqual({ enabled: false, skip: [] });
+		expect(
+			resolveOptions({
+				middleware: { skip: ['/healthz'] },
+				mode: offlineMode(),
+			}).middleware
+		).toEqual({ enabled: true, skip: ['/healthz'] });
 	});
 
 	it('keeps an explicit ui adapter', () => {

--- a/packages/astro/src/__tests__/integration.test.ts
+++ b/packages/astro/src/__tests__/integration.test.ts
@@ -11,7 +11,7 @@ interface SetupCalls {
 	updateConfig: ReturnType<typeof vi.fn>;
 }
 
-const runSetup = function runSetup(options: C15tAstroOptions) {
+const runSetup = async function runSetup(options: C15tAstroOptions) {
 	const integration = c15t(options);
 	const calls: SetupCalls = {
 		addMiddleware: vi.fn(),
@@ -19,7 +19,7 @@ const runSetup = function runSetup(options: C15tAstroOptions) {
 		injectScript: vi.fn(),
 		updateConfig: vi.fn(),
 	};
-	integration.hooks['astro:config:setup']?.(
+	await integration.hooks['astro:config:setup']?.(
 		calls as unknown as Parameters<
 			NonNullable<(typeof integration)['hooks']['astro:config:setup']>
 		>[0]
@@ -32,14 +32,15 @@ const runDone = function runDone(
 	integrationNames: string[]
 ) {
 	const integration = c15t(options);
-	const logger = { error: vi.fn() };
-	return () =>
+	const logger = { error: vi.fn(), warn: vi.fn() };
+	const run = () =>
 		integration.hooks['astro:config:done']?.({
 			config: { integrations: integrationNames.map((name) => ({ name })) },
 			logger,
 		} as unknown as Parameters<
 			NonNullable<(typeof integration)['hooks']['astro:config:done']>
 		>[0]);
+	return Object.assign(run, { logger });
 };
 
 describe('resolveOptions', () => {
@@ -96,38 +97,80 @@ describe('resolveOptions', () => {
 		const resolved = resolveOptions({
 			middleware: false,
 			mode: offlineMode(),
-			requireSvelte: false,
+			requireUIIntegration: false,
 		});
 		expect(resolved).not.toHaveProperty('middleware');
-		expect(resolved).not.toHaveProperty('requireSvelte');
+		expect(resolved).not.toHaveProperty('requireUIIntegration');
+	});
+
+	it('keeps an explicit ui adapter', () => {
+		expect(resolveOptions({ mode: offlineMode(), ui: 'react' }).ui).toBe(
+			'react'
+		);
+		expect(resolveOptions({ mode: offlineMode(), ui: 'vue' }).ui).toBe('vue');
 	});
 });
 
 describe('astro:config:setup', () => {
-	it('registers the middleware before user middleware', () => {
-		const { calls } = runSetup({ mode: hostedMode({ url: '/api/c15t' }) });
+	it('registers the middleware before user middleware', async () => {
+		const { calls } = await runSetup({
+			mode: hostedMode({ url: '/api/c15t' }),
+		});
 		expect(calls.addMiddleware).toHaveBeenCalledWith({
 			entrypoint: '@c15t/astro/middleware',
 			order: 'pre',
 		});
 	});
 
-	it('skips the middleware when disabled', () => {
-		const { calls } = runSetup({ middleware: false, mode: offlineMode() });
+	it('skips the middleware when disabled', async () => {
+		const { calls } = await runSetup({
+			middleware: false,
+			mode: offlineMode(),
+		});
 		expect(calls.addMiddleware).not.toHaveBeenCalled();
 	});
 
-	it('injects a page-level boot script', () => {
-		const { calls } = runSetup({ mode: offlineMode() });
+	it('injects a page-level boot script', async () => {
+		const { calls } = await runSetup({ mode: offlineMode() });
 		const [stage, code] = calls.injectScript.mock.calls[0] as [string, string];
 		expect(stage).toBe('page');
 		expect(code).toContain("import options from 'virtual:c15t/options'");
-		expect(code).toContain("import { boot } from '@c15t/astro/client'");
+		expect(code).toContain("from '@c15t/astro/client'");
 		expect(code).toContain('boot(options);');
 	});
 
-	it('threads a client entrypoint into the boot script', () => {
-		const { calls } = runSetup({
+	it.each([
+		['svelte', '@c15t/astro/ui/svelte', 'consent-dialog-surface.svelte'],
+		['react', '@c15t/astro/ui/react', 'consent-dialog-surface.tsx'],
+		['vue', '@c15t/astro/ui/vue', 'consent-dialog-surface.vue'],
+	] as const)(
+		'registers only the %s adapter and island',
+		async (ui, adapterModule, surfaceFile) => {
+			const { calls } = await runSetup({ mode: offlineMode(), ui });
+			const [, code] = calls.injectScript.mock.calls[0] as [string, string];
+
+			expect(code).toContain(`registerDialogAdapter('${ui}'`);
+			expect(code).toContain(`import('${adapterModule}')`);
+			expect(code).toContain(`import('@c15t/astro/islands/${surfaceFile}')`);
+
+			// The point of injecting these: a build must never see a specifier
+			// for a framework the site did not ask for.
+			for (const other of ['svelte', 'react', 'vue'].filter(
+				(name) => name !== ui
+			)) {
+				expect(code).not.toContain(`@c15t/astro/ui/${other}`);
+			}
+		}
+	);
+
+	it('keeps both island specifiers behind import()', async () => {
+		const { calls } = await runSetup({ mode: offlineMode(), ui: 'react' });
+		const [, code] = calls.injectScript.mock.calls[0] as [string, string];
+		expect(code).not.toMatch(/^import\s[^;]*@c15t\/astro\/(?:ui|islands)\//mu);
+	});
+
+	it('threads a client entrypoint into the boot script', async () => {
+		const { calls } = await runSetup({
 			clientEntrypoint: './src/c15t.client.ts',
 			mode: offlineMode(),
 		});
@@ -136,8 +179,8 @@ describe('astro:config:setup', () => {
 		expect(code).toContain('boot(options, clientOptions);');
 	});
 
-	it('serves the serialized options from the virtual module', () => {
-		const { calls } = runSetup({
+	it('serves the serialized options from the virtual module', async () => {
+		const { calls } = await runSetup({
 			consentCategories: ['necessary', 'measurement'],
 			mode: hostedMode({ url: 'https://consent.example.com' }),
 		});
@@ -166,8 +209,27 @@ describe('astro:config:setup', () => {
 		expect(parsed.consentCategories).toEqual(['necessary', 'measurement']);
 	});
 
-	it('injects the init and manifest routes in manifest mode', () => {
-		const { calls } = runSetup({
+	it("shims Nuxt's #imports for the vue adapter only", async () => {
+		const withVue = await runSetup({ mode: offlineMode(), ui: 'vue' });
+		const [vueConfig] = withVue.calls.updateConfig.mock.calls[0] as [
+			{ vite: { plugins: { name: string }[] } },
+		];
+		expect(vueConfig.vite.plugins.map((plugin) => plugin.name)).toEqual([
+			'c15t:options',
+			'@c15t/vue',
+		]);
+
+		const withSvelte = await runSetup({ mode: offlineMode() });
+		const [svelteConfig] = withSvelte.calls.updateConfig.mock.calls[0] as [
+			{ vite: { plugins: { name: string }[] } },
+		];
+		expect(svelteConfig.vite.plugins.map((plugin) => plugin.name)).toEqual([
+			'c15t:options',
+		]);
+	});
+
+	it('injects the init and manifest routes in manifest mode', async () => {
+		const { calls } = await runSetup({
 			mode: manifestMode({ backendURL: 'https://consent.example.com' }),
 		});
 		expect(calls.injectRoute).toHaveBeenCalledWith({
@@ -182,26 +244,85 @@ describe('astro:config:setup', () => {
 		});
 	});
 
-	it('injects no routes in hosted mode', () => {
-		const { calls } = runSetup({ mode: hostedMode({ url: '/api/c15t' }) });
+	it('injects no routes in hosted mode', async () => {
+		const { calls } = await runSetup({
+			mode: hostedMode({ url: '/api/c15t' }),
+		});
 		expect(calls.injectRoute).not.toHaveBeenCalled();
 	});
 });
 
 describe('astro:config:done', () => {
-	it('fails clearly when @astrojs/svelte is missing', () => {
-		expect(runDone({ mode: offlineMode() }, [])).toThrowError(
-			/missing @astrojs\/svelte/u
+	it.each([
+		['svelte', '@astrojs/svelte'],
+		['react', '@astrojs/react'],
+		['vue', '@astrojs/vue'],
+	] as const)(
+		'fails clearly when %s is selected without %s',
+		(ui, astroIntegration) => {
+			const run = runDone({ mode: offlineMode(), ui }, []);
+			expect(run).toThrowError(
+				new RegExp(`ui: "${ui}" needs ${astroIntegration}`, 'u')
+			);
+		}
+	);
+
+	it('names every package to install in the error log', () => {
+		const run = runDone({ mode: offlineMode(), ui: 'react' }, []);
+		expect(run).toThrow();
+		expect(run.logger.error).toHaveBeenCalledWith(
+			expect.stringContaining('@astrojs/react, @c15t/react, react, react-dom')
 		);
 	});
 
-	it('passes when @astrojs/svelte is installed', () => {
-		expect(runDone({ mode: offlineMode() }, ['@astrojs/svelte'])).not.toThrow();
+	it.each([
+		['svelte', '@astrojs/svelte'],
+		['react', '@astrojs/react'],
+		['vue', '@astrojs/vue'],
+	] as const)('passes when %s has %s installed', (ui, astroIntegration) => {
+		expect(
+			runDone({ mode: offlineMode(), ui }, [astroIntegration])
+		).not.toThrow();
 	});
 
 	it('passes for a banner-only site', () => {
 		expect(
-			runDone({ mode: offlineMode(), requireSvelte: false }, [])
+			runDone({ mode: offlineMode(), requireUIIntegration: false }, [])
 		).not.toThrow();
+	});
+
+	it.each(['@astrojs/react', '@astrojs/vue'])(
+		'suggests reusing %s when ui was left at the default',
+		(astroIntegration) => {
+			const run = runDone({ mode: offlineMode() }, [
+				'@astrojs/svelte',
+				astroIntegration,
+			]);
+			run();
+			expect(run.logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining(astroIntegration)
+			);
+		}
+	);
+
+	it('never switches the adapter on its own', async () => {
+		const options: C15tAstroOptions = { mode: offlineMode() };
+		runDone(options, ['@astrojs/svelte', '@astrojs/react'])();
+
+		// The suggestion is advice, not a decision: the page still boots the
+		// Svelte island until someone sets `ui` themselves.
+		const { calls } = await runSetup(options);
+		const [, code] = calls.injectScript.mock.calls[0] as [string, string];
+		expect(code).toContain("registerDialogAdapter('svelte'");
+		expect(code).not.toContain('@c15t/astro/ui/react');
+	});
+
+	it('stays quiet when ui was chosen explicitly', () => {
+		const run = runDone({ mode: offlineMode(), ui: 'svelte' }, [
+			'@astrojs/svelte',
+			'@astrojs/react',
+		]);
+		run();
+		expect(run.logger.warn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/astro/src/__tests__/integration.test.ts
+++ b/packages/astro/src/__tests__/integration.test.ts
@@ -62,6 +62,15 @@ describe('resolveOptions', () => {
 		);
 	});
 
+	it('names the supported adapters for an unknown ui', () => {
+		// A JavaScript astro.config.mjs has no type checking, so this used to
+		// surface as a TypeError on an undefined adapter entry.
+		expect(() =>
+			resolveOptions({ mode: offlineMode(), ui: 'solid' as never })
+		).toThrowError(/unknown `ui` "solid". Supported adapters: /u);
+		expect(resolveOptions({ mode: offlineMode(), ui: 'vue' }).ui).toBe('vue');
+	});
+
 	it('rejects a manifestURL with nowhere to save consent', () => {
 		// The injected routes serve init and manifest; `POST /subjects` is
 		// the backend's, so a `manifestURL` without one would 404 on save.

--- a/packages/astro/src/__tests__/lazy-surfaces.test.ts
+++ b/packages/astro/src/__tests__/lazy-surfaces.test.ts
@@ -10,10 +10,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const SOURCE_ROOT = new URL('..', import.meta.url).pathname;
+// `URL.pathname` keeps percent-encoding and, on Windows, produces an
+// invalid `/C:/…` path; `fileURLToPath` is what the filesystem wants.
+const SOURCE_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const FRAMEWORK_SPECIFIERS = [
 	'@c15t/react',

--- a/packages/astro/src/__tests__/lazy-surfaces.test.ts
+++ b/packages/astro/src/__tests__/lazy-surfaces.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The guard behind the whole `ui` seam.
+ *
+ * A single static `import` of a framework surface anywhere the client boot
+ * can reach undoes the point of the option: every site's build would then
+ * resolve React, Vue and Svelte, and every visitor would download whichever
+ * one the bundler could not shake out. These assertions read the sources
+ * rather than the bundle, so the failure lands on the line that caused it.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_ROOT = new URL('..', import.meta.url).pathname;
+
+const FRAMEWORK_SPECIFIERS = [
+	'@c15t/react',
+	'@c15t/svelte',
+	'@c15t/vue',
+	'react',
+	'react-dom',
+	'react-dom/client',
+	'svelte',
+	'vue',
+];
+
+const listSources = function listSources(directory: string): string[] {
+	const found: string[] = [];
+	for (const entry of readdirSync(directory)) {
+		const path = join(directory, entry);
+		if (statSync(path).isDirectory()) {
+			if (entry === '__tests__' || entry === 'components') {
+				continue;
+			}
+			found.push(...listSources(path));
+			continue;
+		}
+		if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+			found.push(path);
+		}
+	}
+	return found;
+};
+
+/** `import x from 'y'` and `export * from 'y'`, but never `import('y')`. */
+const staticSpecifiers = function staticSpecifiers(source: string): string[] {
+	const pattern =
+		/^\s*(?:import|export)\b[^;\n]*?from\s+'(?<specifier>[^']+)'/gmu;
+	const bare = /^\s*import\s+'(?<specifier>[^']+)'/gmu;
+	return [...source.matchAll(pattern), ...source.matchAll(bare)]
+		.map((match) => match.groups?.specifier)
+		.filter((specifier): specifier is string => specifier !== undefined);
+};
+
+describe('framework surfaces are reachable only through import()', () => {
+	it.each(listSources(SOURCE_ROOT).map((path) => [path]))(
+		'%s imports no framework statically',
+		(path) => {
+			const source = readFileSync(path, 'utf8');
+			const offenders = staticSpecifiers(source).filter(
+				(specifier) =>
+					FRAMEWORK_SPECIFIERS.includes(specifier) ||
+					specifier.startsWith('./ui/react') ||
+					specifier.startsWith('./ui/vue') ||
+					specifier.startsWith('./ui/svelte') ||
+					specifier.includes('/islands/')
+			);
+			expect(offenders).toEqual([]);
+		}
+	);
+
+	it.each(['react', 'vue', 'svelte'])(
+		'the %s adapter only reaches its framework through import()',
+		(name) => {
+			const source = readFileSync(
+				join(SOURCE_ROOT, 'ui', `${name}.ts`),
+				'utf8'
+			);
+			expect(staticSpecifiers(source)).toEqual([
+				'./adapter',
+				'./provider-props',
+			]);
+			expect(source).toMatch(/await Promise\.all\(\[/u);
+		}
+	);
+
+	it('keeps the adapter registry empty of framework specifiers', () => {
+		const source = readFileSync(join(SOURCE_ROOT, 'ui', 'adapter.ts'), 'utf8');
+		for (const name of ['./svelte', './react', './vue']) {
+			expect(source).not.toContain(`import('${name}')`);
+		}
+	});
+
+	it('leaves island registration to the integration', () => {
+		const componentRoot = join(SOURCE_ROOT, 'components');
+		for (const entry of readdirSync(componentRoot)) {
+			if (!entry.endsWith('.astro')) {
+				continue;
+			}
+			const source = readFileSync(join(componentRoot, entry), 'utf8');
+			expect(source).not.toContain('registerDialogSurface');
+			expect(source).not.toContain('@c15t/astro/islands/');
+		}
+	});
+});

--- a/packages/astro/src/__tests__/manifest-prefetch.test.ts
+++ b/packages/astro/src/__tests__/manifest-prefetch.test.ts
@@ -1,0 +1,217 @@
+import {
+	buildConsentManifestFromConfig,
+	policyPackPresets,
+} from '@c15t/schema/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clearManifestCache } from '../api';
+import { resolveOptions } from '../integration';
+import { createConsentMiddleware } from '../middleware-handler';
+import { manifestMode } from '../mode';
+import type { C15tAstroOptions, C15tLocals } from '../types';
+
+const MANIFEST = await buildConsentManifestFromConfig({
+	branding: 'c15t',
+	policyPacks: [
+		policyPackPresets.europeOptIn(),
+		policyPackPresets.worldNoBanner(),
+	],
+});
+
+const manifestResponse = function manifestResponse(): Response {
+	return new Response(JSON.stringify(MANIFEST), {
+		headers: {
+			'cache-control': 'public, s-maxage=300',
+			'content-type': 'application/json',
+			etag: '"manifest-1"',
+		},
+		status: 200,
+	});
+};
+
+const options = function options(
+	astroOptions: C15tAstroOptions = {
+		mode: manifestMode({ backendURL: 'https://consent.example.com' }),
+	}
+) {
+	return resolveOptions(astroOptions);
+};
+
+interface RenderInput {
+	path?: string;
+	headers?: Record<string, string>;
+	fetch: typeof globalThis.fetch;
+	astroOptions?: C15tAstroOptions;
+}
+
+const render = async function render(
+	input: RenderInput
+): Promise<{ c15t?: C15tLocals; nextCalled: boolean }> {
+	const middleware = createConsentMiddleware(options(input.astroOptions), {
+		fetch: input.fetch,
+	});
+	const locals = {} as { c15t?: C15tLocals };
+	const next = vi.fn(() => new Response('ok'));
+	await middleware(
+		{
+			isPrerendered: false,
+			locals,
+			request: new Request(`https://site.example.com${input.path ?? '/'}`, {
+				headers: new Headers(input.headers ?? {}),
+			}),
+		} as never,
+		next as never
+	);
+	return { c15t: locals.c15t, nextCalled: next.mock.calls.length > 0 };
+};
+
+afterEach(() => {
+	clearManifestCache();
+});
+
+describe('manifest-mode server prefetch', () => {
+	it('fetches the manifest once across consecutive renders', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+
+		const first = await render({ fetch: fetchImpl as never });
+		const second = await render({ fetch: fetchImpl as never });
+
+		// A per-render transport carried its own manifest memo, so every page
+		// view paid the upstream roundtrip. The shared cache is the point of
+		// manifest mode.
+		expect(fetchImpl).toHaveBeenCalledOnce();
+		expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+			'https://consent.example.com/manifest'
+		);
+		expect(first.c15t?.snapshot.policy?.id).toBe(
+			second.c15t?.snapshot.policy?.id
+		);
+	});
+
+	it('still resolves per-request geo off the cached manifest', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+
+		const german = await render({
+			fetch: fetchImpl as never,
+			headers: { 'x-c15t-country': 'DE' },
+		});
+		const american = await render({
+			fetch: fetchImpl as never,
+			headers: { 'x-c15t-country': 'US' },
+		});
+
+		expect(fetchImpl).toHaveBeenCalledOnce();
+		expect(german.c15t?.shouldShowBanner).toBe(true);
+		expect(american.c15t?.shouldShowBanner).toBe(false);
+	});
+
+	it('keeps GPC on the server-resolved overrides', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+		const { c15t } = await render({
+			fetch: fetchImpl as never,
+			headers: { 'sec-gpc': '1', 'x-c15t-country': 'DE' },
+		});
+		expect(c15t?.config.initialOverrides?.gpc).toBe(true);
+	});
+
+	it('resolves a relative manifest URL against the request origin', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+		await render({
+			astroOptions: { mode: manifestMode({ backendURL: '/api/c15t' }) },
+			fetch: fetchImpl as never,
+		});
+		expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+			'https://site.example.com/api/c15t/manifest'
+		);
+	});
+
+	it('degrades to the cookie-only config when the manifest is down', async () => {
+		const fetchImpl = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')));
+		const { c15t } = await render({ fetch: fetchImpl as never });
+		expect(c15t?.snapshot.policy).toBeNull();
+		expect(c15t?.config.initialTranslations?.language).toBe('en');
+	});
+
+	it('serves an inline manifest without any fetch', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+		const { c15t } = await render({
+			astroOptions: { mode: manifestMode({ manifest: MANIFEST }) },
+			fetch: fetchImpl as never,
+			headers: { 'x-c15t-country': 'DE' },
+		});
+		expect(fetchImpl).not.toHaveBeenCalled();
+		expect(c15t?.shouldShowBanner).toBe(true);
+	});
+});
+
+describe('middleware skip list', () => {
+	it('leaves the injected init and manifest routes alone', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+
+		const results = await Promise.all(
+			['/api/c15t/init', '/api/c15t/manifest'].map((path) =>
+				render({ fetch: fetchImpl as never, path })
+			)
+		);
+		// Resolving consent here would fetch the manifest from this same
+		// process, which would resolve consent again: the request never
+		// returns.
+		for (const result of results) {
+			expect(result.c15t).toBeUndefined();
+			expect(result.nextCalled).toBe(true);
+		}
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it('honours custom endpoint paths', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+		const astroOptions: C15tAstroOptions = {
+			endpoints: { initPath: '/consent/init', manifestPath: '/consent/mf' },
+			mode: manifestMode({ backendURL: 'https://consent.example.com' }),
+		};
+		expect(
+			(
+				await render({
+					astroOptions,
+					fetch: fetchImpl as never,
+					path: '/consent/init',
+				})
+			).c15t
+		).toBeUndefined();
+		expect(
+			(
+				await render({
+					astroOptions,
+					fetch: fetchImpl as never,
+					path: '/api/c15t/init',
+				})
+			).c15t
+		).toBeDefined();
+	});
+
+	it('skips the paths the site listed', async () => {
+		const fetchImpl = vi.fn(() => Promise.resolve(manifestResponse()));
+		const astroOptions: C15tAstroOptions = {
+			middleware: { skip: ['/healthz', '/api/webhooks/'] },
+			mode: manifestMode({ backendURL: 'https://consent.example.com' }),
+		};
+		const skipped = await Promise.all(
+			['/healthz', '/api/webhooks', '/api/webhooks/stripe'].map((path) =>
+				render({ astroOptions, fetch: fetchImpl as never, path })
+			)
+		);
+		for (const result of skipped) {
+			expect(result.c15t).toBeUndefined();
+		}
+		// A prefix must not claim a sibling that merely starts with it.
+		expect(
+			(
+				await render({
+					astroOptions,
+					fetch: fetchImpl as never,
+					path: '/healthz-report',
+				})
+			).c15t
+		).toBeDefined();
+	});
+});

--- a/packages/astro/src/__tests__/ui-adapters.dom.test.ts
+++ b/packages/astro/src/__tests__/ui-adapters.dom.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Mount/close/destroy for each shipped dialog adapter.
+ *
+ * The surfaces themselves are stubbed through `registerDialogSurface`: what
+ * matters here is the seam — that each adapter mounts into the host element,
+ * renders the requested dialog kind against the page runtime, closes through
+ * the kernel rather than the DOM, and leaves nothing behind on destroy.
+ */
+
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { hosted } from '@c15t/core';
+import { createConsentRuntime } from '@c15t/core/runtime';
+import type { ConsentRuntime } from '@c15t/core/runtime';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { C15tResolvedOptions } from '../types';
+import { registerDialogSurface } from '../ui/adapter';
+import type { ConsentDialogKind } from '../ui/adapter';
+import { reactDialogAdapter } from '../ui/react';
+import { vueDialogAdapter } from '../ui/vue';
+
+const OPTIONS = {
+	consentCategories: ['necessary', 'marketing'],
+	endpoints: { enabled: false, initPath: '/i', manifestPath: '/m' },
+	mode: { type: 'hosted', url: 'https://consent.example.test' },
+	ui: 'react',
+} as unknown as C15tResolvedOptions;
+
+const runtimes: ConsentRuntime[] = [];
+const hosts: HTMLElement[] = [];
+
+const createRuntime = function createRuntime(): ConsentRuntime {
+	const runtime = createConsentRuntime({
+		mode: hosted({ url: 'https://consent.example.test' }),
+		pkg: '@c15t/astro-test',
+	});
+	runtimes.push(runtime);
+	return runtime;
+};
+
+/** A stub surface: the seam is under test, not the dialog markup. */
+const renderNothing = function renderNothing(): null {
+	return null;
+};
+
+const reactSurface = { default: renderNothing };
+const vueSurface = { default: { setup: () => renderNothing } };
+
+const createHost = function createHost(): HTMLElement {
+	const host = document.createElement('div');
+	document.body.appendChild(host);
+	hosts.push(host);
+	return host;
+};
+
+afterEach(() => {
+	for (const runtime of runtimes.splice(0)) {
+		runtime.dispose();
+	}
+	for (const host of hosts.splice(0)) {
+		host.remove();
+	}
+});
+
+describe('the react dialog adapter', () => {
+	it('mounts the registered surface with the page runtime', async () => {
+		let seen: { runtime?: unknown; kind?: ConsentDialogKind } = {};
+		const recordProps = function recordProps(props: {
+			runtime: unknown;
+			kind: ConsentDialogKind;
+		}): null {
+			seen = props;
+			return null;
+		};
+		registerDialogSurface('react', () =>
+			Promise.resolve({ default: recordProps })
+		);
+		const runtime = createRuntime();
+
+		const handle = await reactDialogAdapter.mount({
+			kind: 'iab',
+			options: OPTIONS,
+			runtime,
+			target: createHost(),
+		});
+		// React 19 renders concurrently; one macrotask is enough in jsdom.
+		await delay(0);
+
+		expect(seen.runtime).toBe(runtime);
+		expect(seen.kind).toBe('iab');
+		await handle.destroy();
+	});
+
+	it('closes through the kernel rather than the DOM', async () => {
+		registerDialogSurface('react', () => Promise.resolve(reactSurface));
+		const runtime = createRuntime();
+		runtime.kernel.set.activeUI('dialog');
+
+		const handle = await reactDialogAdapter.mount({
+			kind: 'preferences',
+			options: OPTIONS,
+			runtime,
+			target: createHost(),
+		});
+		handle.close();
+
+		expect(runtime.kernel.getSnapshot().activeUI).toBe('none');
+		await handle.destroy();
+	});
+
+	it('warms its chunks without mounting anything', async () => {
+		const host = createHost();
+		registerDialogSurface('react', () => Promise.resolve(reactSurface));
+		await reactDialogAdapter.preload?.();
+		expect(host.innerHTML).toBe('');
+	});
+});
+
+describe('the vue dialog adapter', () => {
+	it('mounts the registered surface with the page runtime', async () => {
+		let seen: { kind?: ConsentDialogKind } = {};
+		registerDialogSurface('vue', () =>
+			Promise.resolve({
+				default: {
+					props: ['kind'],
+					setup(props: { kind: ConsentDialogKind }) {
+						seen = props;
+						return renderNothing;
+					},
+				},
+			})
+		);
+		const runtime = createRuntime();
+
+		const handle = await vueDialogAdapter.mount({
+			kind: 'iab',
+			options: OPTIONS,
+			runtime,
+			target: createHost(),
+		});
+
+		expect(seen.kind).toBe('iab');
+		await handle.destroy();
+		// The plugin borrows the runtime, so unmounting must not kill it.
+		expect(runtime.kernel.getSnapshot()).toBeTruthy();
+	});
+
+	it('closes through the kernel rather than the DOM', async () => {
+		registerDialogSurface('vue', () => Promise.resolve(vueSurface));
+		const runtime = createRuntime();
+		runtime.kernel.set.activeUI('dialog');
+
+		const handle = await vueDialogAdapter.mount({
+			kind: 'preferences',
+			options: OPTIONS,
+			runtime,
+			target: createHost(),
+		});
+		handle.close();
+
+		expect(runtime.kernel.getSnapshot().activeUI).toBe('none');
+		await handle.destroy();
+	});
+
+	it('warms its chunks without mounting anything', async () => {
+		const host = createHost();
+		registerDialogSurface('vue', () => Promise.resolve(vueSurface));
+		await vueDialogAdapter.preload?.();
+		expect(host.innerHTML).toBe('');
+	});
+});

--- a/packages/astro/src/api/handlers.ts
+++ b/packages/astro/src/api/handlers.ts
@@ -94,7 +94,11 @@ export const createConsentRouteHandlers = function createConsentRouteHandlers(
 		const payload = await resolveManifestInit({
 			fetch: handlerOptions.fetch,
 			fetchGvl: handlerOptions.fetchGvl,
-			inputs: extractConsentRequestInputs(request.headers),
+			// The same override the SSR path applies, so both resolve one
+			// language — and one set of GVL translations.
+			inputs: extractConsentRequestInputs(request.headers, {
+				language: handlerOptions.options.i18n?.locale,
+			}),
 			manifest,
 		});
 

--- a/packages/astro/src/api/handlers.ts
+++ b/packages/astro/src/api/handlers.ts
@@ -20,21 +20,15 @@ import {
 	MANIFEST_PASSTHROUGH_HEADERS,
 } from '@c15t/core/server';
 import type { ManifestFetch } from '@c15t/core/server';
-import type {
-	ConsentManifest,
-	ConsentManifestGVLReference,
-	GlobalVendorList,
-	InitOutput,
-} from '@c15t/schema/types';
-import {
-	consentInputsToOverrides,
-	extractConsentRequestInputs,
-	resolveBackendURL,
-	resolveInitFromManifest,
-} from '@c15t/schema/types';
-import { baseTranslations } from '@c15t/translations/all';
+import { extractConsentRequestInputs } from '@c15t/schema/types';
 
 import type { C15tResolvedOptions } from '../types';
+import {
+	loadConsentManifest,
+	resolveManifestInit,
+	resolveManifestSourceFrom,
+} from './manifest-init';
+import type { FetchGvl } from './manifest-init';
 
 const INIT_CACHE_CONTROL = 'private, no-store';
 const MANIFEST_ROUTE_SUFFIX = '/manifest';
@@ -49,51 +43,8 @@ export interface ConsentRouteHandlerOptions {
 	 * Fetches the Global Vendor List when the resolved policy is IAB.
 	 * Defaults to a plain `GET` of the manifest's GVL reference.
 	 */
-	fetchGvl?: (input: {
-		reference: ConsentManifestGVLReference;
-		language: string;
-		fetch: ManifestFetch;
-	}) => Promise<GlobalVendorList | null>;
+	fetchGvl?: FetchGvl;
 }
-
-/**
- * How long to wait for the Global Vendor List before giving up on it. The
- * list is a nice-to-have on this route; the response is not.
- */
-const GVL_FETCH_TIMEOUT_MS = 5000;
-
-const getEnv = function getEnv(name: string): string | undefined {
-	if (typeof process === 'undefined') {
-		return undefined;
-	}
-	return (process.env as Record<string, string | undefined> | undefined)?.[
-		name
-	];
-};
-
-const trimSlash = function trimSlash(value: string): string {
-	return value.endsWith('/') ? value.slice(0, -1) : value;
-};
-
-/**
- * Resolves a possibly-relative backend URL against the request.
- *
- * `Request.url` is the only source. The adapter builds it from whatever
- * proxy configuration the deployment declared, so seeding from it both fixes
- * a relative `backendURL` on a plain `http://localhost` dev server and keeps
- * a forged `x-forwarded-host` from steering this server-side fetch at a host
- * of the caller's choosing.
- */
-const resolveAgainstRequest = function resolveAgainstRequest(
-	url: string,
-	request: Request
-): string | null {
-	const requestURL = new URL(request.url);
-	return resolveBackendURL(url, {
-		host: requestURL.host,
-		'x-forwarded-proto': requestURL.protocol.replace(':', ''),
-	});
-};
 
 /**
  * Work out where `GET /manifest` lives for this request.
@@ -109,65 +60,10 @@ export const resolveManifestSourceURL = function resolveManifestSourceURL(
 	request: Request,
 	options: C15tResolvedOptions
 ): string {
-	const { mode } = options;
-	const manifestURL =
-		(mode.type === 'manifest' ? mode.manifestURL : undefined) ??
-		getEnv('C15T_MANIFEST_URL');
-	if (manifestURL) {
-		const resolved = resolveAgainstRequest(manifestURL, request);
-		if (!resolved) {
-			throw new Error('@c15t/astro: invalid manifest URL.');
-		}
-		return resolved;
-	}
-
-	const backendURL =
-		(mode.type === 'manifest' ? mode.backendURL : undefined) ??
-		(mode.type === 'hosted' ? mode.url : undefined) ??
-		getEnv('C15T_BACKEND_URL') ??
-		getEnv('PUBLIC_C15T_BACKEND_URL');
-	if (!backendURL) {
-		throw new Error(
-			'@c15t/astro: manifest mode requires `backendURL` or `manifestURL` (or the C15T_BACKEND_URL environment variable).'
-		);
-	}
-	const resolved = resolveAgainstRequest(backendURL, request);
-	if (!resolved) {
-		throw new Error('@c15t/astro: invalid backend URL.');
-	}
-	return `${trimSlash(resolved)}${MANIFEST_ROUTE_SUFFIX}`;
-};
-
-const shouldFetchGvl = function shouldFetchGvl(
-	manifest: ConsentManifest,
-	payload: InitOutput
-): boolean {
-	return (
-		manifest.iab?.enabled === true &&
-		manifest.iab.gvl !== undefined &&
-		(manifest.policyPacks === undefined || payload.policy?.model === 'iab')
+	return resolveManifestSourceFrom(
+		{ headers: request.headers, url: request.url },
+		options
 	);
-};
-
-const defaultFetchGvl = async function defaultFetchGvl(input: {
-	reference: ConsentManifestGVLReference;
-	language: string;
-	fetch: ManifestFetch;
-}): Promise<GlobalVendorList | null> {
-	const response = await input.fetch(input.reference.url, {
-		headers: { 'accept-language': input.language },
-		method: 'GET',
-		signal: AbortSignal.timeout(GVL_FETCH_TIMEOUT_MS),
-	});
-	if (response.status === 204) {
-		return null;
-	}
-	if (!response.ok) {
-		throw new Error(
-			`@c15t/astro: GVL responded ${response.status} ${response.statusText}`
-		);
-	}
-	return (await response.json()) as GlobalVendorList;
 };
 
 /**
@@ -188,58 +84,19 @@ const defaultFetchGvl = async function defaultFetchGvl(input: {
 export const createConsentRouteHandlers = function createConsentRouteHandlers(
 	handlerOptions: ConsentRouteHandlerOptions
 ) {
-	const fetchImpl =
-		handlerOptions.fetch ??
-		(globalThis.fetch?.bind(globalThis) as ManifestFetch | undefined);
-
 	/** `GET /api/c15t/init` — a resolved `InitOutput`, never cached. */
 	const init = async function init(request: Request): Promise<Response> {
-		const manifestURL = resolveManifestSourceURL(
-			request,
-			handlerOptions.options
-		);
-		const { manifest } = await fetchCachedManifest({
-			config: { manifestURL },
+		const manifest = await loadConsentManifest({
 			fetch: handlerOptions.fetch,
+			options: handlerOptions.options,
+			source: { headers: request.headers, url: request.url },
 		});
-
-		// The same override the SSR path applies, so both resolve one
-		// language — and one set of GVL translations.
-		const inputs = extractConsentRequestInputs(request.headers, {
-			language: handlerOptions.options.i18n?.locale,
-		});
-		const payload = resolveInitFromManifest(
+		const payload = await resolveManifestInit({
+			fetch: handlerOptions.fetch,
+			fetchGvl: handlerOptions.fetchGvl,
+			inputs: extractConsentRequestInputs(request.headers),
 			manifest,
-			{
-				country: inputs.country,
-				gpc: inputs.gpc,
-				language: inputs.language ?? 'en',
-				region: inputs.region,
-			},
-			{ baseTranslations }
-		) as InitOutput & { resolvedOverrides?: Record<string, unknown> };
-
-		if (shouldFetchGvl(manifest, payload) && manifest.iab?.gvl && fetchImpl) {
-			const language = payload.translations.language.split('-')[0] || 'en';
-			try {
-				payload.gvl = await (handlerOptions.fetchGvl ?? defaultFetchGvl)({
-					fetch: fetchImpl,
-					language,
-					reference: manifest.iab.gvl,
-				});
-			} catch {
-				// `gvl` is nullable by contract, and the SSR path's fallback
-				// does not cover this route. A vendor list the client can
-				// treat as unavailable beats a 500 on `/init`.
-				payload.gvl = null;
-			}
-		}
-
-		// The resolver's inputs are the only place GPC survives on the SSR
-		// path — the browser never sends `Sec-GPC` to this route when the
-		// page was server-rendered. Echo them back so the kernel folds the
-		// same overrides it would have derived client-side.
-		payload.resolvedOverrides = consentInputsToOverrides(inputs);
+		});
 
 		return Response.json(payload, {
 			headers: { 'cache-control': INIT_CACHE_CONTROL },

--- a/packages/astro/src/api/index.ts
+++ b/packages/astro/src/api/index.ts
@@ -12,6 +12,16 @@ export {
 } from './handlers';
 export type { ConsentRouteHandlerOptions } from './handlers';
 export {
+	loadConsentManifest,
+	resolveManifestInit,
+	resolveManifestSourceFrom,
+} from './manifest-init';
+export type {
+	FetchGvl,
+	RequestSource,
+	ResolvedInitOutput,
+} from './manifest-init';
+export {
 	clearManifestCache,
 	createManifestRequestURL,
 	fetchCachedManifest,

--- a/packages/astro/src/api/manifest-init.ts
+++ b/packages/astro/src/api/manifest-init.ts
@@ -68,28 +68,28 @@ const trimSlash = function trimSlash(value: string): string {
  * Seeds the protocol from the request URL rather than letting the shared
  * resolver fall back to `https`, so a relative `backendURL` still resolves
  * on a plain `http://localhost` dev server.
+ *
+ * Only the request's own URL or `Host` decides the origin — never a
+ * forwarded header the caller supplied. The adapter builds `Request.url`
+ * from whatever proxy configuration the deployment declared, so trusting
+ * `x-forwarded-host` on top of it would let a forged header steer this
+ * server-side fetch at a host of the caller's choosing, and a forged
+ * `x-forwarded-proto: https` would send a plain-HTTP dev server at a TLS
+ * handshake it cannot answer.
  */
 const resolveAgainstRequest = function resolveAgainstRequest(
 	url: string,
 	source: RequestSource
 ): string | null {
-	const headers: Record<string, string> = {};
-	const hostHeader = source.headers.get('host');
-	if (hostHeader) {
-		headers.host = hostHeader;
-	}
 	if (source.url) {
 		const requestURL = new URL(source.url);
-		headers.host = requestURL.host;
-		headers['x-forwarded-proto'] = requestURL.protocol.replace(':', '');
+		return resolveBackendURL(url, {
+			host: requestURL.host,
+			'x-forwarded-proto': requestURL.protocol.replace(':', ''),
+		});
 	}
-	for (const name of ['x-forwarded-host', 'x-forwarded-proto', 'referer']) {
-		const value = source.headers.get(name);
-		if (value) {
-			headers[name] = value;
-		}
-	}
-	return resolveBackendURL(url, headers);
+	const hostHeader = source.headers.get('host');
+	return hostHeader ? resolveBackendURL(url, { host: hostHeader }) : null;
 };
 
 /**
@@ -178,11 +178,19 @@ const shouldFetchGvl = function shouldFetchGvl(
 	);
 };
 
+/**
+ * How long to wait for the Global Vendor List before giving up on it. The
+ * list is a nice-to-have on this path; the response is not, and an open
+ * request would hold the page or the route open with it.
+ */
+const GVL_FETCH_TIMEOUT_MS = 5000;
+
 /** Plain `GET` of the manifest's GVL reference. */
 export const defaultFetchGvl: FetchGvl = async function defaultFetchGvl(input) {
 	const response = await input.fetch(input.reference.url, {
 		headers: { 'accept-language': input.language },
 		method: 'GET',
+		signal: AbortSignal.timeout(GVL_FETCH_TIMEOUT_MS),
 	});
 	if (response.status === 204) {
 		return null;
@@ -205,7 +213,7 @@ export type ResolvedInitOutput = InitOutput & {
  *
  * @param input - The manifest, the request inputs, and the GVL seams.
  * @returns The resolved init payload, with `resolvedOverrides` echoed back.
- * @throws {Error} When the GVL fetch fails.
+ *   `gvl` is `null` when the vendor list could not be fetched.
  */
 export const resolveManifestInit = async function resolveManifestInit(input: {
 	manifest: ConsentManifest;
@@ -229,11 +237,18 @@ export const resolveManifestInit = async function resolveManifestInit(input: {
 		input.fetch ?? (globalThis.fetch?.bind(globalThis) as ManifestFetch);
 	if (shouldFetchGvl(manifest, payload) && manifest.iab?.gvl && fetchImpl) {
 		const language = payload.translations.language.split('-')[0] || 'en';
-		payload.gvl = await (input.fetchGvl ?? defaultFetchGvl)({
-			fetch: fetchImpl,
-			language,
-			reference: manifest.iab.gvl,
-		});
+		try {
+			payload.gvl = await (input.fetchGvl ?? defaultFetchGvl)({
+				fetch: fetchImpl,
+				language,
+				reference: manifest.iab.gvl,
+			});
+		} catch {
+			// `gvl` is nullable by contract, and neither the init route nor
+			// the SSR path has a boundary above this. A vendor list the
+			// client can treat as unavailable beats a 500.
+			payload.gvl = null;
+		}
 	}
 
 	// The resolver's inputs are the only place GPC survives on the SSR

--- a/packages/astro/src/api/manifest-init.ts
+++ b/packages/astro/src/api/manifest-init.ts
@@ -1,0 +1,245 @@
+/**
+ * Manifest resolution shared by the injected routes and the middleware.
+ *
+ * Both paths need the same three steps: work out where the manifest lives
+ * for this request, get it through the process-wide cache in
+ * `@c15t/core/server`, and resolve `/init` from it locally. Keeping them on
+ * one implementation is what makes manifest mode cheap — a per-render
+ * transport would carry its own memo and re-fetch the manifest on every
+ * page render, which is exactly the cost manifest mode exists to remove.
+ */
+
+import { fetchCachedManifest } from '@c15t/core/server';
+import type { ManifestFetch } from '@c15t/core/server';
+import type {
+	ConsentManifest,
+	ConsentManifestGVLReference,
+	ConsentRequestHeaderInputs,
+	GlobalVendorList,
+	InitOutput,
+} from '@c15t/schema/types';
+import {
+	consentInputsToOverrides,
+	resolveBackendURL,
+	resolveInitFromManifest,
+} from '@c15t/schema/types';
+import { baseTranslations } from '@c15t/translations/all';
+
+import type { C15tResolvedOptions } from '../types';
+
+const MANIFEST_ROUTE_SUFFIX = '/manifest';
+
+/** Fetches the Global Vendor List when the resolved policy is IAB. */
+export type FetchGvl = (input: {
+	reference: ConsentManifestGVLReference;
+	language: string;
+	fetch: ManifestFetch;
+}) => Promise<GlobalVendorList | null>;
+
+/**
+ * The parts of a request URL resolution needs.
+ *
+ * The middleware has `Astro.locals`-adjacent `Headers` and a URL string; the
+ * route handlers have a whole `Request`. Both narrow to this.
+ */
+export interface RequestSource {
+	/** The absolute request URL, when the caller has one. */
+	url?: string;
+	/** The incoming request headers. */
+	headers: Headers;
+}
+
+const getEnv = function getEnv(name: string): string | undefined {
+	if (typeof process === 'undefined') {
+		return undefined;
+	}
+	return (process.env as Record<string, string | undefined> | undefined)?.[
+		name
+	];
+};
+
+const trimSlash = function trimSlash(value: string): string {
+	return value.endsWith('/') ? value.slice(0, -1) : value;
+};
+
+/**
+ * Resolves a possibly-relative backend URL against the request.
+ *
+ * Seeds the protocol from the request URL rather than letting the shared
+ * resolver fall back to `https`, so a relative `backendURL` still resolves
+ * on a plain `http://localhost` dev server.
+ */
+const resolveAgainstRequest = function resolveAgainstRequest(
+	url: string,
+	source: RequestSource
+): string | null {
+	const headers: Record<string, string> = {};
+	const hostHeader = source.headers.get('host');
+	if (hostHeader) {
+		headers.host = hostHeader;
+	}
+	if (source.url) {
+		const requestURL = new URL(source.url);
+		headers.host = requestURL.host;
+		headers['x-forwarded-proto'] = requestURL.protocol.replace(':', '');
+	}
+	for (const name of ['x-forwarded-host', 'x-forwarded-proto', 'referer']) {
+		const value = source.headers.get(name);
+		if (value) {
+			headers[name] = value;
+		}
+	}
+	return resolveBackendURL(url, headers);
+};
+
+/**
+ * Work out where `GET /manifest` lives for this request.
+ *
+ * Explicit options win, then `C15T_MANIFEST_URL` / `C15T_BACKEND_URL`.
+ *
+ * @param source - The request URL and headers, used to resolve relative URLs.
+ * @param options - The resolved integration options.
+ * @returns An absolute manifest URL.
+ * @throws {Error} When neither a manifest URL nor a backend URL is configured.
+ */
+export const resolveManifestSourceFrom = function resolveManifestSourceFrom(
+	source: RequestSource,
+	options: C15tResolvedOptions
+): string {
+	const { mode } = options;
+	const manifestURL =
+		(mode.type === 'manifest' ? mode.manifestURL : undefined) ??
+		getEnv('C15T_MANIFEST_URL');
+	if (manifestURL) {
+		const resolved = resolveAgainstRequest(manifestURL, source);
+		if (!resolved) {
+			throw new Error('@c15t/astro: invalid manifest URL.');
+		}
+		return resolved;
+	}
+
+	const backendURL =
+		(mode.type === 'manifest' ? mode.backendURL : undefined) ??
+		(mode.type === 'hosted' ? mode.url : undefined) ??
+		getEnv('C15T_BACKEND_URL') ??
+		getEnv('PUBLIC_C15T_BACKEND_URL');
+	if (!backendURL) {
+		throw new Error(
+			'@c15t/astro: manifest mode requires `backendURL` or `manifestURL` (or the C15T_BACKEND_URL environment variable).'
+		);
+	}
+	const resolved = resolveAgainstRequest(backendURL, source);
+	if (!resolved) {
+		throw new Error('@c15t/astro: invalid backend URL.');
+	}
+	return `${trimSlash(resolved)}${MANIFEST_ROUTE_SUFFIX}`;
+};
+
+/**
+ * Load the manifest for this request through the shared in-process cache.
+ *
+ * An inline `manifest` short-circuits the network entirely; otherwise this
+ * is `fetchCachedManifest`, so concurrent requests collapse into one
+ * upstream call and later ones revalidate by `ETag` on the backend's
+ * schedule instead of re-downloading per render.
+ *
+ * @param input - Request source, integration options, and a fetch seam.
+ * @returns The tenant manifest.
+ * @throws {Error} When the manifest source cannot be resolved or the
+ * upstream responds non-2xx.
+ */
+export const loadConsentManifest = async function loadConsentManifest(input: {
+	source: RequestSource;
+	options: C15tResolvedOptions;
+	fetch?: ManifestFetch;
+	query?: string;
+}): Promise<ConsentManifest> {
+	const { mode } = input.options;
+	if (mode.type === 'manifest' && mode.manifest) {
+		return mode.manifest;
+	}
+	const manifestURL = resolveManifestSourceFrom(input.source, input.options);
+	const { manifest } = await fetchCachedManifest({
+		config: { manifestURL },
+		fetch: input.fetch,
+		query: input.query,
+	});
+	return manifest;
+};
+
+const shouldFetchGvl = function shouldFetchGvl(
+	manifest: ConsentManifest,
+	payload: InitOutput
+): boolean {
+	return (
+		manifest.iab?.enabled === true &&
+		manifest.iab.gvl !== undefined &&
+		(manifest.policyPacks === undefined || payload.policy?.model === 'iab')
+	);
+};
+
+/** Plain `GET` of the manifest's GVL reference. */
+export const defaultFetchGvl: FetchGvl = async function defaultFetchGvl(input) {
+	const response = await input.fetch(input.reference.url, {
+		headers: { 'accept-language': input.language },
+		method: 'GET',
+	});
+	if (response.status === 204) {
+		return null;
+	}
+	if (!response.ok) {
+		throw new Error(
+			`@c15t/astro: GVL responded ${response.status} ${response.statusText}`
+		);
+	}
+	return (await response.json()) as GlobalVendorList;
+};
+
+/** An `InitOutput` carrying the overrides the request implied. */
+export type ResolvedInitOutput = InitOutput & {
+	resolvedOverrides?: Record<string, unknown>;
+};
+
+/**
+ * Resolve one request's `/init` payload from an already-loaded manifest.
+ *
+ * @param input - The manifest, the request inputs, and the GVL seams.
+ * @returns The resolved init payload, with `resolvedOverrides` echoed back.
+ * @throws {Error} When the GVL fetch fails.
+ */
+export const resolveManifestInit = async function resolveManifestInit(input: {
+	manifest: ConsentManifest;
+	inputs: ConsentRequestHeaderInputs;
+	fetch?: ManifestFetch;
+	fetchGvl?: FetchGvl;
+}): Promise<ResolvedInitOutput> {
+	const { inputs, manifest } = input;
+	const payload = resolveInitFromManifest(
+		manifest,
+		{
+			country: inputs.country,
+			gpc: inputs.gpc,
+			language: inputs.language ?? 'en',
+			region: inputs.region,
+		},
+		{ baseTranslations }
+	) as ResolvedInitOutput;
+
+	const fetchImpl =
+		input.fetch ?? (globalThis.fetch?.bind(globalThis) as ManifestFetch);
+	if (shouldFetchGvl(manifest, payload) && manifest.iab?.gvl && fetchImpl) {
+		const language = payload.translations.language.split('-')[0] || 'en';
+		payload.gvl = await (input.fetchGvl ?? defaultFetchGvl)({
+			fetch: fetchImpl,
+			language,
+			reference: manifest.iab.gvl,
+		});
+	}
+
+	// The resolver's inputs are the only place GPC survives on the SSR
+	// path — the browser never sends `Sec-GPC` to the init route when the
+	// page was server-rendered. Echo them back so the kernel folds the
+	// same overrides it would have derived client-side.
+	payload.resolvedOverrides = consentInputsToOverrides(inputs);
+	return payload;
+};

--- a/packages/astro/src/client.ts
+++ b/packages/astro/src/client.ts
@@ -277,6 +277,13 @@ const createClient = function createClient(
 			dialog?.close();
 		},
 		dispose() {
+			if (disposed) {
+				// A retained reference to a disposed client must not tear down
+				// the replacement that booted after it: the colour-scheme
+				// disposer and the page-swap listeners are window-owned, and
+				// the second call would be running the new client's.
+				return;
+			}
 			disposed = true;
 			detachPageSwapListeners();
 			void dialog?.destroy();

--- a/packages/astro/src/client.ts
+++ b/packages/astro/src/client.ts
@@ -32,6 +32,7 @@ import type {
 	ConsentRuntimeOptions,
 	RuntimeIABOptions,
 } from '@c15t/core/runtime';
+import { setupColorScheme } from '@c15t/ui/utils/dom';
 
 import { lazyCreateIAB, whenIABReady } from './browser/iab';
 import { activateGatedScripts } from './browser/inline-scripts';
@@ -53,6 +54,7 @@ const NO_PAGE_SWAP_LISTENERS = (): void => {
 };
 
 let detachPageSwapListeners: () => void = NO_PAGE_SWAP_LISTENERS;
+const COLOR_SCHEME_KEY = '__c15tAstroColorScheme';
 const CONFIG_KEY = '__c15tAstroConfig';
 const DIALOG_HOST_ID = 'c15t-dialog-host';
 
@@ -112,6 +114,7 @@ type ClientWindow = Window &
 	typeof globalThis & {
 		[GLOBAL_KEY]?: AstroConsentClient;
 		[CONFIG_KEY]?: KernelConfig;
+		[COLOR_SCHEME_KEY]?: () => void;
 	};
 
 const getWindow = function getWindow(): ClientWindow | undefined {
@@ -120,6 +123,50 @@ const getWindow = function getWindow(): ClientWindow | undefined {
 
 const readInlinedConfig = function readInlinedConfig(): KernelConfig {
 	return getWindow()?.[CONFIG_KEY] ?? {};
+};
+
+/**
+ * Apply the configured colour scheme, replacing any previous application.
+ *
+ * `setupColorScheme` is what toggles `c15t-dark` on `<html>` — the
+ * stylesheet has no `prefers-color-scheme` block, so nothing is dark until
+ * something sets that class. The inline `<head>` script gets the first
+ * paint right; this keeps it right afterwards, following the system
+ * setting as the visitor changes it.
+ *
+ * The disposer lives on `window` rather than in a module variable because
+ * ClientRouter re-runs `boot()` against a document whose `<html>` class
+ * list the swap may have replaced: re-applying needs to drop the previous
+ * listener first, or every navigation leaks one.
+ *
+ * @param colorScheme - The resolved colour scheme.
+ */
+const applyColorScheme = function applyColorScheme(
+	colorScheme: C15tResolvedOptions['colorScheme']
+): void {
+	const browserWindow = getWindow();
+	if (!browserWindow) {
+		return;
+	}
+	browserWindow[COLOR_SCHEME_KEY]?.();
+	browserWindow[COLOR_SCHEME_KEY] = undefined;
+
+	// `setupColorScheme` reaches for `matchMedia` whichever scheme it is
+	// given, and a few embedded webviews do not have it. The boot is the
+	// page's only entry point, so a throw here would take consent with it:
+	// honour the pinned schemes by hand instead and leave `system` at the
+	// stylesheet's light default.
+	if (typeof browserWindow.matchMedia !== 'function') {
+		if (colorScheme !== 'system') {
+			document.documentElement.classList.toggle(
+				'c15t-dark',
+				colorScheme === 'dark'
+			);
+		}
+		return;
+	}
+
+	browserWindow[COLOR_SCHEME_KEY] = setupColorScheme(colorScheme);
 };
 
 const ensureDialogHost = function ensureDialogHost(): HTMLElement {
@@ -239,6 +286,8 @@ const createClient = function createClient(
 			runtime.dispose();
 			const browserWindow = getWindow();
 			if (browserWindow) {
+				browserWindow[COLOR_SCHEME_KEY]?.();
+				browserWindow[COLOR_SCHEME_KEY] = undefined;
 				browserWindow[GLOBAL_KEY] = undefined;
 			}
 		},
@@ -402,6 +451,7 @@ export const boot = function boot(
 	const client = createClient(options, extension);
 	browserWindow[GLOBAL_KEY] = client;
 	client.runtime.start();
+	applyColorScheme(options.colorScheme);
 	attachBannerActions();
 
 	client.subscribe((snapshot) => {
@@ -411,17 +461,23 @@ export const boot = function boot(
 
 	// The ClientRouter replaces the document without re-evaluating modules,
 	// so the runtime survives but its DOM does not. Re-attach to the new
-	// markup instead of rebuilding consent state.
-	const onPageSwap = function onPageSwap(): void {
+	// markup instead of rebuilding consent state. The swap also replaces the
+	// `<html>` attributes, taking `c15t-dark` with them, so the colour
+	// scheme is applied again against the new document.
+	const onAfterSwap = function onAfterSwap(): void {
+		applyColorScheme(options.colorScheme);
 		attach(client);
 	};
-	document.addEventListener('astro:after-swap', onPageSwap);
-	document.addEventListener('astro:page-load', onPageSwap);
+	const onPageLoad = function onPageLoad(): void {
+		attach(client);
+	};
+	document.addEventListener('astro:after-swap', onAfterSwap);
+	document.addEventListener('astro:page-load', onPageLoad);
 	// Without this, a dispose-then-boot leaves the old handlers on the
 	// document, and the next swap reattaches a client that is already gone.
 	detachPageSwapListeners = (): void => {
-		document.removeEventListener('astro:after-swap', onPageSwap);
-		document.removeEventListener('astro:page-load', onPageSwap);
+		document.removeEventListener('astro:after-swap', onAfterSwap);
+		document.removeEventListener('astro:page-load', onPageLoad);
 		detachPageSwapListeners = NO_PAGE_SWAP_LISTENERS;
 	};
 

--- a/packages/astro/src/client.ts
+++ b/packages/astro/src/client.ts
@@ -154,15 +154,14 @@ const applyColorScheme = function applyColorScheme(
 	// `setupColorScheme` reaches for `matchMedia` whichever scheme it is
 	// given, and a few embedded webviews do not have it. The boot is the
 	// page's only entry point, so a throw here would take consent with it:
-	// honour the pinned schemes by hand instead and leave `system` at the
-	// stylesheet's light default.
+	// set the class by hand instead. `system` falls back to light, and it
+	// has to say so — leaving the class alone would keep whatever a previous
+	// scheme or a swapped-in dark shell had put there.
 	if (typeof browserWindow.matchMedia !== 'function') {
-		if (colorScheme !== 'system') {
-			document.documentElement.classList.toggle(
-				'c15t-dark',
-				colorScheme === 'dark'
-			);
-		}
+		document.documentElement.classList.toggle(
+			'c15t-dark',
+			colorScheme === 'dark'
+		);
 		return;
 	}
 

--- a/packages/astro/src/components/consent-banner.astro
+++ b/packages/astro/src/components/consent-banner.astro
@@ -29,7 +29,11 @@ import {
 	shouldFillPolicyActions,
 } from '@c15t/core';
 import type { LegalLinks, TranslationsResponse } from '@c15t/core';
-import { buildConfigScript, markConfigEmitted } from '@c15t/astro/server';
+import {
+	buildColorSchemeScript,
+	buildConfigScript,
+	markConfigEmitted,
+} from '@c15t/astro/server';
 import actionStyles from '@c15t/ui/styles/components/consent-actions';
 import styles from '@c15t/ui/styles/components/consent-banner';
 import buttonStyles from '@c15t/ui/styles/components/button';
@@ -82,6 +86,11 @@ if (!c15t) {
 const { snapshot } = c15t;
 const shouldRender = force || c15t.shouldShowBanner;
 const emitConfig = markConfigEmitted(Astro.locals);
+// A fallback for layouts with no <ConsentScript /> in <head>. It still runs
+// before the banner markup it precedes, so the first paint is right.
+const colorSchemeScript = emitConfig
+	? buildColorSchemeScript(c15t.options.colorScheme)
+	: '';
 
 const fallback = defaultTranslationConfig.translations.en as TranslationsResponse;
 const bundle = (snapshot.translations?.translations ?? fallback) as TranslationsResponse;
@@ -140,6 +149,12 @@ const inlineLegalLinks = (legalLinks ?? []).filter(
 	(key) => c15t.options.legalLinks?.[key]
 );
 ---
+
+{
+	emitConfig && colorSchemeScript && (
+		<script is:inline set:html={colorSchemeScript} />
+	)
+}
 
 {emitConfig && <script is:inline set:html={buildConfigScript(c15t.config)} />}
 

--- a/packages/astro/src/components/consent-dialog.astro
+++ b/packages/astro/src/components/consent-dialog.astro
@@ -2,10 +2,10 @@
 /**
  * The preference-centre dialog.
  *
- * Renders nothing but an empty host element. The surface itself is a Svelte
- * island mounted with Svelte 5's `mount()` the first time something opens
- * it — not `client:load` — so a visitor who accepts or rejects from the
- * banner never downloads a framework at all.
+ * Renders nothing but an empty host element. The surface itself is an
+ * island in whichever framework the `ui` option names, mounted the first
+ * time something opens it — not `client:load` — so a visitor who accepts
+ * or rejects from the banner never downloads a framework at all.
  *
  * ```astro
  * ---
@@ -38,16 +38,12 @@ const { preload = false } = Astro.props;
 		getConsentClient,
 		openDialog,
 		preloadDialog,
-		registerDialogSurface,
 	} from '@c15t/astro/client';
 
-	// The specifier lives here, in a file this app's build compiles, because
-	// only that build knows how to turn a `.svelte` file into a component.
-	registerDialogSurface(
-		'svelte',
-		() => import('@c15t/astro/islands/consent-dialog-surface.svelte')
-	);
-
+	// The island's specifier is not written here: only the integration knows
+	// which framework `ui` selected, and naming all of them would make every
+	// build resolve every framework. It registers the one surface from the
+	// page script it injects.
 	const host = document.querySelector('[data-c15t-dialog-host="preferences"]');
 
 	if (host?.getAttribute('data-preload') === 'true') {

--- a/packages/astro/src/components/consent-script.astro
+++ b/packages/astro/src/components/consent-script.astro
@@ -4,16 +4,28 @@
  *
  * Put this in your layout's `<head>`. It hands the client boot script the
  * decision the server already made — consents, policy, translations — so
- * the page boots with no `/init` roundtrip and no banner flicker.
+ * the page boots with no `/init` roundtrip and no banner flicker, and it
+ * writes the colour-scheme class before the stylesheet paints, so a
+ * system-dark visitor does not get a light banner for a frame.
  *
- * `<ConsentBanner />` renders this itself if it has not been emitted yet,
- * so a site with a banner in every layout does not need it explicitly.
+ * `<ConsentBanner />` renders both itself if they have not been emitted
+ * yet, so a site with a banner in every layout does not need this
+ * explicitly — but `<head>` is where the colour-scheme script belongs.
  */
-import { buildConfigScript, markConfigEmitted } from '@c15t/astro/server';
+import {
+	buildColorSchemeScript,
+	buildConfigScript,
+	markConfigEmitted,
+} from '@c15t/astro/server';
 
 const { c15t } = Astro.locals;
 const shouldEmit = c15t !== undefined && markConfigEmitted(Astro.locals);
+const colorSchemeScript = shouldEmit
+	? buildColorSchemeScript(c15t.options.colorScheme)
+	: '';
 ---
+
+{colorSchemeScript && <script is:inline set:html={colorSchemeScript} />}
 
 {
 	shouldEmit && (

--- a/packages/astro/src/components/iab-consent-dialog.astro
+++ b/packages/astro/src/components/iab-consent-dialog.astro
@@ -24,13 +24,10 @@ const { preload = false } = Astro.props;
 <div data-c15t-dialog-host="iab" data-preload={preload ? 'true' : undefined}></div>
 
 <script>
-	import { preloadDialog, registerDialogSurface } from '@c15t/astro/client';
+	import { preloadDialog } from '@c15t/astro/client';
 
-	registerDialogSurface(
-		'svelte',
-		() => import('@c15t/astro/islands/consent-dialog-surface.svelte')
-	);
-
+	// The integration registers the island for the configured `ui`; see
+	// `<ConsentDialog />` for why the specifier does not live here.
 	const host = document.querySelector('[data-c15t-dialog-host="iab"]');
 
 	if (host?.getAttribute('data-preload') === 'true') {

--- a/packages/astro/src/components/islands/consent-dialog-surface.tsx
+++ b/packages/astro/src/components/islands/consent-dialog-surface.tsx
@@ -1,0 +1,51 @@
+/**
+ * The on-demand React dialog island.
+ *
+ * Mounted with `createRoot()` the first time something opens a dialog —
+ * never with `client:load` — so a visitor who never opens the preference
+ * centre downloads no React from us at all.
+ *
+ * The provider renders against the page's runtime rather than building one
+ * of its own: Astro islands cannot see each other's context, so the kernel
+ * has to be owned outside the component tree. `<ConsentProvider runtime>`
+ * borrows it and leaves `start()`/`dispose()` to the owner.
+ */
+
+import type { ConsentRuntime } from '@c15t/core/runtime';
+import { ConsentDialog, ConsentProvider } from '@c15t/react';
+import { lazy, Suspense } from 'react';
+
+// The TCF surface is the larger half of this island and only an IAB site
+// ever opens it, so it arrives on its own chunk.
+const IABDialogSurface = lazy(() => import('./iab-dialog-surface'));
+
+/** Props the React dialog adapter passes in. */
+export interface ConsentDialogSurfaceProps {
+	/** The page-level runtime. The provider borrows it, it does not own it. */
+	runtime: ConsentRuntime;
+	/** Presentation options forwarded to the provider. */
+	options: Record<string, unknown>;
+	/** Which dialog to render. */
+	kind?: 'preferences' | 'iab';
+}
+
+const ConsentDialogSurface = ({
+	runtime,
+	options,
+	kind = 'preferences',
+}: ConsentDialogSurfaceProps) => (
+	<ConsentProvider
+		runtime={runtime}
+		options={options as never}
+	>
+		{kind === 'iab' ? (
+			<Suspense fallback={null}>
+				<IABDialogSurface />
+			</Suspense>
+		) : (
+			<ConsentDialog />
+		)}
+	</ConsentProvider>
+);
+
+export default ConsentDialogSurface;

--- a/packages/astro/src/components/islands/consent-dialog-surface.tsx
+++ b/packages/astro/src/components/islands/consent-dialog-surface.tsx
@@ -24,6 +24,8 @@ import {
 } from '@c15t/react';
 import { lazy, Suspense } from 'react';
 
+import type { DialogPresentationOptions } from '../../ui/provider-props';
+
 // The TCF surface is the larger half of this island and only an IAB site
 // ever opens it, so it arrives on its own chunk.
 const IABDialogSurface = lazy(() => import('./iab-dialog-surface'));
@@ -33,7 +35,7 @@ export interface ConsentDialogSurfaceProps {
 	/** The page-level runtime. The provider borrows it, it does not own it. */
 	runtime: ConsentRuntime;
 	/** Presentation options forwarded to the provider. */
-	options: Record<string, unknown>;
+	options: DialogPresentationOptions;
 	/** Which dialog to render. */
 	kind?: 'preferences' | 'iab';
 }
@@ -45,7 +47,7 @@ const ConsentDialogSurface = ({
 }: ConsentDialogSurfaceProps) => (
 	<ConsentProvider
 		runtime={runtime}
-		options={options as never}
+		options={options}
 	>
 		{kind === 'iab' ? (
 			<Suspense fallback={null}>

--- a/packages/astro/src/components/islands/consent-dialog-surface.tsx
+++ b/packages/astro/src/components/islands/consent-dialog-surface.tsx
@@ -9,10 +9,19 @@
  * of its own: Astro islands cannot see each other's context, so the kernel
  * has to be owned outside the component tree. `<ConsentProvider runtime>`
  * borrows it and leaves `start()`/`dispose()` to the owner.
+ *
+ * `<ConsentDraftProvider>` is what makes Save work. `useConsentDraft()`
+ * falls back to a draft per hook call when no provider is in scope, so the
+ * category toggles and the Save button would each stage into their own
+ * copy: the switch would flip, and the save would commit nothing.
  */
 
 import type { ConsentRuntime } from '@c15t/core/runtime';
-import { ConsentDialog, ConsentProvider } from '@c15t/react';
+import {
+	ConsentDialog,
+	ConsentDraftProvider,
+	ConsentProvider,
+} from '@c15t/react';
 import { lazy, Suspense } from 'react';
 
 // The TCF surface is the larger half of this island and only an IAB site
@@ -43,7 +52,9 @@ const ConsentDialogSurface = ({
 				<IABDialogSurface />
 			</Suspense>
 		) : (
-			<ConsentDialog />
+			<ConsentDraftProvider>
+				<ConsentDialog />
+			</ConsentDraftProvider>
 		)}
 	</ConsentProvider>
 );

--- a/packages/astro/src/components/islands/consent-dialog-surface.vue
+++ b/packages/astro/src/components/islands/consent-dialog-surface.vue
@@ -1,0 +1,31 @@
+<!--
+	The on-demand Vue dialog island.
+
+	Mounted as its own Vue app the first time something opens a dialog —
+	never with `client:load` — so a visitor who never opens the preference
+	centre downloads no consent UI at all.
+
+	The adapter installs `c15tVue` with the page's runtime before mounting
+	this component: Astro islands cannot see each other's provides, so the
+	kernel has to be owned outside the app. The plugin borrows it and leaves
+	`start()`/`dispose()` to the owner.
+-->
+<script setup lang="ts">
+import ConsentManager from '@c15t/vue/runtime/components/consent-manager.vue';
+import { defineAsyncComponent } from 'vue';
+
+withDefaults(defineProps<{ kind?: 'preferences' | 'iab' }>(), {
+	kind: 'preferences',
+});
+
+// The TCF surface is the larger half of this island and only an IAB site
+// ever opens it, so it arrives on its own chunk.
+const IABDialogSurface = defineAsyncComponent(
+	() => import('./iab-dialog-surface.vue')
+);
+</script>
+
+<template>
+	<IABDialogSurface v-if="kind === 'iab'" />
+	<ConsentManager v-else />
+</template>

--- a/packages/astro/src/components/islands/iab-dialog-surface.tsx
+++ b/packages/astro/src/components/islands/iab-dialog-surface.tsx
@@ -7,8 +7,13 @@
  * every other site downloads does not carry it.
  */
 
+import { ConsentDraftProvider } from '@c15t/react';
 import { IABConsentDialog } from '@c15t/react/iab';
 
-const IABDialogSurface = () => <IABConsentDialog />;
+const IABDialogSurface = () => (
+	<ConsentDraftProvider>
+		<IABConsentDialog />
+	</ConsentDraftProvider>
+);
 
 export default IABDialogSurface;

--- a/packages/astro/src/components/islands/iab-dialog-surface.tsx
+++ b/packages/astro/src/components/islands/iab-dialog-surface.tsx
@@ -1,0 +1,14 @@
+/**
+ * The IAB TCF preference centre, on its own chunk.
+ *
+ * The TCF surface is the biggest thing either dialog can render — vendor
+ * lists, purposes, stacks — and only a site that configured IAB ever shows
+ * it. Keeping it in its own island means the preference-centre chunk that
+ * every other site downloads does not carry it.
+ */
+
+import { IABConsentDialog } from '@c15t/react/iab';
+
+const IABDialogSurface = () => <IABConsentDialog />;
+
+export default IABDialogSurface;

--- a/packages/astro/src/components/islands/iab-dialog-surface.vue
+++ b/packages/astro/src/components/islands/iab-dialog-surface.vue
@@ -1,0 +1,15 @@
+<!--
+	The IAB TCF preference centre, on its own chunk.
+
+	The TCF surface is the biggest thing either dialog can render — vendor
+	lists, purposes, stacks — and only a site that configured IAB ever shows
+	it. Keeping it in its own island means the preference-centre chunk that
+	every other site downloads does not carry it.
+-->
+<script setup lang="ts">
+import IABConsentDialog from '@c15t/vue/runtime/components/iab-consent-dialog.vue';
+</script>
+
+<template>
+	<IABConsentDialog />
+</template>

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -34,6 +34,7 @@ export type { ManifestClientEndpoints } from './mode';
 export type {
 	C15tAstroOptions,
 	C15tClientOptionsExtension,
+	C15tColorScheme,
 	C15tEndpointOptions,
 	C15tHostedDescriptor,
 	C15tI18nOptions,

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -40,6 +40,7 @@ export type {
 	C15tIABOptions,
 	C15tLocals,
 	C15tManifestDescriptor,
+	C15tMiddlewareOptions,
 	C15tModeDescriptor,
 	C15tOfflineDescriptor,
 	C15tResolvedOptions,

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -70,6 +70,9 @@ const UI_ADAPTERS: Record<
 	},
 };
 
+/** Every supported `ui` value, for the error a bad one produces. */
+const UI_ADAPTER_NAMES = Object.keys(UI_ADAPTERS) as C15tUIAdapterName[];
+
 /**
  * Adapters worth suggesting when `ui` was left at the default.
  *
@@ -141,6 +144,14 @@ export const resolveOptions = function resolveOptions(
 	) {
 		throw new Error(
 			'@c15t/astro: manifest mode with a `manifestURL` also needs a `backendURL` (or C15T_BACKEND_URL) — that is where consent is saved, and the injected routes only serve init and manifest.'
+		);
+	}
+	// A JavaScript `astro.config.mjs` has no type checking, so `ui: 'solid'`
+	// reaches `buildBootScript()` and throws a bare `TypeError` on an
+	// undefined adapter entry. Name the supported values instead.
+	if (options.ui !== undefined && !(options.ui in UI_ADAPTERS)) {
+		throw new Error(
+			`@c15t/astro: unknown \`ui\` ${JSON.stringify(options.ui)}. Supported adapters: ${UI_ADAPTER_NAMES.join(', ')}.`
 		);
 	}
 	const {

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -237,8 +237,19 @@ const buildVitePlugins = async function buildVitePlugins(
 		createVirtualOptionsPlugin(resolved),
 	];
 	if (resolved.ui === 'vue') {
-		const { default: shimVueImports } = await import('@c15t/vue/vite');
-		plugins.push(shimVueImports() as unknown as VirtualOptionsPlugin);
+		try {
+			const { default: shimVueImports } = await import('@c15t/vue/vite');
+			plugins.push(shimVueImports() as unknown as VirtualOptionsPlugin);
+		} catch (cause) {
+			// This runs at `astro:config:setup`, before `astro:config:done`
+			// where the peer check lives, so an unresolved import would
+			// otherwise surface as a module error naming a path the site
+			// owner never wrote.
+			throw new Error(
+				`@c15t/astro: \`ui: 'vue'\` needs ${UI_ADAPTERS.vue.packages.join(', ')} installed. Install them, or pick another \`ui\`.`,
+				{ cause }
+			);
+		}
 	}
 	return plugins;
 };

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -140,6 +140,7 @@ export const resolveOptions = function resolveOptions(
 	} = options;
 	return {
 		...rest,
+		colorScheme: options.colorScheme ?? 'system',
 		endpoints: resolveEndpoints(options),
 		ui: options.ui ?? 'svelte',
 	};

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -19,6 +19,7 @@ import type { AstroIntegration } from 'astro';
 import type {
 	C15tAstroOptions,
 	C15tEndpointOptions,
+	C15tMiddlewareOptions,
 	C15tResolvedOptions,
 	C15tUIAdapterName,
 } from './types';
@@ -77,6 +78,16 @@ const UI_ADAPTERS: Record<
  * to be installed would be a worse surprise than a one-line log.
  */
 const SUGGESTIBLE_ADAPTERS: C15tUIAdapterName[] = ['react', 'vue'];
+
+const resolveMiddleware = function resolveMiddleware(
+	options: C15tAstroOptions
+): C15tResolvedOptions['middleware'] {
+	const raw: C15tMiddlewareOptions =
+		typeof options.middleware === 'boolean'
+			? { enabled: options.middleware }
+			: (options.middleware ?? {});
+	return { enabled: raw.enabled ?? true, skip: raw.skip ?? [] };
+};
 
 const resolveEndpoints = function resolveEndpoints(
 	options: C15tAstroOptions
@@ -142,6 +153,7 @@ export const resolveOptions = function resolveOptions(
 		...rest,
 		colorScheme: options.colorScheme ?? 'system',
 		endpoints: resolveEndpoints(options),
+		middleware: resolveMiddleware(options),
 		ui: options.ui ?? 'svelte',
 	};
 };
@@ -329,7 +341,7 @@ export const c15t = function c15t(options: C15tAstroOptions): AstroIntegration {
 					vite: { plugins: await buildVitePlugins(resolved) },
 				});
 
-				if (options.middleware !== false) {
+				if (resolved.middleware.enabled) {
 					addMiddleware({
 						entrypoint: '@c15t/astro/middleware',
 						order: 'pre',

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -20,6 +20,7 @@ import type {
 	C15tAstroOptions,
 	C15tEndpointOptions,
 	C15tResolvedOptions,
+	C15tUIAdapterName,
 } from './types';
 
 const VIRTUAL_ID = 'virtual:c15t/options';
@@ -28,7 +29,54 @@ const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`;
 const DEFAULT_INIT_PATH = '/api/c15t/init';
 const DEFAULT_MANIFEST_PATH = '/api/c15t/manifest';
 
-const SVELTE_INTEGRATION = '@astrojs/svelte';
+/**
+ * What each `ui` adapter needs from the app, keyed by adapter name.
+ *
+ * `astroIntegration` is checked at `astro:config:done`; `packages` is only
+ * ever printed, so the error names everything to install in one go rather
+ * than one failed build per missing package.
+ */
+const UI_ADAPTERS: Record<
+	C15tUIAdapterName,
+	{
+		astroIntegration: string;
+		packages: string[];
+		adapterModule: string;
+		adapterExport: string;
+		surfaceModule: string;
+	}
+> = {
+	react: {
+		adapterExport: 'reactDialogAdapter',
+		adapterModule: '@c15t/astro/ui/react',
+		astroIntegration: '@astrojs/react',
+		packages: ['@astrojs/react', '@c15t/react', 'react', 'react-dom'],
+		surfaceModule: '@c15t/astro/islands/consent-dialog-surface.tsx',
+	},
+	svelte: {
+		adapterExport: 'svelteDialogAdapter',
+		adapterModule: '@c15t/astro/ui/svelte',
+		astroIntegration: '@astrojs/svelte',
+		packages: ['@astrojs/svelte', 'svelte'],
+		surfaceModule: '@c15t/astro/islands/consent-dialog-surface.svelte',
+	},
+	vue: {
+		adapterExport: 'vueDialogAdapter',
+		adapterModule: '@c15t/astro/ui/vue',
+		astroIntegration: '@astrojs/vue',
+		packages: ['@astrojs/vue', '@c15t/vue', 'vue'],
+		surfaceModule: '@c15t/astro/islands/consent-dialog-surface.vue',
+	},
+};
+
+/**
+ * Adapters worth suggesting when `ui` was left at the default.
+ *
+ * Never applied automatically. Switching a site's dialog framework changes
+ * what every visitor downloads, and doing that because a package happened
+ * to be installed would be a worse surprise than a one-line log.
+ */
+const SUGGESTIBLE_ADAPTERS: C15tUIAdapterName[] = ['react', 'vue'];
 
 const resolveEndpoints = function resolveEndpoints(
 	options: C15tAstroOptions
@@ -87,7 +135,7 @@ export const resolveOptions = function resolveOptions(
 	const {
 		endpoints: _endpoints,
 		middleware: _middleware,
-		requireSvelte: _requireSvelte,
+		requireUIIntegration: _requireUIIntegration,
 		...rest
 	} = options;
 	return {
@@ -122,12 +170,30 @@ const createVirtualOptionsPlugin = function createVirtualOptionsPlugin(
 	};
 };
 
+/**
+ * Build the page script the integration injects.
+ *
+ * The adapter and island specifiers are written here, not in `adapter.ts`
+ * or the `.astro` components, because this is the one place that knows
+ * `ui` before the app's bundler runs. A static reference to all three
+ * would make a Svelte-only site's build resolve `@c15t/react` and `vue`.
+ * Both specifiers stay behind `import()`, so nothing loads until someone
+ * opens a dialog.
+ *
+ * @param options - The options passed to `c15t()`.
+ * @param ui - The resolved dialog adapter.
+ * @returns The module source to inject at the `page` stage.
+ */
 const buildBootScript = function buildBootScript(
-	options: C15tAstroOptions
+	options: C15tAstroOptions,
+	ui: C15tUIAdapterName
 ): string {
+	const adapter = UI_ADAPTERS[ui];
 	const lines = [
 		`import options from '${VIRTUAL_ID}';`,
-		"import { boot } from '@c15t/astro/client';",
+		"import { boot, registerDialogAdapter, registerDialogSurface } from '@c15t/astro/client';",
+		`registerDialogAdapter('${ui}', async () => (await import('${adapter.adapterModule}')).${adapter.adapterExport});`,
+		`registerDialogSurface('${ui}', () => import('${adapter.surfaceModule}'));`,
 	];
 	if (options.clientEntrypoint) {
 		lines.push(
@@ -141,12 +207,73 @@ const buildBootScript = function buildBootScript(
 };
 
 /**
+ * The Vite plugins the app needs for the configured `ui`.
+ *
+ * `@c15t/vue`'s shared composables import `#imports`, which only Nuxt
+ * defines; the package ships a Vite plugin that shims it for plain Vue
+ * apps, and an Astro app is one. The import is dynamic so a site on any
+ * other adapter never has to have `@c15t/vue` installed.
+ *
+ * @param resolved - The resolved integration options.
+ * @returns Vite plugins to merge into the app config.
+ */
+const buildVitePlugins = async function buildVitePlugins(
+	resolved: C15tResolvedOptions
+): Promise<VirtualOptionsPlugin[]> {
+	const plugins: VirtualOptionsPlugin[] = [
+		createVirtualOptionsPlugin(resolved),
+	];
+	if (resolved.ui === 'vue') {
+		const { default: shimVueImports } = await import('@c15t/vue/vite');
+		plugins.push(shimVueImports() as unknown as VirtualOptionsPlugin);
+	}
+	return plugins;
+};
+
+/** The narrow slice of Astro's logger this integration uses. */
+interface IntegrationLogger {
+	warn: (message: string) => void;
+	error: (message: string) => void;
+}
+
+/**
+ * Point out a cheaper `ui` when the site already ships that framework.
+ *
+ * Only ever a log. Reading `ui` off whichever integration happens to be
+ * installed would change what every visitor downloads without anyone
+ * asking for it, and a site can install `@astrojs/react` for one unrelated
+ * widget while still wanting the smaller Svelte dialog.
+ *
+ * @param options - The options passed to `c15t()`.
+ * @param installed - Names of the integrations Astro resolved.
+ * @param logger - The integration logger.
+ */
+const suggestUIAdapter = function suggestUIAdapter(
+	options: C15tAstroOptions,
+	installed: Set<string>,
+	logger: IntegrationLogger
+): void {
+	if (options.ui !== undefined) {
+		return;
+	}
+	const match = SUGGESTIBLE_ADAPTERS.find((name) =>
+		installed.has(UI_ADAPTERS[name].astroIntegration)
+	);
+	if (!match) {
+		return;
+	}
+	logger.warn(
+		`this site already loads ${UI_ADAPTERS[match].astroIntegration}; \`ui: '${match}'\` would render the consent dialog with it instead of adding the Svelte runtime. Set \`ui: 'svelte'\` to silence this.`
+	);
+};
+
+/**
  * Create the c15t Astro integration.
  *
  * @param options - Consent configuration for the site.
  * @returns The Astro integration to list in `astro.config.mjs`.
- * @throws {Error} When `mode` is missing, or when a Svelte dialog surface
- * is configured without `@astrojs/svelte` installed.
+ * @throws {Error} When `mode` is missing, or when the Astro integration for
+ * the configured `ui` is not listed in `astro.config`.
  * @example
  * ```js
  * import { defineConfig } from 'astro/config';
@@ -171,31 +298,34 @@ export const c15t = function c15t(options: C15tAstroOptions): AstroIntegration {
 	return {
 		hooks: {
 			'astro:config:done'({ config, logger }) {
-				if (options.requireSvelte === false || resolved.ui !== 'svelte') {
+				const installed = new Set(
+					config.integrations.map((integration) => integration.name)
+				);
+				suggestUIAdapter(options, installed, logger);
+
+				if (options.requireUIIntegration === false) {
 					return;
 				}
-				const hasSvelte = config.integrations.some(
-					(integration) => integration.name === SVELTE_INTEGRATION
-				);
-				if (hasSvelte) {
+				const adapter = UI_ADAPTERS[resolved.ui];
+				if (installed.has(adapter.astroIntegration)) {
 					return;
 				}
 				logger.error(
-					`the preference-centre and IAB dialogs are Svelte islands, so ${SVELTE_INTEGRATION} must be installed and listed in astro.config before c15t(). Run \`npx astro add svelte\`, or pass \`requireSvelte: false\` if you only use the server-rendered banner.`
+					`the preference-centre and IAB dialogs render as ${resolved.ui} islands, so ${adapter.astroIntegration} must be installed and listed in astro.config before c15t(). Install ${adapter.packages.join(', ')} and run \`npx astro add ${resolved.ui}\`, or pass \`requireUIIntegration: false\` if you only use the server-rendered banner.`
 				);
 				throw new Error(
-					`@c15t/astro: missing ${SVELTE_INTEGRATION}. Install it, or set \`requireSvelte: false\` for a banner-only site.`
+					`@c15t/astro: ui: ${JSON.stringify(resolved.ui)} needs ${adapter.astroIntegration}. Install it, or set \`requireUIIntegration: false\` for a banner-only site.`
 				);
 			},
 
-			'astro:config:setup'({
+			async 'astro:config:setup'({
 				addMiddleware,
 				injectRoute,
 				injectScript,
 				updateConfig,
 			}) {
 				updateConfig({
-					vite: { plugins: [createVirtualOptionsPlugin(resolved)] },
+					vite: { plugins: await buildVitePlugins(resolved) },
 				});
 
 				if (options.middleware !== false) {
@@ -207,7 +337,7 @@ export const c15t = function c15t(options: C15tAstroOptions): AstroIntegration {
 
 				// `page` runs the boot on every page, before any island
 				// hydrates, so the runtime exists before anything asks for it.
-				injectScript('page', buildBootScript(options));
+				injectScript('page', buildBootScript(options, resolved.ui));
 
 				if (resolved.endpoints.enabled) {
 					injectRoute({

--- a/packages/astro/src/middleware-handler.ts
+++ b/packages/astro/src/middleware-handler.ts
@@ -18,6 +18,44 @@ export interface ConsentMiddlewareOptions {
 }
 
 /**
+ * `true` when `pathname` is `prefix` or lives underneath it.
+ *
+ * Segment-aware on purpose: `/api` must not claim `/apidocs`.
+ */
+const matchesPrefix = function matchesPrefix(
+	pathname: string,
+	prefix: string
+): boolean {
+	if (!prefix) {
+		return false;
+	}
+	const normalized = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+	return pathname === normalized || pathname.startsWith(`${normalized}/`);
+};
+
+/**
+ * The paths this middleware leaves alone.
+ *
+ * The injected init and manifest routes are always in the list. With the
+ * manifest served by the same process, letting them through would make the
+ * manifest request resolve consent, which fetches the manifest, which
+ * resolves consent — a request that never returns. Nothing on those routes
+ * renders consent UI, so there is nothing to lose by skipping them.
+ *
+ * @param options - The resolved integration options.
+ * @returns Path prefixes to skip.
+ */
+const resolveSkipPaths = function resolveSkipPaths(
+	options: C15tResolvedOptions
+): string[] {
+	return [
+		options.endpoints.initPath,
+		options.endpoints.manifestPath,
+		...(options.middleware?.skip ?? []),
+	].filter(Boolean);
+};
+
+/**
  * Build the `pre`-order middleware that populates `Astro.locals.c15t`.
  *
  * It reads the consent cookie and the geo/GPC headers, resolves the policy
@@ -29,6 +67,10 @@ export interface ConsentMiddlewareOptions {
  * and resolving one would bake one visitor's geo into a shared HTML file.
  * Use `<ConsentBannerDeferred />` when a cached page still needs live geo.
  *
+ * So are the integration's own init and manifest routes, and anything
+ * listed in `middleware.skip` — those run `next()` with `Astro.locals.c15t`
+ * left unset.
+ *
  * @param options - The resolved integration options.
  * @param middlewareOptions - Test seams.
  * @returns An Astro middleware handler.
@@ -37,7 +79,14 @@ export const createConsentMiddleware = function createConsentMiddleware(
 	options: C15tResolvedOptions,
 	middlewareOptions: ConsentMiddlewareOptions = {}
 ): MiddlewareHandler {
+	const skipPaths = resolveSkipPaths(options);
+
 	return async (context, next) => {
+		const { pathname } = new URL(context.request.url);
+		if (skipPaths.some((prefix) => matchesPrefix(pathname, prefix))) {
+			return await next();
+		}
+
 		context.locals.c15t = await resolveConsentContext({
 			fetch: middlewareOptions.fetch,
 			headers: context.request.headers,

--- a/packages/astro/src/mode.ts
+++ b/packages/astro/src/mode.ts
@@ -87,7 +87,19 @@ export const manifestMode = function manifestMode(
 	return { ...options, type: 'manifest' };
 };
 
-const buildInlinePolicy = function buildInlinePolicy(
+/**
+ * The opt-in banner policy an offline site gets when it declared no packs.
+ *
+ * Narrowed to the configured categories: the policy is what every surface
+ * reads to decide which toggles exist, and what a save is recorded against.
+ * The server prefetch builds the same policy, so a page and its islands
+ * cannot disagree about which categories a visitor was offered.
+ *
+ * @param categories - The configured consent categories.
+ * @returns The inline policy, or `undefined` when none applies.
+ * @internal
+ */
+export const buildInlineOfflinePolicy = function buildInlineOfflinePolicy(
 	categories: ProviderTransportContext['consentCategories']
 ): KernelConfig['initialPolicy'] {
 	const fallback = policyDefaults.offlineOptInBanner();
@@ -123,7 +135,7 @@ const createOfflineFactory = function createOfflineFactory(
 		const policy =
 			configuredPolicy ??
 			(policyPacks === undefined
-				? buildInlinePolicy(context.consentCategories)
+				? buildInlineOfflinePolicy(context.consentCategories)
 				: undefined);
 		if (!policy) {
 			return baseTransport;

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -25,7 +25,7 @@ import {
 	CONSENT_STORAGE_KEY,
 	readStoredConsentFromCookie,
 } from '@c15t/core/modules/persistence';
-import { createManifestTransport } from '@c15t/core/transports/manifest';
+import type { ManifestFetch } from '@c15t/core/server';
 import {
 	CONSENT_REQUEST_HEADER_NAMES,
 	consentInputsToOverrides,
@@ -38,6 +38,7 @@ import type {
 } from '@c15t/schema/types';
 import { baseTranslations } from '@c15t/translations/all';
 
+import { loadConsentManifest, resolveManifestInit } from './api/manifest-init';
 import { filterCookieHeader } from './libs/cookies';
 import { buildInlineOfflinePolicy } from './mode';
 import type { C15tColorScheme, C15tLocals, C15tResolvedOptions } from './types';
@@ -333,37 +334,37 @@ const prefetchManifest = async function prefetchManifest(
 	input: PrefetchLocalInput,
 	mode: Extract<C15tResolvedOptions['mode'], { type: 'manifest' }>
 ): Promise<KernelConfig> {
-	const absoluteBackend = mode.backendURL
-		? (resolveAgainstRequest(mode.backendURL, input.headers, input.url) ??
-			undefined)
-		: undefined;
-	const absoluteManifest = mode.manifestURL
-		? (resolveAgainstRequest(mode.manifestURL, input.headers, input.url) ??
-			undefined)
-		: undefined;
-	const cookieTarget = absoluteManifest ?? absoluteBackend;
-	const transport = createManifestTransport({
-		backendURL: absoluteBackend,
-		baseTranslations,
-		fetch: input.fetch,
-		headers: forwardHeaders(input.headers, input.base.initialOverrides ?? {}, {
-			allowCookie: cookieTarget
-				? mayForwardCookie(cookieTarget, input.url)
-				: false,
-			cookieName: consentCookieName(input.options),
-		}),
-		inputs: input.inputs,
-		manifest: mode.manifest,
-		manifestURL: absoluteManifest,
-	});
+	// Deliberately not `createManifestTransport`: its manifest memo lives
+	// on the transport instance, and a render builds a fresh one, so every
+	// page view paid a manifest fetch. The route handlers already go
+	// through the process-wide cache in `@c15t/core/server`; so does this,
+	// which is what makes the second render cost nothing.
+	const source = { headers: input.headers, url: input.url };
+	const target = mode.manifestURL ?? mode.backendURL;
+	const absoluteTarget = target
+		? resolveAgainstRequest(target, input.headers, input.url)
+		: null;
 	try {
-		const response = await transport.init?.({
-			overrides: input.base.initialOverrides ?? {},
-			user: input.base.initialUser ?? null,
+		const manifest = await loadConsentManifest({
+			fetch: input.fetch as ManifestFetch | undefined,
+			options: input.options,
+			source,
 		});
-		return response
-			? mergeInitResponseIntoKernelConfig(input.base, response)
-			: input.base;
+		const payload = await resolveManifestInit({
+			fetch: input.fetch as ManifestFetch | undefined,
+			inputs: input.inputs,
+			manifest,
+		});
+		return mergeInitOutputIntoKernelConfig(
+			input.base,
+			payload,
+			forwardHeaders(input.headers, input.base.initialOverrides ?? {}, {
+				allowCookie: absoluteTarget
+					? mayForwardCookie(absoluteTarget, input.url)
+					: false,
+				cookieName: consentCookieName(input.options),
+			})
+		);
 	} catch {
 		return input.base;
 	}

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -39,6 +39,7 @@ import type {
 import { baseTranslations } from '@c15t/translations/all';
 
 import { filterCookieHeader } from './libs/cookies';
+import { buildInlineOfflinePolicy } from './mode';
 import type { C15tLocals, C15tResolvedOptions } from './types';
 
 /** Input for {@link resolveConsentContext}. */
@@ -387,9 +388,22 @@ const prefetchOffline = async function prefetchOffline(
 			overrides: input.base.initialOverrides ?? {},
 			user: input.base.initialUser ?? null,
 		});
-		return response
-			? mergeInitResponseIntoKernelConfig(input.base, response)
-			: input.base;
+		if (!response) {
+			return input.base;
+		}
+		// Without policy packs the offline transport resolves a policy that
+		// allows every category. Narrow it to what the site configured: the
+		// React dialog reads its toggle list off the policy, so leaving it
+		// wide showed categories the site never asked for while the Svelte
+		// and Vue surfaces — which filter by option — did not.
+		const policy = policyPacks
+			? response.policy
+			: (buildInlineOfflinePolicy(options.consentCategories) ??
+				response.policy);
+		return mergeInitResponseIntoKernelConfig(input.base, {
+			...response,
+			policy,
+		});
 	} catch {
 		return input.base;
 	}

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -40,7 +40,7 @@ import { baseTranslations } from '@c15t/translations/all';
 
 import { filterCookieHeader } from './libs/cookies';
 import { buildInlineOfflinePolicy } from './mode';
-import type { C15tLocals, C15tResolvedOptions } from './types';
+import type { C15tColorScheme, C15tLocals, C15tResolvedOptions } from './types';
 
 /** Input for {@link resolveConsentContext}. */
 export interface ResolveConsentContextOptions {
@@ -508,6 +508,40 @@ export const buildConfigScript = function buildConfigScript(
 	// `<` is escaped so a translation string can never close the script tag.
 	const json = JSON.stringify(config ?? {}).replace(/</gu, '\\u003c');
 	return `window.__c15tAstroConfig=${json};`;
+};
+
+/**
+ * Build the first-paint colour-scheme script.
+ *
+ * Dark mode is the `c15t-dark` class on `<html>`, and the client boot sets
+ * it — but that runs after the stylesheet has already painted the
+ * server-rendered banner in the light palette. This runs in `<head>`,
+ * before the browser has anything to paint, so a system-dark visitor never
+ * sees the flash. It is deliberately framework-free and unbundled: a
+ * module script would be deferred and lose the race.
+ *
+ * `'light'` emits nothing. Light is the absence of the class, so there is
+ * nothing to do before paint.
+ *
+ * @param colorScheme - The resolved colour scheme.
+ * @returns Script source, or an empty string when none is needed.
+ * @example
+ * ```astro
+ * <script is:inline set:html={buildColorSchemeScript('system')} />
+ * ```
+ */
+export const buildColorSchemeScript = function buildColorSchemeScript(
+	colorScheme: C15tColorScheme
+): string {
+	if (colorScheme === 'light') {
+		return '';
+	}
+	if (colorScheme === 'dark') {
+		return "document.documentElement.classList.add('c15t-dark');";
+	}
+	// Wrapped because `matchMedia` is absent in some embedded webviews, and
+	// a throw here would abort the rest of the document's parsing.
+	return "try{document.documentElement.classList.toggle('c15t-dark',matchMedia('(prefers-color-scheme:dark)').matches)}catch(e){}";
 };
 
 export { buildPrefetchScript } from '@c15t/core';

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -61,8 +61,16 @@ export interface C15tManifestDescriptor {
 	manifest?: ConsentManifest;
 }
 
-/** Which framework renders the on-demand dialog islands. */
-export type C15tUIAdapterName = 'svelte';
+/**
+ * Which framework renders the on-demand dialog islands.
+ *
+ * Svelte is the default because it is the smallest: its runtime costs
+ * roughly 14 KB gzipped against React's ~45 KB. A site already shipping
+ * React or Vue should say so and reuse what it has instead of downloading
+ * a second framework for one dialog. The choice is never inferred — a
+ * silent change to what a page downloads is worse than an explicit one.
+ */
+export type C15tUIAdapterName = 'svelte' | 'react' | 'vue';
 
 /** Route paths the integration can inject. */
 export interface C15tEndpointOptions {
@@ -117,8 +125,11 @@ export interface C15tAstroOptions {
 	/**
 	 * Framework used to render the on-demand dialog islands.
 	 *
-	 * `'svelte'` is the only adapter today; the option exists so React, Vue
-	 * and Solid surfaces can be added without a breaking change.
+	 * `'svelte'` ships the least JavaScript and is the default. Pick
+	 * `'react'` or `'vue'` when the site already loads that runtime, so the
+	 * dialog reuses it instead of adding a second framework. Whichever you
+	 * pick, install the matching Astro integration — `@astrojs/svelte`,
+	 * `@astrojs/react` or `@astrojs/vue` — and list it before `c15t()`.
 	 *
 	 * @default 'svelte'
 	 */
@@ -145,12 +156,13 @@ export interface C15tAstroOptions {
 	middleware?: boolean;
 
 	/**
-	 * Fail the build when `@astrojs/svelte` is missing while a Svelte dialog
-	 * surface is configured. Set to `false` for banner-only sites.
+	 * Fail the build when the Astro integration for {@link C15tAstroOptions.ui}
+	 * is missing. Set to `false` for banner-only sites, which render no
+	 * island at all.
 	 *
 	 * @default true
 	 */
-	requireSvelte?: boolean;
+	requireUIIntegration?: boolean;
 }
 
 /**
@@ -212,7 +224,7 @@ export interface C15tClientOptionsExtension {
  */
 export interface C15tResolvedOptions extends Omit<
 	C15tAstroOptions,
-	'endpoints' | 'middleware' | 'requireSvelte'
+	'endpoints' | 'middleware' | 'requireUIIntegration'
 > {
 	ui: C15tUIAdapterName;
 	endpoints: Required<Omit<C15tEndpointOptions, 'enabled'>> & {

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -72,6 +72,16 @@ export interface C15tManifestDescriptor {
  */
 export type C15tUIAdapterName = 'svelte' | 'react' | 'vue';
 
+/**
+ * How the consent surfaces pick light or dark.
+ *
+ * Dark mode is the `c15t-dark` class on `<html>`, not a
+ * `prefers-color-scheme` block, so something has to set it. `'system'`
+ * follows `prefers-color-scheme` and keeps following it; `'light'` and
+ * `'dark'` pin it.
+ */
+export type C15tColorScheme = 'light' | 'dark' | 'system';
+
 /** Route paths the integration can inject. */
 export interface C15tEndpointOptions {
 	/**
@@ -118,6 +128,18 @@ export interface C15tAstroOptions {
 
 	/** Theme tokens applied to the banner and dialog surfaces. */
 	theme?: Theme;
+
+	/**
+	 * Light or dark for the banner and dialogs.
+	 *
+	 * `'system'` follows `prefers-color-scheme` and keeps following it as
+	 * the visitor changes it. `<ConsentScript />` writes the class from a
+	 * tiny inline script in `<head>`, so the server-rendered banner is
+	 * already dark on its first paint rather than flashing light.
+	 *
+	 * @default 'system'
+	 */
+	colorScheme?: C15tColorScheme;
 
 	/** Legal links rendered inline in the banner and dialog. */
 	legalLinks?: LegalLinks;
@@ -227,6 +249,7 @@ export interface C15tResolvedOptions extends Omit<
 	'endpoints' | 'middleware' | 'requireUIIntegration'
 > {
 	ui: C15tUIAdapterName;
+	colorScheme: C15tColorScheme;
 	endpoints: Required<Omit<C15tEndpointOptions, 'enabled'>> & {
 		enabled: boolean;
 	};

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -98,6 +98,30 @@ export interface C15tEndpointOptions {
 	manifestPath?: string;
 }
 
+/** How the integration registers its `pre`-order middleware. */
+export interface C15tMiddlewareOptions {
+	/**
+	 * Register `@c15t/astro/middleware` at all.
+	 *
+	 * @default true
+	 */
+	enabled?: boolean;
+	/**
+	 * Extra path prefixes the middleware leaves alone.
+	 *
+	 * The integration's own init and manifest routes are always skipped, so
+	 * this is only for routes of your own that must not resolve consent —
+	 * health checks, webhooks, anything that would otherwise pay for a
+	 * decision it never renders. A path matches when it is the pathname
+	 * exactly or a parent segment of it, so `'/api'` covers `/api/health`.
+	 *
+	 * `Astro.locals.c15t` is left unset on a skipped route.
+	 *
+	 * @example ['/api/webhooks', '/healthz']
+	 */
+	skip?: string[];
+}
+
 /** Options accepted by the `c15t()` Astro integration. */
 export interface C15tAstroOptions {
 	/**
@@ -173,9 +197,14 @@ export interface C15tAstroOptions {
 	/**
 	 * Register the `pre`-order middleware that populates `Astro.locals.c15t`.
 	 *
+	 * `false` is the same as `{ enabled: false }`. The middleware already
+	 * skips the integration's own init and manifest routes, so a site that
+	 * serves its own manifest does not have to hand-roll one to break the
+	 * cycle; use `skip` to add routes of your own.
+	 *
 	 * @default true
 	 */
-	middleware?: boolean;
+	middleware?: boolean | C15tMiddlewareOptions;
 
 	/**
 	 * Fail the build when the Astro integration for {@link C15tAstroOptions.ui}
@@ -253,6 +282,7 @@ export interface C15tResolvedOptions extends Omit<
 	endpoints: Required<Omit<C15tEndpointOptions, 'enabled'>> & {
 		enabled: boolean;
 	};
+	middleware: Required<C15tMiddlewareOptions>;
 }
 
 /** Consent context the middleware attaches to every request. */

--- a/packages/astro/src/ui/adapter.ts
+++ b/packages/astro/src/ui/adapter.ts
@@ -136,6 +136,22 @@ export const registerDialogAdapter = function registerDialogAdapter(
 };
 
 /**
+ * Empties both registries.
+ *
+ * The registries are module state, so a test that registers an adapter
+ * would otherwise decide what the next one sees.
+ *
+ * Tests only.
+ *
+ * @internal
+ */
+export const resetDialogRegistriesForTest =
+	function resetDialogRegistriesForTest(): void {
+		registry.clear();
+		surfaces.clear();
+	};
+
+/**
  * Load the adapter named by the `ui` option.
  *
  * The import is dynamic so a page that never opens a dialog never

--- a/packages/astro/src/ui/adapter.ts
+++ b/packages/astro/src/ui/adapter.ts
@@ -3,10 +3,16 @@
  *
  * The banner is server-rendered `.astro` with no framework at all, but the
  * preference centre and the IAB dialog need real component state. Rather
- * than hard-wiring Svelte through the whole package, dialogs go through
- * this adapter: one implementation ships today (`svelte`), and React, Vue
- * or Solid surfaces can be added without touching the runtime, the banner
- * or the client boot.
+ * than hard-wiring one framework through the whole package, dialogs go
+ * through this adapter: `svelte`, `react` and `vue` each implement it, and
+ * a site downloads exactly the one its `ui` option names.
+ *
+ * Nothing framework-specific is named here, and the registry starts empty
+ * on purpose. A built-in entry pointing at the React adapter would make
+ * every build resolve `@c15t/react` and `react-dom`, which a Svelte-only
+ * site does not install. The integration knows `ui` at config time, so it
+ * registers the one adapter and the one surface into the page boot script;
+ * that is the only place a framework specifier appears.
  */
 
 import type { ConsentRuntime } from '@c15t/core/runtime';
@@ -46,14 +52,10 @@ const surfaces = new Map<C15tUIAdapterName, ConsentDialogSurfaceLoader>();
  * @param name - The adapter the surface belongs to.
  * @param load - Loader returning the surface module.
  * @example
- * ```astro
- * <script>
- *   import { registerDialogSurface } from '@c15t/astro/client';
- *
- *   registerDialogSurface('svelte', () =>
- *     import('@c15t/astro/islands/consent-dialog-surface.svelte')
- *   );
- * </script>
+ * ```ts
+ * registerDialogSurface('svelte', () =>
+ *   import('@c15t/astro/islands/consent-dialog-surface.svelte')
+ * );
  * ```
  */
 export const registerDialogSurface = function registerDialogSurface(
@@ -76,7 +78,7 @@ export const requireDialogSurface = function requireDialogSurface(
 	const load = surfaces.get(name);
 	if (!load) {
 		throw new Error(
-			`@c15t/astro: no ${name} dialog surface registered. Render <ConsentDialog /> (or <IABConsentDialog />) somewhere on the page — it is what registers the island.`
+			`@c15t/astro: no ${name} dialog surface registered. The integration registers it from the injected page script, so this usually means c15t() is missing from astro.config, or the page was rendered with \`middleware: false\` and no boot script.`
 		);
 	}
 	return load;
@@ -112,7 +114,7 @@ export interface ConsentDialogAdapter {
 const registry = new Map<
 	C15tUIAdapterName,
 	() => Promise<ConsentDialogAdapter>
->([['svelte', async () => (await import('./svelte')).svelteDialogAdapter]]);
+>();
 
 /** First `load()` call per adapter, so a loader runs at most once. */
 const pending = new Map<C15tUIAdapterName, Promise<ConsentDialogAdapter>>();
@@ -153,7 +155,7 @@ export const loadDialogAdapter = async function loadDialogAdapter(
 	const load = registry.get(name);
 	if (!load) {
 		throw new Error(
-			`@c15t/astro: no dialog adapter registered for ui: ${JSON.stringify(name)}.`
+			`@c15t/astro: no dialog adapter registered for ui: ${JSON.stringify(name)}. The integration registers the configured adapter from the injected page script; register your own with registerDialogAdapter().`
 		);
 	}
 	// `registerDialogAdapter` promises the loader runs at most once, and

--- a/packages/astro/src/ui/adapter.ts
+++ b/packages/astro/src/ui/adapter.ts
@@ -149,6 +149,7 @@ export const resetDialogRegistriesForTest =
 	function resetDialogRegistriesForTest(): void {
 		registry.clear();
 		surfaces.clear();
+		pending.clear();
 	};
 
 /**

--- a/packages/astro/src/ui/provider-props.ts
+++ b/packages/astro/src/ui/provider-props.ts
@@ -11,16 +11,24 @@ import type { ConsentRuntime } from '@c15t/core/runtime';
 
 import type { C15tResolvedOptions } from '../types';
 
+/**
+ * The slice of the integration options a dialog island renders with.
+ *
+ * Named so every framework surface can state the same shape instead of
+ * widening to `Record<string, unknown>` and casting it back.
+ */
+export interface DialogPresentationOptions {
+	consentCategories?: C15tResolvedOptions['consentCategories'];
+	legalLinks?: C15tResolvedOptions['legalLinks'];
+	theme?: C15tResolvedOptions['theme'];
+}
+
 /** Props handed to `ConsentManagerProvider` by the Svelte dialog surface. */
 export interface DialogProviderProps {
 	/** The page-level runtime. The provider borrows it, it does not own it. */
 	runtime: ConsentRuntime;
 	/** Presentation options forwarded to the provider. */
-	options: {
-		consentCategories?: C15tResolvedOptions['consentCategories'];
-		legalLinks?: C15tResolvedOptions['legalLinks'];
-		theme?: C15tResolvedOptions['theme'];
-	};
+	options: DialogPresentationOptions;
 }
 
 /**

--- a/packages/astro/src/ui/react.ts
+++ b/packages/astro/src/ui/react.ts
@@ -1,0 +1,62 @@
+/**
+ * The React dialog surface.
+ *
+ * For a site that already ships React, mounting the preference centre in
+ * React costs nothing new: the runtime is on the page already, and the
+ * dialog reuses it instead of pulling a second framework alongside it. A
+ * site that does not ship React should stay on the Svelte default, which
+ * is roughly a third of the runtime weight.
+ *
+ * Mounting happens on the first open through `mount()`, so the island's
+ * chunks are paid for only by visitors who click "Customize".
+ *
+ * The island itself is registered by the integration rather than imported
+ * here: a `.tsx` file can only be compiled by the consuming app's build,
+ * and only that build knows whether `@astrojs/react` is present.
+ */
+
+import type {
+	ConsentDialogAdapter,
+	ConsentDialogContext,
+	ConsentDialogHandle,
+} from './adapter';
+import { requireDialogSurface } from './adapter';
+import { buildProviderProps } from './provider-props';
+
+/** The React 18/19 dialog surface implementation. */
+export const reactDialogAdapter: ConsentDialogAdapter = {
+	async mount(context: ConsentDialogContext): Promise<ConsentDialogHandle> {
+		const [{ createElement }, { createRoot }, surface] = await Promise.all([
+			import('react'),
+			import('react-dom/client'),
+			requireDialogSurface('react')(),
+		]);
+
+		const root = createRoot(context.target);
+		root.render(
+			createElement(surface.default as never, {
+				...buildProviderProps(context.runtime, context.options),
+				kind: context.kind,
+			})
+		);
+
+		return {
+			close() {
+				context.runtime.kernel.set.activeUI('none');
+			},
+			destroy() {
+				root.unmount();
+			},
+		};
+	},
+
+	name: 'react',
+
+	async preload() {
+		await Promise.all([
+			import('react'),
+			import('react-dom/client'),
+			requireDialogSurface('react')(),
+		]);
+	},
+};

--- a/packages/astro/src/ui/vue.ts
+++ b/packages/astro/src/ui/vue.ts
@@ -1,0 +1,62 @@
+/**
+ * The Vue dialog surface.
+ *
+ * Same trade as the React adapter: a site already running Vue reuses that
+ * runtime for the preference centre instead of downloading Svelte for one
+ * dialog. Sites on neither should stay on the default.
+ *
+ * The island is mounted as its own Vue app rather than grafted onto the
+ * host app — Astro islands never share an app instance. The consent state
+ * lives on the page runtime, which the `c15tVue` plugin borrows: it builds
+ * no kernel of its own and disposes nothing.
+ *
+ * The island itself is registered by the integration rather than imported
+ * here: a `.vue` file can only be compiled by the consuming app's build,
+ * and only that build knows whether `@astrojs/vue` is present.
+ */
+
+import type {
+	ConsentDialogAdapter,
+	ConsentDialogContext,
+	ConsentDialogHandle,
+} from './adapter';
+import { requireDialogSurface } from './adapter';
+import { buildProviderProps } from './provider-props';
+
+/** The Vue 3 dialog surface implementation. */
+export const vueDialogAdapter: ConsentDialogAdapter = {
+	async mount(context: ConsentDialogContext): Promise<ConsentDialogHandle> {
+		const [{ createApp }, { c15tVue }, surface] = await Promise.all([
+			import('vue'),
+			import('@c15t/vue/vue-plugin'),
+			requireDialogSurface('vue')(),
+		]);
+
+		const { options, runtime } = buildProviderProps(
+			context.runtime,
+			context.options
+		);
+		const app = createApp(surface.default as never, { kind: context.kind });
+		app.use(c15tVue, { ...options, runtime } as never);
+		app.mount(context.target);
+
+		return {
+			close() {
+				context.runtime.kernel.set.activeUI('none');
+			},
+			destroy() {
+				app.unmount();
+			},
+		};
+	},
+
+	name: 'vue',
+
+	async preload() {
+		await Promise.all([
+			import('vue'),
+			import('@c15t/vue/vue-plugin'),
+			requireDialogSurface('vue')(),
+		]);
+	},
+};

--- a/packages/astro/vitest.config.ts
+++ b/packages/astro/vitest.config.ts
@@ -25,6 +25,7 @@ const virtualOptionsPlugin = {
 			return;
 		}
 		return `export default ${JSON.stringify({
+			colorScheme: 'system',
 			endpoints: {
 				enabled: false,
 				initPath: '/api/c15t/init',

--- a/packages/astro/vitest.config.ts
+++ b/packages/astro/vitest.config.ts
@@ -2,6 +2,10 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { baseConfig } from '@c15t/vitest-config/base';
+// `@c15t/vue`'s shared composables import `#imports`, a Nuxt virtual. The
+// package ships this plugin to shim it for plain Vue apps; the integration
+// adds the same one when `ui: 'vue'`.
+import shimVueImports from '@c15t/vue/vite';
 import { getViteConfig } from 'astro/config';
 import { mergeConfig } from 'vitest/config';
 
@@ -38,7 +42,7 @@ const virtualOptionsPlugin = {
 
 export default getViteConfig(
 	mergeConfig(baseConfig, {
-		plugins: [virtualOptionsPlugin],
+		plugins: [virtualOptionsPlugin, shimVueImports()],
 		resolve: {
 			alias: {
 				'@c15t/astro/server': resolve(__dirname, './src/server.ts'),

--- a/packages/react/src/__tests__/external-runtime-provider.test.tsx
+++ b/packages/react/src/__tests__/external-runtime-provider.test.tsx
@@ -1,0 +1,83 @@
+import { createConsentRuntime } from '@c15t/core/runtime';
+import type { ConsentRuntime } from '@c15t/core/runtime';
+import { useContext } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-react';
+
+import { KernelContext } from '../context';
+import { ConsentProvider, offline } from '../index';
+
+const createRuntime = function createRuntime(): ConsentRuntime {
+	return createConsentRuntime({
+		mode: offline(),
+		pkg: '@c15t/react-external-test',
+	});
+};
+
+const KernelProbe = ({ onKernel }: { onKernel: (value: unknown) => void }) => {
+	onKernel(useContext(KernelContext));
+	return null;
+};
+
+describe('ConsentProvider with an external runtime', () => {
+	test('renders the runtime it was handed instead of building one', async () => {
+		const runtime = createRuntime();
+		const seen = vi.fn();
+
+		await render(
+			<ConsentProvider runtime={runtime}>
+				<KernelProbe onKernel={seen} />
+			</ConsentProvider>
+		);
+
+		expect(seen).toHaveBeenCalledWith(runtime.kernel);
+	});
+
+	test('does not dispose a runtime it does not own', async () => {
+		const runtime = createRuntime();
+		const dispose = vi.spyOn(runtime.kernel, 'dispose');
+
+		const { unmount } = await render(
+			<ConsentProvider runtime={runtime}>
+				<div data-testid="child">borrowed</div>
+			</ConsentProvider>
+		);
+		unmount();
+
+		expect(dispose).not.toHaveBeenCalled();
+		// Still usable afterwards, which a disposed kernel would not be.
+		expect(runtime.kernel.getSnapshot()).toBeTruthy();
+	});
+
+	test('leaves init and every side-effecting module to the owner', async () => {
+		const runtime = createRuntime();
+		const init = vi.spyOn(runtime.kernel.commands, 'init');
+
+		await render(
+			<ConsentProvider runtime={runtime}>
+				<div data-testid="child">borrowed</div>
+			</ConsentProvider>
+		);
+
+		// A microtask turn is enough for the mount effects to have run.
+		await Promise.resolve();
+
+		expect(init).not.toHaveBeenCalled();
+		expect(
+			(window as Window & { c15t?: { pkg: string } }).c15t
+		).toBeUndefined();
+	});
+
+	test('still owns the kernel when no runtime is passed', async () => {
+		const seen = vi.fn();
+		const { unmount } = await render(
+			<ConsentProvider options={{ mode: offline() }}>
+				<KernelProbe onKernel={seen} />
+			</ConsentProvider>
+		);
+		const kernel = seen.mock.calls[0]?.[0] as { dispose: () => void };
+		const dispose = vi.spyOn(kernel, 'dispose');
+		unmount();
+		expect(dispose).toHaveBeenCalled();
+	});
+});

--- a/packages/react/src/context/iab-context-value.ts
+++ b/packages/react/src/context/iab-context-value.ts
@@ -1,0 +1,30 @@
+import type { IABHandle } from '@c15t/iab';
+import { createContext } from 'react';
+
+/**
+ * The IAB slice hooks read: the live CMP handle plus the preference-centre
+ * tab, which is UI state rather than consent state.
+ *
+ * @internal
+ */
+export interface IABContextValue {
+	/** The mounted CMP, or `null` until one is ready. */
+	handle: IABHandle | null;
+	/** Which preference-centre tab is showing. */
+	tab: 'purposes' | 'vendors';
+	/** Switch preference-centre tabs. */
+	setTab: (tab: 'purposes' | 'vendors') => void;
+}
+
+/**
+ * Context carrying the IAB CMP handle.
+ *
+ * It lives in its own module, away from `iab-context.tsx`, because that
+ * file statically imports `createIAB` from `@c15t/iab`. A provider handed
+ * an externally owned runtime already has a CMP and must be able to publish
+ * it here without pulling the TCF encoder into its chunk.
+ *
+ * @internal
+ */
+export const IABContext = createContext<IABContextValue | null>(null);
+IABContext.displayName = 'C15tIABContext';

--- a/packages/react/src/external-iab-context.tsx
+++ b/packages/react/src/external-iab-context.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * The IAB bridge for an externally owned runtime.
+ *
+ * When a host creates the runtime itself — an Astro page, a SvelteKit
+ * layout — that runtime already mounted the CMP and owns its lifecycle.
+ * This provider republishes `runtime.iab` into React context instead of
+ * calling `createIAB()` a second time, which would install a second
+ * `__tcfapi` on the page.
+ *
+ * It deliberately imports nothing from `@c15t/iab`: the module is a peer of
+ * the runtime, not of the component tree, and a preference-centre chunk
+ * that pulled in the TCF encoder would cost every visitor bytes only an IAB
+ * site needs.
+ */
+
+import type { ConsentRuntime } from '@c15t/core/runtime';
+import type { IABHandle } from '@c15t/iab';
+import { useMemo, useState, useSyncExternalStore } from 'react';
+import type { ReactNode } from 'react';
+
+import { IABContext } from './context/iab-context-value';
+import type { IABContextValue } from './context/iab-context-value';
+
+/** Props for {@link ExternalIABProvider}. */
+export interface ExternalIABProviderProps {
+	/** The runtime that owns the CMP. */
+	runtime: ConsentRuntime;
+	children: ReactNode;
+}
+
+const getServerHandle = function getServerHandle(): IABHandle | null {
+	return null;
+};
+
+/**
+ * Publish an externally owned runtime's CMP into React context.
+ *
+ * @param props - The owning runtime and the tree to render.
+ * @returns The children, wrapped in the IAB context.
+ */
+export const ExternalIABProvider = ({
+	runtime,
+	children,
+}: ExternalIABProviderProps) => {
+	const [tab, setTab] = useState<'purposes' | 'vendors'>('purposes');
+	const handle = useSyncExternalStore(
+		(listener) => runtime.onIABChange(listener),
+		() => runtime.iab as IABHandle | null,
+		getServerHandle
+	);
+
+	const value = useMemo<IABContextValue>(
+		() => ({ handle, setTab, tab }),
+		[handle, tab]
+	);
+
+	return <IABContext.Provider value={value}>{children}</IABContext.Provider>;
+};

--- a/packages/react/src/iab-context.tsx
+++ b/packages/react/src/iab-context.tsx
@@ -8,7 +8,6 @@ import type {
 import { createIAB } from '@c15t/iab';
 import type { CreateIABOptions, IABHandle } from '@c15t/iab';
 import {
-	createContext,
 	useContext,
 	useEffect,
 	useMemo,
@@ -19,6 +18,8 @@ import {
 import type { ReactNode } from 'react';
 
 import { KernelContext } from './context';
+import { IABContext } from './context/iab-context-value';
+import type { IABContextValue } from './context/iab-context-value';
 
 export interface ReactIABState extends KernelIABState {
 	config: {
@@ -41,14 +42,6 @@ export interface ReactIABState extends KernelIABState {
 	rejectAll: () => void;
 	save: () => Promise<void>;
 }
-
-interface IABContextValue {
-	handle: IABHandle | null;
-	tab: 'purposes' | 'vendors';
-	setTab: (tab: 'purposes' | 'vendors') => void;
-}
-
-const IABContext = createContext<IABContextValue | null>(null);
 
 export interface IABProviderProps extends Omit<
 	CreateIABOptions,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -130,6 +130,12 @@ export {
 	usePersistence,
 	useScriptLoader,
 } from './module-hooks';
-export type { ConsentProviderOptions, ConsentProviderProps } from './provider';
+export type {
+	ConsentProviderOptions,
+	ConsentProviderProps,
+	ExternalRuntimeProviderOptions,
+	ExternalRuntimeProviderProps,
+	OwnedRuntimeProviderProps,
+} from './provider';
 export { ConsentProvider } from './provider';
 export type { ReactUIOptions } from './types/consent-manager';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -37,6 +37,7 @@ import {
 	resolveWindowDebugMode,
 } from '@c15t/core/modules/window-debug';
 import type { WindowDebugMode } from '@c15t/core/modules/window-debug';
+import type { ConsentRuntime } from '@c15t/core/runtime';
 import type { InitOutput } from '@c15t/schema/types';
 import { deepMergeTranslations } from '@c15t/translations';
 import type { Translations } from '@c15t/translations';
@@ -185,10 +186,44 @@ export interface ConsentProviderOptions extends Pick<
 	__debugPkg?: string;
 }
 
-export interface ConsentProviderProps {
+/**
+ * Options accepted when an external runtime supplies the kernel.
+ *
+ * `mode` belongs to whoever created the runtime, so it is optional here.
+ * Everything the component tree still owns — theme, slots, legal links —
+ * is unchanged.
+ */
+export type ExternalRuntimeProviderOptions = Omit<
+	ConsentProviderOptions,
+	'mode'
+> & {
+	mode?: ConsentProviderOptions['mode'];
+};
+
+/** The provider builds and owns its own kernel. */
+export interface OwnedRuntimeProviderProps {
 	options: ConsentProviderOptions;
 	children: ReactNode;
+	runtime?: undefined;
 }
+
+/**
+ * The provider renders an externally owned runtime.
+ *
+ * Astro islands and a SvelteKit root layout cannot share React context, so
+ * the kernel has to be owned outside the tree. The provider borrows it and
+ * leaves `start()`, `dispose()` and every side-effecting module to the
+ * owner; it still owns rendering — theme, slots and the IAB bridge.
+ */
+export interface ExternalRuntimeProviderProps {
+	options?: ExternalRuntimeProviderOptions;
+	children: ReactNode;
+	runtime: ConsentRuntime;
+}
+
+export type ConsentProviderProps =
+	| OwnedRuntimeProviderProps
+	| ExternalRuntimeProviderProps;
 
 const ALL_CONSENTS_ON = {
 	experience: true,
@@ -206,6 +241,13 @@ const DEFAULT_TRANSLATIONS: KernelTranslations = {
 const LazyIABProvider = lazy(async () => {
 	const module = await import('./iab-context');
 	return { default: module.IABProvider };
+});
+
+// A separate chunk from `LazyIABProvider`: the external bridge republishes
+// a CMP the runtime already mounted, so it must not drag `@c15t/iab` in.
+const LazyExternalIABProvider = lazy(async () => {
+	const module = await import('./external-iab-context');
+	return { default: module.ExternalIABProvider };
 });
 
 const normalizeUser = function normalizeUser(
@@ -634,7 +676,8 @@ const hasRevokedConsent = function hasRevokedConsent(
 const useProviderCallbacks = function useProviderCallbacks(
 	kernel: ConsentKernel,
 	callbacks: Callbacks | undefined,
-	reloadOnConsentRevoked: boolean
+	reloadOnConsentRevoked: boolean,
+	active: boolean
 ) {
 	const callbacksRef = useRef(callbacks);
 	const saveStartedSnapshotRef = useRef<ConsentSnapshot | null>(null);
@@ -645,6 +688,11 @@ const useProviderCallbacks = function useProviderCallbacks(
 	}, [callbacks]);
 
 	useEffect(() => {
+		// An externally owned runtime already wired these through
+		// `wireRuntimeCallbacks`; subscribing again would double-fire them.
+		if (!active) {
+			return;
+		}
 		const notifyConsentSaved = (
 			previous: ConsentSnapshot | null,
 			next: ConsentSnapshot
@@ -731,7 +779,7 @@ const useProviderCallbacks = function useProviderCallbacks(
 				unsubscribe();
 			}
 		};
-	}, [kernel, reloadOnConsentRevoked]);
+	}, [active, kernel, reloadOnConsentRevoked]);
 };
 
 const serializeInitialOnlyOptions = function serializeInitialOnlyOptions(
@@ -750,7 +798,8 @@ const serializeInitialOnlyOptions = function serializeInitialOnlyOptions(
 const useProviderOptionSync = function useProviderOptionSync(
 	kernel: ConsentKernel,
 	options: ConsentProviderOptions,
-	enabled: boolean
+	enabled: boolean,
+	owns: boolean
 ) {
 	const previousEnabledRef = useRef(enabled);
 	const previousUserRef = useRef<string | null>(null);
@@ -758,6 +807,9 @@ const useProviderOptionSync = function useProviderOptionSync(
 	const initialOnlyRef = useRef<string | null>(null);
 
 	useEffect(() => {
+		if (!owns) {
+			return;
+		}
 		const nextUser = normalizeUser(options.user);
 		const serialized = JSON.stringify(nextUser ?? null);
 		if (previousUserRef.current === null) {
@@ -776,9 +828,12 @@ const useProviderOptionSync = function useProviderOptionSync(
 				})();
 			}
 		}
-	}, [kernel, options.user]);
+	}, [kernel, options.user, owns]);
 
 	useEffect(() => {
+		if (!owns) {
+			return;
+		}
 		const serialized = JSON.stringify(options.overrides ?? {});
 		if (previousOverridesRef.current === null) {
 			previousOverridesRef.current = serialized;
@@ -791,10 +846,10 @@ const useProviderOptionSync = function useProviderOptionSync(
 				void kernel.commands.init();
 			}
 		}
-	}, [enabled, kernel, options.overrides]);
+	}, [enabled, kernel, options.overrides, owns]);
 
 	useEffect(() => {
-		if (previousEnabledRef.current === enabled) {
+		if (!owns || previousEnabledRef.current === enabled) {
 			return;
 		}
 		previousEnabledRef.current = enabled;
@@ -804,7 +859,7 @@ const useProviderOptionSync = function useProviderOptionSync(
 		kernel.set.consent(ALL_CONSENTS_ON);
 		kernel.set.activeUI('none');
 		kernel.set.hasConsented(true);
-	}, [enabled, kernel]);
+	}, [enabled, kernel, owns]);
 
 	useEffect(() => {
 		const nodeEnv = (
@@ -1046,12 +1101,14 @@ const IABGate = ({
 	initialModel,
 	kernel,
 	options,
+	runtime,
 	children,
 }: {
 	enabled: boolean;
 	initialModel?: string | null;
 	kernel: ConsentKernel;
 	options: NormalizedIABOptions | null;
+	runtime?: ConsentRuntime;
 	children: ReactNode;
 }) => {
 	const snapshot = useSyncExternalStore(
@@ -1064,6 +1121,23 @@ const IABGate = ({
 		model === 'iab' ||
 		model === null ||
 		(model === undefined && initialModel === 'iab');
+
+	// An external runtime already owns the CMP. Republish its handle rather
+	// than mounting a second one — two `__tcfapi` stubs on a page is a spec
+	// violation, not just wasted bytes.
+	if (runtime) {
+		if (!(enabled && shouldLoadIAB)) {
+			return children;
+		}
+		return (
+			<Suspense fallback={children}>
+				<LazyExternalIABProvider runtime={runtime}>
+					{children}
+				</LazyExternalIABProvider>
+			</Suspense>
+		);
+	}
+
 	const cmpId = options?.cmpId ?? snapshot.iab?.cmpId;
 
 	if (!enabled || !options || !shouldLoadIAB || typeof cmpId !== 'number') {
@@ -1117,6 +1191,8 @@ const normalizeIabOptions = function normalizeIabOptions(
 	};
 };
 
+const EMPTY_OPTIONS = {} as ConsentProviderOptions;
+
 /**
  * v3 ConsentProvider.
  *
@@ -1124,12 +1200,36 @@ const normalizeIabOptions = function normalizeIabOptions(
  * curated v2-like options surface to v3 modules. It does not mirror the
  * snapshot into React state; selector hooks still subscribe directly to
  * the kernel through `useSyncExternalStore`.
+ *
+ * Pass `runtime` to render a runtime someone else created. The provider
+ * then borrows its kernel and mounts none of the side-effecting modules —
+ * no second `init()`, no second persistence handle, no second `window.c15t`
+ * — and does not dispose it on unmount.
+ *
+ * @example
+ * ```tsx
+ * import { createConsentRuntime } from '@c15t/core/runtime';
+ *
+ * const runtime = createConsentRuntime({ mode: hosted({ url: '/api/c15t' }) });
+ * runtime.start();
+ *
+ * <ConsentProvider runtime={runtime} options={{ theme }}>
+ *   <ConsentDialog />
+ * </ConsentProvider>
+ * ```
  */
-export const ConsentProvider = ({
-	options,
-	children,
-}: ConsentProviderProps) => {
+export const ConsentProvider = (props: ConsentProviderProps) => {
+	const { children } = props;
+	const options = (props.options ?? EMPTY_OPTIONS) as ConsentProviderOptions;
+	// Initial-only, like `mode`: swapping the runtime under a mounted tree
+	// would leave every hook subscribed to the old kernel.
+	const [externalRuntime] = useState(() => props.runtime);
+	const ownsRuntime = externalRuntime === undefined;
+
 	const [providerKernelState, setProviderKernelState] = useState(() => {
+		if (props.runtime) {
+			return { eagerInit: false, kernel: props.runtime.kernel };
+		}
 		const created = createProviderKernel(options);
 		// Kick the init roundtrip off during first client render so its
 		// network latency overlaps hydration instead of following it — with
@@ -1151,11 +1251,25 @@ export const ConsentProvider = ({
 	const iabOptions = normalizeIabOptions(options.iab);
 	const { scripts, networkBlocker } = options;
 	const windowDebugPkg = options.__debugPkg ?? '@c15t/react';
-	const windowDebugMode = resolveWindowDebugMode(options.mode);
+	// `mode` is optional when a runtime is handed in — its owner picked the
+	// transport, and this provider mounts no `window.c15t` either way.
+	const windowDebugMode = ownsRuntime
+		? resolveWindowDebugMode(options.mode)
+		: 'hosted';
 
-	useProviderCallbacks(kernel, options.callbacks, reloadOnConsentRevoked);
-	useProviderOptionSync(kernel, options, enabled);
-	useEffect(() => () => kernel.dispose(), [kernel]);
+	useProviderCallbacks(
+		kernel,
+		options.callbacks,
+		reloadOnConsentRevoked,
+		ownsRuntime
+	);
+	useProviderOptionSync(kernel, options, enabled, ownsRuntime);
+	useEffect(() => {
+		if (!ownsRuntime) {
+			return;
+		}
+		return () => kernel.dispose();
+	}, [kernel, ownsRuntime]);
 
 	const userTheme = options.theme;
 
@@ -1188,29 +1302,35 @@ export const ConsentProvider = ({
 
 	useColorScheme(options.colorScheme);
 
+	// Everything below `WindowKernelMount` is a side-effecting module the
+	// runtime already mounts. A borrowed runtime renders none of it.
 	const providerChildren = (
 		<>
-			<InitMount
-				enabled={enabled}
-				kernel={kernel}
-				eagerInit={eagerInit}
-			/>
-			<WindowDebugMount
-				pkg={windowDebugPkg}
-				mode={windowDebugMode}
-			/>
 			<WindowKernelMount kernel={kernel} />
-			{enabled && persistenceOptions ? (
-				<PersistenceMount options={persistenceOptions} />
-			) : null}
-			{enabled && scripts && scripts.length > 0 ? (
-				<ScriptsMount
-					options={options.scriptLoader}
-					scripts={scripts}
-				/>
-			) : null}
-			{enabled && networkBlocker ? (
-				<NetworkBlockerMount options={networkBlocker} />
+			{ownsRuntime ? (
+				<>
+					<InitMount
+						enabled={enabled}
+						kernel={kernel}
+						eagerInit={eagerInit}
+					/>
+					<WindowDebugMount
+						pkg={windowDebugPkg}
+						mode={windowDebugMode}
+					/>
+					{enabled && persistenceOptions ? (
+						<PersistenceMount options={persistenceOptions} />
+					) : null}
+					{enabled && scripts && scripts.length > 0 ? (
+						<ScriptsMount
+							options={options.scriptLoader}
+							scripts={scripts}
+						/>
+					) : null}
+					{enabled && networkBlocker ? (
+						<NetworkBlockerMount options={networkBlocker} />
+					) : null}
+				</>
 			) : null}
 			{children}
 		</>
@@ -1231,6 +1351,7 @@ export const ConsentProvider = ({
 					}
 					kernel={kernel}
 					options={iabOptions}
+					runtime={externalRuntime}
 				>
 					{providerChildren}
 				</IABGate>

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1221,14 +1221,17 @@ const EMPTY_OPTIONS = {} as ConsentProviderOptions;
 export const ConsentProvider = (props: ConsentProviderProps) => {
 	const { children } = props;
 	const options = (props.options ?? EMPTY_OPTIONS) as ConsentProviderOptions;
-	// Initial-only, like `mode`: swapping the runtime under a mounted tree
-	// would leave every hook subscribed to the old kernel.
-	const [externalRuntime] = useState(() => props.runtime);
-	const ownsRuntime = externalRuntime === undefined;
-
-	const [providerKernelState, setProviderKernelState] = useState(() => {
-		if (props.runtime) {
-			return { eagerInit: false, kernel: props.runtime.kernel };
+	// The runtime, like `mode`, is initial-only: swapping it under a mounted
+	// tree would leave every hook subscribed to the old kernel. Capturing it
+	// in the same lazy state as the kernel is what pins it.
+	const [providerKernelState, setProviderKernelState] = useState<{
+		eagerInit: boolean;
+		kernel: ConsentKernel;
+		external?: ConsentRuntime;
+	}>(() => {
+		const external = props.runtime;
+		if (external) {
+			return { eagerInit: false, external, kernel: external.kernel };
 		}
 		const created = createProviderKernel(options);
 		// Kick the init roundtrip off during first client render so its
@@ -1244,7 +1247,8 @@ export const ConsentProvider = (props: ConsentProviderProps) => {
 		return { eagerInit: shouldEagerInit, kernel: created };
 	});
 	void setProviderKernelState;
-	const { kernel, eagerInit } = providerKernelState;
+	const { kernel, eagerInit, external: externalRuntime } = providerKernelState;
+	const ownsRuntime = externalRuntime === undefined;
 	const enabled = getEnabled(options);
 	const reloadOnConsentRevoked = options.reloadOnConsentRevoked !== false;
 	const persistenceOptions = normalizePersistenceOptions(options);

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -59,6 +59,10 @@ export default mergeConfig(
 					'@c15t/core/modules/window-debug',
 					resolve(__dirname, '../core/src/modules/window-debug/index.ts'),
 				],
+				[
+					'@c15t/core/runtime',
+					resolve(__dirname, '../core/src/runtime/index.ts'),
+				],
 				['@c15t/core', resolve(__dirname, '../core/src/index.ts')],
 				['@c15t/schema/types', resolve(__dirname, '../schema/src/types.ts')],
 				[

--- a/packages/vue/src/__tests__/conformance.test.ts
+++ b/packages/vue/src/__tests__/conformance.test.ts
@@ -624,6 +624,7 @@ const createControlledContext = function createControlledContext(
 		},
 		init: computed(() => snapshotToInitOutputForTest(snapshot.value)),
 		kernel,
+		ownsKernel: true,
 		snapshot,
 		storedConsent: computed({
 			get: () => snapshotToStoredConsentForTest(snapshot.value),

--- a/packages/vue/src/__tests__/external-runtime.test.ts
+++ b/packages/vue/src/__tests__/external-runtime.test.ts
@@ -1,0 +1,96 @@
+import { hosted } from '@c15t/core';
+import { createConsentRuntime } from '@c15t/core/runtime';
+import type { ConsentRuntime } from '@c15t/core/runtime';
+import { mount } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+import { defineComponent, h, inject } from 'vue';
+
+import { c15tVue } from '../index';
+import {
+	createVueConsentKernelContext,
+	startVueConsentRuntime,
+} from '../runtime/kernel';
+import { symbolKernel } from '../runtime/utils/symbols';
+
+const createRuntime = function createRuntime(): ConsentRuntime {
+	return createConsentRuntime({
+		mode: hosted({ url: 'https://consent.example.test' }),
+		pkg: '@c15t/vue-test',
+	});
+};
+
+const KernelProbe = defineComponent({
+	setup() {
+		const kernel = inject(symbolKernel);
+		return () => h('div', { 'data-kernel': Boolean(kernel) });
+	},
+});
+
+describe('createVueConsentKernelContext with an external runtime', () => {
+	test('renders the runtime kernel instead of creating one', () => {
+		const runtime = createRuntime();
+		const context = createVueConsentKernelContext({ config: {}, runtime });
+
+		expect(context.kernel).toBe(runtime.kernel);
+		expect(context.ownsKernel).toBe(false);
+		expect(context.snapshot.value).toEqual(runtime.kernel.getSnapshot());
+	});
+
+	test('does not dispose a kernel it was handed', () => {
+		const runtime = createRuntime();
+		const dispose = vi.spyOn(runtime.kernel, 'dispose');
+		const context = createVueConsentKernelContext({ config: {}, runtime });
+
+		context.dispose();
+
+		expect(dispose).not.toHaveBeenCalled();
+		expect(runtime.kernel.getSnapshot()).toBeTruthy();
+	});
+
+	test('still owns the kernel when no runtime is passed', () => {
+		const context = createVueConsentKernelContext({ config: {} });
+		const dispose = vi.spyOn(context.kernel, 'dispose');
+
+		expect(context.ownsKernel).toBe(true);
+		context.dispose();
+		expect(dispose).toHaveBeenCalled();
+	});
+});
+
+describe('startVueConsentRuntime with an external runtime', () => {
+	test('mounts none of the modules the runtime already owns', () => {
+		const runtime = createRuntime();
+		const init = vi.spyOn(runtime.kernel.commands, 'init');
+		const context = createVueConsentKernelContext({ config: {}, runtime });
+
+		const stop = startVueConsentRuntime(context, {});
+
+		expect(init).not.toHaveBeenCalled();
+		expect(
+			(window as Window & { c15t?: { pkg: string } }).c15t
+		).toBeUndefined();
+
+		stop();
+		expect(runtime.kernel.getSnapshot()).toBeTruthy();
+	});
+});
+
+describe('the c15tVue plugin', () => {
+	test('provides the runtime kernel and leaves its lifecycle alone', () => {
+		const runtime = createRuntime();
+		const dispose = vi.spyOn(runtime.kernel, 'dispose');
+		const init = vi.spyOn(runtime.kernel.commands, 'init');
+
+		const wrapper = mount(KernelProbe, {
+			global: { plugins: [[c15tVue, { runtime }]] },
+		});
+
+		expect(wrapper.vm.$.appContext.provides[symbolKernel as symbol]).toBe(
+			runtime.kernel
+		);
+		expect(init).not.toHaveBeenCalled();
+
+		wrapper.unmount();
+		expect(dispose).not.toHaveBeenCalled();
+	});
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,4 @@
+import type { ConsentRuntime } from '@c15t/core/runtime';
 import type { App, Plugin } from 'vue';
 
 import { consentConfigKey } from './runtime/composables/config';
@@ -22,14 +23,37 @@ export type {
 	ConsentConfig as VueConsentConfig,
 } from './runtime/config';
 
-export const c15tVue: Plugin<[Partial<ConsentConfig>?]> = {
-	install(app: App, options?: Partial<ConsentConfig>) {
+/** Options accepted by the {@link c15tVue} plugin. */
+export type C15tVuePluginOptions = Partial<ConsentConfig> & {
+	/**
+	 * A runtime this app should render instead of building its own kernel.
+	 *
+	 * Hosts without a single component tree — an Astro page whose islands
+	 * cannot see each other, a SvelteKit layout — create one runtime with
+	 * `createConsentRuntime()` and hand it to whatever renders. The plugin
+	 * then neither starts nor disposes it, and mounts none of the modules
+	 * the runtime already owns.
+	 *
+	 * @example
+	 * ```ts
+	 * import { createApp } from 'vue';
+	 * import { c15tVue } from '@c15t/vue/vue-plugin';
+	 *
+	 * createApp(Dialog).use(c15tVue, { runtime }).mount(target);
+	 * ```
+	 */
+	runtime?: ConsentRuntime;
+};
+
+export const c15tVue: Plugin<[C15tVuePluginOptions?]> = {
+	install(app: App, options?: C15tVuePluginOptions) {
 		if (options) {
 			app.provide(consentConfigKey, options);
 		}
 
-		const config = (options ?? {}) as ConsentConfig;
-		const context = createVueConsentKernelContext({ config });
+		const { runtime, ...rest } = options ?? {};
+		const config = rest as ConsentConfig;
+		const context = createVueConsentKernelContext({ config, runtime });
 		app.provide(symbolKernelContext, context);
 		app.provide(symbolKernel, context.kernel);
 		app.provide(symbolSnapshot, context.snapshot);

--- a/packages/vue/src/runtime/kernel.ts
+++ b/packages/vue/src/runtime/kernel.ts
@@ -29,6 +29,7 @@ import type {
 import { createScriptLoader } from '@c15t/core/modules/script-loader';
 import type { Script } from '@c15t/core/modules/script-loader';
 import { createWindowDebug } from '@c15t/core/modules/window-debug';
+import type { ConsentRuntime } from '@c15t/core/runtime';
 import type { ConsentActiveUI } from '@c15t/schema/config';
 import {
 	CONSENT_REQUEST_HEADER_NAMES,
@@ -55,6 +56,12 @@ export interface VueConsentKernelContext {
 	init: Ref<InitOutput | undefined>;
 	activeUI: Ref<ConsentActiveUI>;
 	storedConsent: Ref<Consent>;
+	/**
+	 * Whether this context created the kernel. `false` when a
+	 * {@link ConsentRuntime} was handed in — its owner runs `start()` and
+	 * `dispose()`, and every side-effecting module belongs to it.
+	 */
+	ownsKernel: boolean;
 	dispose: () => void;
 }
 
@@ -431,28 +438,64 @@ const createVueManifestTransport = function createVueManifestTransport(
 	};
 };
 
+const createContextKernel = function createContextKernel(options: {
+	config: RuntimeConsentConfig;
+	headers: Record<string, string>;
+	prefetch?: InitOutput;
+	initialStoredConsent?: StoredPayload | null;
+}): ConsentKernel {
+	const { config, headers } = options;
+	const transport = isClientManifestModeEnabled(config)
+		? createVueManifestTransport(config, headers, options.prefetch)
+		: createVueHostedTransport(
+				config,
+				headers,
+				isServerManifestModeEnabled(config)
+					? getNuxtInitFetchTarget(config)?.url
+					: undefined
+			);
+	return createConsentKernel({
+		...initOutputToKernelConfig(options.prefetch, headers),
+		...storedPayloadToKernelConfig(options.initialStoredConsent),
+		transport,
+	});
+};
+
+/**
+ * Build the reactive consent context a Vue app provides.
+ *
+ * @param options - Config, request headers, prefetched init and, optionally,
+ * an externally owned runtime to borrow instead of building a kernel.
+ * @returns Refs and computed values for the composables, plus a disposer.
+ * @example
+ * ```ts
+ * // Borrow a runtime an Astro page already created.
+ * const context = createVueConsentKernelContext({ config: {}, runtime });
+ * ```
+ */
 export const createVueConsentKernelContext =
 	function createVueConsentKernelContext(options: {
 		config: RuntimeConsentConfig;
 		headers?: Record<string, string | undefined>;
 		prefetch?: InitOutput;
 		initialStoredConsent?: StoredPayload | null;
+		/**
+		 * A runtime whose kernel this context should render. When present no
+		 * transport and no kernel are created, and `dispose()` only drops
+		 * this context's own subscription.
+		 */
+		runtime?: ConsentRuntime;
 	}): VueConsentKernelContext {
 		const headers = pickAllowedInitHeaders(options.headers ?? {});
-		const transport = isClientManifestModeEnabled(options.config)
-			? createVueManifestTransport(options.config, headers, options.prefetch)
-			: createVueHostedTransport(
-					options.config,
-					headers,
-					isServerManifestModeEnabled(options.config)
-						? getNuxtInitFetchTarget(options.config)?.url
-						: undefined
-				);
-		const kernel = createConsentKernel({
-			...initOutputToKernelConfig(options.prefetch, headers),
-			...storedPayloadToKernelConfig(options.initialStoredConsent),
-			transport,
-		});
+		const ownsKernel = options.runtime === undefined;
+		const kernel =
+			options.runtime?.kernel ??
+			createContextKernel({
+				config: options.config,
+				headers,
+				initialStoredConsent: options.initialStoredConsent,
+				prefetch: options.prefetch,
+			});
 
 		const snapshot = shallowRef(kernel.getSnapshot());
 		const unsubscribe = kernel.subscribe((next) => {
@@ -475,10 +518,15 @@ export const createVueConsentKernelContext =
 			activeUI,
 			dispose() {
 				unsubscribe();
-				kernel.dispose();
+				// Only the owner disposes. A borrowed kernel outlives this
+				// component tree — other islands on the page still read it.
+				if (ownsKernel) {
+					kernel.dispose();
+				}
 			},
 			init,
 			kernel,
+			ownsKernel,
 			snapshot,
 			storedConsent,
 		};
@@ -545,12 +593,31 @@ const refreshClientGeo = async function refreshClientGeo(
 	}
 };
 
+/**
+ * Mount the browser-side modules a Vue consent app needs.
+ *
+ * A context built around an externally owned runtime mounts nothing: that
+ * runtime already installed persistence, the script loader, the blockers,
+ * `window.c15t` and the initial `init()`, and doing any of it twice would
+ * double-write storage and install a second debug global.
+ *
+ * @param context - The context from {@link createVueConsentKernelContext}.
+ * @param config - The runtime consent configuration.
+ * @param options - Set `runInit: false` to skip the initial `init()`.
+ * @returns A disposer that undoes everything this call mounted.
+ */
 export const startVueConsentRuntime = function startVueConsentRuntime(
 	context: VueConsentKernelContext,
 	config: RuntimeConsentConfig,
 	options: { runInit?: boolean } = {}
 ): () => void {
 	const disposers: (() => void)[] = [];
+
+	if (!context.ownsKernel) {
+		return () => {
+			context.dispose();
+		};
+	}
 
 	if (typeof document !== 'undefined') {
 		const windowDebug = createWindowDebug({

--- a/packages/vue/src/vite.ts
+++ b/packages/vue/src/vite.ts
@@ -24,16 +24,30 @@ const stubPath = resolveRuntimeModule(
 	'./runtime/vue/stubs.js'
 );
 
+const composablesPath = resolveRuntimeModule(
+	'./runtime/composables/index.ts',
+	'./runtime/composables/index.js'
+);
+
+/**
+ * Resolve the Nuxt-shaped specifiers `@c15t/vue`'s shared runtime uses.
+ *
+ * `#imports` and `#c15t/composables` are Nuxt virtuals; a plain Vue or
+ * Astro app has neither. Both are answered from `resolveId` rather than
+ * `resolve.alias` alone: a host that sets its own aliases in array form
+ * (Astro does) replaces the object this plugin's `config()` contributes
+ * instead of merging with it, and the composables specifier then reaches
+ * Rollup unresolved. The alias stays for anything that reads it directly.
+ *
+ * @returns The Vite plugin to list in a non-Nuxt app's config.
+ */
 export const c15tVue = function c15tVue(): Plugin {
 	return {
 		config() {
 			return {
 				resolve: {
 					alias: {
-						'#c15t/composables': resolveRuntimeModule(
-							'./runtime/composables/index.ts',
-							'./runtime/composables/index.js'
-						),
+						'#c15t/composables': composablesPath,
 					},
 				},
 			};
@@ -43,6 +57,9 @@ export const c15tVue = function c15tVue(): Plugin {
 		resolveId(id) {
 			if (id === '#imports') {
 				return stubPath;
+			}
+			if (id === '#c15t/composables') {
+				return composablesPath;
 			}
 		},
 	};

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -69,6 +69,12 @@ export default mergeConfig(
 						'../core/src/transports/manifest.ts'
 					),
 				},
+				{
+					'@c15t/core/runtime': resolve(
+						__dirname,
+						'../core/src/runtime/index.ts'
+					),
+				},
 				{ '@c15t/core': resolve(__dirname, '../core/src/index.ts') },
 				{
 					'@c15t/translations/all': resolve(


### PR DESCRIPTION
## Summary

Lets an Astro site render the consent dialogs with the framework it already ships. Svelte stays the default; `ui: 'react'` and `ui: 'vue'` are explicit opt-ins, never auto-detected. Also wires the colour scheme through to first paint and fixes the Astro server path refetching the manifest on every render.

Stacked on the `@c15t/astro` PR; review this layer's diff only.

## What's in here

**External runtime for the React and Vue providers**

- `@c15t/react`'s `ConsentProvider` accepts `runtime?: ConsentRuntime`. It borrows the handed-in kernel, skips its own module setup, and never starts or disposes it. Its IAB bridge republishes `runtime.iab` from a separate chunk so `@c15t/iab` stays off the preference-centre path.
- `@c15t/vue`'s `c15tVue` plugin accepts a `runtime` option and provides it; the Nuxt module is unchanged.

**`ui: 'react'` and `ui: 'vue'` dialog islands**

- Both are lazily imported surfaces split the same way as the Svelte one: preferences dialog and IAB dialog as separate chunks, each rendering the framework's dialog inside that framework's provider with the page-level runtime passed in.
- The adapter registry ships empty; the integration writes the one chosen adapter and island specifier into the injected page script, both behind `import()`. A source-level guard test enforces that a Svelte-only build never resolves React or Vue.
- Build-time validation: the matching `@astrojs/react` or `@astrojs/vue` integration must be present, with a clear error otherwise, and a one-line suggestion when one is installed while `ui` is left at the default. `react`, `react-dom` and `vue` are optional peers.

**Colour scheme**

- `colorScheme` option (`'light' | 'dark' | 'system'`, default `'system'`). The client boot calls `setupColorScheme()` once per page and re-applies it on `astro:after-swap`, disposing the previous media-query listener.
- `<ConsentScript />` emits a 119-byte inline head script that sets the `c15t-dark` class before the stylesheet paints, so the zero-JS server-rendered banner does not flash light on dark systems. Verified with every `/_astro/*.js` request blocked: the dark context gets the dark surface token and card, the light context gets white.

**Manifest cache on the server render path** (found by the stacked benchmark)

- `prefetchLocal` built a fresh manifest transport per request, so manifest mode refetched the manifest on every render, nine fetches across eight renders and 33 for returning visitors, with 209 ms TTFB at 200 ms backend latency. The middleware path now goes through `fetchCachedManifest` from `@c15t/core/server`, shared with the injected `/api/c15t/init` route.
- `createConsentMiddleware` skips the integration's own init and manifest routes, plus a new `middleware: { skip: [...] }` list, so the `pre` middleware can no longer recurse into its own API routes.

Measured on the Astro bench, mobile profile with 200 ms injected latency:

| Arm | Manifest fetches per 8 renders | TTFB |
| --- | ---: | ---: |
| ssr-manifest before | 9 | 212 ms |
| ssr-manifest after | 1 | 5.7 ms |
| repeat-visitor before | 9 | 214 ms |
| repeat-visitor after | 1 | 6.4 ms |

Banner paint on that arm went from 644 ms to 552 ms.

**Two parity bugs fixed** that building the demo three ways surfaced: React's dialog Save committed nothing without a draft provider, and the offline server prefetch never narrowed the policy to the configured `consentCategories`, so React offered categories the site never configured.

## Bundle proof

`examples/astro-demo` built once per `ui` value, gzip of the dialog chunk graph, content-scanned for exactly one framework runtime each:

| `ui` | Dialog chunk graph |
| --- | ---: |
| svelte | 74.6 KB |
| react | 115.9 KB |
| vue | 139.7 KB |

## Verification

- `packages/astro` 165 tests, `packages/react` 426, `packages/vue` 101, `packages/core` 458; check-types and repo lint clean; `astro check` clean for all three `ui` values
- Playwright against all three real builds: opens the dialog, toggles marketing, saves, zero console errors

## Follow-ups

- The Vue dialog surface is about 1.8x the React and Svelte equivalents.
- The React draft-provider fix is patched in the islands and should move upstream into `@c15t/react`.
- `resolveBackendURL` in `@c15t/schema` defaults a relative backend URL to `https` without `x-forwarded-proto`, which breaks plain-HTTP hosts. Documented, not fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Astro support with Svelte, React, or Vue consent dialogs selectable at build time.
  - Added externally managed runtime support for React and Vue integrations.
  - Added configurable light, dark, and system color schemes.
  - Added middleware path exclusions and improved relative URL handling.
- **Improvements**
  - Cached manifest requests and narrowed offline policies to configured consent categories.
  - Dialog and IAB surfaces now load on demand.
- **Bug Fixes**
  - Improved Vue module resolution with array-based host aliases.
  - Improved validation for unsupported dialog frameworks and repeated client disposal.
- **Documentation**
  - Updated Astro demo documentation for framework selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->