### PR TITLE
test(parity): cross-framework geometry and pixel gate, Astro Storybook, and the drift it caught

### DIFF
--- a/.changeset/react-widget-footer-grouping.md
+++ b/.changeset/react-widget-footer-grouping.md
@@ -1,0 +1,23 @@
+---
+'c15t': patch
+'@c15t/react': patch
+'@c15t/ui': patch
+---
+
+The React consent widget now groups its footer actions the way every other
+surface does.
+
+With a policy that carries no UI hints, `useHeadlessConsentUI` fell back to
+a single undifferentiated action group, so the preference centre rendered
+reject, accept and save in one row while the banner — which had its own
+local `DEFAULT_LAYOUT` — split them. Svelte, Vue and Astro all split.
+
+`@c15t/core` now exports `DEFAULT_POLICY_ACTION_LAYOUT`
+(`[['reject', 'accept'], 'customize']`), re-exported from
+`@c15t/ui/utils`, and `useHeadlessConsentUI` applies it to both surfaces.
+The banner's local constant is gone, so the two cannot drift again.
+
+The banner's `customize` action now renders inside its own sub-group
+rather than as a loose child of the footer, which is what the shared
+`consent-actions` `space-between` layout expects and what the other
+frameworks already produced.

--- a/.changeset/react-widget-footer-grouping.md
+++ b/.changeset/react-widget-footer-grouping.md
@@ -1,5 +1,6 @@
 ---
 'c15t': patch
+'@c15t/core': patch
 '@c15t/react': patch
 '@c15t/ui': patch
 ---

--- a/.changeset/ui-default-theme-tokens.md
+++ b/.changeset/ui-default-theme-tokens.md
@@ -1,0 +1,5 @@
+---
+'@c15t/ui': patch
+---
+
+Ship the default theme tokens in the published stylesheets. `styles.css`, `styles.tw3.css` and the IAB entrypoints now start with the `defaultTheme` tokens (`--c15t-surface`, `--c15t-radius-lg`, `--c15t-font-family`, ...) generated from the same `defaultTheme` the runtime exports, so an app that imports the stylesheet without passing a `theme` gets the default look instead of an unstyled banner — serif fallback font, square corners, transparent buttons. This matters most for server-rendered, zero-JS pages, which can never inject tokens client-side. A provider that does pass a `theme` still overrides them.

--- a/.changeset/ui-title-margin-reset.md
+++ b/.changeset/ui-title-margin-reset.md
@@ -1,0 +1,16 @@
+---
+'@c15t/ui': patch
+---
+
+The banner and dialog titles no longer inherit the user agent's heading
+margins.
+
+React renders both titles as `<h2>` for the heading semantics; Svelte, Vue
+and Astro render `<div role="heading" aria-level="2">`. The shared `.title`
+rules set no `margin`, so the `<h2>` kept the browser default — 13.28px
+above and below on the banner, 11.62px on the dialog — and the same
+component came out 26px taller in React than everywhere else (banner card
+442x217 against 442x191, dialog card 448x533 against 448x510).
+
+The rules now reset `margin` the way the accordion, preference-item and
+IAB title rules already do. React keeps its `<h2>`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - name: 🏗️ Build Storybooks
         # Use turbo so workspace deps (notably @c15t/ui CSS dist) build
         # before the storybook builds consume them via PostCSS @import.
-        run: bun turbo run build --filter=@c15t/storybook-react --filter=@c15t/storybook-svelte --filter=@c15t/storybook-vue
+        run: bun turbo run build --filter=@c15t/storybook-react --filter=@c15t/storybook-svelte --filter=@c15t/storybook-vue --filter=@c15t/storybook-astro
 
       - name: 🌐 Serve Storybooks
         run: |
@@ -297,8 +297,9 @@ jobs:
           bunx --no-install http-server apps/storybook-react/storybook-static --port 6006 --silent &
           bunx --no-install http-server apps/storybook-svelte/storybook-static --port 6007 --silent &
           bunx --no-install http-server apps/storybook-vue/storybook-static --port 6008 --silent &
+          bunx --no-install http-server apps/storybook-astro/storybook-static --port 6010 --silent &
           # Wait for all to be reachable before continuing.
-          for port in 6006 6007 6008; do
+          for port in 6006 6007 6008 6010; do
             ready=false
             for i in {1..30}; do
               if curl --fail --silent "http://127.0.0.1:$port/index.json" >/dev/null; then
@@ -318,7 +319,8 @@ jobs:
           REACT_STORYBOOK_URL: http://127.0.0.1:6006
           SVELTE_STORYBOOK_URL: http://127.0.0.1:6007
           VUE_STORYBOOK_URL: http://127.0.0.1:6008
-          PARITY_FRAMEWORKS: react,svelte,vue
+          ASTRO_STORYBOOK_URL: http://127.0.0.1:6010
+          PARITY_FRAMEWORKS: react,svelte,vue,astro
         # --ignore-snapshots: committed screenshot baselines are darwin-only;
         # DOM/a11y/computed-style parity is still fully enforced. Drop the
         # flag once linux baselines are generated (e.g. via the Playwright
@@ -342,6 +344,12 @@ jobs:
         env:
           STORYBOOK_URL: http://127.0.0.1:6008
         run: bun run --cwd apps/storybook-vue test-storybook
+
+      - name: 📖 Run Storybook interaction tests (astro)
+        if: ${{ !cancelled() }}
+        env:
+          STORYBOOK_URL: http://127.0.0.1:6010
+        run: bun run --cwd apps/storybook-astro test-storybook
 
       - name: ⬆️ Upload Playwright report
         if: failure()

--- a/apps/parity-runner/README.md
+++ b/apps/parity-runner/README.md
@@ -1,13 +1,107 @@
-# Cross-framework comparisons
+# Parity runner
 
-Start the React, Svelte, and Vue Storybooks, then run:
+Cross-framework conformance for the c15t consent surfaces. It loads the
+same story from every framework's Storybook and asserts they are the same
+component, not just components with the same name.
+
+React is the baseline. Everything else is measured against it.
+
+## The checks
+
+`tests/parity.spec.ts` — descriptive parity:
+
+- **DOM** — normalized tree, with framework-specific class hashing and
+  auto-generated ids stripped.
+- **A11y** — the accessibility tree.
+- **Computed style** — every declared property and CSS custom property on
+  every `[data-testid]` element.
+- **Screenshot** — a per-framework committed baseline, which catches
+  regressions inside one framework. It is not a cross-framework diff.
+
+`tests/visual-parity.spec.ts` — visual parity:
+
+- **Geometry** — every `[data-testid]` slot's box (`x`, `y`, `width`,
+  `height`), measured relative to the card it sits in, must match React
+  within **1px**. Deterministic and image-free.
+
+  This exists because the descriptive checks are blind to a whole class of
+  drift. A `<h2 data-testid="consent-banner-title">` and a
+  `<div role="heading" data-testid="consent-banner-title">` have the same
+  normalized DOM, the same a11y node and the same declared CSS — and the
+  `<h2>` carries the user agent's 13.28px block margins, making the banner
+  card 26px taller. Nothing but a measurement sees that.
+
+  Boxes are relative to the card, not the viewport, because each Storybook
+  wraps stories differently; the absolute offset would only ever measure
+  the wrapper. Repeated slots are indexed (`consent-banner-footer-sub-group`,
+  `consent-banner-footer-sub-group[1]`), so a framework that groups its
+  footer actions differently fails on the count.
+
+- **Pixel backstop** — element screenshots of `consent-banner-card` and
+  `consent-dialog-card`, compared to React with a per-channel tolerance of
+  **12** and a mismatch budget of **0.5%** of pixels. Loose on
+  antialiasing, which is never identical between two renderers; strict on
+  size, where a mismatch fails outright. Failures attach the two
+  screenshots and a diff image to the Playwright report.
+
+  Font rasterisation is machine-specific, so the budget is calibrated for
+  CI's pinned Chromium. Set `PARITY_SKIP_PIXEL=1` to skip it locally.
+
+## The allowlist
+
+`src/parity-allowlist.ts` records drift that is real, known, and not the
+current branch's job to fix. Entries are keyed by check, framework, story
+and slot, and every one carries a **required** reason — a link, an issue,
+or the constraint that forces it. An entry with a vague reason is worse
+than a red test, because it hides one without recording why.
+
+`'*'` matches everything in a position. Prefer the narrowest key that
+covers the drift, so an unrelated regression in the same story still
+fails. A bare slot id matches every repeat index of that slot.
+
+Nothing expires on its own, so the geometry check fails on any entry that
+matched nothing during a run — delete a stale allowance rather than
+leaving it to rot.
+
+## Running it
+
+Every Storybook has to be built and served first:
 
 ```sh
-PARITY_FRAMEWORKS=react,svelte,vue bun run --cwd apps/parity-runner test:parity
+bun turbo run build --filter=@c15t/storybook-react --filter=@c15t/storybook-svelte \
+  --filter=@c15t/storybook-vue --filter=@c15t/storybook-astro
+
+bunx http-server apps/storybook-react/storybook-static  --port 6006 --silent &
+bunx http-server apps/storybook-svelte/storybook-static --port 6007 --silent &
+bunx http-server apps/storybook-vue/storybook-static    --port 6008 --silent &
+bunx http-server apps/storybook-astro/storybook-static  --port 6010 --silent &
+
+PARITY_FRAMEWORKS=react,svelte,vue,astro PARITY_SKIP_PIXEL=1 \
+  bun run --cwd apps/parity-runner test:parity --ignore-snapshots
 ```
 
-The default URLs are ports 6006, 6007, and 6008. Override them with
-`REACT_STORYBOOK_URL`, `SVELTE_STORYBOOK_URL`, and `VUE_STORYBOOK_URL`.
+| Variable | Default |
+| --- | --- |
+| `REACT_STORYBOOK_URL` | `http://127.0.0.1:6006` |
+| `SVELTE_STORYBOOK_URL` | `http://127.0.0.1:6007` |
+| `VUE_STORYBOOK_URL` | `http://127.0.0.1:6008` |
+| `SOLID_STORYBOOK_URL` | `http://127.0.0.1:6009` |
+| `ASTRO_STORYBOOK_URL` | `http://127.0.0.1:6010` |
+| `PARITY_FRAMEWORKS` | `react,svelte` |
+| `PARITY_SKIP_PIXEL` | unset |
+| `PARITY_DEBUG` | unset — prints the first DOM/a11y diff |
+
+`--ignore-snapshots` skips the per-framework screenshot baselines, which
+are darwin-only. `--update-snapshots` regenerates them.
+
+## Pairing
+
+Stories pair by stripping the `{FRAMEWORK}` segment from the Storybook
+title, so `COMPONENTS - REACT/Core/Consent Banner` pairs with
+`COMPONENTS - SVELTE/Core/Consent Banner` and
+`COMPONENTS - ASTRO/Core/Consent Banner`. The rest of the title is part of
+the key: rename a section in one Storybook and that framework silently
+drops out of every comparison.
 
 ## DevTools
 

--- a/apps/parity-runner/package.json
+++ b/apps/parity-runner/package.json
@@ -9,11 +9,14 @@
 		"test:update-snapshots": "playwright test --update-snapshots"
 	},
 	"dependencies": {
-		"@c15t/conformance": "workspace:*"
+		"@c15t/conformance": "workspace:*",
+		"pixelmatch": "^7.2.0",
+		"pngjs": "^7.0.0"
 	},
 	"devDependencies": {
 		"@c15t/typescript-config": "workspace:*",
 		"@playwright/test": "^1.55.0",
+		"@types/pngjs": "^6.0.5",
 		"typescript": "6.0.3"
 	}
 }

--- a/apps/parity-runner/src/diff-computed-style.test.ts
+++ b/apps/parity-runner/src/diff-computed-style.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'bun:test';
+
+import {
+	normalizeComputedStyleMap,
+	normalizeCssValue,
+} from './diff-computed-style';
+
+test('normalizeCssValue restores a missing leading zero', () => {
+	expect(normalizeCssValue('.5rem')).toBe('0.5rem');
+	expect(normalizeCssValue('cubic-bezier(.4, 0, .2, 1)')).toBe(
+		'cubic-bezier(0.4, 0, 0.2, 1)'
+	);
+	expect(normalizeCssValue('rgba(0, 0, 0, .08)')).toBe('rgba(0, 0, 0, 0.08)');
+});
+
+test('normalizeCssValue converts seconds to milliseconds', () => {
+	expect(normalizeCssValue('.15s')).toBe('150ms');
+	expect(normalizeCssValue('2s')).toBe('2000ms');
+	expect(normalizeCssValue('0.08s')).toBe('80ms');
+});
+
+test('normalizeCssValue leaves milliseconds alone', () => {
+	expect(normalizeCssValue('150ms')).toBe('150ms');
+	expect(normalizeCssValue('80ms cubic-bezier(0.4, 0, 0.2, 1)')).toBe(
+		'80ms cubic-bezier(0.4, 0, 0.2, 1)'
+	);
+});
+
+test('normalizeCssValue strips the CSS Modules hash from a scoped name', () => {
+	expect(normalizeCssValue('_enter_t5rx4_1')).toBe('enter');
+	expect(
+		normalizeCssValue('_enter_t5rx4_1 80ms cubic-bezier(.4, 0, .2, 1)')
+	).toBe('enter 80ms cubic-bezier(0.4, 0, 0.2, 1)');
+});
+
+test('normalizeCssValue folds the two spellings onto one another', () => {
+	const minified = normalizeCssValue(
+		'enter 80ms cubic-bezier(.4, 0, .2, 1), fade .15s linear'
+	);
+	const authored = normalizeCssValue(
+		'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1), _fade_t5rx4_2 150ms linear'
+	);
+	expect(minified).toBe(authored);
+});
+
+test('normalizeCssValue drops trailing zeros', () => {
+	expect(normalizeCssValue('1.50px')).toBe('1.5px');
+	expect(normalizeCssValue('2.0rem')).toBe('2rem');
+	expect(normalizeCssValue('10px')).toBe('10px');
+});
+
+test('normalizeCssValue leaves values it does not recognise alone', () => {
+	expect(normalizeCssValue('rgb(255, 255, 255)')).toBe('rgb(255, 255, 255)');
+	expect(normalizeCssValue('"Inter", system-ui, sans-serif')).toBe(
+		'"Inter", system-ui, sans-serif'
+	);
+	expect(normalizeCssValue('translate3d(0, 0, 0)')).toBe(
+		'translate3d(0, 0, 0)'
+	);
+	expect(normalizeCssValue('none')).toBe('none');
+});
+
+test('normalizeComputedStyleMap normalizes values, not keys', () => {
+	const normalized = normalizeComputedStyleMap({
+		'consent-banner-card': {
+			customProperties: { '--accordion-radius': '.5rem' },
+			properties: { 'border-radius': '.5rem', display: 'flex' },
+		},
+	});
+
+	expect(normalized).toEqual({
+		'consent-banner-card': {
+			customProperties: { '--accordion-radius': '0.5rem' },
+			properties: { 'border-radius': '0.5rem', display: 'flex' },
+		},
+	});
+});

--- a/apps/parity-runner/src/diff-computed-style.test.ts
+++ b/apps/parity-runner/src/diff-computed-style.test.ts
@@ -38,7 +38,10 @@ test('normalizeCssValue folds the two spellings onto one another', () => {
 		'enter 80ms cubic-bezier(.4, 0, .2, 1), fade .15s linear'
 	);
 	const authored = normalizeCssValue(
-		'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1), _fade_t5rx4_2 150ms linear'
+		[
+			'_enter_t5rx4_1 80ms cubic-bezier(0.4, 0, 0.2, 1),',
+			'_fade_t5rx4_2 150ms linear',
+		].join(' ')
 	);
 	expect(minified).toBe(authored);
 });
@@ -74,4 +77,33 @@ test('normalizeComputedStyleMap normalizes values, not keys', () => {
 			properties: { 'border-radius': '0.5rem', display: 'flex' },
 		},
 	});
+});
+
+test('normalizeCssValue leaves url() payloads alone', () => {
+	// `2s.svg` is a file name, not a duration: folding it would make this
+	// compare equal to a genuinely different `url(/assets/2000ms.svg)`.
+	expect(normalizeCssValue('url(/assets/2s.svg)')).toBe('url(/assets/2s.svg)');
+	expect(normalizeCssValue('url("/assets/.5x_a1b2c3_1.png")')).toBe(
+		'url("/assets/.5x_a1b2c3_1.png")'
+	);
+	expect(normalizeCssValue("url('/a/1.50s.woff2')")).toBe(
+		"url('/a/1.50s.woff2')"
+	);
+});
+
+test('normalizeCssValue leaves quoted strings alone', () => {
+	expect(normalizeCssValue('"2s.svg"')).toBe('"2s.svg"');
+	expect(normalizeCssValue("content: '.5 _x_a1b2c3_1'")).toBe(
+		"content: '.5 _x_a1b2c3_1'"
+	);
+});
+
+test('normalizeCssValue still folds the text around an opaque segment', () => {
+	expect(normalizeCssValue('url(/a/2s.svg) .15s _enter_t5rx4_1')).toBe(
+		'url(/a/2s.svg) 150ms enter'
+	);
+});
+
+test('normalizeCssValue does not read a path segment as a duration', () => {
+	expect(normalizeCssValue('2s/cover')).toBe('2s/cover');
 });

--- a/apps/parity-runner/src/diff-computed-style.ts
+++ b/apps/parity-runner/src/diff-computed-style.ts
@@ -7,6 +7,15 @@
  * via `diffComputedStyleMap` from `@c15t/conformance`.
  * Pass `*` as `elementSelector` to compare all descendants by DOM order.
  *
+ * Values are canonicalised before they leave this module, because each
+ * framework's Storybook reaches the same tokens by a different route and the
+ * browser hands back whatever text that route produced. Custom properties are
+ * the exposed case: `getComputedStyle` resolves a registered property but
+ * returns an unregistered `--*` as the author's literal token, so a stylesheet
+ * a bundler minified (`.5rem`, `.15s`) and one it did not (`0.5rem`, `150ms`)
+ * disagree on spelling while meaning the same thing. See
+ * {@link normalizeCssValue} for what is folded away.
+ *
  * The property list is duplicated here (and in `@c15t/conformance`'s
  * `computed-style.ts`) because Playwright can't import ESM into page context.
  * Keep these in sync.
@@ -59,12 +68,112 @@ const DEFAULT_PROPS = [
 	'direction',
 ] as const;
 
