### PR TITLE
fix(nextjs): forward the client IP and user agent on server-side init

### DIFF
--- a/.changeset/nextjs-forward-client-headers.md
+++ b/.changeset/nextjs-forward-client-headers.md
@@ -1,0 +1,5 @@
+---
+"@c15t/nextjs": patch
+---
+
+Forward `x-forwarded-for` and `user-agent` to the backend on server-side `/init` calls by default, matching what the 2.x server helper sent. A backend that geolocates from the client IP when no CDN geo header is present got no country on server-prefetched requests, and consent records lost the user agent. `forwardHeaders` still adds more.

--- a/internals/next-compat/shared/src/suite/index.ts
+++ b/internals/next-compat/shared/src/suite/index.ts
@@ -237,6 +237,13 @@ export const defineCompatSuite = function defineCompatSuite({
 							expect(serverSide[0]?.headers['x-c15t-country']).toBe(
 								TEST_COUNTRY
 							);
+							// The client's IP and user agent travel with the server call,
+							// so the backend can geolocate and record them as it would
+							// for a browser-initiated /init.
+							expect(serverSide[0]?.headers['x-forwarded-for']).toBeDefined();
+							expect(serverSide[0]?.headers['user-agent']).toContain(
+								'HeadlessChrome'
+							);
 							expect(initialHTML).toContain(BANNER_MARKER);
 							break;
 						}

--- a/packages/nextjs/src/__tests__/prefetch.test.ts
+++ b/packages/nextjs/src/__tests__/prefetch.test.ts
@@ -230,6 +230,48 @@ describe('prefetchInitialConsent: backend call', () => {
 		});
 	});
 
+	test('forwards client IP and user agent by default', async () => {
+		headerStore.set('host', 'app.example.com');
+		headerStore.set('user-agent', 'Mozilla/5.0 compat-test');
+		headerStore.set('x-forwarded-for', '203.0.113.7, 10.0.0.1');
+
+		const fetchSpy = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(createInitOutput()), { status: 200 })
+			);
+
+		await prefetchInitialConsent({
+			backendURL: '/api/c15t',
+			fetch: fetchSpy as unknown as typeof globalThis.fetch,
+		});
+
+		const [, init] = fetchSpy.mock.calls[0] ?? [];
+		const headers = (init as RequestInit).headers as Record<string, string>;
+		expect(headers['user-agent']).toBe('Mozilla/5.0 compat-test');
+		expect(headers['x-forwarded-for']).toBe('203.0.113.7, 10.0.0.1');
+	});
+
+	test('omits default forwarded headers the request lacks', async () => {
+		headerStore.set('host', 'app.example.com');
+
+		const fetchSpy = vi
+			.fn()
+			.mockResolvedValue(
+				new Response(JSON.stringify(createInitOutput()), { status: 200 })
+			);
+
+		await prefetchInitialConsent({
+			backendURL: '/api/c15t',
+			fetch: fetchSpy as unknown as typeof globalThis.fetch,
+		});
+
+		const [, init] = fetchSpy.mock.calls[0] ?? [];
+		const headers = (init as RequestInit).headers as Record<string, string>;
+		expect(headers).not.toHaveProperty('x-forwarded-for');
+		expect(headers).not.toHaveProperty('user-agent');
+	});
+
 	test('forwardHeaders forwards requested request-headers', async () => {
 		headerStore.set('authorization', 'Bearer token-xyz');
 		headerStore.set('x-trace-id', 'trace-1');

--- a/packages/nextjs/src/server.ts
+++ b/packages/nextjs/src/server.ts
@@ -232,8 +232,9 @@ export interface PrefetchInitialConsentOptions extends ReadInitialConsentConfigO
 	fetch?: typeof globalThis.fetch;
 
 	/**
-	 * Forward additional request headers onto the backend call. Cookies
-	 * from the incoming request are forwarded automatically. Use this for
+	 * Forward additional request headers onto the backend call. Cookies,
+	 * `x-forwarded-for`, and `user-agent` from the incoming request are
+	 * forwarded automatically (see {@link DEFAULT_FORWARD_HEADERS}). Use this for
 	 * authentication tokens or custom tracing headers.
 	 */
 	forwardHeaders?: string[];
@@ -308,6 +309,19 @@ const pickRequestHeaders = function pickRequestHeaders(
 	return picked;
 };
 
+/**
+ * Request headers forwarded to the backend on every server-side `/init`.
+ *
+ * The backend geolocates from the client IP when no CDN geo header is
+ * present, and records the user agent with the consent decision, so both
+ * have to travel with a server-initiated call the way they do with a
+ * browser-initiated one. `forwardHeaders` adds to this list.
+ */
+export const DEFAULT_FORWARD_HEADERS = [
+	'x-forwarded-for',
+	'user-agent',
+] as const;
+
 const createForwardHeaders = function createForwardHeaders(
 	cookieHeader: string,
 	requestHeaders: Headers,
@@ -317,7 +331,7 @@ const createForwardHeaders = function createForwardHeaders(
 	if (cookieHeader) {
 		forward.cookie = cookieHeader;
 	}
-	for (const key of forwardHeaders ?? []) {
+	for (const key of [...DEFAULT_FORWARD_HEADERS, ...(forwardHeaders ?? [])]) {
 		const value = requestHeaders.get(key);
 		if (value) {
 			forward[key.toLowerCase()] = value;


### PR DESCRIPTION
## What

Server-side `prefetchInitialConsent` now forwards `x-forwarded-for` and `user-agent` to the backend `/init` call by default, alongside the cookies it already sent. `forwardHeaders` still adds more.

## Why

The 2.x server helper forwarded both on every server-initiated `/init`. v3 dropped them, which had two effects: a backend that geolocates from the client IP when no CDN geo header is present got no country on server-prefetched requests, and consent records lost the user agent. Both came out of comparing the two implementations after the compatibility matrix went green.

The `ssr` scenario in `internals/next-compat` now asserts the backend stub saw the client IP and a browser user agent on the server-side call, so this cannot silently regress again.

## Stack

Sits on top of #1067 (the compatibility matrix and DX round). Patch changeset for `@c15t/nextjs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side initialization now forwards client IP and user-agent information by default.
  * Custom forwarded headers continue to be supported alongside these defaults.
  * Default headers are forwarded only when available in the incoming request.

* **Bug Fixes**
  * Improved server-side initialization requests so available client details are captured consistently.
  * Added coverage to verify header forwarding behavior when client information is present or absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->