### PR TITLE
fix: tolerate blocked browser storage in v3

### DIFF
--- a/.changeset/long-glasses-repair.md
+++ b/.changeset/long-glasses-repair.md
@@ -3,3 +3,5 @@
 ---
 
 Keep consent initialization, hydration, saving, and clearing usable when localStorage access is blocked. Continue using available consent cookies and preserve explicit rejections through hosted failures and recovery.
+
+Preserve in-memory choices, notices, privacy directives, and IAB metadata when storage cannot be read during rehydration.

--- a/.changeset/long-glasses-repair.md
+++ b/.changeset/long-glasses-repair.md
@@ -1,0 +1,5 @@
+---
+"@c15t/core": patch
+---
+
+Keep consent initialization, hydration, saving, and clearing usable when localStorage access is blocked. Continue using available consent cookies and preserve explicit rejections through hosted failures and recovery.

--- a/docs/frameworks/javascript/troubleshooting.mdx
+++ b/docs/frameworks/javascript/troubleshooting.mdx
@@ -8,9 +8,24 @@ group: frameworks
   This page is a placeholder for the v3 docs rewrite.
 </Callout>
 
-## Store does not initialize
+## Browser storage is blocked
 
-TODO.
+Browser restrictions can make the `localStorage` getter or its methods throw.
+c15t reports storage failures through console warnings and continues running.
+It can still read, save, and clear consent cookies when localStorage is
+unavailable. If both storage mechanisms are blocked, choices remain in memory
+for the current page and cannot be restored after a reload.
+
+## Hosted initialization fails
+
+A failed hosted initialization uses a conservative fallback without deleting
+saved choices. Explicit rejections survive backend recovery, including a
+rejection saved during the outage when browser storage is available. A recovered
+opt-out policy does not override an explicit rejection.
+
+Do not set `enabled: false` to work around initialization or storage failures.
+That option grants every category. Leave c15t enabled so unresolved optional
+consent remains denied.
 
 ## Scripts load without consent
 

--- a/docs/frameworks/javascript/troubleshooting.mdx
+++ b/docs/frameworks/javascript/troubleshooting.mdx
@@ -14,7 +14,9 @@ Browser restrictions can make the `localStorage` getter or its methods throw.
 c15t reports storage failures through console warnings and continues running.
 It can still read, save, and clear consent cookies when localStorage is
 unavailable. If both storage mechanisms are blocked, choices remain in memory
-for the current page and cannot be restored after a reload.
+for the current page and cannot be restored after a reload. Rehydrating while
+storage is unreadable preserves those in-memory records. Readable empty storage
+still clears the corresponding records.
 
 ## Hosted initialization fails
 

