### PR TITLE
docs(next): make awaited server prefetch the App Router default and state its cost

### DIFF
--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -123,8 +123,10 @@ With this layout, the server renders the consent subtree only after policy has
 resolved, so the banner arrives already decided and does not change after
 hydration. Because the boundary uses `fallback={null}`, Next.js may stream the
 shell first and the consent subtree a moment later in the same response. A
-returning visitor whose stored choices arrive in the request cookie sees no
-banner. Location rules apply when your host supplies trusted geography
+returning visitor whose request cookie carries a valid stored choice sees no
+banner; an expired choice, a choice recorded under a different policy
+fingerprint, or one that no longer covers every required category prompts
+again. Location rules apply when your host supplies trusted geography
 headers. The [runnable Next.js example](/docs/examples) uses this awaited form.
 
 If the manifest request fails, `prefetchInitialConsent` returns a baseline

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -165,11 +165,10 @@ request data directly in the root layout without it fails the build. Without
 ## What server prefetch costs
 
 `prefetchInitialConsent` reads request cookies and headers through
-`next/headers`, so every route under this layout renders dynamically on each
-request. Next.js cannot statically generate or CDN-cache that HTML. With
-`cacheComponents` (Partial Prerendering) enabled, the static shell outside the
-`Suspense` boundary still prerenders and the consent subtree streams per
-request.
+`next/headers`. Without `cacheComponents`, this makes routes under the layout
+dynamically rendered. With `cacheComponents` enabled, Next.js can prerender
+and cache the static shell outside `Suspense`, while the visitor-specific
+consent subtree resolves and streams per request.
 
 The first request on a new server instance has an empty manifest cache and
 waits for the upstream `/manifest` fetch. In the local benchmark with 150 ms of
