### PR TITLE
docs(next): document geography header forwarding and CSP nonce

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -94,7 +94,13 @@ export default defineDocsConfig({
 							title: 'Policies',
 						},
 						{
-							pages: ['optimization', 'script-loader', 'troubleshooting'],
+							pages: [
+								'optimization',
+								'script-loader',
+								'geography-headers',
+								'content-security-policy',
+								'troubleshooting',
+							],
 							title: 'Integration',
 						},
 						{

--- a/docs/frameworks/next/content-security-policy.mdx
+++ b/docs/frameworks/next/content-security-policy.mdx
@@ -144,11 +144,13 @@ It does not apply to anything else:
 ## Allow the consent backend in connect-src
 
 The browser sends consent submissions to `${backendURL}/subjects`, and, when
-the browser initializes, requests to `${backendURL}/init` or the manifest URL.
-Add the backend origin to `connect-src`:
+the browser initializes or retries after a failed server prefetch, requests to
+`${backendURL}/init` or the manifest URL. Add the backend origin to
+`connect-src`, and the manifest origin too when `manifestURL` is an absolute
+URL on a different host such as a CDN:
 
 ```txt title="Content-Security-Policy (partial)"
-connect-src 'self' https://<your-backend-host>;
+connect-src 'self' https://<your-backend-host> https://<your-manifest-host>;
 ```
 
 Use the endpoint host supplied by your Inth project or your self-hosted backend.

--- a/docs/frameworks/next/content-security-policy.mdx
+++ b/docs/frameworks/next/content-security-policy.mdx
@@ -55,9 +55,11 @@ export function Consent({
 }
 ```
 
-Then read the header in the layout and pass it through:
+Then read the header in the async consent component from the App Router guide
+and pass it through:
 
 ```tsx title="app/layout.tsx"
+import { Suspense } from 'react';
 import type { ReactNode } from 'react';
 import { headers } from 'next/headers';
 import { prefetchInitialConsent } from 'c15t/next/server';
@@ -65,24 +67,33 @@ import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
 import 'c15t/next/styles.css';
 
-export default async function RootLayout({ children }: { children: ReactNode }) {
+async function ResolvedConsent({ children }: { children: ReactNode }) {
   const nonce = (await headers()).get('x-nonce') ?? undefined;
-  const initialConsent = prefetchInitialConsent({ config: consentConfig });
+  const initialConsent = await prefetchInitialConsent({ config: consentConfig });
 
+  return (
+    <Consent config={initialConsent} nonce={nonce}>
+      {children}
+    </Consent>
+  );
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Consent config={initialConsent} nonce={nonce}>{children}</Consent>
+        <Suspense fallback={null}>
+          <ResolvedConsent>{children}</ResolvedConsent>
+        </Suspense>
       </body>
     </html>
   );
 }
 ```
 
-Reading `headers()` makes the layout async and dynamic, which a per-request
-nonce requires anyway. With `cacheComponents: true`, move the `headers()` call
-and the `Consent` wrapper into the Suspense-wrapped async component described in
-[server rendering](/docs/frameworks/next/server-side#await-consent-inside-suspense).
+Reading `headers()` keeps the route dynamic, which a per-request nonce requires
+anyway. The `Suspense` boundary is required with `cacheComponents: true`; see
+[what server prefetch costs](/docs/frameworks/next/app-router#what-server-prefetch-costs).
 
 `options.nonce` is read when the boundary mounts. The provider keeps the latest
 value in a ref, but the script loader is created once per runtime, so a nonce

--- a/docs/frameworks/next/content-security-policy.mdx
+++ b/docs/frameworks/next/content-security-policy.mdx
@@ -99,8 +99,11 @@ Reading `headers()` keeps the route dynamic, which a per-request nonce requires
 anyway. Do not combine a nonce-based policy with `cacheComponents: true`
 (Partial Prerendering): the static shell is rendered once at build time, so its
 scripts cannot carry a per-request nonce and the browser blocks them. Next.js
-documents this limitation in its CSP guide. Use a hash-based or host-based
-`script-src` for the shell, or keep the route fully dynamic.
+documents this limitation in its CSP guide. For a prerendered shell use the
+hash-based policy that guide describes; a host-only `script-src` such as
+`'self'` does not authorize Next.js's inline bootstrap scripts and would need
+`'unsafe-inline'`, which defeats the policy. Otherwise keep the route fully
+dynamic and use the nonce.
 
 `options.nonce` is read when the boundary mounts. The provider keeps the latest
 value in a ref, but the script loader is created once per runtime, so a nonce

--- a/docs/frameworks/next/content-security-policy.mdx
+++ b/docs/frameworks/next/content-security-policy.mdx
@@ -16,9 +16,13 @@ same value on the request as `x-nonce`. See the
 for the header-generating proxy.
 
 If you also run [`c15tProxy`](/docs/frameworks/next/geography-headers), set
-`x-nonce` on `request.headers` before calling it. `c15tProxy` copies the
-incoming request headers into the forwarded request, so the nonce travels with
-the geography headers.
+both `x-nonce` and the generated `Content-Security-Policy` header on
+`request.headers` before calling it, and set the policy on the returned
+response as well. Next.js reads the nonce for its own bootstrap and page
+scripts from the request-side policy header, so forwarding only `x-nonce`
+leaves the framework scripts without a nonce and the browser blocks hydration.
+`c15tProxy` copies the incoming request headers into the forwarded request, so
+both headers travel with the geography headers.
 
 Add a `nonce` prop to the `Consent` wrapper from the
 [App Router guide](/docs/frameworks/next/app-router):
@@ -92,8 +96,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 ```
 
 Reading `headers()` keeps the route dynamic, which a per-request nonce requires
-anyway. The `Suspense` boundary is required with `cacheComponents: true`; see
-[what server prefetch costs](/docs/frameworks/next/app-router#what-server-prefetch-costs).
+anyway. Do not combine a nonce-based policy with `cacheComponents: true`
+(Partial Prerendering): the static shell is rendered once at build time, so its
+scripts cannot carry a per-request nonce and the browser blocks them. Next.js
+documents this limitation in its CSP guide. Use a hash-based or host-based
+`script-src` for the shell, or keep the route fully dynamic.
 
 `options.nonce` is read when the boundary mounts. The provider keeps the latest
 value in a ref, but the script loader is created once per runtime, so a nonce
@@ -119,9 +126,13 @@ It does not apply to anything else:
 - The prebuilt stylesheet `c15t/next/styles.css` is a regular stylesheet from
   your own origin. It is covered by `style-src 'self'`, not by the nonce.
 - Inline `style` attributes on rendered components. A nonce cannot authorize
-  style attributes; only `'unsafe-inline'` or `'unsafe-hashes'` in `style-src`
-  can. The IAB TCF dialog, the consent dialog trigger toolbar and the animated
-  collapse used inside the dialogs render inline `style` attributes. Check the
+  style attributes, and browsers ignore `'unsafe-inline'` in a `style-src` list
+  that also contains a nonce or hash. Allow them with a separate
+  `style-src-attr 'unsafe-inline'` directive, or with `'unsafe-hashes'` plus
+  the matching `'sha256-...'` values; hashes only work for static values, not
+  for the animated collapse heights. The IAB TCF dialog, the consent dialog
+  trigger toolbar and the animated collapse used inside the dialogs render
+  inline `style` attributes. Check the
   browser console with your policy enforced to see whether your setup triggers
   a `style-src` violation.
 - Iframes, images or requests made by vendor scripts. Allow those hosts in

--- a/docs/frameworks/next/content-security-policy.mdx
+++ b/docs/frameworks/next/content-security-policy.mdx
@@ -1,0 +1,161 @@
+---
+title: Content Security Policy
+description: Pass a per-request CSP nonce to ConsentBoundary in Next.js and allow the consent backend in connect-src.
+group: frameworks
+---
+
+## Pass the request nonce to the boundary
+
+Read the nonce from the `x-nonce` request header in the root layout and pass it
+as `options={{ nonce }}` on `ConsentBoundary`. This is the standard Next.js
+nonce pattern: your `proxy.ts` (Next.js 16) or `middleware.ts` (Next.js 15)
+generates a nonce per request, sets the `Content-Security-Policy` response
+header with `'nonce-<value>'` in `script-src` and `style-src`, and forwards the
+same value on the request as `x-nonce`. See the
+[Next.js CSP guide](https://nextjs.org/docs/app/guides/content-security-policy)
+for the header-generating proxy.
+
+If you also run [`c15tProxy`](/docs/frameworks/next/geography-headers), set
+`x-nonce` on `request.headers` before calling it. `c15tProxy` copies the
+incoming request headers into the forwarded request, so the nonce travels with
+the geography headers.
+
+Add a `nonce` prop to the `Consent` wrapper from the
+[App Router guide](/docs/frameworks/next/app-router):
+
+```tsx title="components/consent.tsx (partial)"
+'use client';
+
+import type { ReactNode } from 'react';
+import { ConsentBoundary } from 'c15t/next';
+import type { ConsentBoundaryProps } from 'c15t/next';
+import { consentConfig } from '../c15t.config';
+import { scripts } from '../lib/scripts';
+
+export function Consent({
+  children,
+  config,
+  nonce,
+}: {
+  children: ReactNode;
+  config: ConsentBoundaryProps['config'];
+  nonce?: string;
+}) {
+  return (
+    <ConsentBoundary
+      config={config}
+      consent={consentConfig}
+      options={{ nonce }}
+      scripts={scripts}
+    >
+      {children}
+      {/* banner, dialog and footer as in the App Router guide */}
+    </ConsentBoundary>
+  );
+}
+```
+
+Then read the header in the layout and pass it through:
+
+```tsx title="app/layout.tsx"
+import type { ReactNode } from 'react';
+import { headers } from 'next/headers';
+import { prefetchInitialConsent } from 'c15t/next/server';
+import { consentConfig } from '../c15t.config';
+import { Consent } from '../components/consent';
+import 'c15t/next/styles.css';
+
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+  const initialConsent = prefetchInitialConsent({ config: consentConfig });
+
+  return (
+    <html lang="en">
+      <body>
+        <Consent config={initialConsent} nonce={nonce}>{children}</Consent>
+      </body>
+    </html>
+  );
+}
+```
+
+Reading `headers()` makes the layout async and dynamic, which a per-request
+nonce requires anyway. With `cacheComponents: true`, move the `headers()` call
+and the `Consent` wrapper into the Suspense-wrapped async component described in
+[server rendering](/docs/frameworks/next/server-side#await-consent-inside-suspense).
+
+`options.nonce` is read when the boundary mounts. The provider keeps the latest
+value in a ref, but the script loader is created once per runtime, so a nonce
+that changes during client-side navigation is not applied to scripts already
+created. Each full page load gets the fresh nonce from its own request.
+
+## What the nonce applies to
+
+c15t stamps `options.nonce` on two kinds of DOM nodes:
+
+- Every `<script>` element the script loader creates for a `scripts` entry,
+  both `src` and inline `textContent` scripts. A `nonce` set on an individual
+  `scripts` entry takes precedence over `options.nonce` for that element.
+- The `<style id="c15t-theme">` element the provider injects with the theme's
+  `--c15t-*` custom properties.
+
+It does not apply to anything else:
+
+- Scripts that a vendor script loads itself, such as a tag manager injecting
+  its tags, do not receive the nonce. Add `'strict-dynamic'` to `script-src` so
+  scripts loaded by a nonced script are allowed, or list those vendor hosts
+  explicitly.
+- The prebuilt stylesheet `c15t/next/styles.css` is a regular stylesheet from
+  your own origin. It is covered by `style-src 'self'`, not by the nonce.
+- Inline `style` attributes on rendered components. A nonce cannot authorize
+  style attributes; only `'unsafe-inline'` or `'unsafe-hashes'` in `style-src`
+  can. The IAB TCF dialog, the consent dialog trigger toolbar and the animated
+  collapse used inside the dialogs render inline `style` attributes. Check the
+  browser console with your policy enforced to see whether your setup triggers
+  a `style-src` violation.
+- Iframes, images or requests made by vendor scripts. Allow those hosts in
+  `frame-src`, `img-src` and `connect-src` according to each vendor.
+
+## Allow the consent backend in connect-src
+
+The browser sends consent submissions to `${backendURL}/subjects`, and, when
+the browser initializes, requests to `${backendURL}/init` or the manifest URL.
+Add the backend origin to `connect-src`:
+
+```txt title="Content-Security-Policy (partial)"
+connect-src 'self' https://<your-backend-host>;
+```
+
+Use the endpoint host supplied by your Inth project or your self-hosted backend.
+When you use the same-origin rewrite from
+[Optimization](/docs/frameworks/next/optimization), `backendURL` is `/api/c15t`
+and `'self'` already covers the browser requests; the Next.js server connects to
+the backend outside the browser's CSP. A local manifest route at
+`/api/c15t/manifest` is also same-origin.
+
+IAB TCF policies can fetch the Global Vendor List from the URL the policy
+provides; allow that host in `connect-src` if you use the
+[IAB TCF add-on](/docs/frameworks/next/iab/overview). Server-side prefetch runs
+in Next.js and is not subject to the browser's CSP.
+
+## Verify
+
+Load a page with the policy enforced, not in report-only mode, and open the
+browser console. The banner should render with its theme colors and no CSP
+violation should mention `c15t-theme`. Grant a category that gates one of your
+`scripts` entries, then check:
+
+- The injected `<script>` element carries the request's nonce. Browsers hide
+  the value from `getAttribute('nonce')`; read the element's `nonce` property
+  in the console or inspect it in the Elements panel.
+- The `<style id="c15t-theme">` element carries the same nonce and the
+  `--c15t-*` variables are applied to the banner.
+- No `Refused to load the script` or `Refused to apply inline style` errors
+  mention a c15t element. A refused vendor dependency points to a missing
+  `'strict-dynamic'` or vendor host.
+- The consent submission to `/subjects` succeeds. A `connect-src` violation
+  here means the backend origin is missing.
+
+Reload with a different nonce and confirm the elements update. A stale nonce
+after a full page load usually means a cached HTML response; nonce-based pages
+must not be served from a shared cache.

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -173,9 +173,13 @@ resolution and use it only for non-policy code such as display defaults.
 CloudFront's own geolocation headers, `CloudFront-Viewer-Country` and
 `CloudFront-Viewer-Country-Region`, are not in this list. Forward them to the
 origin with an origin request policy, then map them in `proxy.ts` before
-calling `c15tProxy`; CloudFront Functions cannot do it because the viewer
-location headers are added after the viewer-request stage, and an origin
-request policy forwards but cannot rename:
+calling `c15tProxy`. An origin request policy forwards headers but cannot
+rename them. A CloudFront Function can also read geography headers when a
+cache policy or origin request policy exposes them to the function, as shown
+in [AWS's viewer-request example](https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/redirect-based-on-country).
+
+Clear every country and region input c15t recognizes before mapping the
+trusted CloudFront values:
 
 ```ts title="proxy.ts"
 import { c15tProxy } from 'c15t/next/proxy';
@@ -183,8 +187,20 @@ import { NextRequest } from 'next/server';
 
 export function proxy(request: NextRequest) {
   const headers = new Headers(request.headers);
-  headers.delete('x-c15t-country');
-  headers.delete('x-c15t-region');
+  for (const name of [
+    'x-c15t-country',
+    'cf-ipcountry',
+    'x-vercel-ip-country',
+    'x-amz-cf-ipcountry',
+    'x-country-code',
+    'x-country',
+    'x-c15t-region',
+    'cf-region-code',
+    'x-vercel-ip-country-region',
+    'x-region-code',
+  ]) {
+    headers.delete(name);
+  }
   const country = headers.get('cloudfront-viewer-country');
   const region = headers.get('cloudfront-viewer-country-region');
   if (country) headers.set('x-c15t-country', country);
@@ -193,8 +209,9 @@ export function proxy(request: NextRequest) {
 }
 ```
 
-The `delete` calls drop client-supplied overrides so only the CloudFront value
-can win.
+The `delete` calls drop client-supplied overrides and fallback geography
+headers. When CloudFront omits a country or region, that value stays unknown
+instead of falling through to a header supplied by the visitor.
 
 GPC values are meaningful only as `1` or `0`; any other value is treated as
 absent. The proxy writes the normalized result to `sec-gpc`, so an incoming

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -1,0 +1,183 @@
+---
+title: Forward geography headers
+description: Use c15tProxy in Next.js proxy.ts or middleware.ts so Server Components and Route Handlers receive the visitor's country and region.
+group: frameworks
+---
+
+## When do I need the proxy?
+
+Add `c15tProxy` when your hosting platform exposes the visitor's location to
+Next.js middleware or proxy but strips those headers before Server Components
+and Route Handlers run. Without them, `prefetchInitialConsent`, the awaited
+server helpers and the optional local `/api/c15t/init` handler see an unknown
+location and apply your unknown-location policy rule for every visitor.
+
+c15t reads location from the platform headers listed in
+[Which headers are read?](#which-headers-are-read): Cloudflare (`cf-ipcountry`,
+`cf-region-code`), Vercel (`x-vercel-ip-country`,
+`x-vercel-ip-country-region`), CloudFront (`x-amz-cf-ipcountry`) and generic
+proxy headers (`x-country-code`, `x-country`, `x-region-code`). c15t does not
+keep a list of which hosts strip them. Check your deployment: log
+`(await headers()).get('x-vercel-ip-country')` or the equivalent for your host
+inside a Server Component. If the value is present, you do not need the proxy.
+If it is missing while the same header is present in `proxy.ts`, add the proxy.
+
+The proxy copies the incoming request headers, resolves country, region and
+Global Privacy Control from them, and forwards the result on the request as
+`x-c15t-country`, `x-c15t-region` and `sec-gpc`. Those application override
+headers have the highest precedence, so Server Components and Route Handlers
+read the same values the proxy saw. When no location header is present, the
+proxy sets nothing and the location stays unknown.
+
+The proxy runs on Next.js `^15.0.0 || ^16.0.0`. It does not apply to a
+[static export](/docs/frameworks/next/static-export), which has no server.
+
+## Add the proxy (Next.js 16)
+
+Create `proxy.ts` at the project root, or in `src/` if your app lives there:
+
+```ts title="proxy.ts"
+import { c15tProxy } from 'c15t/next/proxy';
+import type { NextRequest } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  return c15tProxy(request);
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};
+```
+
+`c15tProxy` returns `NextResponse.next()` with the forwarded request headers.
+If you already have a proxy, call `c15tProxy(request)` where you would
+otherwise return `NextResponse.next()`, and set any response headers or
+cookies on the returned response.
+
+`config.matcher` must cover every page that renders the consent boundary,
+because `prefetchInitialConsent` and the awaited helpers run during those page
+requests. It must also cover `/api/c15t/:path*` if you serve the optional local
+init route and want it to resolve policy with the visitor's location. The
+manifest route serves public policy data and does not need location.
+
+## Add the middleware (Next.js 15)
+
+On Next.js 15 the file is `middleware.ts` and the export is `middleware`:
+
+```ts title="middleware.ts"
+import { c15tMiddleware } from 'c15t/next/middleware';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  return c15tMiddleware(request);
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};
+```
+
+`c15tMiddleware` is the same function as `c15tProxy` under the Next.js 15
+name. Both imports stay supported on both Next.js versions. When you upgrade to
+Next.js 16 and rename `middleware.ts` to `proxy.ts`, switch the import to
+`c15tProxy` from `c15t/next/proxy` at the same time. The options type is
+exported as `C15tMiddlewareOptions` and `C15tProxyOptions` respectively.
+
+## Persist geography in cookies
+
+Pass `cookie: true` to also write the resolved location into cookies. Use this
+on runtimes where the forwarded request headers do not reach React Server
+Components, so that your own server code can still read the location on the
+same and later requests:
+
+```ts title="proxy.ts"
+import { c15tProxy } from 'c15t/next/proxy';
+import type { NextRequest } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  return c15tProxy(request, { cookie: true });
+}
+```
+
+The default cookie names are `c15t-country` and `c15t-region`. Both are set
+with `httpOnly: true`, `sameSite: 'lax'` and `path: '/'`, so browser scripts
+cannot read them. Pass an object to rename them:
+
+```ts title="proxy.ts (partial)"
+c15tProxy(request, {
+  cookie: { countryName: 'geo-country', regionName: 'geo-region' },
+});
+```
+
+A cookie is written only when the matching header resolved a value. The
+proxy never clears a stale cookie, so a visitor whose location header
+disappears keeps the previous cookie until it is cleared or the session cookie
+expires.
+
+The c15t server helpers read request headers, not these cookies. To use the
+cookie, read it where you call `prefetchInitialConsent` and pass it as the
+`country` override:
+
+```tsx title="app/layout.tsx (partial)"
+import type { ReactNode } from 'react';
+import { cookies } from 'next/headers';
+import { prefetchInitialConsent } from 'c15t/next/server';
+import { consentConfig } from '../c15t.config';
+
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const country = (await cookies()).get('c15t-country')?.value;
+  const initialConsent = prefetchInitialConsent({ config: consentConfig, country });
+  // render <Consent config={initialConsent}> as in the App Router guide
+}
+```
+
+Awaiting `cookies()` makes the layout async. With `cacheComponents: true`,
+move this into the Suspense-wrapped async component from
+[server rendering](/docs/frameworks/next/server-side#await-consent-inside-suspense)
+instead of the root layout.
+
+`prefetchInitialConsent` accepts `country` and `language` overrides. It has no
+`region` override in the current API, so the region cookie is available only to
+your own code.
+
+## Which headers are read?
+
+`c15tProxy` and the server helpers use the same extraction from
+`@c15t/schema`. Within each group, the first header with a value wins:
+
+| Input | Headers, highest precedence first | Source |
+| --- | --- | --- |
+| Country | `x-c15t-country`, `cf-ipcountry`, `x-vercel-ip-country`, `x-amz-cf-ipcountry`, `x-country-code`, `x-country` | c15t override, Cloudflare, Vercel, CloudFront, generic |
+| Region | `x-c15t-region`, `cf-region-code`, `x-vercel-ip-country-region`, `x-region-code` | c15t override, Cloudflare, Vercel, generic |
+| Global Privacy Control | `x-c15t-gpc`, `sec-gpc` | c15t override, browser signal |
+| Language | `accept-language` | browser |
+
+GPC values are meaningful only as `1` or `0`; any other value is treated as
+absent. The proxy writes the normalized result to `sec-gpc`, so an incoming
+`x-c15t-gpc: 1` reaches Server Components as `sec-gpc: 1`. Browsers refuse to
+let scripts set `Sec-*` request headers, which is why the `x-c15t-gpc` override
+exists for the browser's own init request.
+
+Only trusted infrastructure should set `x-c15t-country`, `x-c15t-region` or
+`x-c15t-gpc` in production: because they always win, a client that can reach
+your origin directly could otherwise choose its own policy.
+
+## Verify
+
+Deploy with the proxy and load the site from two locations with different
+configured policy rules, for example through a VPN or your host's geo testing
+tools. The resolved policy in the initial HTML must match each location: an
+opt-in region shows the banner with optional categories denied, while a region
+configured for notice-only or no notice renders accordingly. Confirm the values
+by logging `(await headers()).get('x-c15t-country')` in a Server Component;
+it should equal the platform header seen in the proxy.
+
+Remove the proxy temporarily and reload. If both locations now resolve the
+unknown-location rule, your platform strips location headers before Server
+Components and the proxy is required. If they still resolve correctly, your
+platform already passes the headers through and the proxy is optional.
+
+With the local init route in the matcher, request `/api/c15t/init` from each
+location and confirm its `policyResolution` reflects the location. If you use
+`cookie: true`, check the response for `Set-Cookie: c15t-country=...` with
+`HttpOnly` and `SameSite=Lax`.

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -87,8 +87,10 @@ exported as `C15tMiddlewareOptions` and `C15tProxyOptions` respectively.
 
 Pass `cookie: true` to also write the resolved location into cookies. Use this
 on runtimes where the forwarded request headers do not reach React Server
-Components, so that your own server code can still read the location on the
-same and later requests:
+Components, so that your own server code can read the location on later
+requests. The proxy writes the cookie on the response, and `cookies()` reads
+the incoming request, so the first visit still resolves as unknown and the
+first request after a location change still sees the previous value:
 
 ```ts title="proxy.ts"
 import { c15tProxy } from 'c15t/next/proxy';
@@ -123,18 +125,21 @@ import type { ReactNode } from 'react';
 import { cookies } from 'next/headers';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
+import { Consent } from '../components/consent';
 
-export default async function RootLayout({ children }: { children: ReactNode }) {
+async function ResolvedConsent({ children }: { children: ReactNode }) {
   const country = (await cookies()).get('c15t-country')?.value;
-  const initialConsent = prefetchInitialConsent({ config: consentConfig, country });
-  // render <Consent config={initialConsent}> as in the App Router guide
+  const initialConsent = await prefetchInitialConsent({
+    config: consentConfig,
+    country,
+  });
+  return <Consent config={initialConsent}>{children}</Consent>;
 }
 ```
 
-Awaiting `cookies()` makes the layout async. With `cacheComponents: true`,
-move this into the Suspense-wrapped async component from
-[server rendering](/docs/frameworks/next/server-side#await-consent-inside-suspense)
-instead of the root layout.
+This is the `ResolvedConsent` component from the
+[App Router guide](/docs/frameworks/next/app-router); keep it inside the
+`Suspense` boundary shown there.
 
 `prefetchInitialConsent` accepts `country` and `language` overrides. It has no
 `region` override in the current API, so the region cookie is available only to
@@ -158,9 +163,13 @@ absent. The proxy writes the normalized result to `sec-gpc`, so an incoming
 let scripts set `Sec-*` request headers, which is why the `x-c15t-gpc` override
 exists for the browser's own init request.
 
-Only trusted infrastructure should set `x-c15t-country`, `x-c15t-region` or
-`x-c15t-gpc` in production: because they always win, a client that can reach
-your origin directly could otherwise choose its own policy.
+Only trusted infrastructure may set `x-c15t-country`, `x-c15t-region` or
+`x-c15t-gpc` in production, because they always win. A client that can reach
+your origin directly can send them and choose its own policy rule, so one of
+these controls is required, not optional: strip incoming `x-c15t-*` headers at
+the edge that terminates all traffic before anything sets them, or block direct
+origin access with a firewall or platform origin protection so every request
+passes through that edge. `c15tProxy` does not strip them itself.
 
 ## Verify
 

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -171,10 +171,30 @@ resolution and use it only for non-policy code such as display defaults.
 | Language | `accept-language` | browser |
 
 CloudFront's own geolocation headers, `CloudFront-Viewer-Country` and
-`CloudFront-Viewer-Country-Region`, are not in this list. On CloudFront, add a
-CloudFront Function or origin request policy that copies them to
-`x-c15t-country` and `x-c15t-region` before the request reaches Next.js, and
-strip any client-supplied `x-c15t-*` headers in the same step.
+`CloudFront-Viewer-Country-Region`, are not in this list. Forward them to the
+origin with an origin request policy, then map them in `proxy.ts` before
+calling `c15tProxy`; CloudFront Functions cannot do it because the viewer
+location headers are added after the viewer-request stage, and an origin
+request policy forwards but cannot rename:
+
+```ts title="proxy.ts"
+import { c15tProxy } from 'c15t/next/proxy';
+import { NextRequest } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  const headers = new Headers(request.headers);
+  headers.delete('x-c15t-country');
+  headers.delete('x-c15t-region');
+  const country = headers.get('cloudfront-viewer-country');
+  const region = headers.get('cloudfront-viewer-country-region');
+  if (country) headers.set('x-c15t-country', country);
+  if (region) headers.set('x-c15t-region', region);
+  return c15tProxy(new NextRequest(request, { headers }));
+}
+```
+
+The `delete` calls drop client-supplied overrides so only the CloudFront value
+can win.
 
 GPC values are meaningful only as `1` or `0`; any other value is treated as
 absent. The proxy writes the normalized result to `sec-gpc`, so an incoming

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -148,11 +148,14 @@ your own code.
 The cookie comes back in the client-controlled `Cookie` header. `HttpOnly`
 stops page scripts from reading it; it does not stop a visitor from sending
 `c15t-country=<value>` and, through the `country` override, choosing a less
-restrictive rule for themselves. Use this fallback only when the edge that
-terminates all traffic strips incoming `c15t-country` and `c15t-region`
-cookies before `c15tProxy` sets them, exactly as it must strip the `x-c15t-*`
-override headers. Where you cannot enforce that, do not pass the cookie as
-`country`; keep it for non-policy code such as display defaults.
+restrictive rule for themselves. Deleting the incoming cookie is not an
+option here, because `cookies()` reads that same request and `c15tProxy` only
+sets the cookie on the response. Use this fallback only when the edge that
+terminates all traffic overwrites the incoming `c15t-country` and
+`c15t-region` cookies with its own trusted geography on every request, or
+when your code signs the value and verifies the signature before passing it
+as `country`. Where you can do neither, keep the cookie out of policy
+resolution and use it only for non-policy code such as display defaults.
 
 ## Which headers are read?
 

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -145,6 +145,15 @@ This is the `ResolvedConsent` component from the
 `region` override in the current API, so the region cookie is available only to
 your own code.
 
+The cookie comes back in the client-controlled `Cookie` header. `HttpOnly`
+stops page scripts from reading it; it does not stop a visitor from sending
+`c15t-country=<value>` and, through the `country` override, choosing a less
+restrictive rule for themselves. Use this fallback only when the edge that
+terminates all traffic strips incoming `c15t-country` and `c15t-region`
+cookies before `c15tProxy` sets them, exactly as it must strip the `x-c15t-*`
+override headers. Where you cannot enforce that, do not pass the cookie as
+`country`; keep it for non-policy code such as display defaults.
+
 ## Which headers are read?
 
 `c15tProxy` and the server helpers use the same extraction from
@@ -164,12 +173,14 @@ let scripts set `Sec-*` request headers, which is why the `x-c15t-gpc` override
 exists for the browser's own init request.
 
 Only trusted infrastructure may set `x-c15t-country`, `x-c15t-region` or
-`x-c15t-gpc` in production, because they always win. A client that can reach
-your origin directly can send them and choose its own policy rule, so one of
-these controls is required, not optional: strip incoming `x-c15t-*` headers at
-the edge that terminates all traffic before anything sets them, or block direct
-origin access with a firewall or platform origin protection so every request
-passes through that edge. `c15tProxy` does not strip them itself.
+`x-c15t-gpc` in production, because they always win. A client that sends them
+chooses its own policy rule, and `c15tProxy` forwards a client-supplied value
+over the platform header rather than stripping it. The edge that terminates all
+traffic must therefore delete incoming `x-c15t-*` headers before anything sets
+them, in every deployment. Blocking direct origin access with a firewall or
+platform origin protection is an additional control that keeps requests on that
+edge; it does not replace the stripping, because a forwarded client header
+still passes through the protected path.
 
 ## Verify
 

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -15,7 +15,8 @@ location and apply your unknown-location policy rule for every visitor.
 c15t reads location from the platform headers listed in
 [Which headers are read?](#which-headers-are-read): Cloudflare (`cf-ipcountry`,
 `cf-region-code`), Vercel (`x-vercel-ip-country`,
-`x-vercel-ip-country-region`), CloudFront (`x-amz-cf-ipcountry`) and generic
+`x-vercel-ip-country-region`), the `x-amz-cf-ipcountry` header some
+CloudFront setups add, and generic
 proxy headers (`x-country-code`, `x-country`, `x-region-code`). c15t does not
 keep a list of which hosts strip them. Check your deployment: log
 `(await headers()).get('x-vercel-ip-country')` or the equivalent for your host
@@ -168,6 +169,12 @@ resolution and use it only for non-policy code such as display defaults.
 | Region | `x-c15t-region`, `cf-region-code`, `x-vercel-ip-country-region`, `x-region-code` | c15t override, Cloudflare, Vercel, generic |
 | Global Privacy Control | `x-c15t-gpc`, `sec-gpc` | c15t override, browser signal |
 | Language | `accept-language` | browser |
+
+CloudFront's own geolocation headers, `CloudFront-Viewer-Country` and
+`CloudFront-Viewer-Country-Region`, are not in this list. On CloudFront, add a
+CloudFront Function or origin request policy that copies them to
+`x-c15t-country` and `x-c15t-region` before the request reaches Next.js, and
+strip any client-supplied `x-c15t-*` headers in the same step.
 
 GPC values are meaningful only as `1` or `0`; any other value is treated as
 absent. The proxy writes the normalized result to `sec-gpc`, so an incoming

--- a/docs/frameworks/next/geography-headers.mdx
+++ b/docs/frameworks/next/geography-headers.mdx
@@ -233,8 +233,8 @@ still passes through the protected path.
 
 Deploy with the proxy and load the site from two locations with different
 configured policy rules, for example through a VPN or your host's geo testing
-tools. The resolved policy in the initial HTML must match each location: an
-opt-in region shows the banner with optional categories denied, while a region
+tools. After server prefetch resolves, the rendered consent policy must match
+each location: an opt-in region shows the banner with optional categories denied, while a region
 configured for notice-only or no notice renders accordingly. Confirm the values
 by logging `(await headers()).get('x-c15t-country')` in a Server Component;
 it should equal the platform header seen in the proxy.

--- a/docs/frameworks/next/troubleshooting.mdx
+++ b/docs/frameworks/next/troubleshooting.mdx
@@ -42,4 +42,18 @@ Check the Next.js server and browser requests after following the
    including submissions. Direct requests to the backend are expected when you
    have not configured a rewrite.
 
+## Why is the visitor's location unknown on the server?
+
+`prefetchInitialConsent` and the local init handler read the visitor's country
+and region from hosting platform headers such as `cf-ipcountry` and
+`x-vercel-ip-country`; c15t never derives location from an IP address itself.
+Some platforms expose those headers to Next.js middleware or proxy but strip
+them before Server Components and Route Handlers run, so every visitor falls
+back to your unknown-location rule. Confirm it by logging
+`(await headers()).get('x-vercel-ip-country')`, or your host's equivalent, in a
+Server Component. If the header is missing there, add `c15tProxy` as described in
+[Forward geography headers](/docs/frameworks/next/geography-headers); it
+forwards the resolved values as `x-c15t-country` and `x-c15t-region`, which take
+precedence everywhere c15t reads location.
+
 <include src="../../guides/troubleshooting.mdx" />


### PR DESCRIPTION
Stacked on #1094 (2/4), depends on the App Router default PR.

## Summary
- New `docs/frameworks/next/geography-headers.mdx`: when `c15tProxy` is needed, `proxy.ts` (Next 16) and `middleware.ts` (Next 15) recipes, `cookie` option, exact header precedence table from `@c15t/schema` geo-headers, verification steps.
- New `docs/frameworks/next/content-security-policy.mdx`: pass `options.nonce` through the `Consent` wrapper from the awaited layout, what the nonce covers (script loader elements, `c15t-theme` style) and what it does not, `connect-src` guidance.
- `troubleshooting.mdx`: "Why is the visitor's location unknown on the server?" entry.
- `docs.config.ts`: both pages added to the Next.js Integration group.

Docs only, no changeset.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Next.js guidance for configuring Content Security Policy with consent components and nonces.
  * Added instructions for forwarding visitor country, region, and Global Privacy Control data through Next.js proxy or middleware.
  * Expanded troubleshooting guidance for unknown visitor locations and missing geography headers.
  * Updated Next.js documentation navigation to include the new integration guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->