--- a/packages/core/src/libs/cookie/operations.ts
+++ b/packages/core/src/libs/cookie/operations.ts
@@ -205,6 +205,7 @@ export const parseCookieValue = function parseCookieValue<ReturnType = unknown>(
  * Reads one cookie's raw value from `document.cookie` without parsing it.
  *
  * @param name - Cookie name to read
+ * @param onUnavailable - Called when browser cookies cannot be read.
  * @returns The raw value, or `null` outside the browser, when the cookie
  * is absent, or when `document.cookie` cannot be read.
  *
@@ -215,9 +216,11 @@ export const parseCookieValue = function parseCookieValue<ReturnType = unknown>(
  * @internal
  */
 export const getRawCookieValue = function getRawCookieValue(
-	name: string
+	name: string,
+	onUnavailable?: () => void
 ): string | null {
 	if (typeof document === 'undefined') {
+		onUnavailable?.();
 		return null;
 	}
 
@@ -225,6 +228,7 @@ export const getRawCookieValue = function getRawCookieValue(
 		return readCookieValueFromHeader(document.cookie, name) ?? null;
 	} catch (error) {
 		console.warn(`Failed to get cookie "${name}":`, error);
+		onUnavailable?.();
 		return null;
 	}
 };

--- a/packages/core/src/modules/persistence/__tests__/storage-access.test.ts
+++ b/packages/core/src/modules/persistence/__tests__/storage-access.test.ts
@@ -1,0 +1,128 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import {
+	matchedResolution,
+	noticeRule,
+	NOW,
+} from '../../../__tests__/fixtures/kernel-fixtures';
+import { createConsentKernel } from '../../../kernel';
+import { createPersistence } from '../index';
+import { clearStoredConsentRecords } from '../record-storage';
+
+const disposers: (() => void)[] = [];
+const resolution = matchedResolution(
+	noticeRule({ privacySignals: { gpc: { denyCategories: ['measurement'] } } })
+);
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+	localStorage.clear();
+	clearStoredConsentRecords();
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const dispose of disposers.splice(0).reverse()) {
+		dispose();
+	}
+	clearStoredConsentRecords();
+	vi.useRealTimers();
+});
+
+const createKernel = () => {
+	const kernel = createConsentKernel({ initialPolicyResolution: resolution });
+	disposers.push(() => kernel.dispose());
+	return kernel;
+};
+
+const persist = (kernel: ReturnType<typeof createKernel>) => {
+	const handle = createPersistence({ kernel });
+	disposers.push(() => handle.dispose());
+	return handle;
+};
+
+const restrictStorage = (restriction: 'getter' | 'methods' | 'missing') => {
+	if (restriction === 'methods') {
+		for (const method of ['getItem', 'setItem', 'removeItem'] as const) {
+			vi.spyOn(Storage.prototype, method).mockImplementation(() => {
+				throw new DOMException('Storage access blocked', 'SecurityError');
+			});
+		}
+		return;
+	}
+	vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+		if (restriction === 'missing') {
+			return undefined as unknown as Storage;
+		}
+		throw new DOMException('Storage access blocked', 'SecurityError');
+	});
+};
+
+test.each(['getter', 'methods', 'missing'] as const)(
+	'hydrates and clears cookie records when localStorage fails through %s',
+	async (restriction) => {
+		const source = createKernel();
+		const writer = persist(source);
+		await source.commands.save({ measurement: false });
+		await source.commands.dismissNotice();
+		source.set.privacySignals({ gpc: true });
+		writer.dispose();
+		const saved = source.getSnapshot();
+		const { cookie } = document;
+		expect(cookie).toContain('c15t=');
+		expect(cookie).toContain('c15t-notice=');
+		expect(cookie).toContain('c15t-privacy=');
+		localStorage.clear();
+		restrictStorage(restriction);
+
+		const restored = createKernel();
+		const reader = persist(restored);
+		expect(restored.getSnapshot().explicitChoice).toEqual(saved.explicitChoice);
+		expect(restored.getSnapshot().noticeDismissal).toEqual(
+			saved.noticeDismissal
+		);
+		expect(restored.getSnapshot().optOutDirectives).toEqual(
+			saved.optOutDirectives
+		);
+		expect(restored.getSnapshot().effectivePermissions.measurement).toBe(false);
+		expect(document.cookie).toBe(cookie);
+
+		reader.clear();
+		expect(document.cookie).toBe('');
+		expect(restored.getSnapshot().explicitChoice).toBeNull();
+		expect(restored.getSnapshot().noticeDismissal).toBeNull();
+		expect(restored.getSnapshot().optOutDirectives).toEqual([]);
+	}
+);
+
+test.each(['getter', 'methods', 'missing'] as const)(
+	'persists choices, notices and privacy directives when localStorage becomes unavailable through %s',
+	async (restriction) => {
+		const kernel = createKernel();
+		const writer = persist(kernel);
+		restrictStorage(restriction);
+		await kernel.commands.save({ measurement: false });
+		await kernel.commands.dismissNotice();
+		kernel.set.privacySignals({ gpc: true });
+		// Flush the deferred writes without advancing the receipt expiry timer.
+		expect(() => vi.advanceTimersByTime(0)).not.toThrow();
+		writer.dispose();
+		expect(document.cookie).toContain('c15t=');
+		expect(document.cookie).toContain('c15t-notice=');
+		expect(document.cookie).toContain('c15t-privacy=');
+		const restored = createKernel();
+		persist(restored);
+		expect(restored.getSnapshot().explicitChoice).toEqual(
+			kernel.getSnapshot().explicitChoice
+		);
+		expect(restored.getSnapshot().noticeDismissal).toEqual(
+			kernel.getSnapshot().noticeDismissal
+		);
+		expect(restored.getSnapshot().optOutDirectives).toEqual(
+			kernel.getSnapshot().optOutDirectives
+		);
+	}
+);

--- a/packages/core/src/modules/persistence/__tests__/storage-access.test.ts
+++ b/packages/core/src/modules/persistence/__tests__/storage-access.test.ts
@@ -2,13 +2,19 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import {
+	explicitChoice,
 	matchedResolution,
 	noticeRule,
 	NOW,
 } from '../../../__tests__/fixtures/kernel-fixtures';
 import { createConsentKernel } from '../../../kernel';