@@ -187,8 +186,9 @@ first paint. See the
 [benchmark results](https://github.com/c15t/c15t/tree/ccfe906682ba06cef7b56a16cc8fd10728df77d3/benchmarks/reports/next-manifest-2026-09-10)
 for conditions.
 
-The rendered HTML contains one visitor's resolved consent state. Do not place it
-in a shared cache; only the public manifest is cacheable. See
+The resolved consent subtree contains one visitor's state. Do not put that
+subtree, or the complete response containing it, in a shared cache. Public
+manifests and the prerendered static shell can be cached separately. See
 [cache policy data without sharing visitor state](/docs/frameworks/next/server-side#cache-policy-data-without-sharing-visitor-state).
 
 When the page shell must not wait for consent, use the

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -26,7 +26,8 @@ them, c15t uses your unknown-location rule. Check the supported
 before deploying.
 
 The default layout awaits consent on the server inside a `Suspense` boundary,
-so the first HTML response already contains the resolved banner. You can also
+so the server renders the resolved banner into the response instead of
+deciding in the browser. You can also
 [stream the page while consent resolves](#stream-the-page-while-consent-resolves)
 or initialize in the browser. Awaiting has a cost; see
 [what server prefetch costs](#what-server-prefetch-costs) before deploying.
@@ -118,11 +119,19 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 }
 ```
 
-With this layout, the resolved banner is part of the first HTML response, and
-the prompt does not appear late or change after hydration. A returning visitor
-whose stored choices arrive in the request cookie sees no banner. Location rules
-apply at first paint when your host supplies trusted geography headers. The
-[runnable Next.js example](/docs/examples) uses this awaited form.
+With this layout, the server renders the consent subtree only after policy has
+resolved, so the banner arrives already decided and does not change after
+hydration. Because the boundary uses `fallback={null}`, Next.js may stream the
+shell first and the consent subtree a moment later in the same response. A
+returning visitor whose stored choices arrive in the request cookie sees no
+banner. Location rules apply when your host supplies trusted geography
+headers. The [runnable Next.js example](/docs/examples) uses this awaited form.
+
+If the manifest request fails, `prefetchInitialConsent` returns a baseline
+config without a resolved policy and logs the failure outside production. The
+page still renders, and the browser resolves policy after hydration, so on that
+request a new visitor sees the prompt appear late. Pass `onError` to report
+these failures; see [troubleshooting](/docs/frameworks/next/troubleshooting).
 
 The `Suspense` boundary is required with `cacheComponents: true`: awaiting
 request data directly in the root layout without it fails the build. Without
@@ -145,8 +154,11 @@ first byte. A build-time manifest seed to remove this cold start is planned in
 
 With a warm manifest cache in the same local benchmark (awaited SSR, new
 visitors, 150 ms simulated backend latency), time to first byte was 7.4 ms
-median and 15.2 ms at p95 across 10 samples, with the banner painted at 28 ms
-and present in the first HTML. See the
+median and 15.2 ms at p95 across 10 samples, and the banner markup was present
+in the first HTML. The benchmark layout awaits the helper without a `Suspense`
+boundary, so it does not measure the streaming behavior of the recipe on this
+page, and its 28 ms banner metric is a post-hydration visibility probe, not
+first paint. See the
 [benchmark results](https://github.com/c15t/c15t/tree/ccfe906682ba06cef7b56a16cc8fd10728df77d3/benchmarks/reports/next-manifest-2026-09-10)
 for conditions.
 
@@ -214,9 +226,28 @@ settings. If resolution fails, use
 
 ## Initialize in the browser
 
-Keep the shared config and manifest route, remove the prefetch import and the
-`ResolvedConsent` component, and pass `config={{}}` to the `Consent` wrapper. The browser loads the manifest and
-resolves policy locally. Without supplied location, geography is unknown.
+Keep the shared config and manifest route. Remove the `prefetchInitialConsent`
+and `Suspense` imports and the `ResolvedConsent` component, and render the
+wrapper directly with an empty config:
+
+```tsx title="app/layout.tsx"
+import type { ReactNode } from 'react';
+import { Consent } from '../components/consent';
+import 'c15t/next/styles.css';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Consent config={{}}>{children}</Consent>
+      </body>
+    </html>
+  );
+}
+```
+
+The browser loads the manifest and resolves policy locally, so the initial
+HTML has no resolved prompt. Without supplied location, geography is unknown.
 For browser initialization with request geography, see the
 [optional local init route](/docs/frameworks/next/api-reference/data-fetching#do-i-need-the-local-init-route).
 

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -25,9 +25,11 @@ them, c15t uses your unknown-location rule. Check the supported
 [geography headers](/docs/frameworks/next/api-reference/data-fetching#geography-and-privacy-signals)
 before deploying.
 
-The default layout starts resolution on the server and streams the page while
-consent is pending. You can also [wait for the result](/docs/frameworks/next/server-side#await-consent-inside-suspense)
-or initialize in the browser.
+The default layout awaits consent on the server inside a `Suspense` boundary,
+so the first HTML response already contains the resolved banner. You can also
+[stream the page while consent resolves](#stream-the-page-while-consent-resolves)
+or initialize in the browser. Awaiting has a cost; see
+[what server prefetch costs](#what-server-prefetch-costs) before deploying.
 
 ## Install c15t and configure your backend
 
@@ -84,6 +86,85 @@ The paths below assume `app/` is at the project root. Adjust imports if you use
 
 ## Start consent resolution in the root layout
 
+Await `prefetchInitialConsent` in an async Server Component and mount that
+component inside `Suspense`. The helper reads request cookies and geographic
+headers, resolves policy from the manifest and returns the visitor's prepared
+state, which the `Consent` wrapper passes to `ConsentBoundary` as `config`.
+
+```tsx title="app/layout.tsx"
+import { Suspense } from 'react';
+import type { ReactNode } from 'react';
+import { prefetchInitialConsent } from 'c15t/next/server';
+import { consentConfig } from '../c15t.config';
+import { Consent } from '../components/consent';
+import 'c15t/next/styles.css';
+
+async function ResolvedConsent({ children }: { children: ReactNode }) {
+  const initialConsent = await prefetchInitialConsent({ config: consentConfig });
+
+  return <Consent config={initialConsent}>{children}</Consent>;
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense fallback={null}>
+          <ResolvedConsent>{children}</ResolvedConsent>
+        </Suspense>
+      </body>
+    </html>
+  );
+}
+```
+
+With this layout, the resolved banner is part of the first HTML response, and
+the prompt does not appear late or change after hydration. A returning visitor
+whose stored choices arrive in the request cookie sees no banner. Location rules
+apply at first paint when your host supplies trusted geography headers. The
+[runnable Next.js example](/docs/examples) uses this awaited form.
+
+The `Suspense` boundary is required with `cacheComponents: true`: awaiting
+request data directly in the root layout without it fails the build. Without
+`cacheComponents`, the boundary is still safe to keep.
+
+## What server prefetch costs
+
+`prefetchInitialConsent` reads request cookies and headers through
+`next/headers`, so every route under this layout renders dynamically on each
+request. Next.js cannot statically generate or CDN-cache that HTML. With
+`cacheComponents` (Partial Prerendering) enabled, the static shell outside the
+`Suspense` boundary still prerenders and the consent subtree streams per
+request.
+
+The first request on a new server instance has an empty manifest cache and
+waits for the upstream `/manifest` fetch. In the local benchmark with 150 ms of
+simulated backend latency, the single cold sample measured a 252 ms time to
+first byte. A build-time manifest seed to remove this cold start is planned in
+[c15t/c15t#1096](https://github.com/c15t/c15t/issues/1096).
+
+With a warm manifest cache in the same local benchmark (awaited SSR, new
+visitors, 150 ms simulated backend latency), time to first byte was 7.4 ms
+median and 15.2 ms at p95 across 10 samples, with the banner painted at 28 ms
+and present in the first HTML. See the
+[benchmark results](https://github.com/c15t/c15t/tree/ccfe906682ba06cef7b56a16cc8fd10728df77d3/benchmarks/reports/next-manifest-2026-09-10)
+for conditions.
+
+The rendered HTML contains one visitor's resolved consent state. Do not place it
+in a shared cache; only the public manifest is cacheable. See
+[cache policy data without sharing visitor state](/docs/frameworks/next/server-side#cache-policy-data-without-sharing-visitor-state).
+
+When the page shell must not wait for consent, use the
+[streaming form](#stream-the-page-while-consent-resolves); it still reads the
+request, so the route stays dynamic. When the site must stay fully static, use
+[client-side initialization](/docs/frameworks/next/client-side).
+
+## Stream the page while consent resolves
+
+To render the page shell before consent resolves, keep the root layout
+synchronous and pass the pending promise from `prefetchInitialConsent` to
+`config`. `ConsentBoundary` accepts either the resolved result or its promise.
+
 ```tsx title="app/layout.tsx"
 import type { ReactNode } from 'react';
 import { prefetchInitialConsent } from 'c15t/next/server';