-export const captureComputedStyleMap = function captureComputedStyleMap(
+/**
+ * A CSS Modules scoped identifier, as Vite's default
+ * `[local]_[hash:base64:5]_[index]` generator spells it: `_enter_t5rx4_1`.
+ * The React Storybook compiles its keyframes through CSS Modules, the others
+ * link the built stylesheet, so the same animation arrives under two names.
+ */
+const CSS_MODULES_SCOPED_NAME =
+	/_(?<localName>[a-zA-Z][\w-]*?)_[a-z0-9]{4,8}_\d+\b/gu;
+
+/** A seconds literal, excluding the `s` that ends `ms`. */
+const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![a-z%-])/gu;
+
+/** A decimal written without its leading zero: `.5rem`, `cubic-bezier(.4`. */
+const BARE_DECIMAL = /(?<before>^|[^\w.])\.(?<digit>\d)/gu;
+
+/** Trailing zeros that carry no value: `1.50px`, `2.0s`. */
+const TRAILING_ZEROS = /(?<whole>\d+)\.(?<fraction>\d*[1-9])?0+(?![\d.])/gu;
+
+/**
+ * Rounds to 6 decimal places, so `0.15 * 1000` reads as `150` rather than
+ * `150.00000000000003`.
+ */
+const roundMilliseconds = function roundMilliseconds(seconds: number): number {
+	return Math.round(seconds * 1e9) / 1e6;
+};
+
+/**
+ * Canonicalises one computed CSS value so two spellings of the same value
+ * compare equal.
+ *
+ * Three rewrites, each folding away a difference in how the value was
+ * serialised rather than a difference in what it means:
+ *
+ * - **Scoped names** — `_enter_t5rx4_1` becomes `enter`, so a keyframe
+ *   compiled through CSS Modules matches the same keyframe linked from a
+ *   plain stylesheet.
+ * - **Times** — seconds become milliseconds, so `.15s` matches `150ms`.
+ * - **Numbers** — a missing leading zero is restored and trailing zeros are
+ *   dropped, so `.5rem` matches `0.5rem` and `cubic-bezier(.4, 0, .2, 1)`
+ *   matches `cubic-bezier(0.4, 0, 0.2, 1)`.
+ *
+ * Anything else is left alone. Two values that still differ after this differ
+ * for a reason the gate should report.
+ *
+ * @param value - A computed property or custom property value.
+ * @returns The canonical spelling of that value.
+ *
+ * @example
+ * ```ts
+ * normalizeCssValue('_enter_t5rx4_1 80ms cubic-bezier(.4, 0, .2, 1)');
+ * // 'enter 80ms cubic-bezier(0.4, 0, 0.2, 1)'
+ * ```
+ */
+export const normalizeCssValue = function normalizeCssValue(
+	value: string
+): string {
+	return value
+		.replace(CSS_MODULES_SCOPED_NAME, '$<localName>')
+		.replace(
+			SECONDS_LITERAL,
+			(_match, seconds: string) => `${roundMilliseconds(Number(seconds))}ms`
+		)
+		.replace(BARE_DECIMAL, '$<before>0.$<digit>')
+		.replace(TRAILING_ZEROS, (_match, whole: string, fraction?: string) =>
+			fraction ? `${whole}.${fraction}` : whole
+		);
+};
+
+/**
+ * Applies {@link normalizeCssValue} to every value in a captured snapshot map,
+ * leaving the element ids and property names untouched.
+ *
+ * @param snapshots - The map `captureComputedStyleMap` collected in the page.
+ * @returns The same map with canonical values.
+ */
+export const normalizeComputedStyleMap = function normalizeComputedStyleMap<
+	MapType extends Record<string, ComputedStyleSnapshot>,
+>(snapshots: MapType): Record<string, ComputedStyleSnapshot> {
+	const normalizeEntries = function normalizeEntries(
+		values: Record<string, string>
+	): Record<string, string> {
+		return Object.fromEntries(
+			Object.entries(values).map(([name, value]) => [
+				name,
+				normalizeCssValue(value),
+			])
+		);
+	};
+
+	return Object.fromEntries(
+		Object.entries(snapshots).map(([id, snapshot]) => [
+			id,
+			{
+				customProperties: normalizeEntries(snapshot.customProperties),
+				properties: normalizeEntries(snapshot.properties),
+			},
+		])
+	);
+};
+
+export const captureComputedStyleMap = async function captureComputedStyleMap(
 	page: Page,
 	selector: string,
 	elementSelector = '[data-testid]'
 ): Promise<Record<string, ComputedStyleSnapshot>> {
-	return page.evaluate(
+	const captured = await page.evaluate(
 		(args: { sel: string; props: readonly string[]; elements: string }) => {
 			const root = document.querySelector(args.sel);
 			if (!root) {
@@ -121,4 +230,6 @@ export const captureComputedStyleMap = function captureComputedStyleMap(
 		},
 		{ elements: elementSelector, props: DEFAULT_PROPS, sel: selector }
 	);
+
+	return normalizeComputedStyleMap(captured);
 };

--- a/apps/parity-runner/src/diff-computed-style.ts
+++ b/apps/parity-runner/src/diff-computed-style.ts
@@ -77,14 +77,27 @@ const DEFAULT_PROPS = [
 const CSS_MODULES_SCOPED_NAME =
 	/_(?<localName>[a-zA-Z][\w-]*?)_[a-z0-9]{4,8}_\d+\b/gu;
 
-/** A seconds literal, excluding the `s` that ends `ms`. */
-const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![a-z%-])/gu;
+/**
+ * A seconds literal, excluding the `s` that ends `ms`.
+ *
+ * The lookahead has to reject `.` and `/` as well as letters: without it
+ * `2s.svg` inside a path reads as a time and comes back as `2000ms.svg`.
+ */
+const SECONDS_LITERAL = /(?<seconds>-?(?:\d+\.?\d*|\.\d+))s(?![\w.%/-])/gu;
 
 /** A decimal written without its leading zero: `.5rem`, `cubic-bezier(.4`. */
 const BARE_DECIMAL = /(?<before>^|[^\w.])\.(?<digit>\d)/gu;
 
 /** Trailing zeros that carry no value: `1.50px`, `2.0s`. */
 const TRAILING_ZEROS = /(?<whole>\d+)\.(?<fraction>\d*[1-9])?0+(?![\d.])/gu;
+
+/**
+ * Text a rewrite must not enter: a `url()` and a quoted string are opaque
+ * payloads, not CSS values. `url(/assets/2s.svg)` is not a two-second
+ * anything, and folding it would make it compare equal to a genuinely
+ * different `url(/assets/2000ms.svg)`.
+ */
+const OPAQUE_SEGMENT = /url\((?:[^)'"]|"[^"]*"|'[^']*')*\)|"[^"]*"|'[^']*'/gu;
 
 /**
  * Rounds to 6 decimal places, so `0.15 * 1000` reads as `150` rather than
@@ -109,6 +122,10 @@ const roundMilliseconds = function roundMilliseconds(seconds: number): number {
  *   dropped, so `.5rem` matches `0.5rem` and `cubic-bezier(.4, 0, .2, 1)`
  *   matches `cubic-bezier(0.4, 0, 0.2, 1)`.
  *
+ * `url()` payloads and quoted strings are left untouched: they carry file
+ * names and content, not CSS values, and rewriting them would fold two
+ * genuinely different assets onto one another.
+ *
  * Anything else is left alone. Two values that still differ after this differ
  * for a reason the gate should report.
  *
@@ -121,10 +138,8 @@ const roundMilliseconds = function roundMilliseconds(seconds: number): number {
  * // 'enter 80ms cubic-bezier(0.4, 0, 0.2, 1)'
  * ```
  */
-export const normalizeCssValue = function normalizeCssValue(
-	value: string
-): string {
-	return value
+const rewriteCssText = function rewriteCssText(text: string): string {
+	return text
 		.replace(CSS_MODULES_SCOPED_NAME, '$<localName>')
 		.replace(
 			SECONDS_LITERAL,
@@ -134,6 +149,19 @@ export const normalizeCssValue = function normalizeCssValue(
 		.replace(TRAILING_ZEROS, (_match, whole: string, fraction?: string) =>
 			fraction ? `${whole}.${fraction}` : whole
 		);
+};
+
+export const normalizeCssValue = function normalizeCssValue(
+	value: string
+): string {
+	let out = '';
+	let cursor = 0;
+	for (const match of value.matchAll(OPAQUE_SEGMENT)) {
+		const start = match.index;
+		out += rewriteCssText(value.slice(cursor, start)) + match[0];
+		cursor = start + match[0].length;
+	}
+	return out + rewriteCssText(value.slice(cursor));
 };
 
 /**

--- a/apps/parity-runner/src/geometry.test.ts
+++ b/apps/parity-runner/src/geometry.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+
+import { diffGeometry, formatGeometryDiffs } from './geometry';
+import type { SlotBox } from './geometry';
+
+const box = function box(
+	slot: string,
+	x: number,
+	y: number,
+	width: number,
+	height: number
+): SlotBox {
+	return { height, slot, width, x, y };
+};
+
+test('identical captures produce no diffs', () => {
+	const a = [box('consent-banner-card', 0, 0, 442, 191)];
+	expect(diffGeometry(a, [...a], 1)).toEqual([]);
+});
+
+test('differences inside the tolerance are not drift', () => {
+	const a = [box('consent-banner-card', 0, 0, 442, 191)];
+	const b = [box('consent-banner-card', 0, 0, 442, 191.5)];
+	expect(diffGeometry(a, b, 1)).toEqual([]);
+});
+
+test('a heading margin shows up as a height difference', () => {
+	const a = [box('consent-banner-card', 0, 0, 442, 217.03)];
+	const b = [box('consent-banner-card', 0, 0, 442, 190.5)];
+	const diffs = diffGeometry(a, b, 1);
+	expect(diffs).toEqual([
+		{ a: 217.03, b: 190.5, field: 'height', slot: 'consent-banner-card' },
+	]);
+	expect(formatGeometryDiffs(diffs)).toEqual([
+		'consent-banner-card.height: 217.03 ≠ 190.5',
+	]);
+});
+
+test('a slot only one framework renders is a presence diff', () => {
+	const diffs = diffGeometry(
+		[],
+		[box('consent-banner-branding', 300, -38, 128, 38)],
+		1
+	);
+	expect(diffs).toEqual([
+		{
+			a: '<missing>',
+			b: 0,
+			field: '<presence>',
+			slot: 'consent-banner-branding',
+		},
+	]);
+});
+
+test('a differing group count shows up on the indexed slot', () => {
+	const single = [box('consent-widget-footer-sub-group', 0, 0, 326, 36)];
+	const split = [
+		box('consent-widget-footer-sub-group', 0, 0, 195, 36),
+		box('consent-widget-footer-sub-group[1]', 240, 0, 115, 36),
+	];
+	const diffs = diffGeometry(single, split, 1);
+	expect(diffs.map((diff) => `${diff.slot}.${diff.field}`)).toEqual([
+		'consent-widget-footer-sub-group.width',
+		'consent-widget-footer-sub-group[1].<presence>',
+	]);
+});

--- a/apps/parity-runner/src/geometry.ts
+++ b/apps/parity-runner/src/geometry.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-framework geometry capture.
+ *
+ * The DOM, a11y and computed-style diffs all compare *descriptions* of a
+ * surface. None of them notices when the same classes and the same tree
+ * lay out differently — a `<h2>` with the user-agent's default margins
+ * against a `<div role="heading">` with none produces identical class
+ * lists, identical roles and identical declared CSS, and a banner card
+ * 26px taller.
+ *
+ * So this measures the boxes. Every slot is reported relative to the card
+ * it sits in rather than to the viewport, because each Storybook wraps
+ * stories differently and absolute position would only ever measure the
+ * wrapper. Sizes are the point; page offsets are not.
+ */
+
+import type { Page } from '@playwright/test';
+
+/** One measured slot. */
+export interface SlotBox {
+	/** `data-testid`, suffixed with an index when it repeats. */
+	slot: string;
+	/** Left edge, relative to the anchoring card. */
+	x: number;
+	/** Top edge, relative to the anchoring card. */
+	y: number;
+	/** Border-box width. */
+	width: number;
+	/** Border-box height. */
+	height: number;
+}
+
+/** A geometry difference between two frameworks. */
+export interface GeometryDiff {
+	/** The slot that differs. */
+	slot: string;
+	/** Which box dimension differs, or `<presence>` for a missing slot. */
+	field: 'x' | 'y' | 'width' | 'height' | '<presence>';
+	/** Baseline value, or `<missing>`. */
+	a: number | '<missing>';
+	/** Compared value, or `<missing>`. */
+	b: number | '<missing>';
+}
+
+/**
+ * Measure every `data-testid` slot on the page.
+ *
+ * Runs in the page rather than over a serialized DOM: the boxes only
+ * exist once the browser has laid the surface out.
+ *
+ * @param page - The page showing a story.
+ * @returns Every visible slot, in document order.
+ */
+export const captureGeometry = function captureGeometry(
+	page: Page
+): Promise<SlotBox[]> {
+	return page.evaluate(() => {
+		/**
+		 * The box a slot is measured against: the card it belongs to, else
+		 * the surface root, else itself. Keeps the numbers about layout
+		 * inside a component instead of where a Storybook put it.
+		 */
+		const anchorOf = function anchorOf(element: Element): Element {
+			return (
+				element.closest('[data-testid$="-card"]') ??
+				element.closest('[data-testid$="-root"]') ??
+				element
+			);
+		};
+
+		const round = function round(value: number): number {
+			// Two decimals: enough to see a 13.28px UA margin, coarse enough
+			// that sub-pixel text metrics do not register as drift.
+			return Math.round(value * 100) / 100;
+		};
+
+		const seen = new Map<string, number>();
+		const boxes: {
+			slot: string;
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+		}[] = [];
+
+		for (const element of document.querySelectorAll('[data-testid]')) {
+			const testId = element.getAttribute('data-testid');
+			if (!testId) {
+				continue;
+			}
+			const rect = element.getBoundingClientRect();
+			// Storybook's own chrome and torn-down portals leave zero-sized
+			// nodes behind; they are not part of any surface.
+			if (rect.width === 0 && rect.height === 0) {
+				continue;
+			}
+			const index = seen.get(testId) ?? 0;
+			seen.set(testId, index + 1);
+			const anchor = anchorOf(element).getBoundingClientRect();
+			boxes.push({
+				height: round(rect.height),
+				slot: index === 0 ? testId : `${testId}[${index}]`,
+				width: round(rect.width),
+				x: round(rect.x - anchor.x),
+				y: round(rect.y - anchor.y),
+			});
+		}
+
+		return boxes;
+	});
+};
+
+/**
+ * Compare two geometry captures.
+ *
+ * @param a - Baseline capture (React).
+ * @param b - The framework under comparison.
+ * @param tolerance - Largest difference, in px, that is not a diff.
+ * @returns Every slot that differs, empty when the two agree.
+ */
+export const diffGeometry = function diffGeometry(
+	a: readonly SlotBox[],
+	b: readonly SlotBox[],
+	tolerance: number
+): GeometryDiff[] {
+	const bySlotA = new Map(a.map((box) => [box.slot, box]));
+	const bySlotB = new Map(b.map((box) => [box.slot, box]));
+	const diffs: GeometryDiff[] = [];
+
+	for (const slot of new Set([...bySlotA.keys(), ...bySlotB.keys()])) {
+		const boxA = bySlotA.get(slot);
+		const boxB = bySlotB.get(slot);
+		if (!boxA || !boxB) {
+			diffs.push({
+				a: boxA ? 0 : '<missing>',
+				b: boxB ? 0 : '<missing>',
+				field: '<presence>',
+				slot,
+			});
+			continue;
+		}
+		for (const field of ['x', 'y', 'width', 'height'] as const) {
+			if (Math.abs(boxA[field] - boxB[field]) > tolerance) {
+				diffs.push({ a: boxA[field], b: boxB[field], field, slot });
+			}
+		}
+	}
+
+	return diffs.sort(
+		(x, y) => x.slot.localeCompare(y.slot) || x.field.localeCompare(y.field)
+	);
+};
+
+/**
+ * Render diffs as one line each, for a test failure message.
+ *
+ * @param diffs - The diffs to describe.
+ * @returns One line per diff.
+ */
+export const formatGeometryDiffs = function formatGeometryDiffs(
+	diffs: readonly GeometryDiff[]
+): string[] {
+	return diffs.map(
+		(diff) => `${diff.slot}.${diff.field}: ${diff.a} ≠ ${diff.b}`
+	);
+};

--- a/apps/parity-runner/src/pair-stories.test.ts
+++ b/apps/parity-runner/src/pair-stories.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'bun:test';
 
-import { frameworkOf, pairStories, storyKey } from './pair-stories';
+import {
+	frameworkOf,
+	pairStories,
+	selectComparablePairs,
+	storyKey,
+} from './pair-stories';
 import type { StoryEntry } from './pair-stories';
 
 test('frameworkOf extracts framework from title', () => {
@@ -79,4 +84,70 @@ test('pairStories returns stable, sorted output', () => {
 		'A-Comp/Default',
 		'Z-Comp/Default',
 	]);
+});
+
+const entryFor = function entryFor(
+	framework: string,
+	component: string,
+	name = 'Default'
+): StoryEntry {
+	return {
+		id: `components-${framework}-${component}--${name.toLowerCase()}`,
+		name,
+		title: `COMPONENTS - ${framework.toUpperCase()}/${component}`,
+	};
+};
+
+test('selectComparablePairs drops pairs only one framework ships', () => {
+	const pairs = selectComparablePairs(
+		{
+			react: [entryFor('react', 'Button'), entryFor('react', 'Frame')],
+			svelte: [entryFor('svelte', 'Button')],
+		},
+		{ frameworks: ['react', 'svelte'] }
+	);
+
+	expect(pairs.map((pair) => pair.key)).toEqual(['Button/Default']);
+});
+
+test('selectComparablePairs reports the frameworks a pair is missing', () => {
+	const [pair] = selectComparablePairs(
+		{
+			react: [entryFor('react', 'Button')],
+			svelte: [entryFor('svelte', 'Button')],
+		},
+		{ frameworks: ['react', 'svelte', 'vue', 'astro'] }
+	);
+
+	expect(pair?.missing).toEqual(['vue', 'astro']);
+});
+
+test('selectComparablePairs requires the baseline when one is named', () => {
+	const pairs = selectComparablePairs(
+		{
+			svelte: [entryFor('svelte', 'Button')],
+			vue: [entryFor('vue', 'Button')],
+		},
+		{ baseline: 'react', frameworks: ['react', 'svelte', 'vue'] }
+	);
+
+	expect(pairs).toEqual([]);
+});
+
+test('selectComparablePairs honours excluded key prefixes', () => {
+	const pairs = selectComparablePairs(
+		{
+			react: [
+				entryFor('react', 'Button'),
+				entryFor('react', 'Core/DevTools/Panel'),
+			],
+			svelte: [
+				entryFor('svelte', 'Button'),
+				entryFor('svelte', 'Core/DevTools/Panel'),
+			],
+		},
+		{ excludeKeyPrefixes: ['Core/DevTools/'], frameworks: ['react', 'svelte'] }
+	);
+
+	expect(pairs.map((pair) => pair.key)).toEqual(['Button/Default']);
 });

--- a/apps/parity-runner/src/pair-stories.ts
+++ b/apps/parity-runner/src/pair-stories.ts
@@ -64,3 +64,65 @@ export const pairStories = function pairStories(
 		.map(([key, entries]) => ({ entries, key }))
 		.sort((a, b) => a.key.localeCompare(b.key));
 };
+
+/**
+ * Frameworks that were compared and that a pair is missing.
+ *
+ * A pair with fewer entries than the run enables is not automatically
+ * wrong: the Storybook apps do not carry the same catalogue (React ships
+ * 17 story files, Solid 5, Astro 4), so most pairs are legitimately
+ * partial. What matters is that the gap is visible in the report rather
+ * than silently absent, and that both comparisons compute it the same way.
+ */
+export const missingFrameworks = function missingFrameworks(
+	pair: PairedStory,
+	frameworks: readonly string[]
+): string[] {
+	return frameworks.filter((framework) => !pair.entries[framework]);
+};
+
+/** A pair the gate will compare, plus the frameworks it does not cover. */
+export interface ComparablePair extends PairedStory {
+	/** Enabled frameworks that ship no equivalent of this story. */
+	missing: string[];
+}
+
+/** How a caller narrows the paired set it will compare. */
+export interface ComparablePairOptions {
+	/** The frameworks this run was told to check. */
+	frameworks: readonly string[];
+	/**
+	 * A framework every pair must include, when the comparison measures
+	 * against one. The visual gate needs React; the descriptive checks
+	 * compare whatever pair they are given.
+	 */
+	baseline?: string;
+	/** Story-key prefixes this comparison owns elsewhere. */
+	excludeKeyPrefixes?: readonly string[];
+}
+
+/**
+ * The one place a paired story is judged comparable.
+ *
+ * Both gates used to filter their own way — one required two entries and
+ * dropped DevTools, the other required React — so a change to one silently
+ * changed what the other compared. They call this instead.
+ *
+ * @param entriesByFramework - Story entries per framework code.
+ * @param options - Enabled frameworks, optional baseline and exclusions.
+ * @returns Comparable pairs, each carrying the frameworks it is missing.
+ */
+export const selectComparablePairs = function selectComparablePairs(
+	entriesByFramework: Readonly<Record<string, readonly StoryEntry[]>>,
+	options: ComparablePairOptions
+): ComparablePair[] {
+	const excluded = options.excludeKeyPrefixes ?? [];
+	return pairStories(entriesByFramework)
+		.filter((pair) => Object.keys(pair.entries).length >= 2)
+		.filter((pair) => !options.baseline || pair.entries[options.baseline])
+		.filter((pair) => !excluded.some((prefix) => pair.key.startsWith(prefix)))
+		.map((pair) => ({
+			...pair,
+			missing: missingFrameworks(pair, options.frameworks),
+		}));
+};

--- a/apps/parity-runner/src/pair-stories.ts
+++ b/apps/parity-runner/src/pair-stories.ts
@@ -3,9 +3,9 @@
  *
  * React titles live under `COMPONENTS - REACT/...`; Svelte under
  * `COMPONENTS - SVELTE/...`; Vue under `COMPONENTS - VUE/...`; Solid
- * under `COMPONENTS - SOLID/...`. Pairing strips the `{FRAMEWORK}`
- * segment so `COMPONENTS - REACT/Button` pairs with
- * `COMPONENTS - SVELTE/Button`, `COMPONENTS - VUE/Button`, etc.
+ * under `COMPONENTS - SOLID/...`; Astro under `COMPONENTS - ASTRO/...`.
+ * Pairing strips the `{FRAMEWORK}` segment so `COMPONENTS - REACT/Button`
+ * pairs with `COMPONENTS - SVELTE/Button`, `COMPONENTS - VUE/Button`, etc.
  */
 
 export interface StoryEntry {
@@ -25,7 +25,7 @@ export interface PairedStory {
 }
 
 const FRAMEWORK_SEGMENT =
-	/^components\s*-\s*(?<capture1>react|svelte|vue|solid)\//iu;
+	/^components\s*-\s*(?<capture1>react|svelte|vue|solid|astro)\//iu;
 
 /**
  * Extract the framework code from a Storybook title, or null if the title

--- a/apps/parity-runner/src/parity-allowlist.test.ts
+++ b/apps/parity-runner/src/parity-allowlist.test.ts
@@ -93,12 +93,29 @@ test('unused entries are scoped to the checks that ran', () => {
 	const geometry = entry();
 	const pixel = entry({ check: 'pixel' });
 	const list = [geometry, pixel];
-	expect(unusedAllowlistEntries(new Set(), ['geometry'], list)).toEqual([
-		geometry,
-	]);
 	expect(
-		unusedAllowlistEntries(new Set([geometry]), ['geometry'], list)
+		unusedAllowlistEntries(new Set(), ['geometry'], ['vue'], list)
+	).toEqual([geometry]);
+	expect(
+		unusedAllowlistEntries(new Set([geometry]), ['geometry'], ['vue'], list)
 	).toEqual([]);
+});
+
+test('a Vue allowance is not stale in a run that never compared Vue', () => {
+	const vue = entry({ framework: 'vue' });
+	const svelte = entry({ framework: 'svelte' });
+	const list = [vue, svelte];
+	expect(
+		unusedAllowlistEntries(new Set(), ['geometry'], ['svelte'], list)
+	).toEqual([svelte]);
+});
+
+test('a wildcard allowance is stale only when some framework ran', () => {
+	const list = [entry({ framework: '*' })];
+	expect(
+		unusedAllowlistEntries(new Set(), ['geometry'], ['svelte'], list)
+	).toEqual(list);
+	expect(unusedAllowlistEntries(new Set(), ['geometry'], [], list)).toEqual([]);
 });
 
 test('every shipped entry carries a reason', () => {

--- a/apps/parity-runner/src/parity-allowlist.test.ts
+++ b/apps/parity-runner/src/parity-allowlist.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'bun:test';
+
+import {
+	findAllowEntry,
+	PARITY_ALLOWLIST,
+	unusedAllowlistEntries,
+} from './parity-allowlist';
+import type { ParityAllowEntry } from './parity-allowlist';
+
+const entry = function entry(
+	overrides: Partial<ParityAllowEntry> = {}
+): ParityAllowEntry {
+	return {
+		check: 'geometry',
+		framework: 'vue',
+		reason: 'because',
+		slot: 'consent-banner-card',
+		story: 'Core/Consent Banner/Default',
+		...overrides,
+	};
+};
+
+test('an exact key matches', () => {
+	const list = [entry()];
+	expect(
+		findAllowEntry(
+			{
+				check: 'geometry',
+				framework: 'vue',
+				slot: 'consent-banner-card',
+				story: 'Core/Consent Banner/Default',
+			},
+			list
+		)
+	).toBe(list[0] as ParityAllowEntry);
+});
+
+test('the check has to match', () => {
+	expect(
+		findAllowEntry(
+			{
+				check: 'pixel',
+				framework: 'vue',
+				slot: 'consent-banner-card',
+				story: 'Core/Consent Banner/Default',
+			},
+			[entry()]
+		)
+	).toBeUndefined();
+});
+
+test('a trailing star matches a slot prefix', () => {
+	const list = [entry({ slot: 'consent-widget-accordion-trigger-*' })];
+	expect(
+		findAllowEntry(
+			{
+				check: 'geometry',
+				framework: 'vue',
+				slot: 'consent-widget-accordion-trigger-necessary',
+				story: 'Core/Consent Banner/Default',
+			},
+			list
+		)
+	).toBeDefined();
+	expect(
+		findAllowEntry(
+			{
+				check: 'geometry',
+				framework: 'vue',
+				slot: 'consent-widget-footer',
+				story: 'Core/Consent Banner/Default',
+			},
+			list
+		)
+	).toBeUndefined();
+});
+
+test('a bare slot id covers its repeat indices', () => {
+	expect(
+		findAllowEntry(
+			{
+				check: 'geometry',
+				framework: 'vue',
+				slot: 'consent-banner-card[2]',
+				story: 'Core/Consent Banner/Default',
+			},
+			[entry()]
+		)
+	).toBeDefined();
+});
+
+test('unused entries are scoped to the checks that ran', () => {
+	const geometry = entry();
+	const pixel = entry({ check: 'pixel' });
+	const list = [geometry, pixel];
+	expect(unusedAllowlistEntries(new Set(), ['geometry'], list)).toEqual([
+		geometry,
+	]);
+	expect(
+		unusedAllowlistEntries(new Set([geometry]), ['geometry'], list)
+	).toEqual([]);
+});
+
+test('every shipped entry carries a reason', () => {
+	for (const shipped of PARITY_ALLOWLIST) {
+		expect(shipped.reason.length).toBeGreaterThan(20);
+	}
+});

--- a/apps/parity-runner/src/parity-allowlist.ts
+++ b/apps/parity-runner/src/parity-allowlist.ts
@@ -271,17 +271,33 @@ export const findAllowEntry = function findAllowEntry(
  * test and only ever consults its own entries — a geometry run knows
  * nothing about whether the pixel entries were needed.
  *
+ * Scoped to the enabled frameworks for the same reason. `PARITY_FRAMEWORKS`
+ * defaults to `react,svelte`, so a full-matrix allowlist carries Vue and
+ * Astro entries a default run never gets the chance to use. Reporting those
+ * as stale would fail every default run and teach the reader to ignore the
+ * one signal this check exists to give. A `'*'` entry is in scope whenever
+ * any framework is.
+ *
  * @param used - The entries that did match.
  * @param checks - The checks whose entries this run is responsible for.
+ * @param frameworks - The frameworks this run enabled.
  * @param allowlist - The full allowlist.
  * @returns Entries that can be deleted.
  */
 export const unusedAllowlistEntries = function unusedAllowlistEntries(
 	used: ReadonlySet<ParityAllowEntry>,
 	checks: readonly ParityCheck[],
+	frameworks: readonly string[],
 	allowlist: readonly ParityAllowEntry[] = PARITY_ALLOWLIST
 ): ParityAllowEntry[] {
+	const inScope = function inScope(entry: ParityAllowEntry): boolean {
+		return entry.framework === '*'
+			? frameworks.length > 0
+			: frameworks.includes(entry.framework);
+	};
+
 	return allowlist.filter(
-		(entry) => checks.includes(entry.check) && !used.has(entry)
+		(entry) =>
+			checks.includes(entry.check) && inScope(entry) && !used.has(entry)
 	);
 };

--- a/apps/parity-runner/src/parity-allowlist.ts
+++ b/apps/parity-runner/src/parity-allowlist.ts
@@ -161,21 +161,6 @@ export const PARITY_ALLOWLIST: readonly ParityAllowEntry[] = [
 	},
 	{
 		check: 'css',
-		framework: 'vue',
-		reason: 'Svelte-to-Vue widget drift, pre-dating this gate. See v3.md.',
-		slot: '*',
-		story: 'Core/Consent Widget/Expanded Categories',
-	},
-	{
-		check: 'css',
-		framework: 'svelte',
-		reason:
-			'The React Storybook resolves some `@c15t/ui` primitives to source, so custom-property values serialise unminified. A build-configuration difference, not a component one.',
-		slot: '*',
-		story: 'Core/Consent Dialog Link/Default',
-	},
-	{
-		check: 'css',
 		framework: 'svelte',
 		reason:
 			'The React frame placeholder renders neither `frame-placeholder` nor `frame-open-dialog`. See the geometry entry.',

--- a/apps/parity-runner/src/parity-allowlist.ts
+++ b/apps/parity-runner/src/parity-allowlist.ts
@@ -28,9 +28,14 @@ export interface ParityAllowEntry {
 	/** The paired story key (e.g. `Core/Consent Banner/Default`), or `'*'`. */
 	story: string;
 	/**
-	 * The `data-testid` slot, or `'*'`. Geometry slots may carry a repeat
-	 * index (`consent-widget-footer-sub-group[1]`); a bare id matches every
-	 * index of that slot.
+	 * The `data-testid` slot, or `'*'`. A trailing `*` matches a prefix
+	 * (`consent-widget-accordion-trigger-*`), which is how per-category
+	 * slots are covered without one entry per category. Geometry slots may
+	 * carry a repeat index (`consent-widget-footer-sub-group[1]`); a bare id
+	 * matches every index of that slot.
+	 *
+	 * The descriptive DOM, a11y and computed-style checks report one result
+	 * per story rather than per element, so their entries use `'*'`.
 	 */
 	slot: string;
 	/** Why this drift is allowed. Required; keep it specific. */
@@ -38,21 +43,182 @@ export interface ParityAllowEntry {
 }
 
 export const PARITY_ALLOWLIST: readonly ParityAllowEntry[] = [
+	// ---------------------------------------------------------------------
+	// Vue. Out of scope for the visual parity gate: its footer nesting and
+	// control sizing both diverge from React, and v3.md tracks bringing the
+	// Vue surfaces in line as its own piece of work. Narrow these to
+	// specific slots as that lands, rather than deleting them wholesale.
+	// ---------------------------------------------------------------------
 	{
 		check: 'geometry',
 		framework: 'vue',
 		reason:
-			'Vue nests its footer actions one level deeper than React and Svelte, so the sub-group boxes do not line up. Tracked in v3.md as a known Vue footer-nesting difference; out of scope for the visual parity gate.',
-		slot: 'consent-banner-footer-sub-group',
+			'Vue nests its footer actions one level deeper than React and Svelte and sizes its buttons 4px taller, so nothing on a Vue surface lines up. Tracked in v3.md; excluded from this gate until the Vue surfaces are brought in line.',
+		slot: '*',
 		story: '*',
 	},
 	{
-		check: 'geometry',
+		check: 'pixel',
 		framework: 'vue',
 		reason:
-			'Same Vue footer nesting as the banner, on the dialog surface. See v3.md.',
-		slot: 'consent-widget-footer-sub-group',
+			'Follows the geometry allowance above: the Vue cards are 4px taller, so a pixel comparison can only report the size mismatch. See v3.md.',
+		slot: '*',
 		story: '*',
+	},
+
+	// ---------------------------------------------------------------------
+	// Accordion trigger structure. React wraps the trigger's content in
+	// `consent-widget-accordion-trigger-inner-*` and lets the trigger fill
+	// the row; Svelte, Vue and Astro put the padding on the trigger itself
+	// and have no inner element. Same visual result, different boxes.
+	// ---------------------------------------------------------------------
+	{
+		check: 'geometry',
+		framework: '*',
+		reason:
+			'React puts the accordion row padding on an inner wrapper the other adapters do not render, so the trigger box is the full row in React and the inset content elsewhere. Pre-existing structural drift in the shared accordion primitive; converging it is its own change.',
+		slot: 'consent-widget-accordion-trigger-*',
+		story: '*',
+	},
+
+	// ---------------------------------------------------------------------
+	// Dialog root. React's `consent-dialog-root` is the viewport-filling
+	// positioning container; the other adapters put that testid on the
+	// inset panel wrapper.
+	// ---------------------------------------------------------------------
+	{
+		check: 'geometry',
+		framework: '*',
+		reason:
+			'`consent-dialog-root` names the viewport-filling positioning container in React and the inset panel wrapper everywhere else, so its box is 1280x800 against 1232x510. The card inside it does match. Deciding which element owns the testid is its own change.',
+		slot: 'consent-dialog-root',
+		story: '*',
+	},
+
+	// ---------------------------------------------------------------------
+	// Surfaces this branch did not touch.
+	// ---------------------------------------------------------------------
+	{
+		check: 'geometry',
+		framework: 'svelte',
+		reason:
+			'The React frame placeholder renders neither `frame-placeholder` nor `frame-open-dialog`; Svelte renders both. A real gap in the React frame, out of scope for the visual parity gate.',
+		slot: 'frame-*',
+		story: 'Core/Frame/Placeholder',
+	},
+	{
+		check: 'geometry',
+		framework: 'svelte',
+		reason:
+			'The IAB banner has never been through a cross-framework pass — card, header, footer and every button differ. Out of scope here; the gate now records it instead of ignoring it.',
+		slot: 'iab-consent-banner-*',
+		story: 'IAB/IAB Consent Banner/Default',
+	},
+
+	// ---------------------------------------------------------------------
+	// The descriptive checks. Restoring React's story-title prefixes (see
+	// `fix(storybook): restore the section prefixes on React story titles`)
+	// put React back into these comparisons after #1063 silently dropped it,
+	// which surfaced drift that had been invisible rather than absent.
+	// Each entry below is a real difference nobody has fixed yet.
+	// ---------------------------------------------------------------------
+	{
+		check: 'css',
+		framework: '*',
+		reason:
+			'The banner portals to `document.body` in Svelte, Vue and Astro but renders inside `#storybook-root` in React, and the computed-style capture is scoped to that root — so every banner slot reads as missing on one side. The capture scope is the bug, not the components; fixing it is its own change.',
+		slot: '*',
+		story: 'Core/Consent Banner/Default',
+	},
+	{
+		check: 'dom',
+		framework: '*',
+		reason: 'Same portal-vs-root capture scope as the CSS entry above.',
+		slot: '*',
+		story: 'Core/Consent Banner/Default',
+	},
+	{
+		check: 'a11y',
+		framework: '*',
+		reason: 'Same portal-vs-root capture scope as the CSS entry above.',
+		slot: '*',
+		story: 'Core/Consent Banner/Default',
+	},
+	{
+		check: 'css',
+		framework: '*',
+		reason:
+			'The accordion trigger structure differs (see the geometry entry), and the React Storybook resolves a handful of `@c15t/ui` primitives to source while the others use the built stylesheet, so token values serialise differently (`0.5rem` against `.5rem`). Neither is a runtime difference; both need their own change.',
+		slot: '*',
+		story: 'Core/Consent Widget/Default',
+	},
+	{
+		check: 'dom',
+		framework: '*',
+		reason: 'Accordion trigger structure. See the geometry entry.',
+		slot: '*',
+		story: 'Core/Consent Widget/Default',
+	},
+	{
+		check: 'css',
+		framework: 'vue',
+		reason: 'Svelte-to-Vue widget drift, pre-dating this gate. See v3.md.',
+		slot: '*',
+		story: 'Core/Consent Widget/Expanded Categories',
+	},
+	{
+		check: 'css',
+		framework: 'svelte',
+		reason:
+			'The React Storybook resolves some `@c15t/ui` primitives to source, so custom-property values serialise unminified. A build-configuration difference, not a component one.',
+		slot: '*',
+		story: 'Core/Consent Dialog Link/Default',
+	},
+	{
+		check: 'css',
+		framework: 'svelte',
+		reason:
+			'The React frame placeholder renders neither `frame-placeholder` nor `frame-open-dialog`. See the geometry entry.',
+		slot: '*',
+		story: 'Core/Frame/Placeholder',
+	},
+	{
+		check: 'dom',
+		framework: 'svelte',
+		reason: 'React frame placeholder gap. See the geometry entry.',
+		slot: '*',
+		story: 'Core/Frame/Placeholder',
+	},
+	{
+		check: 'a11y',
+		framework: 'svelte',
+		reason: 'React frame placeholder gap. See the geometry entry.',
+		slot: '*',
+		story: 'Core/Frame/Placeholder',
+	},
+	{
+		check: 'dom',
+		framework: 'astro',
+		reason:
+			'The Astro dialog is a Svelte island mounted into a server-rendered host, so the tree carries the host wrapper React does not have. Structural by design.',
+		slot: '*',
+		story: 'Core/Consent Dialog/Default',
+	},
+	{
+		check: 'dom',
+		framework: 'astro',
+		reason:
+			'Astro renders the IAB dialog as the same Svelte island, inside its server-rendered host wrapper.',
+		slot: '*',
+		story: 'IAB/IAB Consent Dialog/Overview',
+	},
+	{
+		check: 'a11y',
+		framework: 'astro',
+		reason:
+			'Astro renders the IAB dialog as the same Svelte island, inside its server-rendered host wrapper.',
+		slot: '*',
+		story: 'IAB/IAB Consent Dialog/Overview',
 	},
 ];
 
@@ -62,6 +228,9 @@ const matches = function matches(
 	stripIndex: boolean
 ): boolean {
 	if (pattern === '*' || pattern === value) {
+		return true;
+	}
+	if (pattern.endsWith('*') && value.startsWith(pattern.slice(0, -1))) {
 		return true;
 	}
 	return stripIndex && value.replace(/\[\d+\]$/u, '') === pattern;
@@ -96,15 +265,23 @@ export const findAllowEntry = function findAllowEntry(
 };
 
 /**
- * Entries that matched nothing in a run.
+ * Entries for one check that matched nothing in a run.
+ *
+ * Scoped to a single check because each check runs in its own Playwright
+ * test and only ever consults its own entries — a geometry run knows
+ * nothing about whether the pixel entries were needed.
  *
  * @param used - The entries that did match.
+ * @param checks - The checks whose entries this run is responsible for.
  * @param allowlist - The full allowlist.
  * @returns Entries that can be deleted.
  */
 export const unusedAllowlistEntries = function unusedAllowlistEntries(
 	used: ReadonlySet<ParityAllowEntry>,
+	checks: readonly ParityCheck[],
 	allowlist: readonly ParityAllowEntry[] = PARITY_ALLOWLIST
 ): ParityAllowEntry[] {
-	return allowlist.filter((entry) => !used.has(entry));
+	return allowlist.filter(
+		(entry) => checks.includes(entry.check) && !used.has(entry)
+	);
 };

--- a/apps/parity-runner/src/parity-allowlist.ts
+++ b/apps/parity-runner/src/parity-allowlist.ts
@@ -1,0 +1,110 @@
+/**
+ * Known cross-framework drift.
+ *
+ * An entry here says "this difference is real, we know about it, and it is
+ * not this branch's job to fix it". Every entry needs a reason a reviewer
+ * can act on — a link, an issue, or the constraint that forces it. An
+ * entry with a vague reason is worse than a red test, because it hides one
+ * without recording why.
+ *
+ * Entries are keyed by check, framework, story and slot. `'*'` matches
+ * everything in that position; prefer the narrowest key that covers the
+ * drift, so an unrelated regression in the same story still fails.
+ *
+ * Nothing expires automatically. Delete an entry when the drift is fixed —
+ * {@link unusedAllowlistEntries} reports entries that matched nothing, so a
+ * stale allowance shows up as soon as the drift goes away.
+ */
+
+/** The checks an entry can silence. */
+export type ParityCheck = 'geometry' | 'pixel' | 'dom' | 'a11y' | 'css';
+
+/** One allowed difference. */
+export interface ParityAllowEntry {
+	/** Which check the allowance applies to. */
+	check: ParityCheck;
+	/** The framework that differs from the React baseline, or `'*'`. */
+	framework: string;
+	/** The paired story key (e.g. `Core/Consent Banner/Default`), or `'*'`. */
+	story: string;
+	/**
+	 * The `data-testid` slot, or `'*'`. Geometry slots may carry a repeat
+	 * index (`consent-widget-footer-sub-group[1]`); a bare id matches every
+	 * index of that slot.
+	 */
+	slot: string;
+	/** Why this drift is allowed. Required; keep it specific. */
+	reason: string;
+}
+
+export const PARITY_ALLOWLIST: readonly ParityAllowEntry[] = [
+	{
+		check: 'geometry',
+		framework: 'vue',
+		reason:
+			'Vue nests its footer actions one level deeper than React and Svelte, so the sub-group boxes do not line up. Tracked in v3.md as a known Vue footer-nesting difference; out of scope for the visual parity gate.',
+		slot: 'consent-banner-footer-sub-group',
+		story: '*',
+	},
+	{
+		check: 'geometry',
+		framework: 'vue',
+		reason:
+			'Same Vue footer nesting as the banner, on the dialog surface. See v3.md.',
+		slot: 'consent-widget-footer-sub-group',
+		story: '*',
+	},
+];
+
+const matches = function matches(
+	pattern: string,
+	value: string,
+	stripIndex: boolean
+): boolean {
+	if (pattern === '*' || pattern === value) {
+		return true;
+	}
+	return stripIndex && value.replace(/\[\d+\]$/u, '') === pattern;
+};
+
+/** A difference being tested against the allowlist. */
+export interface ParityFinding {
+	check: ParityCheck;
+	framework: string;
+	story: string;
+	slot: string;
+}
+
+/**
+ * Whether a finding is covered by an allowlist entry.
+ *
+ * @param finding - The difference the check found.
+ * @param allowlist - The entries to test against.
+ * @returns The matching entry, or undefined.
+ */
+export const findAllowEntry = function findAllowEntry(
+	finding: ParityFinding,
+	allowlist: readonly ParityAllowEntry[] = PARITY_ALLOWLIST
+): ParityAllowEntry | undefined {
+	return allowlist.find(
+		(entry) =>
+			entry.check === finding.check &&
+			matches(entry.framework, finding.framework, false) &&
+			matches(entry.story, finding.story, false) &&
+			matches(entry.slot, finding.slot, true)
+	);
+};
+
+/**
+ * Entries that matched nothing in a run.
+ *
+ * @param used - The entries that did match.
+ * @param allowlist - The full allowlist.
+ * @returns Entries that can be deleted.
+ */
+export const unusedAllowlistEntries = function unusedAllowlistEntries(
+	used: ReadonlySet<ParityAllowEntry>,
+	allowlist: readonly ParityAllowEntry[] = PARITY_ALLOWLIST
+): ParityAllowEntry[] {
+	return allowlist.filter((entry) => !used.has(entry));
+};

--- a/apps/parity-runner/src/pixel-diff.ts
+++ b/apps/parity-runner/src/pixel-diff.ts
@@ -1,0 +1,84 @@
+/**
+ * Cross-framework pixel comparison.
+ *
+ * The geometry check catches boxes that lay out differently. This catches
+ * everything else a box cannot describe: a wrong colour, a missing border,
+ * a font that resolved differently, an icon that did not render.
+ *
+ * It is deliberately loose — a per-channel tolerance and a mismatch budget
+ * — because text antialiasing is never identical between two renderers.
+ * Different image sizes are not a tolerance question and fail outright.
+ */
+
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+/** The outcome of one comparison. */
+export interface PixelComparison {
+	/** Whether the two images are within budget. */
+	ok: boolean;
+	/** Human-readable failure reason, when `ok` is false. */
+	reason?: string;
+	/** Pixels that differed beyond the channel tolerance. */
+	mismatched: number;
+	/** `mismatched` as a share of the image. */
+	ratio: number;
+	/** A PNG marking the differing pixels, when sizes matched. */
+	diff?: Buffer;
+}
+
+/** Comparison budget. */
+export interface PixelBudget {
+	/** Per-channel tolerance, 0-255. */
+	threshold: number;
+	/** Largest allowed share of differing pixels, 0-1. */
+	maxRatio: number;
+}
+
+/**
+ * Compare two PNG buffers.
+ *
+ * @param baseline - The React screenshot.
+ * @param candidate - The other framework's screenshot.
+ * @param budget - Channel tolerance and mismatch budget.
+ * @returns The comparison, including a diff image when sizes matched.
+ */
+export const comparePng = function comparePng(
+	baseline: Buffer,
+	candidate: Buffer,
+	budget: PixelBudget
+): PixelComparison {
+	const a = PNG.sync.read(baseline);
+	const b = PNG.sync.read(candidate);
+
+	if (a.width !== b.width || a.height !== b.height) {
+		return {
+			mismatched: Number.NaN,
+			ok: false,
+			ratio: Number.NaN,
+			reason: `size ${a.width}x${a.height} ≠ ${b.width}x${b.height}`,
+		};
+	}
+
+	const diff = new PNG({ height: a.height, width: a.width });
+	const mismatched = pixelmatch(a.data, b.data, diff.data, a.width, a.height, {
+		// pixelmatch's threshold is a 0-1 share of the maximum YIQ distance,
+		// not a channel value; the budget is expressed in 0-255 channel terms
+		// because that is how a reviewer thinks about "close enough".
+		threshold: budget.threshold / 255,
+	});
+	const ratio = mismatched / (a.width * a.height);
+
+	return {
+		diff: PNG.sync.write(diff),
+		mismatched,
+		ok: ratio <= budget.maxRatio,
+		ratio,
+		reason:
+			ratio <= budget.maxRatio
+				? undefined
+				: `${mismatched} px differ (${(ratio * 100).toFixed(2)}% > ${(
+						budget.maxRatio * 100
+					).toFixed(2)}%)`,
+	};
+};

--- a/apps/parity-runner/tests/devtools.spec.ts
+++ b/apps/parity-runner/tests/devtools.spec.ts
@@ -17,7 +17,8 @@ const urls: Record<string, string> = {
 const frameworks = (process.env.PARITY_FRAMEWORKS ?? 'react,svelte')
 	.split(',')
 	.map((value) => value.trim())
-	.filter((value) => value in urls)
+	// `in` would also accept `toString` and friends off the prototype.
+	.filter((value) => Object.hasOwn(urls, value))
 	.sort((left, right) => Number(right === 'react') - Number(left === 'react'));
 const tabs = [
 	'Consents',

--- a/apps/parity-runner/tests/devtools.spec.ts
+++ b/apps/parity-runner/tests/devtools.spec.ts
@@ -11,10 +11,13 @@ const urls: Record<string, string> = {
 	svelte: process.env.SVELTE_STORYBOOK_URL ?? 'http://127.0.0.1:6007',
 	vue: process.env.VUE_STORYBOOK_URL ?? 'http://127.0.0.1:6008',
 };
+// Only the frameworks that ship a DevTools panel. `PARITY_FRAMEWORKS` also
+// names Astro, whose Storybook renders the server banner and the dialog
+// islands — there is no DevTools surface there to compare.
 const frameworks = (process.env.PARITY_FRAMEWORKS ?? 'react,svelte')
 	.split(',')
 	.map((value) => value.trim())
-	.filter(Boolean)
+	.filter((value) => value in urls)
 	.sort((left, right) => Number(right === 'react') - Number(left === 'react'));
 const tabs = [
 	'Consents',

--- a/apps/parity-runner/tests/parity.spec.ts
+++ b/apps/parity-runner/tests/parity.spec.ts
@@ -33,8 +33,8 @@ import type { Page } from '@playwright/test';
 import { captureA11yTree } from '../src/diff-a11y';
 import { captureComputedStyleMap } from '../src/diff-computed-style';
 import { captureDomSnapshot } from '../src/diff-dom';
-import { pairStories } from '../src/pair-stories';
-import type { PairedStory } from '../src/pair-stories';
+import { selectComparablePairs } from '../src/pair-stories';
+import type { ComparablePair } from '../src/pair-stories';
 import {
 	findAllowEntry,
 	unusedAllowlistEntries,
@@ -60,7 +60,7 @@ const ENABLED_FRAMEWORKS = (process.env.PARITY_FRAMEWORKS ?? 'react,svelte')
  * in its own context, so this executes once per run unless sharded.
  */
 const loadPairedStories = async function loadPairedStories(): Promise<
-	PairedStory[]
+	ComparablePair[]
 > {
 	const byFramework: Record<
 		string,
@@ -85,12 +85,33 @@ const loadPairedStories = async function loadPairedStories(): Promise<
 			);
 		}
 	}
-	return pairStories(byFramework).filter(
+	return selectComparablePairs(byFramework, {
 		// DevTools owns a dedicated portal-aware comparison in devtools.spec.ts,
 		// including same-run pixel checks that also execute on Linux CI.
-		(pair) =>
-			Object.keys(pair.entries).length >= 2 &&
-			!pair.key.startsWith('Core/DevTools/')
+		excludeKeyPrefixes: ['Core/DevTools/'],
+		frameworks: ENABLED_FRAMEWORKS,
+	});
+};
+
+/**
+ * Logs which frameworks each pair is missing.
+ *
+ * The Storybook apps do not carry the same catalogue, so a partial pair is
+ * normal — but an unnoticed one is how drift escapes a comparison. Naming
+ * the gaps once per run puts them in the report instead.
+ */
+const reportPairCoverage = function reportPairCoverage(
+	label: string,
+	paired: readonly { key: string; missing: string[] }[]
+): void {
+	const gaps = paired.filter((pair) => pair.missing.length > 0);
+	if (gaps.length === 0) {
+		return;
+	}
+	console.log(
+		`[PARITY] ${label}: ${gaps.length} pair(s) not compared across every enabled framework — ${gaps
+			.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
+			.join('; ')}`
 	);
 };
 
@@ -188,6 +209,11 @@ test.describe('cross-framework parity', () => {
 				/**
 				 * Whether this story's result for one check is a known,
 				 * documented difference.
+				 *
+				 * Call this only once a check has actually failed. Marking
+				 * an entry used before that keeps a stale allowance alive
+				 * forever, which is the one thing the stale-entry gate
+				 * exists to catch.
 				 */
 				const allowed = function allowed(
 					check: 'dom' | 'a11y' | 'css'
@@ -235,10 +261,8 @@ test.describe('cross-framework parity', () => {
 					}
 				}
 
-				const styleDiffs = allowed('css')
-					? []
-					: diffComputedStyleMap(baselineStyles, styles);
-				if (styleDiffs.length > 0) {
+				const styleDiffs = diffComputedStyleMap(baselineStyles, styles);
+				if (styleDiffs.length > 0 && !allowed('css')) {
 					// Summarize to keep the failure output legible; the first few
 					// diffs usually point at the offending class contract.
 					const sample = styleDiffs
@@ -265,6 +289,7 @@ test.describe('cross-framework parity', () => {
 			);
 		}
 
+		reportPairCoverage('DOM+a11y+CSS', paired);
 		console.log(`[PARITY] DOM+a11y+CSS: ${failures.length} failure(s)`);
 		expect(failures, failures.join('\n')).toHaveLength(0);
 	});

--- a/apps/parity-runner/tests/parity.spec.ts
+++ b/apps/parity-runner/tests/parity.spec.ts
@@ -75,9 +75,14 @@ const loadPairedStories = async function loadPairedStories(): Promise<
 			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 			byFramework[framework] = await loadStorybookIndex(url);
 		} catch (err) {
-			// If a Storybook isn't running, skip that framework's entries.
-			// Downstream pairing will just produce fewer entries.
-			console.warn(`[parity] could not load ${framework} index: ${err}`);
+			// Dropping the framework here would leave the run comparing the
+			// ones that did load and reporting a pass, which is the one
+			// outcome a gate must never produce for a framework it was told
+			// to check.
+			throw new Error(
+				`[parity] ${framework} Storybook index did not load from ${url}`,
+				{ cause: err }
+			);
 		}
 	}
 	return pairStories(byFramework).filter(
@@ -250,11 +255,11 @@ test.describe('cross-framework parity', () => {
 			}
 		}
 
-		for (const entry of unusedAllowlistEntries(usedEntries, [
-			'dom',
-			'a11y',
-			'css',
-		])) {
+		for (const entry of unusedAllowlistEntries(
+			usedEntries,
+			['dom', 'a11y', 'css'],
+			ENABLED_FRAMEWORKS
+		)) {
 			failures.push(
 				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
 			);

--- a/apps/parity-runner/tests/parity.spec.ts
+++ b/apps/parity-runner/tests/parity.spec.ts
@@ -108,11 +108,11 @@ const reportPairCoverage = function reportPairCoverage(
 	if (gaps.length === 0) {
 		return;
 	}
-	console.log(
-		`[PARITY] ${label}: ${gaps.length} pair(s) not compared across every enabled framework — ${gaps
-			.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
-			.join('; ')}`
-	);
+	const detail = gaps
+		.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
+		.join('; ');
+	console.log(`[PARITY] ${label}: ${gaps.length} pair(s) missing a framework`);
+	console.log(`[PARITY] ${label}: ${detail}`);
 };
 
 const openStory = async function openStory(

--- a/apps/parity-runner/tests/parity.spec.ts
+++ b/apps/parity-runner/tests/parity.spec.ts
@@ -17,6 +17,8 @@
  * Environment variables:
  *   - `REACT_STORYBOOK_URL` (default http://127.0.0.1:6006)
  *   - `SVELTE_STORYBOOK_URL` (default http://127.0.0.1:6007)
+ *   - `VUE_STORYBOOK_URL` (default http://127.0.0.1:6008)
+ *   - `ASTRO_STORYBOOK_URL` (default http://127.0.0.1:6010)
  *   - `PARITY_FRAMEWORKS` (comma list, default `react,svelte`)
  */
 
@@ -32,6 +34,7 @@ import type { PairedStory } from '../src/pair-stories';
 import { loadStorybookIndex } from '../src/storybook-index';
 
 const FRAMEWORK_URLS: Record<string, string> = {
+	astro: process.env.ASTRO_STORYBOOK_URL ?? 'http://127.0.0.1:6010',
 	react: process.env.REACT_STORYBOOK_URL ?? 'http://127.0.0.1:6006',
 	solid: process.env.SOLID_STORYBOOK_URL ?? 'http://127.0.0.1:6009',
 	svelte: process.env.SVELTE_STORYBOOK_URL ?? 'http://127.0.0.1:6007',

--- a/apps/parity-runner/tests/parity.spec.ts
+++ b/apps/parity-runner/tests/parity.spec.ts
@@ -20,6 +20,10 @@
  *   - `VUE_STORYBOOK_URL` (default http://127.0.0.1:6008)
  *   - `ASTRO_STORYBOOK_URL` (default http://127.0.0.1:6010)
  *   - `PARITY_FRAMEWORKS` (comma list, default `react,svelte`)
+ *
+ * Known drift these checks are not expected to catch lives in
+ * `src/parity-allowlist.ts`. These three report one result per story
+ * rather than per element, so their entries use `slot: '*'`.
  */
 
 import { diffComputedStyleMap } from '@c15t/conformance';
@@ -31,6 +35,11 @@ import { captureComputedStyleMap } from '../src/diff-computed-style';
 import { captureDomSnapshot } from '../src/diff-dom';
 import { pairStories } from '../src/pair-stories';
 import type { PairedStory } from '../src/pair-stories';
+import {
+	findAllowEntry,
+	unusedAllowlistEntries,
+} from '../src/parity-allowlist';
+import type { ParityAllowEntry } from '../src/parity-allowlist';
 import { loadStorybookIndex } from '../src/storybook-index';
 
 const FRAMEWORK_URLS: Record<string, string> = {
@@ -138,6 +147,7 @@ test.describe('cross-framework parity', () => {
 	}) => {
 		const paired = await loadPairedStories();
 		const failures: string[] = [];
+		const usedEntries = new Set<ParityAllowEntry>();
 
 		for (const pair of paired) {
 			const entries = Object.entries(pair.entries);
@@ -170,6 +180,24 @@ test.describe('cross-framework parity', () => {
 				if (!url) {
 					continue;
 				}
+				/**
+				 * Whether this story's result for one check is a known,
+				 * documented difference.
+				 */
+				const allowed = function allowed(
+					check: 'dom' | 'a11y' | 'css'
+				): boolean {
+					const allowEntry = findAllowEntry({
+						check,
+						framework,
+						slot: '*',
+						story: pair.key,
+					});
+					if (allowEntry) {
+						usedEntries.add(allowEntry);
+					}
+					return Boolean(allowEntry);
+				};
 				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 				await openStory(page, url, entry.id);
 				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
@@ -179,7 +207,7 @@ test.describe('cross-framework parity', () => {
 				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 				const styles = await captureComputedStyleMap(page, '#storybook-root');
 
-				if (dom !== baselineDom) {
+				if (dom !== baselineDom && !allowed('dom')) {
 					failures.push(
 						`[DOM] ${pair.key}: ${baselineFramework} ≠ ${framework}`
 					);
@@ -190,7 +218,7 @@ test.describe('cross-framework parity', () => {
 						);
 					}
 				}
-				if (a11y !== baselineA11y) {
+				if (a11y !== baselineA11y && !allowed('a11y')) {
 					failures.push(
 						`[A11Y] ${pair.key}: ${baselineFramework} ≠ ${framework}`
 					);
@@ -202,7 +230,9 @@ test.describe('cross-framework parity', () => {
 					}
 				}
 
-				const styleDiffs = diffComputedStyleMap(baselineStyles, styles);
+				const styleDiffs = allowed('css')
+					? []
+					: diffComputedStyleMap(baselineStyles, styles);
 				if (styleDiffs.length > 0) {
 					// Summarize to keep the failure output legible; the first few
 					// diffs usually point at the offending class contract.
@@ -218,6 +248,16 @@ test.describe('cross-framework parity', () => {
 					);
 				}
 			}
+		}
+
+		for (const entry of unusedAllowlistEntries(usedEntries, [
+			'dom',
+			'a11y',
+			'css',
+		])) {
+			failures.push(
+				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
+			);
 		}
 
 		console.log(`[PARITY] DOM+a11y+CSS: ${failures.length} failure(s)`);

--- a/apps/parity-runner/tests/visual-parity.spec.ts
+++ b/apps/parity-runner/tests/visual-parity.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * Cross-framework visual parity.
+ *
+ * Two checks, both against React as the baseline, both driven by the same
+ * story pairing the DOM/a11y/CSS spec uses:
+ *
+ *   1. **Geometry** — every `data-testid` slot's box, relative to the card
+ *      it sits in, must match React within 1px. Deterministic, no images,
+ *      and it fails on exactly the class of drift the descriptive diffs
+ *      cannot see: same markup, different layout.
+ *   2. **Pixel backstop** — element screenshots of the banner card and the
+ *      dialog card, compared to React with a per-channel tolerance and a
+ *      small mismatch budget. Loose on antialiasing, strict on size.
+ *
+ * Known drift that is out of scope goes in `src/parity-allowlist.ts` with
+ * a reason, keyed by check + framework + story + slot.
+ *
+ * Environment variables:
+ *   - `{REACT,SVELTE,VUE,ASTRO}_STORYBOOK_URL`
+ *   - `PARITY_FRAMEWORKS` (comma list, default `react,svelte`)
+ *   - `PARITY_SKIP_PIXEL=1` skips the pixel backstop. Font rasterisation is
+ *     machine-specific, so the budget is calibrated for CI's pinned
+ *     Chromium and a local run will produce noise.
+ */
+
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+import {
+	captureGeometry,
+	diffGeometry,
+	formatGeometryDiffs,
+} from '../src/geometry';
+import { pairStories } from '../src/pair-stories';
+import type { PairedStory } from '../src/pair-stories';
+import {
+	findAllowEntry,
+	unusedAllowlistEntries,
+} from '../src/parity-allowlist';
+import type { ParityAllowEntry } from '../src/parity-allowlist';
+import { comparePng } from '../src/pixel-diff';
+import { loadStorybookIndex } from '../src/storybook-index';
+
+const FRAMEWORK_URLS: Record<string, string> = {
+	astro: process.env.ASTRO_STORYBOOK_URL ?? 'http://127.0.0.1:6010',
+	react: process.env.REACT_STORYBOOK_URL ?? 'http://127.0.0.1:6006',
+	solid: process.env.SOLID_STORYBOOK_URL ?? 'http://127.0.0.1:6009',
+	svelte: process.env.SVELTE_STORYBOOK_URL ?? 'http://127.0.0.1:6007',
+	vue: process.env.VUE_STORYBOOK_URL ?? 'http://127.0.0.1:6008',
+};
+
+const ENABLED_FRAMEWORKS = (process.env.PARITY_FRAMEWORKS ?? 'react,svelte')
+	.split(',')
+	.map((framework) => framework.trim())
+	.filter(Boolean);
+
+/** React is the baseline every other framework is measured against. */
+const BASELINE = 'react';
+
+/** Largest box difference, in px, that is not drift. */
+const GEOMETRY_TOLERANCE = 1;
+
+/** The cards the pixel backstop photographs. */
+const PIXEL_SLOTS = ['consent-banner-card', 'consent-dialog-card'];
+
+const PIXEL_BUDGET = { maxRatio: 0.005, threshold: 12 };
+
+const loadPairedStories = async function loadPairedStories(): Promise<
+	PairedStory[]
+> {
+	const byFramework: Record<
+		string,
+		Awaited<ReturnType<typeof loadStorybookIndex>>
+	> = {};
+	for (const framework of ENABLED_FRAMEWORKS) {
+		const url = FRAMEWORK_URLS[framework];
+		if (!url) {
+			continue;
+		}
+		try {
+			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+			byFramework[framework] = await loadStorybookIndex(url);
+		} catch (err) {
+			console.warn(`[parity] could not load ${framework} index: ${err}`);
+		}
+	}
+	// Only stories React also has: React is the baseline, so a pair without
+	// it has nothing to be measured against.
+	return pairStories(byFramework).filter(
+		(pair) => pair.entries[BASELINE] && Object.keys(pair.entries).length >= 2
+	);
+};
+
+const openStory = async function openStory(
+	page: Page,
+	baseUrl: string,
+	storyId: string
+): Promise<void> {
+	const url = new URL(`/iframe.html?id=${storyId}&viewMode=story`, baseUrl);
+	await page.goto(url.toString(), { waitUntil: 'networkidle' });
+	await page.locator('#storybook-root').waitFor({ state: 'attached' });
+	await page.evaluate(() => document.fonts.ready);
+	// Enter/leave transitions on the banner and dialog settle well inside
+	// this; `animations: 'disabled'` only applies to screenshots.
+	await page.waitForTimeout(250);
+};
+
+test.describe('cross-framework visual parity', () => {
+	test.use({
+		colorScheme: 'light',
+		deviceScaleFactor: 1,
+		reducedMotion: 'reduce',
+		viewport: { height: 800, width: 1280 },
+	});
+
+	test('paired stories lay out identically to React', async ({ page }) => {
+		const paired = await loadPairedStories();
+		expect(paired.length, 'no paired stories to compare').toBeGreaterThan(0);
+
+		const failures: string[] = [];
+		const usedEntries = new Set<ParityAllowEntry>();
+
+		for (const pair of paired) {
+			const baselineEntry = pair.entries[BASELINE];
+			const baselineUrl = FRAMEWORK_URLS[BASELINE];
+			if (!(baselineEntry && baselineUrl)) {
+				continue;
+			}
+			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+			await openStory(page, baselineUrl, baselineEntry.id);
+			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+			const baseline = await captureGeometry(page);
+
+			for (const [framework, entry] of Object.entries(pair.entries)) {
+				const url = FRAMEWORK_URLS[framework];
+				if (framework === BASELINE || !url) {
+					continue;
+				}
+				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+				await openStory(page, url, entry.id);
+				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+				const candidate = await captureGeometry(page);
+
+				const diffs = diffGeometry(
+					baseline,
+					candidate,
+					GEOMETRY_TOLERANCE
+				).filter((diff) => {
+					const allowed = findAllowEntry({
+						check: 'geometry',
+						framework,
+						slot: diff.slot,
+						story: pair.key,
+					});
+					if (allowed) {
+						usedEntries.add(allowed);
+					}
+					return !allowed;
+				});
+
+				if (diffs.length > 0) {
+					failures.push(
+						`[GEOMETRY] ${pair.key}: ${BASELINE} ≠ ${framework}\n    ${formatGeometryDiffs(
+							diffs
+						).join('\n    ')}`
+					);
+				}
+			}
+		}
+
+		for (const entry of unusedAllowlistEntries(usedEntries)) {
+			failures.push(
+				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
+			);
+		}
+
+		console.log(`[PARITY] geometry: ${failures.length} failure(s)`);
+		expect(failures, failures.join('\n')).toHaveLength(0);
+	});
+
+	test('paired story cards match React pixel-for-pixel', async ({
+		page,
+	}, testInfo) => {
+		test.skip(
+			process.env.PARITY_SKIP_PIXEL === '1',
+			'PARITY_SKIP_PIXEL=1: the budget is calibrated for CI’s pinned Chromium.'
+		);
+
+		const paired = await loadPairedStories();
+		const failures: string[] = [];
+
+		for (const pair of paired) {
+			const baselineEntry = pair.entries[BASELINE];
+			const baselineUrl = FRAMEWORK_URLS[BASELINE];
+			if (!(baselineEntry && baselineUrl)) {
+				continue;
+			}
+			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+			await openStory(page, baselineUrl, baselineEntry.id);
+
+			const baselineShots = new Map<string, Buffer>();
+			for (const slot of PIXEL_SLOTS) {
+				const locator = page.locator(`[data-testid="${slot}"]`).first();
+				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+				if ((await locator.count()) === 0) {
+					continue;
+				}
+				baselineShots.set(
+					slot,
+					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+					await locator.screenshot({ animations: 'disabled' })
+				);
+			}
+			if (baselineShots.size === 0) {
+				continue;
+			}
+
+			for (const [framework, entry] of Object.entries(pair.entries)) {
+				const url = FRAMEWORK_URLS[framework];
+				if (framework === BASELINE || !url) {
+					continue;
+				}
+				// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+				await openStory(page, url, entry.id);
+
+				for (const [slot, baselineShot] of baselineShots) {
+					if (
+						findAllowEntry({ check: 'pixel', framework, slot, story: pair.key })
+					) {
+						continue;
+					}
+					const locator = page.locator(`[data-testid="${slot}"]`).first();
+					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+					if ((await locator.count()) === 0) {
+						failures.push(
+							`[PIXEL] ${pair.key} ${slot}: ${framework} does not render this slot`
+						);
+						continue;
+					}
+					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+					const shot = await locator.screenshot({ animations: 'disabled' });
+					const result = comparePng(baselineShot, shot, PIXEL_BUDGET);
+					if (result.ok) {
+						continue;
+					}
+					failures.push(
+						`[PIXEL] ${pair.key} ${slot}: ${BASELINE} ≠ ${framework} — ${result.reason}`
+					);
+					const name = `${pair.key}-${slot}-${framework}`.replace(
+						/[^a-z0-9]+/giu,
+						'-'
+					);
+					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+					await testInfo.attach(`${name}-react.png`, {
+						body: baselineShot,
+						contentType: 'image/png',
+					});
+					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+					await testInfo.attach(`${name}-${framework}.png`, {
+						body: shot,
+						contentType: 'image/png',
+					});
+					if (result.diff) {
+						// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
+						await testInfo.attach(`${name}-diff.png`, {
+							body: result.diff,
+							contentType: 'image/png',
+						});
+					}
+				}
+			}
+		}
+
+		console.log(`[PARITY] pixel: ${failures.length} failure(s)`);
+		expect(failures, failures.join('\n')).toHaveLength(0);
+	});
+});

--- a/apps/parity-runner/tests/visual-parity.spec.ts
+++ b/apps/parity-runner/tests/visual-parity.spec.ts
@@ -168,7 +168,7 @@ test.describe('cross-framework visual parity', () => {
 			}
 		}
 
-		for (const entry of unusedAllowlistEntries(usedEntries)) {
+		for (const entry of unusedAllowlistEntries(usedEntries, ['geometry'])) {
 			failures.push(
 				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
 			);
@@ -188,6 +188,7 @@ test.describe('cross-framework visual parity', () => {
 
 		const paired = await loadPairedStories();
 		const failures: string[] = [];
+		const usedEntries = new Set<ParityAllowEntry>();
 
 		for (const pair of paired) {
 			const baselineEntry = pair.entries[BASELINE];
@@ -224,9 +225,14 @@ test.describe('cross-framework visual parity', () => {
 				await openStory(page, url, entry.id);
 
 				for (const [slot, baselineShot] of baselineShots) {
-					if (
-						findAllowEntry({ check: 'pixel', framework, slot, story: pair.key })
-					) {
+					const allowed = findAllowEntry({
+						check: 'pixel',
+						framework,
+						slot,
+						story: pair.key,
+					});
+					if (allowed) {
+						usedEntries.add(allowed);
 						continue;
 					}
 					const locator = page.locator(`[data-testid="${slot}"]`).first();
@@ -269,6 +275,12 @@ test.describe('cross-framework visual parity', () => {
 					}
 				}
 			}
+		}
+
+		for (const entry of unusedAllowlistEntries(usedEntries, ['pixel'])) {
+			failures.push(
+				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
+			);
 		}
 
 		console.log(`[PARITY] pixel: ${failures.length} failure(s)`);

--- a/apps/parity-runner/tests/visual-parity.spec.ts
+++ b/apps/parity-runner/tests/visual-parity.spec.ts
@@ -31,8 +31,8 @@ import {
 	diffGeometry,
 	formatGeometryDiffs,
 } from '../src/geometry';
-import { pairStories } from '../src/pair-stories';
-import type { PairedStory } from '../src/pair-stories';
+import { selectComparablePairs } from '../src/pair-stories';
+import type { ComparablePair } from '../src/pair-stories';
 import {
 	findAllowEntry,
 	unusedAllowlistEntries,
@@ -66,7 +66,7 @@ const PIXEL_SLOTS = ['consent-banner-card', 'consent-dialog-card'];
 const PIXEL_BUDGET = { maxRatio: 0.005, threshold: 12 };
 
 const loadPairedStories = async function loadPairedStories(): Promise<
-	PairedStory[]
+	ComparablePair[]
 > {
 	const byFramework: Record<
 		string,
@@ -93,8 +93,31 @@ const loadPairedStories = async function loadPairedStories(): Promise<
 	}
 	// Only stories React also has: React is the baseline, so a pair without
 	// it has nothing to be measured against.
-	return pairStories(byFramework).filter(
-		(pair) => pair.entries[BASELINE] && Object.keys(pair.entries).length >= 2
+	return selectComparablePairs(byFramework, {
+		baseline: BASELINE,
+		frameworks: ENABLED_FRAMEWORKS,
+	});
+};
+
+/**
+ * Logs which frameworks each pair is missing.
+ *
+ * The Storybook apps do not carry the same catalogue, so a partial pair is
+ * normal — but an unnoticed one is how drift escapes a comparison. Naming
+ * the gaps once per run puts them in the report instead.
+ */
+const reportPairCoverage = function reportPairCoverage(
+	label: string,
+	paired: readonly { key: string; missing: string[] }[]
+): void {
+	const gaps = paired.filter((pair) => pair.missing.length > 0);
+	if (gaps.length === 0) {
+		return;
+	}
+	console.log(
+		`[PARITY] ${label}: ${gaps.length} pair(s) not compared across every enabled framework — ${gaps
+			.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
+			.join('; ')}`
 	);
 };
 
@@ -185,6 +208,7 @@ test.describe('cross-framework visual parity', () => {
 			);
 		}
 
+		reportPairCoverage('geometry', paired);
 		console.log(`[PARITY] geometry: ${failures.length} failure(s)`);
 		expect(failures, failures.join('\n')).toHaveLength(0);
 	});
@@ -236,28 +260,41 @@ test.describe('cross-framework visual parity', () => {
 				await openStory(page, url, entry.id);
 
 				for (const [slot, baselineShot] of baselineShots) {
-					const allowed = findAllowEntry({
-						check: 'pixel',
-						framework,
-						slot,
-						story: pair.key,
-					});
-					if (allowed) {
+					/**
+					 * The allowance for this slot, marked used.
+					 *
+					 * Only called once a comparison has actually failed:
+					 * marking an entry used before that keeps a stale
+					 * allowance alive forever, which is the one thing the
+					 * stale-entry gate exists to catch.
+					 */
+					const suppress = function suppress(): boolean {
+						const allowed = findAllowEntry({
+							check: 'pixel',
+							framework,
+							slot,
+							story: pair.key,
+						});
+						if (!allowed) {
+							return false;
+						}
 						usedEntries.add(allowed);
-						continue;
-					}
+						return true;
+					};
 					const locator = page.locator(`[data-testid="${slot}"]`).first();
 					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 					if ((await locator.count()) === 0) {
-						failures.push(
-							`[PIXEL] ${pair.key} ${slot}: ${framework} does not render this slot`
-						);
+						if (!suppress()) {
+							failures.push(
+								`[PIXEL] ${pair.key} ${slot}: ${framework} does not render this slot`
+							);
+						}
 						continue;
 					}
 					// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 					const shot = await locator.screenshot({ animations: 'disabled' });
 					const result = comparePng(baselineShot, shot, PIXEL_BUDGET);
-					if (result.ok) {
+					if (result.ok || suppress()) {
 						continue;
 					}
 					failures.push(

--- a/apps/parity-runner/tests/visual-parity.spec.ts
+++ b/apps/parity-runner/tests/visual-parity.spec.ts
@@ -81,7 +81,14 @@ const loadPairedStories = async function loadPairedStories(): Promise<
 			// oxlint-disable-next-line no-await-in-loop -- Preserve sequential execution and callback compatibility.
 			byFramework[framework] = await loadStorybookIndex(url);
 		} catch (err) {
-			console.warn(`[parity] could not load ${framework} index: ${err}`);
+			// Dropping the framework here would leave the run comparing the
+			// ones that did load and reporting a pass, which is the one
+			// outcome a gate must never produce for a framework it was told
+			// to check.
+			throw new Error(
+				`[parity] ${framework} Storybook index did not load from ${url}`,
+				{ cause: err }
+			);
 		}
 	}
 	// Only stories React also has: React is the baseline, so a pair without
@@ -168,7 +175,11 @@ test.describe('cross-framework visual parity', () => {
 			}
 		}
 
-		for (const entry of unusedAllowlistEntries(usedEntries, ['geometry'])) {
+		for (const entry of unusedAllowlistEntries(
+			usedEntries,
+			['geometry'],
+			ENABLED_FRAMEWORKS
+		)) {
 			failures.push(
 				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
 			);
@@ -277,7 +288,11 @@ test.describe('cross-framework visual parity', () => {
 			}
 		}
 
-		for (const entry of unusedAllowlistEntries(usedEntries, ['pixel'])) {
+		for (const entry of unusedAllowlistEntries(
+			usedEntries,
+			['pixel'],
+			ENABLED_FRAMEWORKS
+		)) {
 			failures.push(
 				`[ALLOWLIST] stale entry matched nothing — delete it: ${entry.check} ${entry.framework} ${entry.story} ${entry.slot}`
 			);

--- a/apps/parity-runner/tests/visual-parity.spec.ts
+++ b/apps/parity-runner/tests/visual-parity.spec.ts
@@ -114,11 +114,11 @@ const reportPairCoverage = function reportPairCoverage(
 	if (gaps.length === 0) {
 		return;
 	}
-	console.log(
-		`[PARITY] ${label}: ${gaps.length} pair(s) not compared across every enabled framework — ${gaps
-			.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
-			.join('; ')}`
-	);
+	const detail = gaps
+		.map((pair) => `${pair.key} (missing ${pair.missing.join(', ')})`)
+		.join('; ');
+	console.log(`[PARITY] ${label}: ${gaps.length} pair(s) missing a framework`);
+	console.log(`[PARITY] ${label}: ${detail}`);
 };
 
 const openStory = async function openStory(

--- a/apps/storybook-astro/.storybook/astro-prerender.ts
+++ b/apps/storybook-astro/.storybook/astro-prerender.ts
@@ -138,7 +138,7 @@ const renderVariants = async function renderVariants(
 			if (!file) {
 				throw new Error(`Unknown Astro component: ${variant.component}`);
 			}
-			// oxlint-disable-next-line no-await-in-loop -- One shared container; renders must not interleave.
+			// oxlint-disable-next-line no-await-in-loop -- One shared container.
 			const component = await server.ssrLoadModule(path.join(astroSrc, file));
 			const astroOptions: Record<string, unknown> = {
 				colorScheme: variant.options?.colorScheme ?? 'light',

--- a/apps/storybook-astro/.storybook/astro-prerender.ts
+++ b/apps/storybook-astro/.storybook/astro-prerender.ts
@@ -34,6 +34,10 @@ const repoRoot = path.resolve(storybookDir, '../../..');
 const astroPackage = path.resolve(repoRoot, 'packages/astro');
 const astroSrc = path.resolve(astroPackage, 'src');
 
+/**
+ * The virtual module this plugin serves, imported by
+ * `render-astro-story.ts` to reach the prerendered variants.
+ */
 export const VIRTUAL_ID = 'virtual:c15t-astro-prerendered';
 const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`;
 

--- a/apps/storybook-astro/.storybook/astro-prerender.ts
+++ b/apps/storybook-astro/.storybook/astro-prerender.ts
@@ -1,0 +1,199 @@
+/**
+ * Build-time `.astro` prerendering for Storybook.
+ *
+ * There is no official Astro renderer for Storybook. The community
+ * `storybook-astro` package renders through the Vite dev server's HMR
+ * channel, so a static `storybook build` — which is what CI serves to the
+ * parity runner — has no renderer at all, and it offers no way to populate
+ * `Astro.locals`, which every c15t `.astro` component needs. So this
+ * plugin does the rendering itself.
+ *
+ * It boots one Vite server in middleware mode with Astro's own plugins (via
+ * `getViteConfig`), which is what makes `.astro` files loadable, then
+ * renders every variant in the catalogue through
+ * `experimental_AstroContainer` exactly the way `packages/astro`'s unit
+ * tests do — same `resolveOptions`, same `resolveConsentContext`. The
+ * results are exposed as one virtual module the stories import.
+ *
+ * The fragments are static server output, so `<script>` tags are stripped:
+ * Astro's build pipeline is what would normally bundle them, and the story
+ * boots `@c15t/astro/client` itself instead. The inline config script the
+ * banner emits is captured separately and replayed as
+ * `window.__c15tAstroConfig`, which is what a real page does.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { Plugin, ViteDevServer } from 'vite';
+
+import type { AstroStoryVariant } from '../src/story-variants';
+
+const storybookDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(storybookDir, '../../..');
+const astroPackage = path.resolve(repoRoot, 'packages/astro');
+const astroSrc = path.resolve(astroPackage, 'src');
+
+export const VIRTUAL_ID = 'virtual:c15t-astro-prerendered';
+const RESOLVED_VIRTUAL_ID = `\0${VIRTUAL_ID}`;
+
+/** One prerendered variant, as the browser receives it. */
+export interface PrerenderedVariant {
+	/** Server-rendered markup, with every `<script>` removed. */
+	html: string;
+	/** The kernel config the server inlined, replayed on the client. */
+	config: unknown;
+	/** The resolved integration options the story boots with. */
+	options: unknown;
+}
+
+const SCRIPT_TAG = /<script\b[^>]*>[\s\S]*?<\/script>/giu;
+const CONFIG_SCRIPT =
+	/window\.__c15tAstroConfig\s*=\s*(?<config>[\s\S]*?);?\s*$/u;
+
+/**
+ * Pull the kernel config out of the inline script the banner emits.
+ *
+ * @param html - The container's raw output.
+ * @returns The parsed config, or `{}` when the fragment emitted none.
+ */
+const extractConfig = function extractConfig(html: string): unknown {
+	for (const tag of html.match(SCRIPT_TAG) ?? []) {
+		const body = tag
+			.replace(/^<script\b[^>]*>/iu, '')
+			.replace(/<\/script>$/iu, '');
+		const config = CONFIG_SCRIPT.exec(body.trim())?.groups?.config;
+		if (config) {
+			return JSON.parse(config);
+		}
+	}
+	return {};
+};
+
+const COMPONENT_FILES: Record<string, string> = {
+	'consent-banner': 'components/consent-banner.astro',
+	'consent-dialog': 'components/consent-dialog.astro',
+	'consent-dialog-trigger': 'components/consent-dialog-trigger.astro',
+	'iab-consent-dialog': 'components/iab-consent-dialog.astro',
+};
+
+/**
+ * Astro strips `data-astro-source-*` in production but not in dev. The
+ * fragments have to be byte-stable for the parity DOM diff, so they are
+ * removed unconditionally.
+ */
+const stripDevAttributes = function stripDevAttributes(html: string): string {
+	return html.replace(/\s+data-astro-source-(?:file|loc)="[^"]*"/gu, '');
+};
+
+const renderVariants = async function renderVariants(
+	variants: readonly AstroStoryVariant[]
+): Promise<Record<string, PrerenderedVariant>> {
+	// Imported lazily: pulling Astro's config entrypoint in at module scope
+	// would load it for every Storybook process, including the browser build
+	// that never renders anything.
+	const [{ createServer }, { getViteConfig }, { experimental_AstroContainer }] =
+		await Promise.all([
+			import('vite'),
+			import('astro/config'),
+			import('astro/container'),
+		]);
+
+	// Rooted at `packages/astro`, not the repo root: Vite externalises
+	// Astro's own runtime (`astro/compiler-runtime`) and resolves it from
+	// the server root, and `astro` is a dependency of that package alone.
+	const configFn = getViteConfig({}, { root: astroPackage });
+	// `serve` rather than `build`: under `build` Vite externalises Astro's
+	// runtime and then resolves it from the server root instead of the
+	// importing `.astro` file, which fails in a workspace where `astro` is a
+	// dependency of `packages/astro` alone.
+	const viteConfig = await configFn({ command: 'serve', mode: 'development' });
+	// `getViteConfig` is shaped for Vitest; the test block means nothing to a
+	// plain dev server and Vite rejects unknown top-level keys.
+	delete (viteConfig as { test?: unknown }).test;
+
+	let server: ViteDevServer | undefined;
+	try {
+		server = await createServer({
+			...viteConfig,
+			appType: 'custom',
+			logLevel: 'error',
+			server: { hmr: false, middlewareMode: true },
+		});
+
+		const [serverModule, integration, mode] = await Promise.all([
+			server.ssrLoadModule(path.join(astroSrc, 'server.ts')),
+			server.ssrLoadModule(path.join(astroSrc, 'integration.ts')),
+			server.ssrLoadModule(path.join(astroSrc, 'mode.ts')),
+		]);
+		const container = await experimental_AstroContainer.create();
+
+		const out: Record<string, PrerenderedVariant> = {};
+		for (const variant of variants) {
+			const file = COMPONENT_FILES[variant.component];
+			if (!file) {
+				throw new Error(`Unknown Astro component: ${variant.component}`);
+			}
+			// oxlint-disable-next-line no-await-in-loop -- One shared container; renders must not interleave.
+			const component = await server.ssrLoadModule(path.join(astroSrc, file));
+			const astroOptions: Record<string, unknown> = {
+				colorScheme: variant.options?.colorScheme ?? 'light',
+				consentCategories: variant.options?.consentCategories,
+				mode: mode.offlineMode(),
+				ui: 'svelte',
+			};
+			if (variant.options?.iab) {
+				astroOptions.iab = {};
+			}
+			const resolved = integration.resolveOptions(astroOptions);
+			// oxlint-disable-next-line no-await-in-loop -- See above.
+			const locals = await serverModule.resolveConsentContext({
+				headers: new Headers(),
+				options: resolved,
+			});
+			// oxlint-disable-next-line no-await-in-loop -- See above.
+			const raw = await container.renderToString(component.default, {
+				locals: { c15t: locals },
+				props: variant.props ?? {},
+				slots: variant.slots,
+			});
+			out[variant.id] = {
+				config: extractConfig(raw),
+				html: stripDevAttributes(raw.replace(SCRIPT_TAG, '')).trim(),
+				options: resolved,
+			};
+		}
+		return out;
+	} finally {
+		await server?.close();
+	}
+};
+
+/**
+ * Prerender every catalogued `.astro` variant and serve the result as
+ * {@link VIRTUAL_ID}.
+ *
+ * @param variants - The story catalogue.
+ * @returns A Vite plugin.
+ */
+export const astroPrerender = function astroPrerender(
+	variants: readonly AstroStoryVariant[]
+): Plugin {
+	let pending: Promise<Record<string, PrerenderedVariant>> | undefined;
+
+	return {
+		enforce: 'pre',
+		async load(id: string) {
+			if (id !== RESOLVED_VIRTUAL_ID) {
+				return;
+			}
+			pending ??= renderVariants(variants);
+			const rendered = await pending;
+			return `export default ${JSON.stringify(rendered)};`;
+		},
+		name: 'c15t:astro-prerender',
+		resolveId(id: string) {
+			return id === VIRTUAL_ID ? RESOLVED_VIRTUAL_ID : undefined;
+		},
+	};
+};

--- a/apps/storybook-astro/.storybook/astro-prerender.ts
+++ b/apps/storybook-astro/.storybook/astro-prerender.ts
@@ -27,7 +27,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { Plugin, ViteDevServer } from 'vite';
 
-import type { AstroStoryVariant } from '../src/story-variants';
+import type { AstroStoryVariant } from '../src/story-variants.ts';
 
 const storybookDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(storybookDir, '../../..');

--- a/apps/storybook-astro/.storybook/main.ts
+++ b/apps/storybook-astro/.storybook/main.ts
@@ -5,8 +5,8 @@ import type { StorybookConfig } from '@storybook/html-vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { mergeConfig } from 'vite';
 
-import { astroStoryVariants } from '../src/story-variants';
-import { astroPrerender } from './astro-prerender';
+import { astroStoryVariants } from '../src/story-variants.ts';
+import { astroPrerender } from './astro-prerender.ts';
 
 const storybookDir = path.dirname(fileURLToPath(import.meta.url));
 const workspace = (...segments: string[]) =>

--- a/apps/storybook-astro/.storybook/main.ts
+++ b/apps/storybook-astro/.storybook/main.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { StorybookConfig } from '@storybook/html-vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { mergeConfig } from 'vite';
+
+import { astroStoryVariants } from '../src/story-variants';
+import { astroPrerender } from './astro-prerender';
+
+const storybookDir = path.dirname(fileURLToPath(import.meta.url));
+const workspace = (...segments: string[]) =>
+	path.resolve(storybookDir, '../../..', ...segments);
+
+const config: StorybookConfig = {
+	addons: ['@storybook/addon-a11y'],
+	framework: {
+		name: '@storybook/html-vite',
+		options: {},
+	},
+	stories: ['../src/**/*.stories.@(ts|js)'],
+	viteFinal: (configLocal) =>
+		mergeConfig(configLocal, {
+			plugins: [
+				astroPrerender(astroStoryVariants),
+				// The preference-centre island is a `.svelte` file the
+				// integration hands to the consuming app's build; here that
+				// build is Storybook's.
+				svelte(),
+			],
+			resolve: {
+				alias: [
+					{
+						find: /^@c15t\/conformance\/(?<capture1>.*)$/u,
+						replacement: workspace('internals/conformance/src/$1'),
+					},
+					// `@c15t/astro` is consumed through its published entrypoints
+					// so the Storybook exercises the same client boot, adapter and
+					// island a real site loads.
+					{
+						find: /^@c15t\/svelte$/u,
+						replacement: workspace('packages/svelte/src/lib/index.ts'),
+					},
+					{
+						find: /^c15t$/u,
+						replacement: workspace('packages/core/src/index.ts'),
+					},
+					{
+						find: /^@c15t\/translations$/u,
+						replacement: workspace('packages/translations/src/index.ts'),
+					},
+				],
+			},
+		}),
+};
+
+export default config;

--- a/apps/storybook-astro/.storybook/preview.ts
+++ b/apps/storybook-astro/.storybook/preview.ts
@@ -1,0 +1,50 @@
+import type { Preview } from '@storybook/html-vite';
+
+// The shipped stylesheet, the same one an Astro site imports. It now
+// carries the default theme tokens, so nothing has to inject a theme at
+// runtime — which is the whole point of a server-rendered banner.
+import '@c15t/astro/styles.css';
+import '@c15t/ui/iab/styles.css';
+
+const storybookCanvasStyleId = 'c15t-storybook-canvas';
+const canvasCSS = `
+	:root {
+		color: var(--c15t-text);
+		background: var(--c15t-surface-hover);
+		font-family: var(--c15t-font-family);
+	}
+
+	body {
+		font-family: var(--c15t-font-family);
+		color: var(--c15t-text);
+		background: var(--c15t-surface-hover);
+	}
+`;
+
+const ensureGlobalStyle = function ensureGlobalStyle(
+	id: string,
+	cssText: string
+) {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	if (document.getElementById(id)) {
+		return;
+	}
+
+	const style = document.createElement('style');
+	style.id = id;
+	style.textContent = cssText;
+	document.head.appendChild(style);
+};
+
+ensureGlobalStyle(storybookCanvasStyleId, canvasCSS);
+
+const preview: Preview = {
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+export default preview;

--- a/apps/storybook-astro/declaration.d.ts
+++ b/apps/storybook-astro/declaration.d.ts
@@ -1,8 +1,9 @@
 declare module 'virtual:c15t-astro-prerendered' {
-	const prerendered: Record<
-		string,
-		{ html: string; config: unknown; options: unknown }
-	>;
+	// The producer's own type, so the two cannot drift: the plugin builds
+	// this module and exports the shape it returns.
+	import type { PrerenderedVariant } from './.storybook/astro-prerender';
+
+	const prerendered: Record<string, PrerenderedVariant>;
 	export default prerendered;
 }
 

--- a/apps/storybook-astro/declaration.d.ts
+++ b/apps/storybook-astro/declaration.d.ts
@@ -1,0 +1,12 @@
+declare module 'virtual:c15t-astro-prerendered' {
+	const prerendered: Record<
+		string,
+		{ html: string; config: unknown; options: unknown }
+	>;
+	export default prerendered;
+}
+
+declare module '*.astro' {
+	const component: unknown;
+	export default component;
+}

--- a/apps/storybook-astro/package.json
+++ b/apps/storybook-astro/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@c15t/storybook-astro",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "storybook build",
+		"prestorybook": "bun --cwd ../../packages/core prebuild && bun --cwd ../../packages/svelte prebuild && bun --cwd ../../packages/iab prebuild",
+		"storybook": "bun run prestorybook && portless run --name storybook-astro sh -c 'storybook dev --port \"$PORT\" --host \"$HOST\"'",
+		"test-storybook": "test-storybook --url ${STORYBOOK_URL:-http://127.0.0.1:6010}"
+	},
+	"dependencies": {
+		"@c15t/astro": "workspace:*",
+		"@c15t/conformance": "workspace:*",
+		"@c15t/core": "workspace:*",
+		"@c15t/svelte": "workspace:*",
+		"@c15t/ui": "workspace:*",
+		"svelte": "^5.56.4"
+	},
+	"devDependencies": {
+		"@storybook/addon-a11y": "10.4.6",
+		"@storybook/html-vite": "10.4.6",
+		"@storybook/test-runner": "^0.24.4",
+		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"astro": "^5.16.0",
+		"storybook": "10.4.6",
+		"typescript": "6.0.3",
+		"vite": "7.3.2"
+	}
+}

--- a/apps/storybook-astro/package.json
+++ b/apps/storybook-astro/package.json
@@ -4,8 +4,10 @@
 	"type": "module",
 	"scripts": {
 		"build": "storybook build",
-		"prestorybook": "bun --cwd ../../packages/core prebuild && bun --cwd ../../packages/svelte prebuild && bun --cwd ../../packages/iab prebuild",
-		"storybook": "bun run prestorybook && portless run --name storybook-astro sh -c 'storybook dev --port \"$PORT\" --host \"$HOST\"'",
+		"prebuild": "bun run prepare:deps",
+		"prepare:deps": "bun --cwd ../../packages/core prebuild && bun --cwd ../../packages/svelte prebuild && bun --cwd ../../packages/iab prebuild",
+		"prestorybook": "bun run prepare:deps",
+		"storybook": "portless run --name storybook-astro sh -c 'storybook dev --port \"$PORT\" --host \"$HOST\"'",
 		"test-storybook": "test-storybook --url ${STORYBOOK_URL:-http://127.0.0.1:6010}"
 	},
 	"dependencies": {

--- a/apps/storybook-astro/src/consent-banner.stories.ts
+++ b/apps/storybook-astro/src/consent-banner.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/html-vite';
+
+import { renderAstroStory } from './render-astro-story';
+
+const meta = {
+	parameters: {
+		layout: 'fullscreen',
+	},
+	title: 'COMPONENTS - ASTRO/Core/Consent Banner',
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => renderAstroStory('consent-banner--default'),
+};
+
+export const Dark: Story = {
+	render: () => renderAstroStory('consent-banner--dark'),
+};

--- a/apps/storybook-astro/src/consent-dialog-trigger.stories.ts
+++ b/apps/storybook-astro/src/consent-dialog-trigger.stories.ts
@@ -13,6 +13,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+/**
+ * Astro's trigger is an inline `<button>` that carries `data-c15t-action`
+ * and nothing else — a site styles it. React's is a draggable floating
+ * widget with its own stylesheet. They share a `data-testid` but they are
+ * not the same component, so this story deliberately does not use the
+ * name the other frameworks pair on.
+ */
+export const InlineButton: Story = {
 	render: () => renderAstroStory('consent-dialog-trigger--default'),
 };

--- a/apps/storybook-astro/src/consent-dialog-trigger.stories.ts
+++ b/apps/storybook-astro/src/consent-dialog-trigger.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/html-vite';
+
+import { renderAstroStory } from './render-astro-story';
+
+const meta = {
+	parameters: {
+		layout: 'fullscreen',
+	},
+	title: 'COMPONENTS - ASTRO/Core/Consent Dialog Trigger',
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => renderAstroStory('consent-dialog-trigger--default'),
+};

--- a/apps/storybook-astro/src/consent-dialog.stories.ts
+++ b/apps/storybook-astro/src/consent-dialog.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/html-vite';
+
+import { renderAstroStory } from './render-astro-story';
+
+const meta = {
+	parameters: {
+		layout: 'fullscreen',
+	},
+	title: 'COMPONENTS - ASTRO/Core/Consent Dialog',
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * `<ConsentDialog />` server-renders only its host element; the surface is
+ * an island mounted on first open. This story is that resting state.
+ */
+export const Default: Story = {
+	render: () => renderAstroStory('consent-dialog--default'),
+};
+
+/** The same host with the island mounted, which is what a visitor sees. */
+export const Opened: Story = {
+	render: () => renderAstroStory('consent-dialog--opened'),
+};

--- a/apps/storybook-astro/src/consent-dialog.stories.ts
+++ b/apps/storybook-astro/src/consent-dialog.stories.ts
@@ -14,14 +14,19 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
- * `<ConsentDialog />` server-renders only its host element; the surface is
- * an island mounted on first open. This story is that resting state.
+ * The dialog a visitor sees: the island mounted into the server-rendered
+ * host. Named `Default` so it pairs with the other frameworks' `Default`,
+ * which are also the open dialog.
  */
 export const Default: Story = {
-	render: () => renderAstroStory('consent-dialog--default'),
+	render: () => renderAstroStory('consent-dialog--opened'),
 };
 
-/** The same host with the island mounted, which is what a visitor sees. */
-export const Opened: Story = {
-	render: () => renderAstroStory('consent-dialog--opened'),
+/**
+ * The resting state unique to Astro: `<ConsentDialog />` server-renders
+ * only its host element and mounts nothing until something opens it. No
+ * other framework has an equivalent, so this story pairs with nothing.
+ */
+export const ServerShell: Story = {
+	render: () => renderAstroStory('consent-dialog--default'),
 };

--- a/apps/storybook-astro/src/iab-consent-dialog.stories.ts
+++ b/apps/storybook-astro/src/iab-consent-dialog.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/html-vite';
+
+import { renderAstroStory } from './render-astro-story';
+
+const meta = {
+	parameters: {
+		layout: 'fullscreen',
+	},
+	title: 'COMPONENTS - ASTRO/IAB/IAB Consent Dialog',
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+	render: () => renderAstroStory('iab-consent-dialog--overview'),
+};

--- a/apps/storybook-astro/src/render-astro-story.ts
+++ b/apps/storybook-astro/src/render-astro-story.ts
@@ -1,0 +1,110 @@
+/**
+ * Mount a prerendered `.astro` fragment the way a real Astro page would.
+ *
+ * An Astro page is server-rendered HTML plus one boot script. This does the
+ * same two things: it inlines the config the server produced, drops the
+ * markup into the document, and boots `@c15t/astro/client` with the same
+ * resolved options and the same Svelte dialog adapter the integration
+ * registers. Nothing here is Storybook-specific behaviour — the point is
+ * that the story exercises the shipped runtime, not a stand-in.
+ */
+
+import {
+	boot,
+	getConsentClient,
+	registerDialogAdapter,
+	registerDialogSurface,
+} from '@c15t/astro/client';
+import prerendered from 'virtual:c15t-astro-prerendered';
+
+import { requireStoryVariant } from './story-variants';
+
+const DIALOG_HOST_ID = 'c15t-dialog-host';
+
+let adaptersRegistered = false;
+
+const registerAdapters = function registerAdapters(): void {
+	if (adaptersRegistered) {
+		return;
+	}
+	adaptersRegistered = true;
+	registerDialogAdapter(
+		'svelte',
+		async () => (await import('@c15t/astro/ui/svelte')).svelteDialogAdapter
+	);
+	registerDialogSurface(
+		'svelte',
+		() => import('@c15t/astro/islands/consent-dialog-surface.svelte')
+	);
+};
+
+const clearCookies = function clearCookies(): void {
+	for (const cookie of document.cookie.split(';')) {
+		const name = cookie.split('=')[0]?.trim();
+		if (name) {
+			document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+		}
+	}
+};
+
+/**
+ * Tear the previous story's page down.
+ *
+ * The runtime is a page-level singleton on `window`, so without this the
+ * second story in a session would silently reuse the first one's kernel,
+ * its consent state and its mounted dialog.
+ */
+const resetPage = function resetPage(): void {
+	getConsentClient()?.dispose();
+	document.getElementById(DIALOG_HOST_ID)?.remove();
+	for (const host of document.querySelectorAll('[data-c15t-story-host]')) {
+		host.remove();
+	}
+	document.documentElement.classList.remove('c15t-dark');
+	window.localStorage.clear();
+	clearCookies();
+};
+
+/**
+ * Render one catalogued Astro variant into the Storybook canvas.
+ *
+ * @param variantId - The id from the story catalogue.
+ * @returns The element Storybook should mount.
+ */
+export const renderAstroStory = function renderAstroStory(
+	variantId: string
+): HTMLElement {
+	const variant = requireStoryVariant(variantId);
+	const entry = prerendered[variantId];
+	if (!entry) {
+		throw new Error(`Astro variant "${variantId}" was not prerendered.`);
+	}
+
+	resetPage();
+	registerAdapters();
+
+	const host = document.createElement('div');
+	host.setAttribute('data-c15t-story-host', variantId);
+	host.innerHTML = entry.html;
+
+	// The banner reads its kernel config off `window` exactly as it does on
+	// a server-rendered page, so it must be there before `boot()` runs.
+	(window as unknown as Record<string, unknown>).__c15tAstroConfig =
+		entry.config;
+
+	if (variant.dark) {
+		document.documentElement.classList.add('c15t-dark');
+	}
+
+	// Storybook mounts the returned element after the story function
+	// returns, but `boot()` has to see the markup to wire the banner. Queue
+	// the boot for the next task instead of guessing.
+	queueMicrotask(() => {
+		const client = boot(entry.options as Parameters<typeof boot>[0]);
+		if (variant.openDialog) {
+			void client.openDialog(variant.openDialog);
+		}
+	});
+
+	return host;
+};

--- a/apps/storybook-astro/src/story-variants.ts
+++ b/apps/storybook-astro/src/story-variants.ts
@@ -54,6 +54,15 @@ const CATEGORIES = [
 	'marketing',
 ];
 
+/**
+ * Every Astro variant this Storybook can show.
+ *
+ * Read twice from opposite sides of the build: the `astro-prerender` Vite
+ * plugin walks it at build time to server-render each entry, and
+ * `render-astro-story.ts` looks entries up by `id` in the browser. One list
+ * is what keeps a story from being prerendered without a renderer, or
+ * rendered without markup.
+ */
 export const astroStoryVariants: readonly AstroStoryVariant[] = [
 	{
 		component: 'consent-banner',

--- a/apps/storybook-astro/src/story-variants.ts
+++ b/apps/storybook-astro/src/story-variants.ts
@@ -1,0 +1,111 @@
+/**
+ * The Astro story catalogue.
+ *
+ * One entry per rendered variant. The module is imported from both sides
+ * of the build: the Vite prerender plugin reads it in Node to render the
+ * `.astro` components through Astro's container, and the stories read it
+ * in the browser to look the rendered fragment up again. It must therefore
+ * stay free of any `.astro`, Node or DOM import.
+ */
+
+/** The `.astro` components the Storybook renders. */
+export type AstroComponentName =
+	| 'consent-banner'
+	| 'consent-dialog'
+	| 'consent-dialog-trigger'
+	| 'iab-consent-dialog';
+
+/** A single prerendered variant. */
+export interface AstroStoryVariant {
+	/** Stable key. Also the virtual-module record key. */
+	id: string;
+	/** Which `.astro` component to render. */
+	component: AstroComponentName;
+	/** Props handed to the component. */
+	props?: Record<string, unknown>;
+	/** Slot content, by slot name. */
+	slots?: Record<string, string>;
+	/**
+	 * Integration options, in the shape `c15t()` takes in `astro.config`.
+	 * The prerender resolves them with the package's own `resolveOptions`,
+	 * so the server context and the browser boot see the same object a real
+	 * site would.
+	 */
+	options?: {
+		consentCategories?: string[];
+		colorScheme?: 'light' | 'dark' | 'system';
+		iab?: boolean;
+	};
+	/** Put `c15t-dark` on `<html>` while the story is mounted. */
+	dark?: boolean;
+	/**
+	 * Open a dialog once the runtime has booted. `<ConsentDialog />` only
+	 * renders a host element; the surface is an island mounted on demand,
+	 * so a story that wants the dialog visible has to ask for it.
+	 */
+	openDialog?: 'preferences' | 'iab';
+}
+
+const CATEGORIES = [
+	'necessary',
+	'functionality',
+	'measurement',
+	'experience',
+	'marketing',
+];
+
+export const astroStoryVariants: readonly AstroStoryVariant[] = [
+	{
+		component: 'consent-banner',
+		id: 'consent-banner--default',
+		options: { colorScheme: 'light', consentCategories: CATEGORIES },
+		props: { force: true },
+	},
+	{
+		component: 'consent-banner',
+		dark: true,
+		id: 'consent-banner--dark',
+		options: { colorScheme: 'dark', consentCategories: CATEGORIES },
+		props: { force: true },
+	},
+	{
+		component: 'consent-dialog',
+		id: 'consent-dialog--default',
+		options: { colorScheme: 'light', consentCategories: CATEGORIES },
+	},
+	{
+		component: 'consent-dialog',
+		id: 'consent-dialog--opened',
+		openDialog: 'preferences',
+		options: { colorScheme: 'light', consentCategories: CATEGORIES },
+	},
+	{
+		component: 'consent-dialog-trigger',
+		id: 'consent-dialog-trigger--default',
+		options: { colorScheme: 'light', consentCategories: CATEGORIES },
+		slots: { default: 'Cookie preferences' },
+	},
+	{
+		component: 'iab-consent-dialog',
+		id: 'iab-consent-dialog--overview',
+		openDialog: 'iab',
+		options: { colorScheme: 'light', iab: true },
+	},
+];
+
+/**
+ * Look a variant up by id.
+ *
+ * @param id - The variant id.
+ * @returns The variant.
+ * @throws {Error} When no variant carries that id.
+ */
+export const requireStoryVariant = function requireStoryVariant(
+	id: string
+): AstroStoryVariant {
+	const variant = astroStoryVariants.find((entry) => entry.id === id);
+	if (!variant) {
+		throw new Error(`No Astro story variant registered for id: ${id}`);
+	}
+	return variant;
+};

--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -101,16 +101,6 @@ const config: StorybookConfig = {
 						replacement: ui('styles', 'primitives', 'index.ts'),
 					},
 					{
-						// oxlint-disable-next-line prefer-named-capture-group -- Preserve declaration order, interface shape, and public compatibility.
-						find: /^@c15t\/ui\/styles\/components\/(.+)\.module\.css$/u,
-						replacement: ui('styles', 'components', '$1.module.css'),
-					},
-					{
-						// oxlint-disable-next-line prefer-named-capture-group -- Preserve declaration order, interface shape, and public compatibility.
-						find: /^@c15t\/ui\/styles\/components\/(.+)$/u,
-						replacement: ui('styles', 'components', '$1.module.css'),
-					},
-					{
 						find: /^@c15t\/ui\/theme$/u,
 						replacement: ui('theme', 'index.ts'),
 					},

--- a/apps/storybook-react/src/consent-banner.stories.tsx
+++ b/apps/storybook-react/src/consent-banner.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	title: 'COMPONENTS - REACT/Consent Banner',
+	title: 'COMPONENTS - REACT/Core/Consent Banner',
 } satisfies Meta<typeof ConsentBanner>;
 
 export default meta;

--- a/apps/storybook-react/src/consent-dialog-trigger.stories.tsx
+++ b/apps/storybook-react/src/consent-dialog-trigger.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	title: 'COMPONENTS - REACT/Consent Dialog Trigger',
+	title: 'COMPONENTS - REACT/Core/Consent Dialog Trigger',
 } satisfies Meta<typeof ConsentDialogTrigger>;
 
 export default meta;

--- a/apps/storybook-react/src/consent-dialog-trigger.stories.tsx
+++ b/apps/storybook-react/src/consent-dialog-trigger.stories.tsx
@@ -1,3 +1,4 @@
+import { triggerOpensDialog } from '@c15t/conformance/play/consent-dialog-trigger';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import {
@@ -19,6 +20,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+	// The same conformance play function the Svelte story runs, so `Default`
+	// means the same thing in both: the trigger clicked, the dialog open.
+	play: triggerOpensDialog,
 	render: () => (
 		<StorybookConsentProvider
 			storedConsent={{

--- a/apps/storybook-react/src/consent-dialog.stories.tsx
+++ b/apps/storybook-react/src/consent-dialog.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	title: 'COMPONENTS - REACT/Consent Dialog',
+	title: 'COMPONENTS - REACT/Core/Consent Dialog',
 } satisfies Meta<typeof ConsentDialog>;
 
 export default meta;

--- a/apps/storybook-react/src/consent-widget.stories.tsx
+++ b/apps/storybook-react/src/consent-widget.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 	parameters: {
 		layout: 'centered',
 	},
-	title: 'COMPONENTS - REACT/Consent Widget',
+	title: 'COMPONENTS - REACT/Core/Consent Widget',
 } satisfies Meta<typeof ConsentWidget>;
 
 export default meta;

--- a/apps/storybook-react/src/frame.stories.tsx
+++ b/apps/storybook-react/src/frame.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 	parameters: {
 		layout: 'centered',
 	},
-	title: 'COMPONENTS - REACT/Frame',
+	title: 'COMPONENTS - REACT/Core/Frame',
 } satisfies Meta<typeof Frame>;
 
 export default meta;

--- a/apps/storybook-react/src/iab-consent-banner.stories.tsx
+++ b/apps/storybook-react/src/iab-consent-banner.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	title: 'COMPONENTS - REACT/IAB Consent Banner',
+	title: 'COMPONENTS - REACT/IAB/IAB Consent Banner',
 } satisfies Meta<typeof IABConsentBanner>;
 
 export default meta;

--- a/apps/storybook-react/src/iab-consent-dialog.stories.tsx
+++ b/apps/storybook-react/src/iab-consent-dialog.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 	parameters: {
 		layout: 'fullscreen',
 	},
-	title: 'COMPONENTS - REACT/IAB Consent Dialog',
+	title: 'COMPONENTS - REACT/IAB/IAB Consent Dialog',
 } satisfies Meta<typeof IABConsentDialog>;
 
 export default meta;

--- a/apps/storybook-svelte/.storybook/preview.ts
+++ b/apps/storybook-svelte/.storybook/preview.ts
@@ -1,16 +1,12 @@
 import type { Preview } from '@storybook/svelte-vite';
 
+// The stylesheets ship the `defaultTheme` tokens themselves, so the canvas
+// only has to opt into them — no `generateThemeCSS(defaultTheme)` injection.
 import '../../../packages/svelte/src/styles.css';
 import '../../../packages/svelte/src/iab/styles.css';
-import {
-	defaultTheme,
-	generateThemeCSS,
-} from '../../../packages/ui/src/theme/utils';
 
-const storybookThemeStyleId = 'c15t-storybook-theme';
 const storybookCanvasStyleId = 'c15t-storybook-canvas';
 
-const themeCSS = generateThemeCSS(defaultTheme);
 const canvasCSS = `
 	:root {
 		color: var(--c15t-text);
@@ -43,7 +39,6 @@ const ensureGlobalStyle = function ensureGlobalStyle(
 	document.head.appendChild(style);
 };
 
-ensureGlobalStyle(storybookThemeStyleId, themeCSS);
 ensureGlobalStyle(storybookCanvasStyleId, canvasCSS);
 
 const preview: Preview = {

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,27 @@
         "typescript": "6.0.3",
       },
     },
+    "apps/storybook-astro": {
+      "name": "@c15t/storybook-astro",
+      "dependencies": {
+        "@c15t/astro": "workspace:*",
+        "@c15t/conformance": "workspace:*",
+        "@c15t/core": "workspace:*",
+        "@c15t/svelte": "workspace:*",
+        "@c15t/ui": "workspace:*",
+        "svelte": "^5.56.4",
+      },
+      "devDependencies": {
+        "@storybook/addon-a11y": "10.4.6",
+        "@storybook/html-vite": "10.4.6",
+        "@storybook/test-runner": "^0.24.4",
+        "@sveltejs/vite-plugin-svelte": "^6.2.4",
+        "astro": "^5.16.0",
+        "storybook": "10.4.6",
+        "typescript": "6.0.3",
+        "vite": "7.3.2",
+      },
+    },
     "apps/storybook-react": {
       "name": "@c15t/storybook-react",
       "dependencies": {
@@ -1519,6 +1540,8 @@
 
     "@c15t/solid": ["@c15t/solid@workspace:packages/solid"],
 
+    "@c15t/storybook-astro": ["@c15t/storybook-astro@workspace:apps/storybook-astro"],
+
     "@c15t/storybook-react": ["@c15t/storybook-react@workspace:apps/storybook-react"],
 
     "@c15t/storybook-solid": ["@c15t/storybook-solid@workspace:apps/storybook-solid"],
@@ -2616,6 +2639,10 @@
     "@storybook/csf-plugin": ["@storybook/csf-plugin@10.4.6", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.4.6", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA=="],
 
     "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
+
+    "@storybook/html": ["@storybook/html@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.4.6" } }, "sha512-vUITtWVSP70csV10fRJVk5aQeXl9xDYr20IKDRyLtuJDoF+kETrc4nQ8f1/xnFwTg6tHSJuzYxaU8KXpHY3sLg=="],
+
+    "@storybook/html-vite": ["@storybook/html-vite@10.4.6", "", { "dependencies": { "@storybook/builder-vite": "10.4.6", "@storybook/html": "10.4.6" }, "peerDependencies": { "storybook": "^10.4.6", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-X5CwPgtEQh5HoH0jSEGHnP8wiUX74xr69M2WOjgX6ll/QW/+mOZw4m0X+CjS+Aq1oDUSMacw+kKg6L230yjOEg=="],
 
     "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
 
@@ -6017,6 +6044,10 @@
 
     "@c15t/solid/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
+    "@c15t/storybook-astro/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
+
+    "@c15t/storybook-astro/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
     "@c15t/storybook-react/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
 
     "@c15t/storybook-react/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
@@ -6446,6 +6477,10 @@
     "@storybook/csf-plugin/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
 
     "@storybook/csf-plugin/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "@storybook/html/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
+
+    "@storybook/html-vite/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
 
     "@storybook/react/storybook": ["storybook@10.4.6", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0", "open": "^10.2.0", "oxc-parser": "^0.127.0", "oxc-resolver": "^11.19.1", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "prettier": "^2 || ^3", "vite-plus": "^0.1.15" }, "optionalPeers": ["@types/react", "prettier", "vite-plus"], "bin": "./dist/bin/dispatcher.js" }, "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A=="],
 
@@ -7923,6 +7958,24 @@
 
     "@c15t/scripts/playwright/playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
+    "@c15t/storybook-astro/storybook/@storybook/icons": ["@storybook/icons@2.1.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg=="],
+
+    "@c15t/storybook-astro/storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@c15t/storybook-astro/storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@c15t/storybook-astro/storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
+
+    "@c15t/storybook-astro/vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "@c15t/storybook-astro/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "@c15t/storybook-astro/vite/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "@c15t/storybook-astro/vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "@c15t/storybook-react/storybook/@storybook/icons": ["@storybook/icons@2.1.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg=="],
 
     "@c15t/storybook-react/storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
@@ -8430,6 +8483,26 @@
     "@storybook/csf-plugin/storybook/oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
 
     "@storybook/csf-plugin/unplugin/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "@storybook/html-vite/storybook/@storybook/icons": ["@storybook/icons@2.1.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg=="],
+
+    "@storybook/html-vite/storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@storybook/html-vite/storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@storybook/html-vite/storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "@storybook/html-vite/storybook/oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
+
+    "@storybook/html/storybook/@storybook/icons": ["@storybook/icons@2.1.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg=="],
+
+    "@storybook/html/storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@storybook/html/storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@storybook/html/storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "@storybook/html/storybook/oxc-parser": ["oxc-parser@0.127.0", "", { "dependencies": { "@oxc-project/types": "^0.127.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.127.0", "@oxc-parser/binding-android-arm64": "0.127.0", "@oxc-parser/binding-darwin-arm64": "0.127.0", "@oxc-parser/binding-darwin-x64": "0.127.0", "@oxc-parser/binding-freebsd-x64": "0.127.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0", "@oxc-parser/binding-linux-arm64-gnu": "0.127.0", "@oxc-parser/binding-linux-arm64-musl": "0.127.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0", "@oxc-parser/binding-linux-riscv64-musl": "0.127.0", "@oxc-parser/binding-linux-s390x-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-gnu": "0.127.0", "@oxc-parser/binding-linux-x64-musl": "0.127.0", "@oxc-parser/binding-openharmony-arm64": "0.127.0", "@oxc-parser/binding-wasm32-wasi": "0.127.0", "@oxc-parser/binding-win32-arm64-msvc": "0.127.0", "@oxc-parser/binding-win32-ia32-msvc": "0.127.0", "@oxc-parser/binding-win32-x64-msvc": "0.127.0" } }, "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA=="],
 
     "@storybook/react-dom-shim/storybook/@storybook/icons": ["@storybook/icons@2.1.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg=="],
 
@@ -10043,6 +10116,108 @@
 
     "@c15t/next-compat-16-static-export/next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.4", "", { "os": "win32", "cpu": "x64" }, "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg=="],
 
+    "@c15t/storybook-astro/storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@c15t/storybook-astro/storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "@c15t/storybook-astro/storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@c15t/storybook-astro/storybook/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@c15t/storybook-astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
     "@c15t/storybook-react/storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@c15t/storybook-react/storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
@@ -10883,6 +11058,106 @@
 
     "@storybook/csf-plugin/storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
+    "@storybook/html-vite/storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@storybook/html-vite/storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "@storybook/html-vite/storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@storybook/html-vite/storybook/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@storybook/html/storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@storybook/html/storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "@storybook/html/storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@storybook/html/storybook/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.127.0", "", { "os": "android", "cpu": "arm" }, "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-android-arm64": ["@oxc-parser/binding-android-arm64@0.127.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-darwin-arm64": ["@oxc-parser/binding-darwin-arm64@0.127.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-darwin-x64": ["@oxc-parser/binding-darwin-x64@0.127.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-freebsd-x64": ["@oxc-parser/binding-freebsd-x64@0.127.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-arm-gnueabihf": ["@oxc-parser/binding-linux-arm-gnueabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-arm-musleabihf": ["@oxc-parser/binding-linux-arm-musleabihf@0.127.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-gnu": ["@oxc-parser/binding-linux-arm64-gnu@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-arm64-musl": ["@oxc-parser/binding-linux-arm64-musl@0.127.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-ppc64-gnu": ["@oxc-parser/binding-linux-ppc64-gnu@0.127.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-gnu": ["@oxc-parser/binding-linux-riscv64-gnu@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-riscv64-musl": ["@oxc-parser/binding-linux-riscv64-musl@0.127.0", "", { "os": "linux", "cpu": "none" }, "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-s390x-gnu": ["@oxc-parser/binding-linux-s390x-gnu@0.127.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-x64-gnu": ["@oxc-parser/binding-linux-x64-gnu@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-linux-x64-musl": ["@oxc-parser/binding-linux-x64-musl@0.127.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-openharmony-arm64": ["@oxc-parser/binding-openharmony-arm64@0.127.0", "", { "os": "none", "cpu": "arm64" }, "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi": ["@oxc-parser/binding-wasm32-wasi@0.127.0", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-win32-arm64-msvc": ["@oxc-parser/binding-win32-arm64-msvc@0.127.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-win32-ia32-msvc": ["@oxc-parser/binding-win32-ia32-msvc@0.127.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.127.0", "", { "os": "win32", "cpu": "x64" }, "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
     "@storybook/react-dom-shim/storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@storybook/react-dom-shim/storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
@@ -11625,6 +11900,16 @@
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "@c15t/storybook-astro/storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@c15t/storybook-astro/storybook/@vitest/expect/chai/deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@c15t/storybook-react/storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
     "@c15t/storybook-react/storybook/@vitest/expect/chai/deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
@@ -11802,6 +12087,26 @@
     "@storybook/csf-plugin/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@storybook/csf-plugin/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@storybook/html-vite/storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@storybook/html-vite/storybook/@vitest/expect/chai/deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@storybook/html/storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@storybook/html/storybook/@vitest/expect/chai/deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@storybook/react-dom-shim/storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 
@@ -12043,6 +12348,10 @@
 
     "wait-port/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@c15t/storybook-astro/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "@c15t/storybook-react/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@c15t/storybook-react/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
@@ -12124,6 +12433,14 @@
     "@storybook/csf-plugin/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@storybook/csf-plugin/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@storybook/html-vite/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@storybook/html/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@storybook/react-dom-shim/storybook/oxc-parser/@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -81,10 +81,13 @@
       "name": "@c15t/parity-runner",
       "dependencies": {
         "@c15t/conformance": "workspace:*",
+        "pixelmatch": "^7.2.0",
+        "pngjs": "^7.0.0",
       },
       "devDependencies": {
         "@c15t/typescript-config": "workspace:*",
         "@playwright/test": "^1.55.0",
+        "@types/pngjs": "^6.0.5",
         "typescript": "6.0.3",
       },
     },
@@ -2902,6 +2905,8 @@
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
 
+    "@types/pngjs": ["@types/pngjs@6.0.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ=="],
+
     "@types/prettier": ["@types/prettier@3.0.0", "", { "dependencies": { "prettier": "*" } }, "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA=="],
 
     "@types/qs": ["@types/qs@6.15.0", "", {}, "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow=="],
@@ -4825,6 +4830,8 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 

--- a/packages/astro/src/__tests__/banner.test.ts
+++ b/packages/astro/src/__tests__/banner.test.ts
@@ -121,9 +121,15 @@ describe('<ConsentBanner />', () => {
 
 	it('renders the branding tag with the shared markup', async () => {
 		const html = await render(await buildLocals());
-		expect(html).toContain('data-testid="consent-banner-branding"');
-		expect(html).toContain('data-variant="banner-tag"');
-		expect(html).toContain('data-branding="c15t"');
+		// Matched as one element: separate `toContain` checks would pass
+		// with the testid, the variant and the branding on three different
+		// nodes.
+		const branding = /<[^>]*data-testid="consent-banner-branding"[^>]*>/u.exec(
+			html
+		)?.[0];
+		expect(branding).toBeDefined();
+		expect(branding).toContain('data-variant="banner-tag"');
+		expect(branding).toContain('data-branding="c15t"');
 		expect(html).toContain('Secured by');
 		// It sits beside the card, not inside it, so the tag can overlap the
 		// card's top edge the way the Svelte and React banners do.

--- a/packages/astro/src/__tests__/banner.test.ts
+++ b/packages/astro/src/__tests__/banner.test.ts
@@ -119,6 +119,24 @@ describe('<ConsentBanner />', () => {
 		expect(html).toContain('data-testid="consent-banner-root"');
 	});
 
+	it('renders the branding tag with the shared markup', async () => {
+		const html = await render(await buildLocals());
+		expect(html).toContain('data-testid="consent-banner-branding"');
+		expect(html).toContain('data-variant="banner-tag"');
+		expect(html).toContain('data-branding="c15t"');
+		expect(html).toContain('Secured by');
+		// It sits beside the card, not inside it, so the tag can overlap the
+		// card's top edge the way the Svelte and React banners do.
+		expect(html.indexOf('consent-banner-branding')).toBeLessThan(
+			html.indexOf('consent-banner-card')
+		);
+	});
+
+	it('drops the branding tag with `hideBranding`', async () => {
+		const html = await render(await buildLocals(), { hideBranding: true });
+		expect(html).not.toContain('data-testid="consent-banner-branding"');
+	});
+
 	it('fails loudly when the middleware did not run', async () => {
 		await expect(
 			container.renderToString(ConsentBanner, { locals: {}, props: {} })

--- a/packages/astro/src/components/branding.astro
+++ b/packages/astro/src/components/branding.astro
@@ -1,0 +1,149 @@
+---
+/**
+ * The "Secured by c15t" tag.
+ *
+ * Server-rendered with the same markup, classes and `data-testid` as the
+ * Svelte and React banners, so the shared stylesheet positions it
+ * identically and cross-framework tests compare like with like.
+ *
+ * Rendered by `<ConsentBanner />`; a site turns it off with
+ * `<ConsentBanner hideBranding />`. Which brand it shows comes from the
+ * consent snapshot, not from a prop.
+ */
+import type { ConsentSnapshot } from '@c15t/core';
+import styles from '@c15t/ui/styles/components/branding';
+
+type BrandingVariant = 'footer' | 'dialog-tag' | 'banner-tag';
+
+interface Props {
+	/** Render nothing. */
+	hide?: boolean;
+	/** Ship the DOM without the bundled stylesheet's class names. */
+	noStyle?: boolean;
+	/** Which surface the tag belongs to. */
+	variant?: BrandingVariant;
+	/** The brand the server resolved. */
+	branding: ConsentSnapshot['branding'];
+	/** "Secured by", already resolved from the translation bundle. */
+	securedBy: string;
+	/** The host to attribute the referral to. */
+	hostname?: string;
+	/** Test id, so each surface keeps its own. */
+	'data-testid'?: string;
+}
+
+const {
+	hide = false,
+	noStyle = false,
+	variant = 'banner-tag',
+	branding,
+	securedBy,
+	hostname,
+	'data-testid': testId,
+} = Astro.props;
+
+const resolveBranding = function resolveBranding(
+	value: ConsentSnapshot['branding']
+): 'c15t' | 'inth' | 'none' {
+	if (value === 'none') {
+		return 'none';
+	}
+	if (value === 'inth' || value === 'consent') {
+		return 'inth';
+	}
+	return 'c15t';
+};
+
+const resolved = resolveBranding(branding);
+const show = !hide && resolved !== 'none';
+const refParam = hostname ? `?ref=${hostname}` : '';
+const href =
+	resolved === 'inth'
+		? `https://inth.com${refParam}`
+		: `https://c15t.com${refParam}`;
+
+const className = noStyle
+	? ''
+	: [
+			styles.branding,
+			variant === 'footer' ? '' : styles.brandingTag,
+			variant === 'dialog-tag' ? styles.brandingTagDialog : '',
+			variant === 'banner-tag' ? styles.brandingTagBanner : '',
+		]
+			.filter(Boolean)
+			.join(' ');
+---
+
+{
+	show && (
+		<a
+			class={className}
+			data-branding={resolved}
+			data-testid={testId}
+			data-variant={variant}
+			dir="ltr"
+			href={href}
+		>
+			<span class={noStyle ? '' : styles.brandingCopy}>
+				<span class={noStyle ? '' : styles.brandingText}>{securedBy}</span>
+			</span>
+			{resolved === 'inth' ? (
+				<span
+					class={
+						noStyle
+							? ''
+							: `${styles.brandingWordmark} ${styles.brandingInth}`
+					}
+					dir="ltr"
+				>
+					<svg
+						aria-labelledby="inth-logo"
+						fill="none"
+						viewBox="0 0 88 90"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<title id="inth-logo">INTH</title>
+						<path
+							d="M40.9164 0V8.26444H27.6933V26.7966H40.9164V35.0608H6.15594V26.7966H19.3788V8.26444H6.15594V0H40.9164Z"
+							fill="currentColor"
+						/>
+						<path
+							d="M72.1149 20.1264V0H80.0343V35.0608H74.2747L54.9798 14.8193V35.0608H47.0604V0H52.964L72.1149 20.1264Z"
+							fill="currentColor"
+						/>
+						<path
+							clip-rule="evenodd"
+							d="M71.36 41.6H88V89.6H0V41.6H61.12V31.04L71.36 41.6ZM6.15594 48.0891V56.4034H19.1784V83.2H27.4428V56.4034H40.5656V48.0891H6.15594ZM47.0603 48.1391V83.2H55.3247V70.2441H71.7531V83.2H80.0675V48.1391H71.7531V61.9797H55.3247V48.1391H47.0603Z"
+							fill="currentColor"
+							fill-rule="evenodd"
+						/>
+					</svg>
+				</span>
+			) : (
+				<span
+					class={
+						noStyle
+							? ''
+							: `${styles.brandingWordmark} ${styles.brandingC15T}`
+					}
+					dir="ltr"
+				>
+					<span class={noStyle ? '' : styles.brandingC15TMark}>
+						<svg
+							aria-labelledby="c15t-icon"
+							viewBox="0 0 446 445"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<title id="c15t-icon">c15t</title>
+							<path
+								d="M223.178.313c39.064 0 70.732 31.668 70.732 70.732-.001 39.064-31.668 70.731-70.732 70.731-12.181 0-23.642-3.079-33.649-8.502l-55.689 55.689a70.267 70.267 0 0 1 5.574 13.441h167.531c8.695-29.217 35.762-50.523 67.804-50.523 39.064 0 70.731 31.668 70.731 70.732s-31.668 70.732-70.731 70.732c-32.042 0-59.108-21.306-67.803-50.523H139.413a70.417 70.417 0 0 1-7.888 17.396l54.046 54.046c10.893-6.851 23.786-10.815 37.605-10.815 39.064 0 70.732 31.669 70.732 70.733 0 39.064-31.668 70.731-70.732 70.731s-70.732-31.667-70.732-70.731c0-10.518 2.296-20.499 6.414-29.471l-57.78-57.78c-8.972 4.117-18.952 6.414-29.47 6.414-39.063 0-70.731-31.668-70.732-70.732 0-39.064 31.669-70.732 70.733-70.732 12.18 0 23.642 3.079 33.649 8.502l55.688-55.688c-5.423-10.007-8.502-21.469-8.502-33.65 0-39.064 31.668-70.733 70.732-70.733Zm0 343.555c-16.742 0-30.314 13.572-30.314 30.314 0 16.741 13.572 30.313 30.314 30.313s30.314-13.572 30.314-30.313c0-16.742-13.572-30.314-30.314-30.314ZM71.611 192.299c-16.742 0-30.315 13.572-30.315 30.314s13.573 30.314 30.315 30.314c16.741 0 30.313-13.572 30.313-30.314 0-16.741-13.572-30.314-30.313-30.314Zm303.138 0c-16.729 0-30.294 13.551-30.315 30.275l.001.039-.001.038c.021 16.725 13.586 30.276 30.315 30.276 16.741 0 30.313-13.572 30.313-30.314 0-16.741-13.572-30.314-30.313-30.314ZM223.178 40.73c-16.742 0-30.314 13.573-30.314 30.315s13.573 30.313 30.314 30.313c16.742 0 30.313-13.572 30.314-30.313 0-16.742-13.572-30.314-30.314-30.315Z"
+								fill="currentColor"
+							/>
+						</svg>
+					</span>
+					<span class={noStyle ? '' : styles.brandingWordmarkLabel}>c15t</span>
+				</span>
+			)}
+		</a>
+	)
+}

--- a/packages/astro/src/components/consent-banner.astro
+++ b/packages/astro/src/components/consent-banner.astro
@@ -20,6 +20,7 @@
  * ```
  */
 import {
+	DEFAULT_POLICY_ACTION_LAYOUT,
 	defaultTranslationConfig,
 	resolvePolicyActionGroups,
 	resolvePolicyAllowedActions,
@@ -34,6 +35,7 @@ import {
 	buildConfigScript,
 	markConfigEmitted,
 } from '@c15t/astro/server';
+import Branding from './branding.astro';
 import actionStyles from '@c15t/ui/styles/components/consent-actions';
 import styles from '@c15t/ui/styles/components/consent-banner';
 import buttonStyles from '@c15t/ui/styles/components/button';
@@ -54,6 +56,8 @@ interface Props {
 	noStyle?: boolean;
 	/** Extra class on the banner root. */
 	class?: string;
+	/** Drop the "Secured by c15t" tag. */
+	hideBranding?: boolean;
 	/** Which legal links to render inline. `null` renders none. */
 	legalLinks?: (keyof LegalLinks)[] | null;
 	/**
@@ -71,6 +75,7 @@ const {
 	customizeButtonText,
 	noStyle = false,
 	class: className,
+	hideBranding = false,
 	legalLinks = null,
 	force = false,
 } = Astro.props;
@@ -101,6 +106,7 @@ const copy = {
 	description:
 		description ?? bundle.cookieBanner?.description ?? fallback.cookieBanner.description,
 	reject: rejectButtonText ?? bundle.common?.rejectAll ?? fallback.common.rejectAll,
+	securedBy: bundle.common?.securedBy ?? fallback.common.securedBy,
 	title: title ?? bundle.cookieBanner?.title ?? fallback.cookieBanner.title,
 };
 
@@ -114,7 +120,7 @@ const allowedActions = resolvePolicyAllowedActions({
 const layout =
 	(snapshot.policyBanner?.layout?.length ?? 0) > 0
 		? snapshot.policyBanner?.layout
-		: [['reject', 'accept'], 'customize'];
+		: DEFAULT_POLICY_ACTION_LAYOUT;
 const orderedActions = resolvePolicyOrderedActions({ allowedActions, layout });
 const actionGroups = resolvePolicyActionGroups({ allowedActions, layout });
 const direction = resolvePolicyDirection(snapshot.policyBanner?.direction);
@@ -169,6 +175,15 @@ const inlineLegalLinks = (legalLinks ?? []).filter(
 			lang={snapshot.translations?.language}
 		>
 			<div class={noStyle ? '' : styles.cardShell}>
+				<Branding
+					branding={snapshot.branding}
+					data-testid="consent-banner-branding"
+					hide={hideBranding}
+					hostname={Astro.url.hostname}
+					noStyle={noStyle}
+					securedBy={copy.securedBy}
+					variant="banner-tag"
+				/>
 				<div
 					aria-label={copy.title}
 					aria-modal="false"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@
  */
 
 export {
+	DEFAULT_POLICY_ACTION_LAYOUT,
 	flattenPolicyActionGroups,
 	hasPolicyHints,
 	resolvePolicyActionGroups,

--- a/packages/core/src/libs/policy-actions.ts
+++ b/packages/core/src/libs/policy-actions.ts
@@ -30,6 +30,30 @@ const DEFAULT_POLICY_ACTIONS: PolicyUiAction[] = [
 	'customize',
 ];
 
+/**
+ * The grouping a surface uses when the policy supplies no layout: the two
+ * write actions together, "customize" on its own, laid out with
+ * `space-between`.
+ *
+ * It is the same shape `policyDefaults`' compact profile ships, so a
+ * surface rendered without policy hints matches one rendered with them.
+ * Adapters should prefer this over a component-local constant — a banner
+ * and a preference centre that disagree about the default is exactly the
+ * drift the cross-framework parity gate exists to catch.
+ *
+ * @example
+ * ```ts
+ * const groups = resolvePolicyActionGroups({
+ *   allowedActions,
+ *   layout: policy.layout?.length ? policy.layout : DEFAULT_POLICY_ACTION_LAYOUT,
+ * });
+ * ```
+ */
+export const DEFAULT_POLICY_ACTION_LAYOUT: PolicyUiActionGroup[] = [
+	['reject', 'accept'],
+	'customize',
+];
+
 const dedupeActions = function dedupeActions(
 	actions?: PolicyUiAction[]
 ): PolicyUiAction[] {

--- a/packages/core/src/libs/policy-actions.ts
+++ b/packages/core/src/libs/policy-actions.ts
@@ -45,7 +45,9 @@ const DEFAULT_POLICY_ACTIONS: PolicyUiAction[] = [
  * ```ts
  * const groups = resolvePolicyActionGroups({
  *   allowedActions,
- *   layout: policy.layout?.length ? policy.layout : DEFAULT_POLICY_ACTION_LAYOUT,
+ *   layout: policy.layout?.length
+ *     ? policy.layout
+ *     : DEFAULT_POLICY_ACTION_LAYOUT,
  * });
  * ```
  */

--- a/packages/react/src/component-hooks/use-headless-consent-ui.ts
+++ b/packages/react/src/component-hooks/use-headless-consent-ui.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+	DEFAULT_POLICY_ACTION_LAYOUT,
 	hasPolicyHints,
 	resolvePolicyActionGroups,
 	resolvePolicyAllowedActions,
@@ -61,13 +62,21 @@ const resolveSurfaceState = function resolveSurfaceState(
 	const allowedActions = resolvePolicyAllowedActions({
 		allowedActions: policy.allowedActions,
 	});
+	// A policy that ships no UI hints still gets the standard grouping —
+	// reject and accept together, customize on its own — rather than one
+	// undifferentiated row. Both surfaces read it from here, so the banner
+	// and the preference centre cannot drift apart.
+	const layout =
+		(policy.layout?.length ?? 0) > 0
+			? policy.layout
+			: DEFAULT_POLICY_ACTION_LAYOUT;
 	const actionGroups = resolvePolicyActionGroups({
 		allowedActions,
-		layout: policy.layout,
+		layout,
 	});
 	const orderedActions = resolvePolicyOrderedActions({
 		allowedActions,
-		layout: policy.layout,
+		layout,
 	});
 	const direction = resolvePolicyDirection(policy.direction);
 

--- a/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
+++ b/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
@@ -158,7 +158,7 @@ describe('ConsentBanner policy ordering', () => {
 		expect(rejectButton?.className).toContain('button-secondary-marker');
 	});
 
-	test('filters out actions disallowed by policy even when local layout includes them', async () => {
+	test('drops policy-disallowed actions from a local layout', async () => {
 		await renderBanner(
 			{
 				layout: ['reject', 'customize', 'accept'],
@@ -217,6 +217,41 @@ describe('ConsentBanner policy ordering', () => {
 		expect(footerGroups).toEqual([
 			['consent-banner-reject-button', 'consent-banner-accept-button'],
 			['consent-banner-customize-button'],
+		]);
+	});
+
+	test('keeps the subgroup shape of a scalar policy layout', async () => {
+		// `banner.actionGroups` normalizes a scalar entry into a
+		// single-element array; the banner's own filter does the same, so
+		// the rendered subgroups have to match the policy's shape either
+		// way, with `customize` on its own rather than folded in.
+		await renderBanner(
+			{},
+			{
+				policyBanner: {
+					allowedActions: ['reject', 'accept', 'customize'],
+					direction: 'row',
+					layout: ['customize', ['reject', 'accept']],
+					primaryActions: ['accept'],
+				},
+			}
+		);
+
+		await waitForBanner();
+
+		const footerGroups = Array.from(
+			document.querySelectorAll(
+				'[data-testid="consent-banner-footer-sub-group"]'
+			)
+		).map((group) =>
+			Array.from(group.querySelectorAll<HTMLButtonElement>('button')).map(
+				(button) => button.dataset.testid
+			)
+		);
+
+		expect(footerGroups).toEqual([
+			['consent-banner-customize-button'],
+			['consent-banner-reject-button', 'consent-banner-accept-button'],
 		]);
 	});
 

--- a/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
+++ b/packages/react/src/components/consent-banner/__tests__/consent-banner-policy-ordering.test.tsx
@@ -186,7 +186,7 @@ describe('ConsentBanner policy ordering', () => {
 		).not.toBeInTheDocument();
 	});
 
-	test('keeps the default layout when policy has hints but no policy layout', async () => {
+	test('groups the default layout when policy has hints but no policy layout', async () => {
 		await renderBanner(
 			{},
 			{
@@ -211,12 +211,13 @@ describe('ConsentBanner policy ordering', () => {
 			)
 		);
 
+		// Two sub-groups, not one plus a loose button: the shared default
+		// layout is what Svelte, Vue and Astro render, and `space-between`
+		// only works when both sides are groups.
 		expect(footerGroups).toEqual([
 			['consent-banner-reject-button', 'consent-banner-accept-button'],
+			['consent-banner-customize-button'],
 		]);
-		expect(
-			document.querySelector('[data-testid="consent-banner-customize-button"]')
-		).toBeInTheDocument();
 	});
 
 	test('shows branding by default and hides it when hideBranding is true', async () => {

--- a/packages/react/src/components/consent-banner/consent-banner.tsx
+++ b/packages/react/src/components/consent-banner/consent-banner.tsx
@@ -51,8 +51,6 @@ export type ConsentBannerLayout = (
 	| ConsentBannerButton[]
 )[];
 
-const DEFAULT_LAYOUT: ConsentBannerLayout = [['reject', 'accept'], 'customize'];
-
 /**
  * Props for configuring and customizing the ConsentBanner component.
  *
@@ -229,9 +227,9 @@ export const ConsentBanner: FC<ConsentBannerProps> = ({
 	const allowedActions = new Set(orderedActions);
 	const effectivePrimaryButton =
 		banner.primaryActions.length > 0 ? banner.primaryActions : primaryButton;
-	const resolvedLayout: ConsentBannerLayout =
-		layout ??
-		((banner.layout?.length ?? 0) > 0 ? banner.actionGroups : DEFAULT_LAYOUT);
+	// `banner.actionGroups` already falls back to the shared default layout
+	// when the policy carries no hints, so there is nothing to duplicate here.
+	const resolvedLayout: ConsentBannerLayout = layout ?? banner.actionGroups;
 	const resolvedDirection = direction ?? banner.direction ?? 'row';
 	const activeGroups = resolvedLayout
 		.map((item) =>

--- a/packages/ui/scripts/generate-css-entrypoints.ts
+++ b/packages/ui/scripts/generate-css-entrypoints.ts
@@ -262,9 +262,12 @@ const collectCssParts = function collectCssParts(
  * stylesheet into a cascade layer (`@import ... layer(c15t)`), since unlayered
  * declarations outrank every layer.
  */
-const DEFAULT_THEME_CSS = `/* default theme tokens (generated from defaultTheme) */\n${generateThemeCSS(
-	defaultTheme
-)}`;
+const DEFAULT_THEME_BANNER =
+	'/* default theme tokens (generated from defaultTheme) */';
+const DEFAULT_THEME_CSS = [
+	DEFAULT_THEME_BANNER,
+	generateThemeCSS(defaultTheme),
+].join('\n');
 
 /**
  * Generate layered CSS: component rules wrapped in @layer components.

--- a/packages/ui/scripts/generate-css-entrypoints.ts
+++ b/packages/ui/scripts/generate-css-entrypoints.ts
@@ -5,6 +5,10 @@
  * 2. Generates aggregated CSS entrypoints from `dist/styles/primitives` and
  *    the flat component CSS in `dist/styles/components` (produced by
  *    `generate-style-artifacts.ts`, which must run first):
+ *    - the `defaultTheme` base tokens (`--c15t-surface`, `--c15t-radius-lg`,
+ *      `--c15t-font-family`, ...) are emitted first and unlayered, so an app
+ *      that imports the stylesheet without passing a `theme` still renders the
+ *      styled UI instead of falling back to browser defaults
  *    - :root custom properties and @keyframes stay unlayered
  *    - `styles.css` / `iab/styles.css` wrap component rules in `@layer components`
  *      for Tailwind 4 and native CSS layer consumers
@@ -20,6 +24,8 @@ import {
 	writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+
+import { defaultTheme, generateThemeCSS } from '../src/theme/utils';
 
 const DIST_DIR = join(import.meta.dirname, '..', 'dist');
 const PRIMITIVES_DIR = join(DIST_DIR, 'styles', 'primitives');
@@ -239,6 +245,28 @@ const collectCssParts = function collectCssParts(
 };
 
 /**
+ * The `defaultTheme` base tokens, rendered by the same `generateThemeCSS` a
+ * host calls when it passes `theme`. Every component stylesheet resolves its
+ * colours, radii, fonts and motion through these, mostly without `var()`
+ * fallbacks, so a stylesheet that ships without them renders unstyled in any
+ * app that does not pass a `theme` — including server-rendered, zero-JS pages
+ * that can never inject them.
+ *
+ * `defaultTheme` stays the single source of truth: this is generated at build
+ * time from the same object the runtime exports, so CSS and JS cannot drift.
+ *
+ * Emitted first and **unlayered** in every entrypoint. A provider's injected
+ * `<style id="c15t-theme">` still wins: it carries the same selectors and the
+ * same specificity, and lands later in the cascade — later in `<head>` when
+ * the defaults are unlayered too, and unconditionally when a host imports the
+ * stylesheet into a cascade layer (`@import ... layer(c15t)`), since unlayered
+ * declarations outrank every layer.
+ */
+const DEFAULT_THEME_CSS = `/* default theme tokens (generated from defaultTheme) */\n${generateThemeCSS(
+	defaultTheme
+)}`;
+
+/**
  * Generate layered CSS: component rules wrapped in @layer components.
  * Use with Tailwind 4 — import Tailwind normally; c15t joins the components layer automatically.
  */
@@ -246,7 +274,7 @@ const buildLayeredCss = function buildLayeredCss(
 	rootParts: string[],
 	ruleParts: string[]
 ): string {
-	const parts: string[] = [];
+	const parts: string[] = [DEFAULT_THEME_CSS];
 	if (rootParts.length) {
 		parts.push(rootParts.join('\n\n'));
 	}
@@ -267,7 +295,7 @@ const buildFlatCss = function buildFlatCss(
 	rootParts: string[],
 	ruleParts: string[]
 ): string {
-	const parts: string[] = [];
+	const parts: string[] = [DEFAULT_THEME_CSS];
 	if (rootParts.length) {
 		parts.push(rootParts.join('\n\n'));
 	}

--- a/packages/ui/src/styles/__tests__/default-tokens.test.ts
+++ b/packages/ui/src/styles/__tests__/default-tokens.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Guards the default theme tokens that `generate-css-entrypoints.ts` bakes
+ * into every published stylesheet.
+ *
+ * Without them every component rule resolves `var(--c15t-surface)`,
+ * `var(--c15t-radius-lg)` and friends against nothing, and an app that imports
+ * the stylesheet without passing a `theme` renders the banner unstyled.
+ *
+ * These read the built artifacts, so `bun run --cwd packages/ui build` (or
+ * `turbo run build --filter=@c15t/ui`, which `test` depends on) must have run.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { defaultTheme, generateThemeCSS, themeToVars } from '../../theme/utils';
+
+const DIST_DIR = join(__dirname, '..', '..', '..', 'dist');
+
+const ENTRYPOINTS = [
+	'styles.css',
+	'styles.tw3.css',
+	join('iab', 'styles.css'),
+	join('iab', 'styles.tw3.css'),
+];
+
+const readEntrypoint = function readEntrypoint(relativePath: string): string {
+	const path = join(DIST_DIR, relativePath);
+
+	if (!existsSync(path)) {
+		throw new Error(
+			`Missing ${path}. Build @c15t/ui first: bun run --cwd packages/ui build`
+		);
+	}
+
+	return readFileSync(path, 'utf8');
+};
+
+/**
+ * Slice out one `selector { ... }` block by brace matching, so nested blocks
+ * inside the stylesheet do not truncate it early.
+ */
+const readBlock = function readBlock(
+	css: string,
+	selector: string
+): string | null {
+	const start = css.indexOf(`${selector} {`);
+
+	if (start === -1) {
+		return null;
+	}
+
+	const bodyStart = css.indexOf('{', start) + 1;
+	let depth = 1;
+
+	for (let index = bodyStart; index < css.length; index += 1) {
+		const char = css[index];
+
+		if (char === '{') {
+			depth += 1;
+		} else if (char === '}') {
+			depth -= 1;
+
+			if (depth === 0) {
+				return css.slice(bodyStart, index);
+			}
+		}
+	}
+
+	return null;
+};
+
+const LIGHT_SELECTOR = ':root, .c15t-theme-root';
+const DARK_SELECTOR =
+	':root.dark, .dark .c15t-theme-root, :root.c15t-dark, .c15t-dark .c15t-theme-root';
+
+describe.each(ENTRYPOINTS)('%s', (entrypoint) => {
+	const css = readEntrypoint(entrypoint);
+
+	test('defines every light token themeToVars(defaultTheme) emits', () => {
+		const block = readBlock(css, LIGHT_SELECTOR);
+		expect(block).not.toBeNull();
+
+		for (const [name, value] of Object.entries(
+			themeToVars(defaultTheme, false)
+		)) {
+			expect(block).toContain(`${name}: ${value};`);
+		}
+	});
+
+	test('defines every dark token themeToVars(defaultTheme, true) emits', () => {
+		const block = readBlock(css, DARK_SELECTOR);
+		expect(block).not.toBeNull();
+
+		for (const [name, value] of Object.entries(
+			themeToVars(defaultTheme, true)
+		)) {
+			expect(block).toContain(`${name}: ${value};`);
+		}
+	});
+
+	test('emits the tokens first, so they read as the file preamble', () => {
+		expect(css.startsWith('/* default theme tokens')).toBe(true);
+	});
+
+	test('matches what a host passing theme: defaultTheme would inject', () => {
+		// Byte-for-byte parity with `generateThemeCSS(defaultTheme)` is what
+		// keeps CSS and JS from drifting, and what makes the defaults behave
+		// exactly like a provider-injected theme.
+		expect(css).toContain(generateThemeCSS(defaultTheme));
+	});
+
+	test('emits the tokens unlayered', () => {
+		// A provider's injected `<style id="c15t-theme">` is unlayered. Unlayered
+		// declarations outrank every cascade layer, so keeping the defaults
+		// unlayered too is what leaves source order — and therefore the injected
+		// override — in charge. If a host imports this stylesheet into a layer
+		// (`@import ... layer(c15t)`, as examples/sveltekit-demo does), the
+		// override wins by layer precedence instead.
+		const layerStart = css.indexOf('@layer');
+		const tokensEnd = css.indexOf('}', css.indexOf(LIGHT_SELECTOR));
+
+		if (layerStart !== -1) {
+			expect(tokensEnd).toBeLessThan(layerStart);
+		}
+	});
+});
+
+describe('an app that imports the stylesheet without a theme', () => {
+	beforeEach(() => {
+		document.head.innerHTML = '';
+		document.documentElement.className = '';
+	});
+
+	/**
+	 * jsdom's CSS parser rejects the whole stylesheet — it does not understand
+	 * `@layer`, `color-mix()` or range media queries — and a rejected sheet
+	 * contributes nothing to the cascade. Mount the real artifact's token
+	 * preamble instead: still the shipped bytes, minus the component rules
+	 * jsdom could not apply anyway.
+	 */
+	const mountStylesheet = function mountStylesheet() {
+		const css = readEntrypoint('styles.css');
+		const componentsStart = css.indexOf('/* primitives/');
+		expect(componentsStart).toBeGreaterThan(0);
+
+		const style = document.createElement('style');
+		style.textContent = css.slice(0, componentsStart);
+		document.head.appendChild(style);
+	};
+
+	test('resolves the base tokens on :root', () => {
+		mountStylesheet();
+
+		const computed = getComputedStyle(document.documentElement);
+
+		expect(computed.getPropertyValue('--c15t-surface')).toBe(
+			defaultTheme.colors.surface
+		);
+		expect(computed.getPropertyValue('--c15t-radius-lg')).toBe(
+			defaultTheme.radius.lg
+		);
+		expect(computed.getPropertyValue('--c15t-font-family')).toBe(
+			defaultTheme.typography.fontFamily
+		);
+	});
+
+	test('lets a provider-injected <style id="c15t-theme"> override them', () => {
+		mountStylesheet();
+
+		const injected = document.createElement('style');
+		injected.id = 'c15t-theme';
+		injected.textContent = `${LIGHT_SELECTOR} { --c15t-surface: rebeccapurple; }`;
+		document.head.appendChild(injected);
+
+		expect(
+			getComputedStyle(document.documentElement).getPropertyValue(
+				'--c15t-surface'
+			)
+		).toBe('rebeccapurple');
+	});
+});

--- a/packages/ui/src/styles/__tests__/default-tokens.test.ts
+++ b/packages/ui/src/styles/__tests__/default-tokens.test.ts
@@ -72,8 +72,12 @@ const readBlock = function readBlock(
 };
 
 const LIGHT_SELECTOR = ':root, .c15t-theme-root';
-const DARK_SELECTOR =
-	':root.dark, .dark .c15t-theme-root, :root.c15t-dark, .c15t-dark .c15t-theme-root';
+const DARK_SELECTOR = [
+	':root.dark',
+	'.dark .c15t-theme-root',
+	':root.c15t-dark',
+	'.c15t-dark .c15t-theme-root',
+].join(', ');
 
 describe.each(ENTRYPOINTS)('%s', (entrypoint) => {
 	const css = readEntrypoint(entrypoint);

--- a/packages/ui/src/styles/components/consent-banner.module.css
+++ b/packages/ui/src/styles/components/consent-banner.module.css
@@ -300,6 +300,11 @@
 	}
 
 	.title:not(:global(.headless)) {
+		/* React renders the title as an `<h2>` for the heading semantics;
+		   Svelte, Vue and Astro use `<div role="heading">`. Without this the
+		   user agent's block margins make the React card 26px taller for the
+		   same markup. */
+		margin: 0;
 		font-size: 1rem;
 		line-height: 1.5rem;
 		letter-spacing: -0.011em;

--- a/packages/ui/src/styles/components/consent-dialog.module.css
+++ b/packages/ui/src/styles/components/consent-dialog.module.css
@@ -383,6 +383,9 @@
 	}
 
 	.title:not(:global(.headless)) {
+		/* Same heading-element reset as the banner: React's `<h2>` must not
+		   bring the user agent's margins with it. */
+		margin: 0;
 		font-weight: var(--consent-dialog-title-font-weight);
 		font-size: var(--consent-dialog-title-font-size);
 		line-height: 1;

--- a/packages/ui/src/styles/components/frame.module.css
+++ b/packages/ui/src/styles/components/frame.module.css
@@ -63,6 +63,8 @@
 	}
 
 	.title {
+		/* Reset in case a host renders the placeholder title as a heading. */
+		margin: 0;
 		font-size: 1rem;
 		line-height: 1.5rem;
 		letter-spacing: -0.011em;

--- a/packages/ui/src/utils/policy-actions.ts
+++ b/packages/ui/src/utils/policy-actions.ts
@@ -6,6 +6,7 @@ export type {
 	PolicyUiSurfaceConfig,
 } from '@c15t/core';
 export {
+	DEFAULT_POLICY_ACTION_LAYOUT,
 	flattenPolicyActionGroups,
 	hasPolicyHints,
 	resolvePolicyActionGroups,


### PR DESCRIPTION
## Summary

Makes cross-framework visual parity a merge gate. The parity runner now compares layout geometry and pixels across React, Svelte, Vue and Astro, and Astro joins the matrix through its own Storybook. The checks were committed first and shown red on real drift, then the drift was fixed and the suite is green.

Stacked on the benchmark runners PR; review this layer's diff only.

## What the gate found before anything was fixed

Restoring React's pairing surfaced a bug hiding since #1063: that PR renamed React story titles from `COMPONENTS - REACT/Core/Consent Banner` to `COMPONENTS - REACT/Consent Banner` while Svelte and Vue kept the prefix, so the runner had paired nothing against React and stayed green by comparing nothing. Fixed in the first commit.

With pairing restored, the new geometry check failed on exactly the three drifts found by hand:

```
[GEOMETRY] Core/Consent Banner/Default: react ≠ svelte
    consent-banner-card.height: 217.03 ≠ 190.5
    consent-banner-header.height: 146.53 ≠ 120
    consent-banner-footer-sub-group[1].<presence>: <missing> ≠ 0
[GEOMETRY] Core/Consent Dialog/Default: react ≠ svelte
    consent-dialog-card.height: 532.72 ≠ 509.5
    consent-widget-footer-save-button.x: 235.69 ≠ 307.73
    consent-widget-footer-sub-group[1].<presence>: <missing> ≠ 0
[PIXEL] Core/Consent Banner/Default consent-banner-card: react ≠ svelte — size 442x218 ≠ 442x191
[PIXEL] Core/Consent Dialog/Default consent-dialog-card: react ≠ svelte — size 448x534 ≠ 448x510
```

Astro's banner produced no branding slot at all, so its surface was 38 px shorter than the others.

## Fixes

- `@c15t/ui`: reset user-agent margins on the banner and dialog title rules. React renders `<h2>`, Svelte and Astro render `<div role="heading">`; the shared `.title` rule never set `margin: 0`.
- `@c15t/react`: the widget footer groups actions through the shared `DEFAULT_POLICY_ACTION_LAYOUT` (`[['reject', 'accept'], 'customize']`) like its own banner and every other surface, instead of one flat group.
- `@c15t/astro`: the server banner renders the branding tag with the same markup, test id and `hideBranding` option as Svelte, via a new `branding.astro` component.

After the fixes: React, Svelte and Astro render a 442x191 banner card and a 448x510 dialog card, pixel-identical inside the budget.

```
[PARITY] pixel: 0 failure(s)
[PARITY] geometry: 0 failure(s)
[PARITY] DOM+a11y+CSS: 0 failure(s)
  5 passed (46.4s)
```

## The gate

- **Geometry** (`visual-parity.spec.ts`): for each paired story, bounding boxes of every shared slot by test id (card, header, title, description, footer, sub-groups, buttons, branding, widget rows) must match React within 1 px. Deterministic, no screenshots.
- **Pixel backstop**: element screenshots of the banner and dialog cards, 1280x800, device scale 1, reduced motion, fonts ready; per-channel tolerance 12, mismatch budget 0.5%; size mismatch fails outright. Diff images are test artifacts. No committed baselines needed, so it runs unconditionally, unlike the darwin-only per-framework baselines.
- **Allowlist** keyed by framework, story and slot, each entry with a required reason; an entry that matches nothing fails the check, so no allowance can outlive its drift. Unit tests cover the geometry diff and the allowlist.

## Astro in the matrix

`apps/storybook-astro` on `@storybook/html-vite`, with a Vite plugin that boots one Vite server with Astro's own plugins, renders each variant through `experimental_AstroContainer` with the real option and consent-context resolvers, and serves the fragments as a virtual module. Stories mount the fragment, replay the server's config script and call the shipped `@c15t/astro/client` boot, so the dialog island and gated scripts work in-story. Titles follow `COMPONENTS - ASTRO/Core/...` so pairing is automatic. Six stories, all passing `test-storybook`, wired into the CI parity job.

The `storybook-astro` community package was evaluated and rejected: it renders through the Vite dev server's HMR channel, so a static `storybook build` has no renderer, and it cannot populate `Astro.locals`, which every c15t `.astro` component reads.

## Allowlisted drift, out of scope here

Restoring React's pairing exposed drift that had been invisible, not absent. Each entry is scoped as narrowly as the check allows and names what it is:

- **Vue, wholesale.** Footer nesting and control sizing both diverge; Vue buttons are 4 px taller and 8 px wider. Vue is effectively not gated until that is fixed; it should be its own task.
- Accordion trigger box structure: React wraps the row content and lets the trigger fill the row; the others put the padding on the trigger. Same pixels, different boxes.
- `consent-dialog-root` names the viewport-filling container in React and the inset panel elsewhere; the card inside matches.
- React's frame placeholder renders neither `frame-placeholder` nor `frame-open-dialog`; Svelte renders both. A real React gap.
- The IAB banner has never had a cross-framework pass.
- The DOM, a11y and CSS comparison captures from `#storybook-root`, but Svelte, Vue and Astro portal the banner to `document.body`. A capture-scope bug in the existing check, not in the components.

Also noted: the shared branding tag in dark mode is about 2.6:1 contrast, flagged by the a11y addon on the Astro dark story; React and Svelte have it too but have no dark story to surface it.

## Verification

- Full package and Storybook build, 23 tasks
- `PARITY_FRAMEWORKS=react,svelte,vue,astro` parity suite: 5 passed; runner unit tests: 17 passed
- Package suites: core, ui 358, react 426, astro 167, svelte 245, vue 101; `test-storybook` react 37, svelte 44, vue 35, astro 6
- Lint and format clean; check-types for core, ui, react, astro, svelte. `@c15t/vue#check-types` fails on a pre-existing `*.vue` module declaration issue, reproduced on a sibling worktree without these changes.

The first commit cherry-picks the default-tokens fix from #1072 so rendering is styled without runtime injection; it rebases away once #1072 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Consent banners and preference centres now use consistent action grouping, keeping “Customize” separate from “Accept” and “Reject.”
  - Astro consent banners now support “Secured by” branding with configurable visibility and attribution.
  - Published stylesheets now include default theme tokens, while custom provider themes continue to take precedence.

- **Bug Fixes**
  - Reset heading margins in banners, dialogs, and frames for consistent sizing across frameworks.
  - Expanded cross-framework visual, accessibility, and styling parity coverage, including Astro.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->