+import { readStoredRecords } from '../hydrate';
 import { createPersistence } from '../index';
-import { clearStoredConsentRecords } from '../record-storage';
+import {
+	clearStoredConsentRecords,
+	readStoredConsentRecord,
+	writeStoredConsentEnvelope,
+} from '../record-storage';
 
 const disposers: (() => void)[] = [];
 const resolution = matchedResolution(
@@ -47,7 +53,7 @@ const persist = (kernel: ReturnType<typeof createKernel>) => {
 const restrictStorage = (restriction: 'getter' | 'methods' | 'missing') => {
 	if (restriction === 'methods') {
 		for (const method of ['getItem', 'setItem', 'removeItem'] as const) {
-			vi.spyOn(Storage.prototype, method).mockImplementation(() => {
+			vi.spyOn(localStorage, method).mockImplementation(() => {
 				throw new DOMException('Storage access blocked', 'SecurityError');
 			});
 		}
@@ -60,6 +66,105 @@ const restrictStorage = (restriction: 'getter' | 'methods' | 'missing') => {
 		throw new DOMException('Storage access blocked', 'SecurityError');
 	});
 };
+
+test.each(['getter', 'methods', 'missing'] as const)(
+	'keeps in-memory records when cookie reads fail and localStorage is unavailable through %s',
+	async (restriction) => {
+		const kernel = createKernel();
+		const handle = persist(kernel);
+		restrictStorage(restriction);
+		vi.spyOn(document, 'cookie', 'get').mockImplementation(() => {
+			throw new DOMException('Cookies blocked', 'SecurityError');
+		});
+		vi.spyOn(document, 'cookie', 'set').mockImplementation(() => {
+			throw new DOMException('Cookies blocked', 'SecurityError');
+		});
+		await kernel.commands.save({ measurement: false });
+		await kernel.commands.dismissNotice();
+		kernel.set.privacySignals({ gpc: true });
+		const before = kernel.getSnapshot();
+
+		expect(handle.hydrate()).toBe(false);
+		expect(kernel.getSnapshot().explicitChoice).toEqual(before.explicitChoice);
+		expect(kernel.getSnapshot().subject).toEqual(before.subject);
+		expect(kernel.getSnapshot().noticeDismissal).toEqual(
+			before.noticeDismissal
+		);
+		expect(kernel.getSnapshot().optOutDirectives).toEqual(
+			before.optOutDirectives
+		);
+		expect(kernel.getSnapshot().effectivePermissions.measurement).toBe(false);
+	}
+);
+
+test('distinguishes unreadable records from readable empty storage', async () => {
+	const kernel = createKernel();
+	const handle = persist(kernel);
+	await kernel.commands.save({ measurement: false });
+	await kernel.commands.dismissNotice();
+	vi.advanceTimersByTime(0);
+	clearStoredConsentRecords();
+
+	expect(handle.hydrate()).toBe(false);
+	expect(kernel.getSnapshot().explicitChoice).toBeNull();
+	expect(kernel.getSnapshot().subject).toBeNull();
+	expect(kernel.getSnapshot().noticeDismissal).toBeNull();
+});
+
+test('preserves IAB metadata on the next save after unreadable hydration', async () => {
+	const iab = { customVendorConsents: { acme: false } };
+	writeStoredConsentEnvelope(
+		{
+			categories: explicitChoice({ measurement: false }).categories,
+			iab,
+			version: 3,
+		},
+		{ now: NOW }
+	);
+	const kernel = createKernel();
+	const handle = persist(kernel);
+	restrictStorage('getter');
+	vi.spyOn(document, 'cookie', 'get').mockImplementation(() => {
+		throw new DOMException('Cookies blocked', 'SecurityError');
+	});
+
+	expect(handle.hydrate()).toBe(false);
+	vi.restoreAllMocks();
+	await kernel.commands.save({ measurement: false });
+	vi.advanceTimersByTime(0);
+	expect(readStoredConsentRecord(undefined, NOW).selected?.iab).toEqual(iab);
+});
+
+test('hydrates readable choices without clearing unreadable notice and privacy records', async () => {
+	const kernel = createKernel();
+	const handle = persist(kernel);
+	await kernel.commands.save({ measurement: false });
+	await kernel.commands.dismissNotice();
+	kernel.set.privacySignals({ gpc: true });
+	vi.advanceTimersByTime(0);
+	const before = kernel.getSnapshot();
+	const storedChoice = localStorage.getItem('c15t');
+	expect(storedChoice).not.toBeNull();
+	vi.spyOn(document, 'cookie', 'get').mockImplementation(() => {
+		throw new DOMException('Cookies blocked', 'SecurityError');
+	});
+	vi.spyOn(localStorage, 'getItem').mockImplementation((key) => {
+		if (key === 'c15t-notice' || key === 'c15t-privacy') {
+			throw new DOMException('Record blocked', 'SecurityError');
+		}
+		return key === 'c15t' ? storedChoice : null;
+	});
+
+	const stored = readStoredRecords(undefined, NOW);
+	expect(stored.records).not.toHaveProperty('noticeDismissal');
+	expect(stored.records).not.toHaveProperty('optOutDirectives');
+	expect(handle.hydrate()).toBe(true);
+	expect(kernel.getSnapshot().explicitChoice).toEqual(before.explicitChoice);
+	expect(kernel.getSnapshot().noticeDismissal).toEqual(before.noticeDismissal);
+	expect(kernel.getSnapshot().optOutDirectives).toEqual(
+		before.optOutDirectives
+	);
+});
 
 test.each(['getter', 'methods', 'missing'] as const)(
 	'hydrates and clears cookie records when localStorage fails through %s',

--- a/packages/core/src/modules/persistence/hydrate.ts
+++ b/packages/core/src/modules/persistence/hydrate.ts
@@ -99,16 +99,18 @@ export const readStoredRecordsFromCookieHeader =
 /**
  * Read stored records and apply them to the kernel. Returns the read
  * result so the caller can keep the IAB metadata for the next save, or
- * `null` when storage APIs are unavailable.
+ * `null` outside the browser.
  */
 export const hydrateFromStorage = function hydrateFromStorage(
 	kernel: ConsentKernel,
 	storageConfig: StorageConfig | undefined,
 	now: number
 ): StoredRecords | null {
-	if (typeof document === 'undefined' || typeof localStorage === 'undefined') {
+	if (typeof document === 'undefined') {
 		return null;
 	}
+	// Cookies can remain usable when localStorage is blocked. Let each
+	// storage reader guard its own access, including property getters.
 	const stored = readStoredRecords(storageConfig, now);
 	const result = kernel.hydrate(stored.records);
 	if (result.ok === false) {

--- a/packages/core/src/modules/persistence/hydrate.ts
+++ b/packages/core/src/modules/persistence/hydrate.ts
@@ -23,6 +23,7 @@ import type { StorageConfig } from './types';
 
 /** Stored records plus the IAB transport metadata the next save preserves. */
 export interface StoredRecords {
+	/** Unreadable records are omitted so hydration preserves in-memory values. */
 	records: HydrationRecords;
 	iab: StoredIabMetadata | null;
 	/** Whether any valid record was found. */
@@ -60,12 +61,32 @@ export const readStoredRecords = function readStoredRecords(
 	storageConfig: StorageConfig | undefined,
 	now: number
 ): StoredRecords {
-	return composeRecords(
-		readStoredConsentRecord(storageConfig, now),
-		readStoredNoticeDismissal(storageConfig, now),
-		readStoredPrivacyOptOuts(storageConfig, now),
-		now
-	);
+	let choiceUnavailable = false;
+	let noticeUnavailable = false;
+	let privacyUnavailable = false;
+	const selection = readStoredConsentRecord(storageConfig, now, () => {
+		choiceUnavailable = true;
+	});
+	const notice = readStoredNoticeDismissal(storageConfig, now, () => {
+		noticeUnavailable = true;
+	});
+	const privacy = readStoredPrivacyOptOuts(storageConfig, now, () => {
+		privacyUnavailable = true;
+	});
+	const stored = composeRecords(selection, notice, privacy, now);
+	// An absent value only clears memory when every candidate was readable.
+	// A valid record from an available source can still hydrate normally.
+	if (!selection.selected && choiceUnavailable) {
+		delete stored.records.choice;
+		delete stored.records.subject;
+	}
+	if (!notice?.ok && noticeUnavailable) {
+		delete stored.records.noticeDismissal;
+	}
+	if (!privacy?.ok && privacyUnavailable) {
+		delete stored.records.optOutDirectives;
+	}
+	return stored;
 };
 
 /**

--- a/packages/core/src/modules/persistence/index.ts
+++ b/packages/core/src/modules/persistence/index.ts
@@ -62,8 +62,6 @@ export const createPersistence = function createPersistence(
 ): PersistenceHandle {
 	const { kernel, storageConfig } = options;
 	const now = options.now ?? (() => Date.now());
-	const hasStorageAPIs =
-		typeof document !== 'undefined' && typeof localStorage !== 'undefined';
 
 	// IAB transport metadata carried by the stored record. Preserved on the
 	// next explicit save so an envelope rewrite never drops it.
@@ -127,7 +125,7 @@ export const createPersistence = function createPersistence(
 		clear() {
 			cancelAll();
 			storedIab = null;
-			if (hasStorageAPIs) {
+			if (typeof document !== 'undefined') {
 				clearStoredConsentRecords(undefined, storageConfig);
 			}
 			kernel.hydrate({

--- a/packages/core/src/modules/persistence/index.ts
+++ b/packages/core/src/modules/persistence/index.ts
@@ -113,7 +113,9 @@ export const createPersistence = function createPersistence(
 		if (!stored) {
 			return false;
 		}
-		storedIab = stored.iab;
+		if (stored.records.choice !== undefined) {
+			storedIab = stored.iab;
+		}
 		return stored.found;
 	};
 

--- a/packages/core/src/modules/persistence/record-storage.ts
+++ b/packages/core/src/modules/persistence/record-storage.ts
@@ -381,7 +381,8 @@ export const parseRawCookieCandidate = function parseRawCookieCandidate(
 };
 
 const readLocalStorageText = function readLocalStorageText(
-	key: string
+	key: string,
+	onUnavailable?: () => void
 ): string | null {
 	try {
 		if (typeof window !== 'undefined' && window.localStorage) {
@@ -390,14 +391,16 @@ const readLocalStorageText = function readLocalStorageText(
 	} catch (error) {
 		console.warn('Failed to read consent from localStorage:', error);
 	}
+	onUnavailable?.();
 	return null;
 };
 
 const parseLocalStorageCandidate = function parseLocalStorageCandidate(
 	source: StoredRecordSource,
-	key: string
+	key: string,
+	onUnavailable?: () => void
 ): RawStoredCandidate {
-	const text = readLocalStorageText(key);
+	const text = readLocalStorageText(key, onUnavailable);
 	if (text === null || text === '') {
 		return { key, source, status: 'absent' };
 	}
@@ -422,16 +425,24 @@ const parseLocalStorageCandidate = function parseLocalStorageCandidate(
  */
 export const readRawStoredConsentCandidates =
 	function readRawStoredConsentCandidates(
-		config?: StorageConfig
+		config?: StorageConfig,
+		onUnavailable?: () => void
 	): RawStoredCandidate[] {
 		const keys = resolveStorageKeys(config);
 		const candidates: RawStoredCandidate[] = [
-			parseRawCookieCandidate(getRawCookieValue(keys.consent), keys.consent),
-			parseLocalStorageCandidate('local-storage', keys.consent),
+			parseRawCookieCandidate(
+				getRawCookieValue(keys.consent, onUnavailable),
+				keys.consent
+			),
+			parseLocalStorageCandidate('local-storage', keys.consent, onUnavailable),
 		];
 		if (keys.legacyConsent) {
 			candidates.push(
-				parseLocalStorageCandidate('legacy-local-storage', keys.legacyConsent)
+				parseLocalStorageCandidate(
+					'legacy-local-storage',
+					keys.legacyConsent,
+					onUnavailable
+				)
 			);
 		}
 		return candidates;
@@ -589,9 +600,13 @@ export const selectStoredConsent = function selectStoredConsent(
  */
 export const readStoredConsentRecord = function readStoredConsentRecord(
 	config: StorageConfig | undefined,
-	now: number
+	now: number,
+	onUnavailable?: () => void
 ): StoredConsentSelection {
-	return selectStoredConsent(readRawStoredConsentCandidates(config), now);
+	return selectStoredConsent(
+		readRawStoredConsentCandidates(config, onUnavailable),
+		now
+	);
 };
 
 /**
@@ -725,9 +740,10 @@ export const writeStoredConsentEnvelope = function writeStoredConsentEnvelope(
 
 const readLocalJson = function readLocalJson<RecordType>(
 	key: string,
-	decode: (value: unknown) => DecodeResult<RecordType>
+	decode: (value: unknown) => DecodeResult<RecordType>,
+	onUnavailable?: () => void
 ): DecodeResult<RecordType> | null {
-	const text = readLocalStorageText(key);
+	const text = readLocalStorageText(key, onUnavailable);
 	if (text === null || text === '') {
 		return null;
 	}
@@ -779,18 +795,23 @@ export interface AuxiliaryWriteReport {
  */
 export const readStoredNoticeDismissal = function readStoredNoticeDismissal(
 	config: StorageConfig | undefined,
-	now: number
+	now: number,
+	onUnavailable?: () => void
 ): DecodeResult<StoredNoticeDismissal> | null {
 	const keys = resolveStorageKeys(config);
-	const fromCookie = readCompactCookie(getRawCookieValue(keys.notice), (text) =>
-		decodeNoticeDismissalCompact(text, now)
+	const fromCookie = readCompactCookie(
+		getRawCookieValue(keys.notice, onUnavailable),
+		(text) => decodeNoticeDismissalCompact(text, now)
 	);
 	if (fromCookie?.ok) {
 		return fromCookie;
 	}
 	return (
-		readLocalJson(keys.notice, (value) => decodeNoticeDismissal(value, now)) ??
-		fromCookie
+		readLocalJson(
+			keys.notice,
+			(value) => decodeNoticeDismissal(value, now),
+			onUnavailable
+		) ?? fromCookie
 	);
 };
 
@@ -859,19 +880,23 @@ export const clearStoredNoticeDismissal = function clearStoredNoticeDismissal(
  */
 export const readStoredPrivacyOptOuts = function readStoredPrivacyOptOuts(
 	config: StorageConfig | undefined,
-	now: number
+	now: number,
+	onUnavailable?: () => void
 ): DecodeResult<StoredPrivacyOptOuts> | null {
 	const keys = resolveStorageKeys(config);
 	const fromCookie = readCompactCookie(
-		getRawCookieValue(keys.privacy),
+		getRawCookieValue(keys.privacy, onUnavailable),
 		(text) => decodePrivacyOptOutsCompact(text, now)
 	);
 	if (fromCookie?.ok) {
 		return fromCookie;
 	}
 	return (
-		readLocalJson(keys.privacy, (value) => decodePrivacyOptOuts(value, now)) ??
-		fromCookie
+		readLocalJson(
+			keys.privacy,
+			(value) => decodePrivacyOptOuts(value, now),
+			onUnavailable
+		) ?? fromCookie
 	);
 };
 

--- a/packages/core/src/modules/persistence/types.ts
+++ b/packages/core/src/modules/persistence/types.ts
@@ -28,7 +28,11 @@ export interface PersistenceOptions {
 
 export interface PersistenceHandle {
 	dispose: () => void;
-	/** Re-run hydration from storage. Returns whether any record was found. */
+	/**
+	 * Re-run hydration from storage. Returns whether any record was found.
+	 * Unreadable records preserve their in-memory values; readable empty
+	 * storage clears them.
+	 */
 	hydrate: () => boolean;
 	/**
 	 * Cancel queued writes, clear every c15t record (choice, notice, privacy,

--- a/packages/core/src/modules/persistence/write.ts
+++ b/packages/core/src/modules/persistence/write.ts
@@ -17,10 +17,6 @@ import {
 } from './record-storage';
 import type { StorageConfig } from './types';
 
-const hasStorageAPIs = function hasStorageAPIs(): boolean {
-	return typeof document !== 'undefined' && typeof localStorage !== 'undefined';
-};
-
 /** Envelope a snapshot's explicit choice serializes to, or `null`. */
 export const buildStoredEnvelope = function buildStoredEnvelope(
 	snapshot: ConsentSnapshot,
@@ -52,7 +48,7 @@ export const writeChoiceToStorage = function writeChoiceToStorage(
 	storageConfig: StorageConfig | undefined,
 	now: number
 ): void {
-	if (!hasStorageAPIs()) {
+	if (typeof document === 'undefined') {
 		return;
 	}
 	const envelope = buildStoredEnvelope(snapshot, iab);
@@ -74,7 +70,7 @@ export const writeNoticeToStorage = function writeNoticeToStorage(
 	storageConfig: StorageConfig | undefined,
 	now: number
 ): void {
-	if (!hasStorageAPIs() || !snapshot.noticeDismissal) {
+	if (typeof document === 'undefined' || !snapshot.noticeDismissal) {
 		return;
 	}
 	writeStoredNoticeDismissal(snapshot.noticeDismissal, storageConfig, now);
@@ -86,7 +82,7 @@ export const writePrivacyToStorage = function writePrivacyToStorage(
 	storageConfig: StorageConfig | undefined,
 	now: number
 ): void {
-	if (!hasStorageAPIs()) {
+	if (typeof document === 'undefined') {
 		return;
 	}
 	writeStoredPrivacyOptOuts(snapshot.optOutDirectives, storageConfig, now);

--- a/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
+++ b/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
@@ -1,0 +1,180 @@
+/** @vitest-environment jsdom */
+import { writePolicyResolutionWire } from '@c15t/schema/types';
+import { translations } from '@c15t/translations/en';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import {
+	matchedResolution,
+	noneRule,
+	optOutRule,
+} from '../../__tests__/fixtures/kernel-fixtures';
+import { clearStoredConsentRecords } from '../../modules/persistence/record-storage';
+import { hosted } from '../../transports/mode';
+import { c15tProtocolHeaders } from '../../transports/version-header';
+import { createConsentRuntime } from '../index';
+import type { ConsentRuntime } from '../types';
+
+const runtimes: ConsentRuntime[] = [];
+const originalPolicy = matchedResolution(optOutRule());
+let policy = originalPolicy;
+let unavailable = false;
+
+beforeEach(() => {
+	localStorage.clear();
+	clearStoredConsentRecords();
+	policy = originalPolicy;
+	unavailable = false;
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	for (const runtime of runtimes.splice(0)) {
+		runtime.dispose();
+		runtime.kernel.dispose();
+	}
+	vi.restoreAllMocks();
+	clearStoredConsentRecords();
+});
+
+const createRuntime = () => {
+	const runtime = createConsentRuntime({
+		consentCategories: ['necessary', 'measurement'],
+		mode: hosted({
+			fetch: (input) => {
+				if (unavailable) {
+					return Promise.resolve(new Response(null, { status: 503 }));
+				}
+				return Promise.resolve(
+					Response.json(
+						String(input).endsWith('/init')
+							? {
+									branding: 'c15t',
+									location: { countryCode: 'US', regionCode: 'CA' },
+									policyResolution: writePolicyResolutionWire(policy),
+									translations: { language: 'en', translations },
+								}
+							: {},
+						{ headers: c15tProtocolHeaders }
+					)
+				);
+			},
+			url: '/api/c15t',
+		}),
+		prefetch: { initRetry: false },
+	});
+	runtimes.push(runtime);
+	return runtime;
+};
+
+const start = async () => {
+	const runtime = createRuntime();
+	const completed = Promise.withResolvers<undefined>();
+	runtime.kernel.events.on('command:init:completed', () =>
+		completed.resolve(undefined)
+	);
+	runtime.start();
+	await completed.promise;
+	return runtime;
+};
+
+const close = (runtime: ConsentRuntime) => {
+	runtime.dispose();
+	runtime.kernel.dispose();
+};
+
+test('hosted startup, save and clear survive blocked storage getters', async () => {
+	unavailable = true;
+	vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+		throw new DOMException('Storage access blocked', 'SecurityError');
+	});
+	vi.spyOn(document, 'cookie', 'get').mockImplementation(() => {
+		throw new DOMException('Cookies blocked', 'SecurityError');
+	});
+	vi.spyOn(document, 'cookie', 'set').mockImplementation(() => {
+		throw new DOMException('Cookies blocked', 'SecurityError');
+	});
+	const runtime = await start();
+	expect(runtime.kernel.getSnapshot().resolution).toMatchObject({
+		reason: 'transport',
+		status: 'failed',
+	});
+	expect(runtime.kernel.getSnapshot().effectivePermissions.measurement).toBe(
+		false
+	);
+	await runtime.kernel.commands.save('none');
+	expect(
+		runtime.kernel.getSnapshot().explicitChoice?.categories.measurement?.value
+	).toBe(false);
+	expect(() => runtime.clearRecords()).not.toThrow();
+	expect(runtime.kernel.getSnapshot().explicitChoice).toBeNull();
+	close(runtime);
+	expect(console.warn).toHaveBeenCalled();
+});
+
+test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(
+	'preserves a rejection across hosted init failure and %s recovery',
+	async (recovery) => {
+		const initial = await start();
+		expect(initial.kernel.getSnapshot().effectivePermissions.measurement).toBe(
+			true
+		);
+		if (recovery !== 'offline-rejection') {
+			await initial.kernel.commands.save('none');
+		}
+		close(initial);
+		const savedChoice = initial.kernel.getSnapshot().explicitChoice;
+		const savedLocal = localStorage.getItem('c15t');
+		const savedCookie = document.cookie;
+
+		unavailable = true;
+		const outage = await start();
+		expect(outage.kernel.getSnapshot().resolution).toMatchObject({
+			reason: 'transport',
+			status: 'failed',
+		});
+		expect(outage.kernel.getSnapshot().effectivePermissions.measurement).toBe(
+			false
+		);
+		if (recovery === 'offline-rejection') {
+			await outage.kernel.commands.save('none');
+		}
+		close(outage);
+		const outageChoice = outage.kernel.getSnapshot().explicitChoice;
+		expect(outageChoice?.categories.measurement?.value).toBe(false);
+		if (recovery !== 'offline-rejection') {
+			expect(outageChoice).toEqual(savedChoice);
+			expect(localStorage.getItem('c15t')).toBe(savedLocal);
+			expect(document.cookie).toBe(savedCookie);
+		}
+
+		unavailable = false;
+		if (recovery === 'none') {
+			policy = matchedResolution(noneRule());
+		}
+		if (recovery === 'changed-policy') {
+			policy = matchedResolution(
+				optOutRule({ categories: ['measurement'], scopeMode: 'strict' })
+			);
+			expect(policy.fingerprints.choice).not.toBe(
+				originalPolicy.fingerprints.choice
+			);
+		}
+		const recovered = await start();
+		expect(recovered.kernel.getSnapshot().resolution.status).toBe('matched');
+		expect(recovered.kernel.getSnapshot().explicitChoice).toEqual(outageChoice);
+		expect(
+			recovered.kernel.getSnapshot().effectivePermissions.measurement
+		).toBe(false);
+		close(recovered);
+
+		unavailable = true;
+		const repeated = await start();
+		close(repeated);
+		unavailable = false;
+		const final = await start();
+		expect(final.kernel.getSnapshot().explicitChoice).toEqual(outageChoice);
+		expect(final.kernel.getSnapshot().effectivePermissions.measurement).toBe(
+			false
+		);
+	}
+);

--- a/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
+++ b/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
@@ -108,7 +108,10 @@ test('hosted startup, save and clear survive blocked storage getters', async () 
 	expect(() => runtime.clearRecords()).not.toThrow();
 	expect(runtime.kernel.getSnapshot().explicitChoice).toBeNull();
 	close(runtime);
-	expect(console.warn).toHaveBeenCalled();
+	expect(console.warn).toHaveBeenCalledWith(
+		'Failed to read consent from localStorage:',
+		expect.objectContaining({ name: 'SecurityError' })
+	);
 });
 
 test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(


### PR DESCRIPTION
## Overview

A blocked `localStorage` getter could throw during v3 runtime startup, hydration, and consent writes. Remove the unguarded capability checks and let the existing storage helpers handle access failures independently, so available consent cookies continue to work for reading, saving, and clearing records.

Add regression tests for blocked getters, throwing methods, missing localStorage, and hosted startup with both cookies and localStorage blocked. Also cover saved rejections across init failures, repeated outages, policy changes, and recovery, including a rejection recorded during an outage. The reported rejection-loss sequence did not reproduce on v3; these tests protect its existing behavior.

Rehydration now distinguishes failed reads from empty storage for each record. Unreadable records preserve the current in-memory choice, subject, notice dismissal, privacy directives, and IAB metadata. Available records still hydrate, and readable empty storage still clears records. The hosted storage test also matches the specific localStorage warning and its SecurityError.

Includes a core patch changeset and updated troubleshooting docs, with bundled docs regenerated.

## Related issues

Related to #1085 and #1084. This PR targets **v3 only**. Both issues must remain open for the separate v2 fixes.

## Type of change

- [x] Bug fix
- [x] Documentation

## Testing

- [x] 925 core tests passed, including 17 new regression cases, with coverage thresholds enabled.
- [x] Seven Chromium checks passed against the changed source, using a local HTTP backend and real storage/reloads.
- [x] Core build and production type checks passed.
- [x] Changed-file lint, formatting, docs lint, and diff checks passed.
- [x] Pre-commit checks passed.

The separate `check-types:test` command reports pre-existing errors. Its output is identical on untouched `origin/v3` and this change.

Full Local CI was attempted but could not start its Docker jobs because the Docker engine is not running. The direct checks above completed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Consent initialization, hydration, saving, and clearing now continue to work when browser storage is blocked or unavailable.
  - Consent cookies remain usable, with a memory-only fallback when persistent storage cannot be accessed.
  - Explicit rejections are preserved during hosted service failures and recovery.
  - Recovery no longer overrides saved opt-out choices unexpectedly.

- **Documentation**
  - Added troubleshooting guidance for blocked storage, hosted initialization failures, fallback behavior, and consent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->