@@ -102,17 +183,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 }
 ```
 
-The helper reads request cookies and geographic headers, then resolves policy
-from the manifest. Passing its promise lets the page stream while consent
-resolves. The current promise form initializes consent in the browser when the server
-result arrives. It does not render the banner in the initial HTML. Use the
-[awaited setup below](#wait-for-consent-before-rendering-its-subtree) to render
-consent UI on the server, as the runnable example does.
-
-`config` receives the prepared visitor state or its promise. `consent` contains
-the shared URLs. Keep this layout synchronous, including when Next.js
-`cacheComponents` is enabled. Request helpers need a request context even though
-the layout passes a promise.
+This promise form does not render the banner in the initial HTML. The provider
+mounts with a provisional policy, consent surfaces stay hidden until the
+promise resolves, and the browser then applies the server result. Keep this
+layout synchronous, including when Next.js `cacheComponents` is enabled; the
+form works with `cacheComponents: true`. Request helpers still need a request
+context even though the layout passes a promise. See
+[server rendering](/docs/frameworks/next/server-side) for the comparison of
+rendering paths.
 
 ## Verify the manifest path
 
@@ -134,18 +212,10 @@ settings. If resolution fails, use
 [Troubleshooting](/docs/frameworks/next/troubleshooting), then run
 [the consent checks](/docs/guides/verify-consent).
 
-## Wait for consent before rendering its subtree
-
-To await the result, put the async consent component inside React `Suspense`,
-as shown in [server rendering](/docs/frameworks/next/server-side#await-consent-inside-suspense).
-With `cacheComponents: true`, awaiting request data directly in the root layout
-without that boundary causes a build error. The fallback can stream before the
-resolved consent subtree.
-
 ## Initialize in the browser
 
-Keep the shared config and manifest route, remove the prefetch import and call,
-and pass `config={{}}` to the `Consent` wrapper. The browser loads the manifest and
+Keep the shared config and manifest route, remove the prefetch import and the
+`ResolvedConsent` component, and pass `config={{}}` to the `Consent` wrapper. The browser loads the manifest and
 resolves policy locally. Without supplied location, geography is unknown.
 For browser initialization with request geography, see the
 [optional local init route](/docs/frameworks/next/api-reference/data-fetching#do-i-need-the-local-init-route).

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -46,6 +46,17 @@ the steps below. Offline setups do not need an endpoint; use the
 
 <CommandTabs command="@c15t/scripts" mode="install" />
 
+Add the prebuilt stylesheet to your global CSS, after any Tailwind import, so
+its component layer follows Tailwind's:
+
+```css title="app/globals.css"
+@import 'tailwindcss';
+@import 'c15t/next/styles.css';
+```
+
+The layouts on this page import `./globals.css`; without Tailwind the same
+`@import` line goes at the top of whatever global stylesheet the layout loads.
+
 Set `NEXT_PUBLIC_C15T_BACKEND_URL` to the absolute endpoint supplied by Inth or
 your self-hosted backend, including any path prefix. This is a public endpoint,
 not a secret. Configure the backend to allow your app's origin.
@@ -98,7 +109,7 @@ import type { ReactNode } from 'react';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
-import 'c15t/next/styles.css';
+import './globals.css';
 
 async function ResolvedConsent({ children }: { children: ReactNode }) {
   const initialConsent = await prefetchInitialConsent({ config: consentConfig });
@@ -192,7 +203,7 @@ import type { ReactNode } from 'react';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
-import 'c15t/next/styles.css';
+import './globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   const initialConsent = prefetchInitialConsent({ config: consentConfig });
@@ -243,7 +254,7 @@ wrapper directly with an empty config:
 ```tsx title="app/layout.tsx"
 import type { ReactNode } from 'react';
 import { Consent } from '../components/consent';
-import 'c15t/next/styles.css';
+import './globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -46,13 +46,17 @@ the steps below. Offline setups do not need an endpoint; use the
 
 <CommandTabs command="@c15t/scripts" mode="install" />
 
-Add the prebuilt stylesheet to your global CSS, after any Tailwind import, so
-its component layer follows Tailwind's:
+With Tailwind CSS 4, add the prebuilt stylesheet to your global CSS after
+Tailwind so its component layer follows Tailwind's:
 
 ```css title="app/globals.css"
 @import 'tailwindcss';
 @import 'c15t/next/styles.css';
 ```
+
+For Tailwind CSS 3, use the [Tailwind 3 stylesheet recipe](/docs/frameworks/next/styling/overview#stylesheet)
+instead. It loads `c15t/next/styles.tw3.css` between the `components` and
+`utilities` directives to prevent Tailwind from purging c15t selectors.
 
 The layouts on this page import `./globals.css`; without Tailwind the same
 `@import` line goes at the top of whatever global stylesheet the layout loads.

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -91,21 +91,16 @@ Await `prefetchInitialConsent` in an async Server Component and mount that
 component inside `Suspense`. The helper reads request cookies and geographic
 headers, resolves policy from the manifest and returns the visitor's prepared
 state, which the `Consent` wrapper passes to `ConsentBoundary` as `config`.
-`await connection()` marks the component as request-time before the helper
-reads the clock; without it, `cacheComponents: true` fails the route during
-prerendering, and with `cacheComponents` off it is a no-op.
 
 ```tsx title="app/layout.tsx"
 import { Suspense } from 'react';
 import type { ReactNode } from 'react';
-import { connection } from 'next/server';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
 import 'c15t/next/styles.css';
 
 async function ResolvedConsent({ children }: { children: ReactNode }) {
-  await connection();
   const initialConsent = await prefetchInitialConsent({ config: consentConfig });
 
   return <Consent config={initialConsent}>{children}</Consent>;

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -91,16 +91,21 @@ Await `prefetchInitialConsent` in an async Server Component and mount that
 component inside `Suspense`. The helper reads request cookies and geographic
 headers, resolves policy from the manifest and returns the visitor's prepared
 state, which the `Consent` wrapper passes to `ConsentBoundary` as `config`.
+`await connection()` marks the component as request-time before the helper
+reads the clock; without it, `cacheComponents: true` fails the route during
+prerendering, and with `cacheComponents` off it is a no-op.
 
 ```tsx title="app/layout.tsx"
 import { Suspense } from 'react';
 import type { ReactNode } from 'react';
+import { connection } from 'next/server';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
 import 'c15t/next/styles.css';
 
 async function ResolvedConsent({ children }: { children: ReactNode }) {
+  await connection();
   const initialConsent = await prefetchInitialConsent({ config: consentConfig });
 
   return <Consent config={initialConsent}>{children}</Consent>;

--- a/docs/frameworks/next/app-router.mdx
+++ b/docs/frameworks/next/app-router.mdx
@@ -133,6 +133,14 @@ page still renders, and the browser resolves policy after hydration, so on that
 request a new visitor sees the prompt appear late. Pass `onError` to report
 these failures; see [troubleshooting](/docs/frameworks/next/troubleshooting).
 
+The page content waits with the consent subtree. Because `{children}` sits
+inside `ResolvedConsent` and the fallback is `null`, a slow manifest response
+leaves the whole page blank until the helper returns or its 10 second fetch
+timeout fires and the baseline renders. A warm manifest cache makes this a few
+milliseconds; a cold cache pays the backend round trip. If the site cannot
+accept that, use the [streaming form](#stream-the-page-while-consent-resolves),
+which renders the shell immediately.
+
 The `Suspense` boundary is required with `cacheComponents: true`: awaiting
 request data directly in the root layout without it fails the build. Without
 `cacheComponents`, the boundary is still safe to keep.

--- a/docs/frameworks/next/client-side.mdx
+++ b/docs/frameworks/next/client-side.mdx
@@ -72,12 +72,13 @@ export function Consent({ children }: { children: ReactNode }) {
 `config={{}}` supplies no server-prefetched policy. The boundary starts hosted
 initialization in the browser. Keep it mounted across client navigation.
 
-For App Router, mount the wrapper in the root layout:
+For App Router, load the [stylesheet for your Tailwind version](/docs/frameworks/next/styling/overview#stylesheet)
+from `app/globals.css`, then mount the wrapper in the root layout:
 
 ```tsx title="app/layout.tsx"
 import type { ReactNode } from 'react';
 import { Consent } from '../components/consent';
-import 'c15t/next/styles.css';
+import './globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/docs/frameworks/next/client-side.mdx
+++ b/docs/frameworks/next/client-side.mdx
@@ -10,9 +10,9 @@ Use browser initialization when consent does not need to be resolved in the
 initial HTML. This works with prerendered pages and client navigation. No
 `prefetchInitialConsent`, manifest route or rewrite is required for this setup.
 
-Use [server rendering](/docs/frameworks/next/server-side) when the first HTML
-response should contain the resolved consent UI, or when resolution should
-start on the server while the page streams.
+Use [server rendering](/docs/frameworks/next/server-side) when consent UI should
+render on the server after policy resolution, or when resolution should start
+on the server while the page streams.
 
 "Client-side initialization" describes where consent resolves. Next.js can
 still prerender a Client Component's initial markup. Optional permissions stay

--- a/docs/frameworks/next/components/consent-banner.mdx
+++ b/docs/frameworks/next/components/consent-banner.mdx
@@ -36,8 +36,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
 The banner renders what the resolved policy rule requires. This example lets
 the page render while the prompt waits for the prefetch promise. Await the
-helper when you need resolved consent UI in the initial HTML. The server and
-client use the same prepared state:
+helper inside `Suspense` to render resolved consent UI on the server; the
+surrounding shell may stream first. The server and client use the same
+prepared state:
 
 - A `choice` prompt shows the actions the rule allows: reject and accept at
   equal prominence, plus customize when the rule offers it.

--- a/docs/frameworks/next/quickstart.mdx
+++ b/docs/frameworks/next/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Add c15t to Next.js with Inth. Choose your router or static export below.
+description: Add c15t consent management to Next.js with Inth, with setup guides for the App Router, the Pages Router and static export.
 group: frameworks
 ---
 

--- a/docs/frameworks/next/script-loader.mdx
+++ b/docs/frameworks/next/script-loader.mdx
@@ -21,20 +21,26 @@ URLs connect initialization and consent submissions to the same backend.
 
 ## Pass prepared consent through your router
 
-App Router passes the prefetch promise from its synchronous layout. This partial
-example replaces the boundary in your existing layout, keeping its `html`,
-`body` and stylesheet:
+App Router awaits the prefetch in the `ResolvedConsent` Server Component from
+the [App Router guide](/docs/frameworks/next/app-router) and renders the
+wrapper inside it. This partial example is that component; keep the
+`Suspense` boundary, `html`, `body` and stylesheet from your existing layout:
 
 ```tsx
+import type { ReactNode } from 'react';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
 
-// Inside the layout:
-const initialConsent = prefetchInitialConsent({ config: consentConfig });
-
-<Consent config={initialConsent}>{children}</Consent>
+async function ResolvedConsent({ children }: { children: ReactNode }) {
+  const initialConsent = await prefetchInitialConsent({ config: consentConfig });
+  return <Consent config={initialConsent}>{children}</Consent>;
+}
 ```
+
+To stream the page shell before consent resolves instead, pass the unawaited
+promise from a synchronous layout as described in
+[stream the page while consent resolves](/docs/frameworks/next/app-router#stream-the-page-while-consent-resolves).
 
 Pages Router passes `config={pageProps.initialConsent ?? {}}` to this wrapper
 in `_app.tsx`. Keep `getServerSideProps` and its `c15t/next/pages` helper.

--- a/docs/frameworks/next/server-side.mdx
+++ b/docs/frameworks/next/server-side.mdx
@@ -12,8 +12,8 @@ Fetching and rendering are separate choices. The examples here keep the shared
 
 | Rendering path | Pass to `ConsentBoundary` | What the visitor receives |
 | --- | --- | --- |
-| Stream while consent resolves | The `prefetchInitialConsent` promise | The page renders immediately; the browser initializes consent when the result arrives. |
 | Await consent | The resolved `prefetchInitialConsent` result | The consent subtree renders after resolution. A surrounding Suspense fallback may stream first. |
+| Stream while consent resolves | The `prefetchInitialConsent` promise | The page renders immediately; the browser initializes consent when the result arrives. |
 | [Browser initialization](/docs/frameworks/next/client-side) | `config={{}}` and the shared `consent` config | The browser initializes after mount; the initial HTML has no resolved consent prompt. |
 
 Client Components can still be prerendered by Next.js. Browser initialization
@@ -35,8 +35,10 @@ props. The streaming examples on this page are for App Router.
 
 ## Stream the page while consent resolves
 
-The App Router guide passes the promise from a synchronous layout to its
-script-owning client wrapper. This partial example keeps that wrapper:
+The App Router guide awaits `prefetchInitialConsent` inside `Suspense` by
+default and offers this promise form as the streaming alternative. Pass the
+promise from a synchronous layout to the script-owning client wrapper. This
+partial example keeps that wrapper:
 
 ```tsx
 import { prefetchInitialConsent } from 'c15t/next/server';
@@ -62,7 +64,7 @@ If the consent subtree should wait for resolution, move it into an async Server
 Component under `Suspense`. With `cacheComponents: true`, awaiting request data
 directly in the root layout without this boundary causes a build error.
 
-This replaces the root layout from the App Router guide. Keep its shared
+This is the default root layout from the App Router guide. Keep its shared
 `c15t.config.ts`, manifest route and script-owning `Consent` wrapper:
 
 ```tsx title="app/layout.tsx"


### PR DESCRIPTION
Stacked on #1094 (1/4). Merge-blocker follow-up from the #1094 review.

## Summary
- `app-router.mdx`: the default root layout now awaits `prefetchInitialConsent` inside `Suspense` (the form the runnable example and the benchmark use), so the banner is in the first HTML. The promise/streaming form moves to its own "Stream the page while consent resolves" section.
- New "What server prefetch costs" section: routes render dynamically (`next/headers`), no static/CDN HTML unless `cacheComponents`; cold-manifest cost with conditions and link to #1096; warm numbers with conditions; do not cache personalized HTML.
- `server-side.mdx`: reordered the rendering-path table and removed the sentence that contradicted the new default.
- `quickstart.mdx`: meta description no longer says "below".

Docs only, no changeset. `bun run lint:docs` and `bun run test:scripts` pass.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Next.js App Router guidance to resolve initial consent within a Suspense boundary by default.
  - Added guidance on server-prefetch costs, caching, and streaming pages while consent resolves.
  - Updated stylesheet setup instructions, including Tailwind CSS and `app/globals.css`.
  - Clarified consent resolution options and refreshed script loader and consent banner examples.
  - Expanded the Next.js quickstart description to cover consent management and App Router, Pages Router, and static export guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->