### PR TITLE
docs: share framework-neutral consent content between Next.js and React pages

### DIFF
--- a/docs/frameworks/next/components/consent-banner.mdx
+++ b/docs/frameworks/next/components/consent-banner.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConsentBanner
-description: Pre-built consent banner shown when consent is required.
+description: Render the pre-built ConsentBanner inside a Next.js ConsentBoundary and configure its variants, per-policy buttons and compound parts.
 group: frameworks
 ---
 
@@ -73,26 +73,7 @@ and keep preferences reachable after the banner closes.
 
 ## Props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `title` | `ReactNode` | translation | Overrides the title. Under a notice the default is `cookieBanner.noticeTitle`. |
-| `description` | `ReactNode` | translation | Overrides the description. Under a notice the default is `cookieBanner.noticeDescription`. |
-| `acceptButtonText` | `ReactNode` | `common.acceptAll` | Accept label. |
-| `rejectButtonText` | `ReactNode` | `common.rejectAll` | Reject label. |
-| `customizeButtonText` | `ReactNode` | `common.customize` | Customize label. |
-| `dismissButtonText` | `ReactNode` | `common.acknowledge` | Label of the notice acknowledgement. |
-| `variant` | `PromptVariant` | `floating` | Shape of the prompt. See [Variants](#variants). |
-| `position` | `PromptPosition` | per variant | Where the prompt sits. Must be valid for the variant. |
-| `blocking` | `boolean` | `true` on `wall` | Backdrop, scroll lock, focus trap, and no outside dismissal, as one value. |
-| `layout` | `ConsentBannerLayout` | policy default | Orders and groups actions. Required actions the layout omits are restored. |
-| `primaryButton` | `ConsentBannerButton \| ConsentBannerButton[]` | `'customize'` | Which actions get the primary treatment. On a notice, dismiss is primary when it is the only action. |
-| `direction` | `'row' \| 'column'` | `'row'` | How action groups flow. |
-| `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which configured legal links render inline. |
-| `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag. |
-| `scrollLock` | `boolean` | unset | Deprecated. Use `blocking` to control scrolling, focus and backdrop together. |
-| `trapFocus` | `boolean` | unset | Deprecated. Use `blocking`. |
-| `disableAnimation` | `boolean` | `false` | Skips enter and exit animations. |
-| `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+<import src="../../../shared/react/components/consent-banner.mdx#props" />
 
 ## Per-policy buttons
 

--- a/docs/frameworks/next/components/consent-dialog-trigger.mdx
+++ b/docs/frameworks/next/components/consent-dialog-trigger.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConsentDialogTrigger
-description: Floating button and toolbar that reopen the preference center after the first prompt.
+description: Add the floating ConsentDialogTrigger button or toolbar to a Next.js ConsentBoundary so visitors can reopen the preference center.
 group: frameworks
 ---
 
@@ -28,15 +28,7 @@ The button carries `data-c15t-rights` with the rights the active policy guarante
 
 ## Props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `icon` | `'branding' \| 'fingerprint' \| 'settings' \| ReactNode` | `'branding'` | Icon rendered inside the button. |
-| `defaultPosition` | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'` | `'bottom-right'` | Corner the button starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the corner the visitor dragged it to. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the button is visible. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
-| `ariaLabel` | `string` | `'Open privacy settings'` | Accessible name. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+<import src="../../../shared/react/components/consent-dialog-trigger.mdx#props" />
 
 ## Configurable toolbar
 
@@ -88,17 +80,7 @@ Toolbars are horizontal by default. Set `orientation="vertical"` to stack the ac
 
 ### Toolbar props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `actions` | `ConsentDialogTriggerToolbarAction[]` | `[]` | App-owned actions rendered beside the preferences action. |
-| `preferences` | `ConsentDialogTriggerToolbarPreferences` | `{}` | Overrides for the built-in action: `icon`, `label`, `onSelect`, `className`, `style`. The label defaults to the opt-out or preferences right on the active rule. |
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
-| `defaultPosition` | `CornerPosition` | `'bottom-right'` | Corner the toolbar starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the dragged corner. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the built-in preferences action is visible. App-owned actions always render. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of each action. |
-| `ariaLabel` | `string` | `'Privacy controls'` | Accessible name for the toolbar group. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+<import src="../../../shared/react/components/consent-dialog-trigger.mdx#toolbar-props" />
 
 ### Toolbar styling
 

--- a/docs/frameworks/next/components/dev-tools.mdx
+++ b/docs/frameworks/next/components/dev-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: DevTools
-description: A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
+description: Load the c15t DevTools panel only in Next.js development builds to inspect consent state, scripts, policy and events inside ConsentBoundary.
 group: frameworks
 ---
 

--- a/docs/frameworks/next/headless.mdx
+++ b/docs/frameworks/next/headless.mdx
@@ -1,30 +1,25 @@
 ---
 title: Headless
-description: Build your own consent UI on top of the c15t hooks.
+description: Build a custom consent banner in Next.js with the c15t/next/headless hooks inside your existing ConsentBoundary.
 group: frameworks
 ---
 
 ## When to go headless
 
-The pre-built banner and dialog cover most designs through props, slots, and
-the stylesheet. Go headless when your markup has to be something else
-entirely: a design system component, a native sheet, or a layout the compound
-parts cannot express.
-
-Headless code owns the rendered controls, so it also owns the compliance
-outcome. The hooks hand you the actions a policy requires, the rights it must
-keep reachable, and diagnostics when your presentation drops one. Render from
-those lists rather than from a fixed set of buttons, and a site that later adds
-a notice region keeps working without a code change.
+<import src="../../shared/react/headless.mdx#when-to-go-headless" />
 
 Check for a policy before rendering your own surfaces. `useModel()` from
-`c15t/next` returns `null` while no rule has resolved and `'none'` under a rule that owes no consent UI, and the pre-built
-surfaces render nothing in that state.
+`c15t/next` returns `null` while no rule has resolved and `'none'` under a rule
+that owes no consent UI, and the pre-built surfaces render nothing in that
+state.
 
 ## Minimal example
 
-Render this Client Component inside your existing consent boundary in place of
-the stock banner. Keep the dialog and persistent preferences control.
+The headless hooks read the runtime from the `ConsentBoundary` set up in your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) guide, so they only run in a
+Client Component. Render this component inside that existing boundary in place
+of the stock banner. Keep the dialog and persistent preferences control.
 
 ```tsx title="components/consent-banner.tsx"
 'use client';
@@ -73,25 +68,4 @@ export function Banner() {
 }
 ```
 
-`banner.actionGroups` is the resolved layout: reject and accept share a group
-at equal prominence, and the rest follow. `banner.orderedActions` is the same
-list flattened. Under a notice the only action is `dismiss`, and
-`banner.preferenceControls` recommends additional buttons for opening
-preferences. Under a notice it contains `opt-out`, which selects the
-"Do not sell or share my data" label. The example renders that button and
-an "OK" button. Both controls keep their own command: opening
-preferences and dismissing the notice.
-
-The list is a rendering helper. It does not establish that your UI implements
-all policy rights. Provide disclosure and persistent preferences access.
-
-`performAction` saves all categories for `accept`, none for `reject`, the
-current draft for `save`, records a dismissal for `dismiss`, and opens the
-preference center for `customize`. `banner.diagnostics` reports when a host
-layout drops a required action or gives equivalent actions different
-prominence. Review each diagnostic when configuring custom presentation.
-
-`banner.variant`, `banner.position`, and `banner.blocking` carry the resolved
-shape from `presentation.prompt`, so a headless surface can follow the same
-bar, widget, or wall choice the pre-built banner would make, and can trap
-focus and lock scroll exactly when `blocking` is true.
+<import src="../../shared/react/headless.mdx#banner-api" />

--- a/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/next/hooks/use-consent-manager/overview.mdx
@@ -1,13 +1,20 @@
 ---
 title: Hooks
-description: Choose focused consent hooks for feature gates, explicit choices and preference actions.
+description: Gate features and save consent choices in Next.js Client Components with the focused hooks exported from c15t/next.
 group: frameworks
 ---
 
 ## Read only the state you need
 
-```tsx
+Every hook reads the runtime from the `ConsentBoundary` set up in your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) guide, so call them from a
+Client Component rendered inside that boundary and import them from
+`c15t/next`.
+
+```tsx title="components/optional-feature.tsx"
 'use client';
+
 import { useConsent } from 'c15t/next';
 
 export function OptionalFeature() {
@@ -16,19 +23,7 @@ export function OptionalFeature() {
 }
 ```
 
-Call hooks inside the consent provider. `useConsent` reads effective permission,
-which can be true under an opt-out policy without a recorded grant.
-
-| Need | Hook |
-| --- | --- |
-| One category's current permission | `useConsent(category)` |
-| All current permissions | `useConsents()` |
-| Recorded per-category choices | `useExplicitChoice()` |
-| Whether a prompt is required | `usePromptRequirement()` |
-| Active policy and resolution | `usePolicyRule()`, `usePolicyResolution()` |
-| Save an explicit choice | `useSaveConsents()` |
-| Open or close a consent surface | `useSetActiveUI()` |
-| Acknowledge a notice | `useDismissNotice()` |
+<import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#read-state" />
 
 ## Save from a visitor action
 
@@ -45,12 +40,4 @@ export function RejectButton() {
 }
 ```
 
-This is an isolated action example, not a complete policy-aware banner. Use the
-stock UI or headless surface actions for a complete prompt. Do not call save on
-mount to persist a state derived from permissions.
-
-`useConsentManager` remains available for the combined UI API, including draft
-management. Prefer focused hooks for simple feature gates and use the headless
-UI hook when implementing a complete custom prompt. Read
-[consent state](/docs/guides/consent-state) before treating a callback as evidence
-of a choice.
+<import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#save-guidance" />

--- a/docs/frameworks/next/iab/overview.mdx
+++ b/docs/frameworks/next/iab/overview.mdx
@@ -1,19 +1,23 @@
 ---
 title: IAB TCF
-description: Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+description: Mount the IAB TCF banner and dialog inside a Next.js ConsentBoundary and configure the CMP ID, policy and vendor data.
 group: frameworks
 ---
 
 ## Prepare the IAB configuration
 
-Use the IAB integration when your application needs the Transparency and Consent
-Framework. Configure an IAB policy, the correct CMP identity and vendor data for
-your deployment. A demo CMP ID is not a production configuration.
+<import src="../../../shared/react/iab/overview.mdx#prepare" />
 
-Install `@c15t/iab` alongside your framework adapter. Inside an existing consent
-provider connected to Inth, mount the IAB components:
+Next.js uses the React IAB components. There is no `c15t/next/iab` JavaScript
+entry point, so import the components from `c15t/react/iab` and render this
+Client Component inside the `ConsentBoundary` from your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) setup. Import
+`c15t/next/iab/styles.css` at your global stylesheet entry.
 
-```tsx
+```tsx title="components/iab-consent.tsx"
+'use client';
+
 import { IABProvider, IABConsentBanner, IABConsentDialog } from 'c15t/react/iab';
 
 export function IABConsent({ cmpId }: { cmpId: number }) {
@@ -26,27 +30,4 @@ export function IABConsent({ cmpId }: { cmpId: number }) {
 }
 ```
 
-Import `c15t/next/iab/styles.css` at your global stylesheet entry. Supply the CMP ID
-from your deployment's IAB configuration. Keep a persistent preferences entry
-point through the surrounding consent provider.
-
-Next.js uses the React IAB components. There is no `c15t/next/iab` JavaScript
-entry point; keep the component import above when using the Next.js adapter.
-
-## Resolve the policy before rendering
-
-IAB components remain hidden until an applicable policy resolves. Forcing a
-dialog open does not create a policy or vendor list. Inspect resolution and the
-Global Vendor List response before changing rendering conditions.
-
-IAB presentation follows `presentation.prompt.blocking` and
-`presentation.preferences.blocking`. A blocking dialog needs focus management,
-scroll locking and a backdrop together. See [migration](/docs/upgrade-v3) for
-legacy option behavior.
-
-## Verify vendor and purpose choices
-
-Test category choices alongside vendor, purpose, legitimate-interest and special
-feature controls used by your integration. Confirm the TC String and `__tcfapi`
-reflect the saved state, and verify the vendor's actual requests. A category-only
-banner test does not establish that the IAB flow works.
+<import src="../../../shared/react/iab/overview.mdx#configure" />

--- a/docs/frameworks/next/styling/overview.mdx
+++ b/docs/frameworks/next/styling/overview.mdx
@@ -1,22 +1,19 @@
 ---
 title: Styling
-description: Theme c15t components with tokens, slots, and class names.
+description: Import the Next.js stylesheet and theme c15t components with tokens, slots, and class names through ConsentBoundary options.
 group: frameworks
 ---
 
 ## Stylesheet
 
-Import the stylesheet once, next to your global CSS:
+Import the stylesheet once, next to your global CSS. In the App Router that is
+`app/layout.tsx`; in the Pages Router it is `pages/_app.tsx`:
 
 ```tsx
 import 'c15t/next/styles.css';
 ```
 
-Every rule lives in `@layer components`, so unlayered utilities from Tailwind
-v4 and atomic classes from StyleX override it without specificity tricks.
-Tailwind v3 treats `@layer components` as its own directive, so import the
-Tailwind 3 build from your Tailwind entry instead, between the `components`
-and `utilities` directives:
+<import src="../../../shared/react/styling/overview.mdx#tailwind-layers" />
 
 ```css
 @tailwind base;
@@ -32,9 +29,7 @@ your existing Client Component wrapper, keeping its transport, prefetch,
 children and other options. `ConsentBoundary` also accepts `theme` and
 `components` through `options`.
 
-Colors, radii, shadows, typography, and motion come from `--c15t-*` custom
-properties. Set them on the provider through `theme`, or override the
-variables directly in your CSS.
+<import src="../../../shared/react/styling/overview.mdx#tokens-intro" />
 
 ```tsx
 import { ConsentProvider } from 'c15t/next';
@@ -52,53 +47,7 @@ const theme = defineTheme({
 <ConsentProvider options={{ mode, theme }} />;
 ```
 
-`consentActions` decides how each action role looks: `default` applies to
-every button, `primary` to whichever actions the policy or your props mark
-primary, and `accept`, `reject`, `customize`, and `dismiss` to one role each.
-Per-action keys win over `primary`, which wins over `default`.
-
-Banner sizing has its own variables. Override them in CSS when a variant
-needs a different footprint:
-
-| Variable | Default | Applies to |
-| --- | --- | --- |
-| `--consent-banner-max-width` | `440px` | `floating` cards |
-| `--consent-banner-widget-max-width` | `20rem` | `widget` chips |
-| `--consent-banner-wall-max-width` | `30rem` | `wall` cards |
-
-## Colors by consent model
-
-The primary action can change while the brand color stays the same. Set
-`consentActions.primary` once, then select `primaryButton` per policy as
-shown in [ConsentBanner](../components/consent-banner#per-policy-buttons).
-
-To give opt-in and opt-out banners different colors, scope the tokens to
-the root's attributes. Include hover and foreground colors when overriding
-CSS tokens directly:
-
-```css
-[data-prompt][data-model='opt-in'] {
-	--c15t-primary: #2f6f4e;
-	--c15t-primary-hover: #24563c;
-	--c15t-text-on-primary: #fff;
-}
-
-[data-prompt][data-model='opt-out'] {
-	--c15t-primary: #6b3fa0;
-	--c15t-primary-hover: #55327f;
-	--c15t-text-on-primary: #fff;
-}
-```
-
-These colors apply to the action marked primary. Button layout and color
-changes do not change the policy or expire a saved choice.
-
-## Slots
-
-Each component part is a slot. A slot accepts any attributes the element
-takes, so the contract is the same whether you write class strings or pass an
-object with `className` and `style`. Set slots on the provider under
-`components`, keyed by component and part.
+<import src="../../../shared/react/styling/overview.mdx#token-roles" />
 
 For a full-width notice, use the supported `bar` variant. In a Client Component
 inside the existing boundary, replace the stock banner with:
@@ -131,79 +80,4 @@ const bannerSlots = {
 // banner: bannerSlots
 ```
 
-The root also carries `data-variant`, so you can restyle one shape without
-touching the others. Tailwind, giving a `bar` a brand-colored top edge and
-tighter text:
-
-```tsx
-<ConsentProvider
-	options={{
-		mode,
-		presentation: { prompt: { variant: 'bar' } },
-		components: {
-			banner: {
-				root: { className: 'group' },
-				card: {
-					className:
-						'group-data-[variant=bar]:border-t-4 group-data-[variant=bar]:border-t-emerald-600',
-				},
-			},
-			description: {
-				banner: { className: 'group-data-[variant=bar]:text-xs' },
-			},
-		},
-	}}
-/>
-```
-
-`data-variant` sits on the root, so child slots use Tailwind's `group`
-prefix to read it.
-
-StyleX, spreading the result of `stylex.props()` into a slot:
-
-```tsx
-import * as stylex from '@stylexjs/stylex';
-
-const styles = stylex.create({
-	card: { borderRadius: 0, boxShadow: 'none' },
-	rightLink: { textUnderlineOffset: 4, color: 'rgb(185 28 28)' },
-});
-
-<ConsentProvider
-	options={{
-		mode,
-		components: {
-			banner: {
-				card: stylex.props(styles.card),
-				rightLink: stylex.props(styles.rightLink),
-			},
-		},
-	}}
-/>;
-```
-
-Set `noStyle` on a component to drop the built-in classes from every part and
-keep only what your slots pass. Set `noStyle` in the provider options to do it
-for every component.
-
-Banner slot keys under `components.banner`:
-
-| Key | Element |
-| --- | --- |
-| `root` | Fixed-position wrapper carrying `data-prompt`, `data-model`, `data-variant`, `data-position`, and `data-blocking` |
-| `cardShell` | Sizes the card and holds the branding tag |
-| `card` | The visible card, carrying `data-state` |
-| `header` | Title and description container |
-| `title` | Heading |
-| `footer` | Action area |
-| `actions` | Group of action groups |
-| `actionGroup` | One group of equally prominent actions |
-| `rights` | Group of right links, rendered before the actions |
-| `rightLink` | One right link, carrying `data-action="right"` and `data-right` |
-| `overlay` | Backdrop shown when the banner blocks the page |
-
-Action buttons carry `data-action` and `data-variant`, and right links carry
-`data-action="right"`, so a single rule such as `[data-action='dismiss']` or
-`[data-action='right']` styles one role across every surface. Right links are
-underlined text by default, so the only button on a notice is the primary
-action.
+<import src="../../../shared/react/styling/overview.mdx#slot-recipes" />

--- a/docs/frameworks/react/components/consent-banner.mdx
+++ b/docs/frameworks/react/components/consent-banner.mdx
@@ -59,26 +59,7 @@ and keep preferences reachable after the banner closes.
 
 ## Props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `title` | `ReactNode` | translation | Overrides the title. Under a notice the default is `cookieBanner.noticeTitle`. |
-| `description` | `ReactNode` | translation | Overrides the description. Under a notice the default is `cookieBanner.noticeDescription`. |
-| `acceptButtonText` | `ReactNode` | `common.acceptAll` | Accept label. |
-| `rejectButtonText` | `ReactNode` | `common.rejectAll` | Reject label. |
-| `customizeButtonText` | `ReactNode` | `common.customize` | Customize label. |
-| `dismissButtonText` | `ReactNode` | `common.acknowledge` | Label of the notice acknowledgement. |
-| `variant` | `PromptVariant` | `floating` | Shape of the prompt. See [Variants](#variants). |
-| `position` | `PromptPosition` | per variant | Where the prompt sits. Must be valid for the variant. |
-| `blocking` | `boolean` | `true` on `wall` | Backdrop, scroll lock, focus trap, and no outside dismissal, as one value. |
-| `layout` | `ConsentBannerLayout` | policy default | Orders and groups actions. Required actions the layout omits are restored. |
-| `primaryButton` | `ConsentBannerButton \| ConsentBannerButton[]` | `'customize'` | Which actions get the primary treatment. On a notice, dismiss is primary when it is the only action. |
-| `direction` | `'row' \| 'column'` | `'row'` | How action groups flow. |
-| `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which configured legal links render inline. |
-| `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag. |
-| `scrollLock` | `boolean` | unset | Deprecated. Use `blocking` to control scrolling, focus and backdrop together. |
-| `trapFocus` | `boolean` | unset | Deprecated. Use `blocking`. |
-| `disableAnimation` | `boolean` | `false` | Skips enter and exit animations. |
-| `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+<import src="../../../shared/react/components/consent-banner.mdx#props" />
 
 ## Per-policy buttons
 

--- a/docs/frameworks/react/components/consent-dialog-trigger.mdx
+++ b/docs/frameworks/react/components/consent-dialog-trigger.mdx
@@ -37,15 +37,7 @@ The button carries `data-c15t-rights` with the rights the active policy guarante
 
 ## Props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `icon` | `'branding' \| 'fingerprint' \| 'settings' \| ReactNode` | `'branding'` | Icon rendered inside the button. |
-| `defaultPosition` | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'` | `'bottom-right'` | Corner the button starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the corner the visitor dragged it to. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the button is visible. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
-| `ariaLabel` | `string` | `'Open privacy settings'` | Accessible name. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+<import src="../../../shared/react/components/consent-dialog-trigger.mdx#props" />
 
 ## Configurable toolbar
 
@@ -94,17 +86,7 @@ Toolbars are horizontal by default. Set `orientation="vertical"` to stack the ac
 
 ### Toolbar props
 
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `actions` | `ConsentDialogTriggerToolbarAction[]` | `[]` | App-owned actions rendered beside the preferences action. |
-| `preferences` | `ConsentDialogTriggerToolbarPreferences` | `{}` | Overrides for the built-in action: `icon`, `label`, `onSelect`, `className`, `style`. The label defaults to the opt-out or preferences right on the active rule. |
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
-| `defaultPosition` | `CornerPosition` | `'bottom-right'` | Corner the toolbar starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the dragged corner. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the built-in preferences action is visible. App-owned actions always render. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of each action. |
-| `ariaLabel` | `string` | `'Privacy controls'` | Accessible name for the toolbar group. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+<import src="../../../shared/react/components/consent-dialog-trigger.mdx#toolbar-props" />
 
 ### Toolbar styling
 

--- a/docs/frameworks/react/headless.mdx
+++ b/docs/frameworks/react/headless.mdx
@@ -1,29 +1,25 @@
 ---
 title: Headless
-description: Build your own consent UI on top of the c15t hooks.
+description: Build a custom consent banner in React with the c15t/react/headless hooks inside your ConsentProvider.
 group: frameworks
 ---
 
 ## When to go headless
 
-The pre-built banner and dialog cover most designs through props, slots, and
-the stylesheet. Go headless when your markup has to be something else
-entirely: a design system component, a native sheet, or a layout the compound
-parts cannot express.
-
-Headless code owns the rendered controls, so it also owns the compliance
-outcome. The hooks hand you the actions a policy requires, the rights it must
-keep reachable, and diagnostics when your presentation drops one. Render from
-those lists rather than from a fixed set of buttons, and a site that later adds
-a notice region keeps working without a code change.
+<import src="../../shared/react/headless.mdx#when-to-go-headless" />
 
 Check for a policy before rendering your own surfaces. `useModel()` from
-`c15t/react` returns `null` while no rule has resolved and `'none'` under a rule that owes no consent UI, and the pre-built
-surfaces render nothing in that state.
+`c15t/react` returns `null` while no rule has resolved and `'none'` under a
+rule that owes no consent UI, and the pre-built surfaces render nothing in that
+state.
 
 ## Minimal example
 
-```tsx
+The headless hooks read the runtime from the nearest `ConsentProvider` from
+`c15t/react`. Render this component inside that provider in place of the stock
+banner, and keep the dialog and persistent preferences control.
+
+```tsx title="src/consent-banner.tsx"
 import { useHeadlessConsentUI, useTranslations } from 'c15t/react/headless';
 
 const ACTION_LABELS = {
@@ -68,25 +64,4 @@ export function Banner() {
 }
 ```
 
-`banner.actionGroups` is the resolved layout: reject and accept share a group
-at equal prominence, and the rest follow. `banner.orderedActions` is the same
-list flattened. Under a notice the only action is `dismiss`, and
-`banner.preferenceControls` recommends additional buttons for opening
-preferences. Under a notice it contains `opt-out`, which selects the
-"Do not sell or share my data" label. The example renders that button and
-an "OK" button. Both controls keep their own command: opening
-preferences and dismissing the notice.
-
-The list is a rendering helper. It does not establish that your UI implements
-all policy rights. Provide disclosure and persistent preferences access.
-
-`performAction` saves all categories for `accept`, none for `reject`, the
-current draft for `save`, records a dismissal for `dismiss`, and opens the
-preference center for `customize`. `banner.diagnostics` reports when a host
-layout drops a required action or gives equivalent actions different
-prominence. Review each diagnostic when configuring custom presentation.
-
-`banner.variant`, `banner.position`, and `banner.blocking` carry the resolved
-shape from `presentation.prompt`, so a headless surface can follow the same
-bar, widget, or wall choice the pre-built banner would make, and can trap
-focus and lock scroll exactly when `blocking` is true.
+<import src="../../shared/react/headless.mdx#banner-api" />

--- a/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/frameworks/react/hooks/use-consent-manager/overview.mdx
@@ -1,13 +1,16 @@
 ---
 title: Hooks
-description: Choose focused consent hooks for feature gates, explicit choices and preference actions.
+description: Gate features and save consent choices in React components with the focused hooks exported from c15t/react.
 group: frameworks
 ---
 
 ## Read only the state you need
 
-```tsx
-'use client';
+Every hook reads the runtime from the nearest `ConsentProvider`, so call them
+from components rendered inside that provider and import them from
+`c15t/react`.
+
+```tsx title="src/optional-feature.tsx"
 import { useConsent } from 'c15t/react';
 
 export function OptionalFeature() {
@@ -16,23 +19,13 @@ export function OptionalFeature() {
 }
 ```
 
-Call hooks inside the consent provider. `useConsent` reads effective permission,
-which can be true under an opt-out policy without a recorded grant.
-
-| Need | Hook |
-| --- | --- |
-| One category's current permission | `useConsent(category)` |
-| All current permissions | `useConsents()` |
-| Recorded per-category choices | `useExplicitChoice()` |
-| Whether a prompt is required | `usePromptRequirement()` |
-| Active policy and resolution | `usePolicyRule()`, `usePolicyResolution()` |
-| Save an explicit choice | `useSaveConsents()` |
-| Open or close a consent surface | `useSetActiveUI()` |
-| Acknowledge a notice | `useDismissNotice()` |
+<import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#read-state" />
 
 ## Save from a visitor action
 
-```tsx
+Render this component inside your existing `ConsentProvider`.
+
+```tsx title="src/reject-button.tsx"
 import { useSaveConsents } from 'c15t/react';
 
 export function RejectButton() {
@@ -41,12 +34,4 @@ export function RejectButton() {
 }
 ```
 
-This is an isolated action example, not a complete policy-aware banner. Use the
-stock UI or headless surface actions for a complete prompt. Do not call save on
-mount to persist a state derived from permissions.
-
-`useConsentManager` remains available for the combined UI API, including draft
-management. Prefer focused hooks for simple feature gates and use the headless
-UI hook when implementing a complete custom prompt. Read
-[consent state](/docs/guides/consent-state) before treating a callback as evidence
-of a choice.
+<import src="../../../../shared/react/hooks/use-consent-manager/overview.mdx#save-guidance" />

--- a/docs/frameworks/react/iab/overview.mdx
+++ b/docs/frameworks/react/iab/overview.mdx
@@ -1,19 +1,18 @@
 ---
 title: IAB TCF
-description: Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+description: Mount the IAB TCF banner and dialog inside a React ConsentProvider and configure the CMP ID, policy and vendor data.
 group: frameworks
 ---
 
 ## Prepare the IAB configuration
 
-Use the IAB integration when your application needs the Transparency and Consent
-Framework. Configure an IAB policy, the correct CMP identity and vendor data for
-your deployment. A demo CMP ID is not a production configuration.
+<import src="../../../shared/react/iab/overview.mdx#prepare" />
 
-Install `@c15t/iab` alongside your framework adapter. Inside an existing consent
-provider connected to Inth, mount the IAB components:
+Import the components from `c15t/react/iab` and render them inside your
+existing `ConsentProvider` from `c15t/react`. Import `c15t/react/iab/styles.css`
+at your global stylesheet entry.
 
-```tsx
+```tsx title="src/iab-consent.tsx"
 import { IABProvider, IABConsentBanner, IABConsentDialog } from 'c15t/react/iab';
 
 export function IABConsent({ cmpId }: { cmpId: number }) {
@@ -26,24 +25,4 @@ export function IABConsent({ cmpId }: { cmpId: number }) {
 }
 ```
 
-Import `c15t/react/iab/styles.css` at your global stylesheet entry. Supply the CMP ID
-from your deployment's IAB configuration. Keep a persistent preferences entry
-point through the surrounding consent provider.
-
-## Resolve the policy before rendering
-
-IAB components remain hidden until an applicable policy resolves. Forcing a
-dialog open does not create a policy or vendor list. Inspect resolution and the
-Global Vendor List response before changing rendering conditions.
-
-IAB presentation follows `presentation.prompt.blocking` and
-`presentation.preferences.blocking`. A blocking dialog needs focus management,
-scroll locking and a backdrop together. See [migration](/docs/upgrade-v3) for
-legacy option behavior.
-
-## Verify vendor and purpose choices
-
-Test category choices alongside vendor, purpose, legitimate-interest and special
-feature controls used by your integration. Confirm the TC String and `__tcfapi`
-reflect the saved state, and verify the vendor's actual requests. A category-only
-banner test does not establish that the IAB flow works.
+<import src="../../../shared/react/iab/overview.mdx#configure" />

--- a/docs/frameworks/react/styling/overview.mdx
+++ b/docs/frameworks/react/styling/overview.mdx
@@ -1,22 +1,19 @@
 ---
 title: Styling
-description: Theme c15t components with tokens, slots, and class names.
+description: Import the React stylesheet and theme c15t components with tokens, slots, and class names on ConsentProvider.
 group: frameworks
 ---
 
 ## Stylesheet
 
-Import the stylesheet once, next to your global CSS:
+Import the stylesheet once, next to your global CSS, in the entry module that
+renders `ConsentProvider`:
 
 ```tsx
 import 'c15t/react/styles.css';
 ```
 
-Every rule lives in `@layer components`, so unlayered utilities from Tailwind
-v4 and atomic classes from StyleX override it without specificity tricks.
-Tailwind v3 treats `@layer components` as its own directive, so import the
-Tailwind 3 build from your Tailwind entry instead, between the `components`
-and `utilities` directives:
+<import src="../../../shared/react/styling/overview.mdx#tailwind-layers" />
 
 ```css
 @tailwind base;
@@ -27,9 +24,11 @@ and `utilities` directives:
 
 ## Tokens
 
-Colors, radii, shadows, typography, and motion come from `--c15t-*` custom
-properties. Set them on the provider through `theme`, or override the
-variables directly in your CSS.
+The provider snippets below are partial configuration examples. Apply them to
+your existing `ConsentProvider` from `c15t/react`, keeping its `mode`, children
+and other options.
+
+<import src="../../../shared/react/styling/overview.mdx#tokens-intro" />
 
 ```tsx
 import { ConsentProvider } from 'c15t/react';
@@ -47,53 +46,7 @@ const theme = defineTheme({
 <ConsentProvider options={{ mode, theme }} />;
 ```
 
-`consentActions` decides how each action role looks: `default` applies to
-every button, `primary` to whichever actions the policy or your props mark
-primary, and `accept`, `reject`, `customize`, and `dismiss` to one role each.
-Per-action keys win over `primary`, which wins over `default`.
-
-Banner sizing has its own variables. Override them in CSS when a variant
-needs a different footprint:
-
-| Variable | Default | Applies to |
-| --- | --- | --- |
-| `--consent-banner-max-width` | `440px` | `floating` cards |
-| `--consent-banner-widget-max-width` | `20rem` | `widget` chips |
-| `--consent-banner-wall-max-width` | `30rem` | `wall` cards |
-
-## Colors by consent model
-
-The primary action can change while the brand color stays the same. Set
-`consentActions.primary` once, then select `primaryButton` per policy as
-shown in [ConsentBanner](../components/consent-banner#per-policy-buttons).
-
-To give opt-in and opt-out banners different colors, scope the tokens to
-the root's attributes. Include hover and foreground colors when overriding
-CSS tokens directly:
-
-```css
-[data-prompt][data-model='opt-in'] {
-	--c15t-primary: #2f6f4e;
-	--c15t-primary-hover: #24563c;
-	--c15t-text-on-primary: #fff;
-}
-
-[data-prompt][data-model='opt-out'] {
-	--c15t-primary: #6b3fa0;
-	--c15t-primary-hover: #55327f;
-	--c15t-text-on-primary: #fff;
-}
-```
-
-These colors apply to the action marked primary. Button layout and color
-changes do not change the policy or expire a saved choice.
-
-## Slots
-
-Each component part is a slot. A slot accepts any attributes the element
-takes, so the contract is the same whether you write class strings or pass an
-object with `className` and `style`. Set slots on the provider under
-`components`, keyed by component and part.
+<import src="../../../shared/react/styling/overview.mdx#token-roles" />
 
 For a full-width notice, use the supported `bar` variant. Inside your existing
 provider, replace the stock banner with:
@@ -124,79 +77,4 @@ const bannerSlots = {
 // banner: bannerSlots
 ```
 
-The root also carries `data-variant`, so you can restyle one shape without
-touching the others. Tailwind, giving a `bar` a brand-colored top edge and
-tighter text:
-
-```tsx
-<ConsentProvider
-	options={{
-		mode,
-		presentation: { prompt: { variant: 'bar' } },
-		components: {
-			banner: {
-				root: { className: 'group' },
-				card: {
-					className:
-						'group-data-[variant=bar]:border-t-4 group-data-[variant=bar]:border-t-emerald-600',
-				},
-			},
-			description: {
-				banner: { className: 'group-data-[variant=bar]:text-xs' },
-			},
-		},
-	}}
-/>
-```
-
-`data-variant` sits on the root, so child slots use Tailwind's `group`
-prefix to read it.
-
-StyleX, spreading the result of `stylex.props()` into a slot:
-
-```tsx
-import * as stylex from '@stylexjs/stylex';
-
-const styles = stylex.create({
-	card: { borderRadius: 0, boxShadow: 'none' },
-	rightLink: { textUnderlineOffset: 4, color: 'rgb(185 28 28)' },
-});
-
-<ConsentProvider
-	options={{
-		mode,
-		components: {
-			banner: {
-				card: stylex.props(styles.card),
-				rightLink: stylex.props(styles.rightLink),
-			},
-		},
-	}}
-/>;
-```
-
-Set `noStyle` on a component to drop the built-in classes from every part and
-keep only what your slots pass. Set `noStyle` in the provider options to do it
-for every component.
-
-Banner slot keys under `components.banner`:
-
-| Key | Element |
-| --- | --- |
-| `root` | Fixed-position wrapper carrying `data-prompt`, `data-model`, `data-variant`, `data-position`, and `data-blocking` |
-| `cardShell` | Sizes the card and holds the branding tag |
-| `card` | The visible card, carrying `data-state` |
-| `header` | Title and description container |
-| `title` | Heading |
-| `footer` | Action area |
-| `actions` | Group of action groups |
-| `actionGroup` | One group of equally prominent actions |
-| `rights` | Group of right links, rendered before the actions |
-| `rightLink` | One right link, carrying `data-action="right"` and `data-right` |
-| `overlay` | Backdrop shown when the banner blocks the page |
-
-Action buttons carry `data-action` and `data-variant`, and right links carry
-`data-action="right"`, so a single rule such as `[data-action='dismiss']` or
-`[data-action='right']` styles one role across every surface. Right links are
-underlined text by default, so the only button on a notice is the primary
-action.
+<import src="../../../shared/react/styling/overview.mdx#slot-recipes" />

--- a/docs/shared/react/components/consent-banner.mdx
+++ b/docs/shared/react/components/consent-banner.mdx
@@ -1,0 +1,30 @@
+---
+title: "ConsentBanner"
+description: "Shared ConsentBanner reference tables for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | `ReactNode` | translation | Overrides the title. Under a notice the default is `cookieBanner.noticeTitle`. |
+| `description` | `ReactNode` | translation | Overrides the description. Under a notice the default is `cookieBanner.noticeDescription`. |
+| `acceptButtonText` | `ReactNode` | `common.acceptAll` | Accept label. |
+| `rejectButtonText` | `ReactNode` | `common.rejectAll` | Reject label. |
+| `customizeButtonText` | `ReactNode` | `common.customize` | Customize label. |
+| `dismissButtonText` | `ReactNode` | `common.acknowledge` | Label of the notice acknowledgement. |
+| `variant` | `PromptVariant` | `floating` | Shape of the prompt. See [Variants](#variants). |
+| `position` | `PromptPosition` | per variant | Where the prompt sits. Must be valid for the variant. |
+| `blocking` | `boolean` | `true` on `wall` | Backdrop, scroll lock, focus trap, and no outside dismissal, as one value. |
+| `layout` | `ConsentBannerLayout` | policy default | Orders and groups actions. Required actions the layout omits are restored. |
+| `primaryButton` | `ConsentBannerButton \| ConsentBannerButton[]` | `'customize'` | Which actions get the primary treatment. On a notice, dismiss is primary when it is the only action. |
+| `direction` | `'row' \| 'column'` | `'row'` | How action groups flow. |
+| `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which configured legal links render inline. |
+| `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag. |
+| `scrollLock` | `boolean` | unset | Deprecated. Use `blocking` to control scrolling, focus and backdrop together. |
+| `trapFocus` | `boolean` | unset | Deprecated. Use `blocking`. |
+| `disableAnimation` | `boolean` | `false` | Skips enter and exit animations. |
+| `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+</section>

--- a/docs/shared/react/components/consent-banner.mdx
+++ b/docs/shared/react/components/consent-banner.mdx
@@ -7,24 +7,24 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="props">
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `title` | `ReactNode` | translation | Overrides the title. Under a notice the default is `cookieBanner.noticeTitle`. |
-| `description` | `ReactNode` | translation | Overrides the description. Under a notice the default is `cookieBanner.noticeDescription`. |
-| `acceptButtonText` | `ReactNode` | `common.acceptAll` | Accept label. |
-| `rejectButtonText` | `ReactNode` | `common.rejectAll` | Reject label. |
-| `customizeButtonText` | `ReactNode` | `common.customize` | Customize label. |
-| `dismissButtonText` | `ReactNode` | `common.acknowledge` | Label of the notice acknowledgement. |
-| `variant` | `PromptVariant` | `floating` | Shape of the prompt. See [Variants](#variants). |
-| `position` | `PromptPosition` | per variant | Where the prompt sits. Must be valid for the variant. |
-| `blocking` | `boolean` | `true` on `wall` | Backdrop, scroll lock, focus trap, and no outside dismissal, as one value. |
-| `layout` | `ConsentBannerLayout` | policy default | Orders and groups actions. Required actions the layout omits are restored. |
-| `primaryButton` | `ConsentBannerButton \| ConsentBannerButton[]` | `'customize'` | Which actions get the primary treatment. On a notice, dismiss is primary when it is the only action. |
-| `direction` | `'row' \| 'column'` | `'row'` | How action groups flow. |
-| `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which configured legal links render inline. |
-| `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag. |
-| `scrollLock` | `boolean` | unset | Deprecated. Use `blocking` to control scrolling, focus and backdrop together. |
-| `trapFocus` | `boolean` | unset | Deprecated. Use `blocking`. |
-| `disableAnimation` | `boolean` | `false` | Skips enter and exit animations. |
-| `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `title` | `ReactNode` | translation | Overrides the title. Under a notice the default is `cookieBanner.noticeTitle`. |
+  | `description` | `ReactNode` | translation | Overrides the description. Under a notice the default is `cookieBanner.noticeDescription`. |
+  | `acceptButtonText` | `ReactNode` | `common.acceptAll` | Accept label. |
+  | `rejectButtonText` | `ReactNode` | `common.rejectAll` | Reject label. |
+  | `customizeButtonText` | `ReactNode` | `common.customize` | Customize label. |
+  | `dismissButtonText` | `ReactNode` | `common.acknowledge` | Label of the notice acknowledgement. |
+  | `variant` | `PromptVariant` | `floating` | Shape of the prompt. See [Variants](#variants). |
+  | `position` | `PromptPosition` | per variant | Where the prompt sits. Must be valid for the variant. |
+  | `blocking` | `boolean` | `true` on `wall` | Backdrop, scroll lock, focus trap, and no outside dismissal, as one value. |
+  | `layout` | `ConsentBannerLayout` | policy default | Orders and groups actions. Required actions the layout omits are restored. |
+  | `primaryButton` | `ConsentBannerButton \| ConsentBannerButton[]` | `'customize'` | Which actions get the primary treatment. On a notice, dismiss is primary when it is the only action. |
+  | `direction` | `'row' \| 'column'` | `'row'` | How action groups flow. |
+  | `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which configured legal links render inline. |
+  | `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag. |
+  | `scrollLock` | `boolean` | unset | Deprecated. Use `blocking` to control scrolling, focus and backdrop together. |
+  | `trapFocus` | `boolean` | unset | Deprecated. Use `blocking`. |
+  | `disableAnimation` | `boolean` | `false` | Skips enter and exit animations. |
+  | `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
 </section>

--- a/docs/shared/react/components/consent-dialog-trigger.mdx
+++ b/docs/shared/react/components/consent-dialog-trigger.mdx
@@ -1,0 +1,33 @@
+---
+title: "ConsentDialogTrigger"
+description: "Shared ConsentDialogTrigger reference tables for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `icon` | `'branding' \| 'fingerprint' \| 'settings' \| ReactNode` | `'branding'` | Icon rendered inside the button. |
+| `defaultPosition` | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'` | `'bottom-right'` | Corner the button starts in. |
+| `persistPosition` | `boolean` | `true` | Remember the corner the visitor dragged it to. |
+| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the button is visible. `after-prompt` waits until no choice or notice is owed. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
+| `ariaLabel` | `string` | `'Open privacy settings'` | Accessible name. |
+| `noStyle` | `boolean` | `false` | Remove the default styling. |
+</section>
+
+<section id="toolbar-props">
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `actions` | `ConsentDialogTriggerToolbarAction[]` | `[]` | App-owned actions rendered beside the preferences action. |
+| `preferences` | `ConsentDialogTriggerToolbarPreferences` | `{}` | Overrides for the built-in action: `icon`, `label`, `onSelect`, `className`, `style`. The label defaults to the opt-out or preferences right on the active rule. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
+| `defaultPosition` | `CornerPosition` | `'bottom-right'` | Corner the toolbar starts in. |
+| `persistPosition` | `boolean` | `true` | Remember the dragged corner. |
+| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the built-in preferences action is visible. App-owned actions always render. `after-prompt` waits until no choice or notice is owed. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of each action. |
+| `ariaLabel` | `string` | `'Privacy controls'` | Accessible name for the toolbar group. |
+| `noStyle` | `boolean` | `false` | Remove the default styling. |
+</section>

--- a/docs/shared/react/components/consent-dialog-trigger.mdx
+++ b/docs/shared/react/components/consent-dialog-trigger.mdx
@@ -7,27 +7,27 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="props">
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `icon` | `'branding' \| 'fingerprint' \| 'settings' \| ReactNode` | `'branding'` | Icon rendered inside the button. |
-| `defaultPosition` | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'` | `'bottom-right'` | Corner the button starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the corner the visitor dragged it to. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the button is visible. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
-| `ariaLabel` | `string` | `'Open privacy settings'` | Accessible name. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `icon` | `'branding' \| 'fingerprint' \| 'settings' \| ReactNode` | `'branding'` | Icon rendered inside the button. |
+  | `defaultPosition` | `'bottom-left' \| 'bottom-right' \| 'top-left' \| 'top-right'` | `'bottom-right'` | Corner the button starts in. |
+  | `persistPosition` | `boolean` | `true` | Remember the corner the visitor dragged it to. |
+  | `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the button is visible. `after-prompt` waits until no choice or notice is owed. |
+  | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Button size. |
+  | `ariaLabel` | `string` | `'Open privacy settings'` | Accessible name. |
+  | `noStyle` | `boolean` | `false` | Remove the default styling. |
 </section>
 
 <section id="toolbar-props">
-| Prop | Type | Default | Description |
-| --- | --- | --- | --- |
-| `actions` | `ConsentDialogTriggerToolbarAction[]` | `[]` | App-owned actions rendered beside the preferences action. |
-| `preferences` | `ConsentDialogTriggerToolbarPreferences` | `{}` | Overrides for the built-in action: `icon`, `label`, `onSelect`, `className`, `style`. The label defaults to the opt-out or preferences right on the active rule. |
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
-| `defaultPosition` | `CornerPosition` | `'bottom-right'` | Corner the toolbar starts in. |
-| `persistPosition` | `boolean` | `true` | Remember the dragged corner. |
-| `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the built-in preferences action is visible. App-owned actions always render. `after-prompt` waits until no choice or notice is owed. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of each action. |
-| `ariaLabel` | `string` | `'Privacy controls'` | Accessible name for the toolbar group. |
-| `noStyle` | `boolean` | `false` | Remove the default styling. |
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `actions` | `ConsentDialogTriggerToolbarAction[]` | `[]` | App-owned actions rendered beside the preferences action. |
+  | `preferences` | `ConsentDialogTriggerToolbarPreferences` | `{}` | Overrides for the built-in action: `icon`, `label`, `onSelect`, `className`, `style`. The label defaults to the opt-out or preferences right on the active rule. |
+  | `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction. |
+  | `defaultPosition` | `CornerPosition` | `'bottom-right'` | Corner the toolbar starts in. |
+  | `persistPosition` | `boolean` | `true` | Remember the dragged corner. |
+  | `showWhen` | `'always' \| 'after-prompt' \| 'never'` | `'always'` | When the built-in preferences action is visible. App-owned actions always render. `after-prompt` waits until no choice or notice is owed. |
+  | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Size of each action. |
+  | `ariaLabel` | `string` | `'Privacy controls'` | Accessible name for the toolbar group. |
+  | `noStyle` | `boolean` | `false` | Remove the default styling. |
 </section>

--- a/docs/shared/react/headless.mdx
+++ b/docs/shared/react/headless.mdx
@@ -1,0 +1,45 @@
+---
+title: "Headless"
+description: "Shared headless consent UI content for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="when-to-go-headless">
+The pre-built banner and dialog cover most designs through props, slots, and
+the stylesheet. Go headless when your markup has to be something else
+entirely: a design system component, a native sheet, or a layout the compound
+parts cannot express.
+
+Headless code owns the rendered controls, so it also owns the compliance
+outcome. The hooks hand you the actions a policy requires, the rights it must
+keep reachable, and diagnostics when your presentation drops one. Render from
+those lists rather than from a fixed set of buttons, and a site that later adds
+a notice region keeps working without a code change.
+</section>
+
+<section id="banner-api">
+`banner.actionGroups` is the resolved layout: reject and accept share a group
+at equal prominence, and the rest follow. `banner.orderedActions` is the same
+list flattened. Under a notice the only action is `dismiss`, and
+`banner.preferenceControls` recommends additional buttons for opening
+preferences. Under a notice it contains `opt-out`, which selects the
+"Do not sell or share my data" label. The example renders that button and
+an "OK" button. Both controls keep their own command: opening
+preferences and dismissing the notice.
+
+The list is a rendering helper. It does not establish that your UI implements
+all policy rights. Provide disclosure and persistent preferences access.
+
+`performAction` saves all categories for `accept`, none for `reject`, the
+current draft for `save`, records a dismissal for `dismiss`, and opens the
+preference center for `customize`. `banner.diagnostics` reports when a host
+layout drops a required action or gives equivalent actions different
+prominence. Review each diagnostic when configuring custom presentation.
+
+`banner.variant`, `banner.position`, and `banner.blocking` carry the resolved
+shape from `presentation.prompt`, so a headless surface can follow the same
+bar, widget, or wall choice the pre-built banner would make, and can trap
+focus and lock scroll exactly when `blocking` is true.
+</section>

--- a/docs/shared/react/headless.mdx
+++ b/docs/shared/react/headless.mdx
@@ -7,39 +7,39 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="when-to-go-headless">
-The pre-built banner and dialog cover most designs through props, slots, and
-the stylesheet. Go headless when your markup has to be something else
-entirely: a design system component, a native sheet, or a layout the compound
-parts cannot express.
+  The pre-built banner and dialog cover most designs through props, slots, and
+  the stylesheet. Go headless when your markup has to be something else
+  entirely: a design system component, a native sheet, or a layout the compound
+  parts cannot express.
 
-Headless code owns the rendered controls, so it also owns the compliance
-outcome. The hooks hand you the actions a policy requires, the rights it must
-keep reachable, and diagnostics when your presentation drops one. Render from
-those lists rather than from a fixed set of buttons, and a site that later adds
-a notice region keeps working without a code change.
+  Headless code owns the rendered controls, so it also owns the compliance
+  outcome. The hooks hand you the actions a policy requires, the rights it must
+  keep reachable, and diagnostics when your presentation drops one. Render from
+  those lists rather than from a fixed set of buttons, and a site that later adds
+  a notice region keeps working without a code change.
 </section>
 
 <section id="banner-api">
-`banner.actionGroups` is the resolved layout: reject and accept share a group
-at equal prominence, and the rest follow. `banner.orderedActions` is the same
-list flattened. Under a notice the only action is `dismiss`, and
-`banner.preferenceControls` recommends additional buttons for opening
-preferences. Under a notice it contains `opt-out`, which selects the
-"Do not sell or share my data" label. The example renders that button and
-an "OK" button. Both controls keep their own command: opening
-preferences and dismissing the notice.
+  `banner.actionGroups` is the resolved layout: reject and accept share a group
+  at equal prominence, and the rest follow. `banner.orderedActions` is the same
+  list flattened. Under a notice the only action is `dismiss`, and
+  `banner.preferenceControls` recommends additional buttons for opening
+  preferences. Under a notice it contains `opt-out`, which selects the
+  "Do not sell or share my data" label. The example renders that button and
+  an "OK" button. Both controls keep their own command: opening
+  preferences and dismissing the notice.
 
-The list is a rendering helper. It does not establish that your UI implements
-all policy rights. Provide disclosure and persistent preferences access.
+  The list is a rendering helper. It does not establish that your UI implements
+  all policy rights. Provide disclosure and persistent preferences access.
 
-`performAction` saves all categories for `accept`, none for `reject`, the
-current draft for `save`, records a dismissal for `dismiss`, and opens the
-preference center for `customize`. `banner.diagnostics` reports when a host
-layout drops a required action or gives equivalent actions different
-prominence. Review each diagnostic when configuring custom presentation.
+  `performAction` saves all categories for `accept`, none for `reject`, the
+  current draft for `save`, records a dismissal for `dismiss`, and opens the
+  preference center for `customize`. `banner.diagnostics` reports when a host
+  layout drops a required action or gives equivalent actions different
+  prominence. Review each diagnostic when configuring custom presentation.
 
-`banner.variant`, `banner.position`, and `banner.blocking` carry the resolved
-shape from `presentation.prompt`, so a headless surface can follow the same
-bar, widget, or wall choice the pre-built banner would make, and can trap
-focus and lock scroll exactly when `blocking` is true.
+  `banner.variant`, `banner.position`, and `banner.blocking` carry the resolved
+  shape from `presentation.prompt`, so a headless surface can follow the same
+  bar, widget, or wall choice the pre-built banner would make, and can trap
+  focus and lock scroll exactly when `blocking` is true.
 </section>

--- a/docs/shared/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/shared/react/hooks/use-consent-manager/overview.mdx
@@ -7,29 +7,29 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="read-state">
-Call hooks inside the consent provider. `useConsent` reads effective permission,
-which can be true under an opt-out policy without a recorded grant.
+  Call hooks inside the consent provider. `useConsent` reads effective permission,
+  which can be true under an opt-out policy without a recorded grant.
 
-| Need | Hook |
-| --- | --- |
-| One category's current permission | `useConsent(category)` |
-| All current permissions | `useConsents()` |
-| Recorded per-category choices | `useExplicitChoice()` |
-| Whether a prompt is required | `usePromptRequirement()` |
-| Active policy and resolution | `usePolicyRule()`, `usePolicyResolution()` |
-| Save an explicit choice | `useSaveConsents()` |
-| Open or close a consent surface | `useSetActiveUI()` |
-| Acknowledge a notice | `useDismissNotice()` |
+  | Need | Hook |
+  | --- | --- |
+  | One category's current permission | `useConsent(category)` |
+  | All current permissions | `useConsents()` |
+  | Recorded per-category choices | `useExplicitChoice()` |
+  | Whether a prompt is required | `usePromptRequirement()` |
+  | Active policy and resolution | `usePolicyRule()`, `usePolicyResolution()` |
+  | Save an explicit choice | `useSaveConsents()` |
+  | Open or close a consent surface | `useSetActiveUI()` |
+  | Acknowledge a notice | `useDismissNotice()` |
 </section>
 
 <section id="save-guidance">
-This is an isolated action example, not a complete policy-aware banner. Use the
-stock UI or headless surface actions for a complete prompt. Do not call save on
-mount to persist a state derived from permissions.
+  This is an isolated action example, not a complete policy-aware banner. Use the
+  stock UI or headless surface actions for a complete prompt. Do not call save on
+  mount to persist a state derived from permissions.
 
-`useConsentManager` remains available for the combined UI API, including draft
-management. Prefer focused hooks for simple feature gates and use the headless
-UI hook when implementing a complete custom prompt. Read
-[consent state](/docs/guides/consent-state) before treating a callback as evidence
-of a choice.
+  `useConsentManager` remains available for the combined UI API, including draft
+  management. Prefer focused hooks for simple feature gates and use the headless
+  UI hook when implementing a complete custom prompt. Read
+  [consent state](/docs/guides/consent-state) before treating a callback as evidence
+  of a choice.
 </section>

--- a/docs/shared/react/hooks/use-consent-manager/overview.mdx
+++ b/docs/shared/react/hooks/use-consent-manager/overview.mdx
@@ -1,0 +1,35 @@
+---
+title: "Hooks"
+description: "Shared consent hook guidance for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="read-state">
+Call hooks inside the consent provider. `useConsent` reads effective permission,
+which can be true under an opt-out policy without a recorded grant.
+
+| Need | Hook |
+| --- | --- |
+| One category's current permission | `useConsent(category)` |
+| All current permissions | `useConsents()` |
+| Recorded per-category choices | `useExplicitChoice()` |
+| Whether a prompt is required | `usePromptRequirement()` |
+| Active policy and resolution | `usePolicyRule()`, `usePolicyResolution()` |
+| Save an explicit choice | `useSaveConsents()` |
+| Open or close a consent surface | `useSetActiveUI()` |
+| Acknowledge a notice | `useDismissNotice()` |
+</section>
+
+<section id="save-guidance">
+This is an isolated action example, not a complete policy-aware banner. Use the
+stock UI or headless surface actions for a complete prompt. Do not call save on
+mount to persist a state derived from permissions.
+
+`useConsentManager` remains available for the combined UI API, including draft
+management. Prefer focused hooks for simple feature gates and use the headless
+UI hook when implementing a complete custom prompt. Read
+[consent state](/docs/guides/consent-state) before treating a callback as evidence
+of a choice.
+</section>

--- a/docs/shared/react/iab/overview.mdx
+++ b/docs/shared/react/iab/overview.mdx
@@ -1,0 +1,39 @@
+---
+title: "IAB TCF"
+description: "Shared IAB TCF setup guidance for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="prepare">
+Use the IAB integration when your application needs the Transparency and Consent
+Framework. Configure an IAB policy, the correct CMP identity and vendor data for
+your deployment. A demo CMP ID is not a production configuration.
+
+Install `@c15t/iab` alongside your framework adapter, then mount the IAB
+components inside an existing consent provider connected to Inth.
+</section>
+
+<section id="configure">
+Supply the CMP ID from your deployment's IAB configuration. Keep a persistent
+preferences entry point through the surrounding consent provider.
+
+## Resolve the policy before rendering
+
+IAB components remain hidden until an applicable policy resolves. Forcing a
+dialog open does not create a policy or vendor list. Inspect resolution and the
+Global Vendor List response before changing rendering conditions.
+
+IAB presentation follows `presentation.prompt.blocking` and
+`presentation.preferences.blocking`. A blocking dialog needs focus management,
+scroll locking and a backdrop together. See [migration](/docs/upgrade-v3) for
+legacy option behavior.
+
+## Verify vendor and purpose choices
+
+Test category choices alongside vendor, purpose, legitimate-interest and special
+feature controls used by your integration. Confirm the TC String and `__tcfapi`
+reflect the saved state, and verify the vendor's actual requests. A category-only
+banner test does not establish that the IAB flow works.
+</section>

--- a/docs/shared/react/iab/overview.mdx
+++ b/docs/shared/react/iab/overview.mdx
@@ -7,33 +7,33 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="prepare">
-Use the IAB integration when your application needs the Transparency and Consent
-Framework. Configure an IAB policy, the correct CMP identity and vendor data for
-your deployment. A demo CMP ID is not a production configuration.
+  Use the IAB integration when your application needs the Transparency and Consent
+  Framework. Configure an IAB policy, the correct CMP identity and vendor data for
+  your deployment. A demo CMP ID is not a production configuration.
 
-Install `@c15t/iab` alongside your framework adapter, then mount the IAB
-components inside an existing consent provider connected to Inth.
+  Install `@c15t/iab` alongside your framework adapter, then mount the IAB
+  components inside an existing consent provider connected to Inth.
 </section>
 
 <section id="configure">
-Supply the CMP ID from your deployment's IAB configuration. Keep a persistent
-preferences entry point through the surrounding consent provider.
+  Supply the CMP ID from your deployment's IAB configuration. Keep a persistent
+  preferences entry point through the surrounding consent provider.
 
-## Resolve the policy before rendering
+  ## Resolve the policy before rendering
 
-IAB components remain hidden until an applicable policy resolves. Forcing a
-dialog open does not create a policy or vendor list. Inspect resolution and the
-Global Vendor List response before changing rendering conditions.
+  IAB components remain hidden until an applicable policy resolves. Forcing a
+  dialog open does not create a policy or vendor list. Inspect resolution and the
+  Global Vendor List response before changing rendering conditions.
 
-IAB presentation follows `presentation.prompt.blocking` and
-`presentation.preferences.blocking`. A blocking dialog needs focus management,
-scroll locking and a backdrop together. See [migration](/docs/upgrade-v3) for
-legacy option behavior.
+  IAB presentation follows `presentation.prompt.blocking` and
+  `presentation.preferences.blocking`. A blocking dialog needs focus management,
+  scroll locking and a backdrop together. See [migration](/docs/upgrade-v3) for
+  legacy option behavior.
 
-## Verify vendor and purpose choices
+  ## Verify vendor and purpose choices
 
-Test category choices alongside vendor, purpose, legitimate-interest and special
-feature controls used by your integration. Confirm the TC String and `__tcfapi`
-reflect the saved state, and verify the vendor's actual requests. A category-only
-banner test does not establish that the IAB flow works.
+  Test category choices alongside vendor, purpose, legitimate-interest and special
+  feature controls used by your integration. Confirm the TC String and `__tcfapi`
+  reflect the saved state, and verify the vendor's actual requests. A category-only
+  banner test does not establish that the IAB flow works.
 </section>

--- a/docs/shared/react/styling/overview.mdx
+++ b/docs/shared/react/styling/overview.mdx
@@ -7,144 +7,144 @@ group: reference
 {/* This file is NOT rendered directly. Sections are imported by framework pages. */}
 
 <section id="tailwind-layers">
-Every rule lives in `@layer components`, so unlayered utilities from Tailwind
-v4 and atomic classes from StyleX override it without specificity tricks.
-Tailwind v3 treats `@layer components` as its own directive, so import the
-Tailwind 3 build from your Tailwind entry instead, between the `components`
-and `utilities` directives:
+  Every rule lives in `@layer components`, so unlayered utilities from Tailwind
+  v4 and atomic classes from StyleX override it without specificity tricks.
+  Tailwind v3 treats `@layer components` as its own directive, so import the
+  Tailwind 3 build from your Tailwind entry instead, between the `components`
+  and `utilities` directives:
 </section>
 
 <section id="tokens-intro">
-Colors, radii, shadows, typography, and motion come from `--c15t-*` custom
-properties. Set them on the provider through `theme`, or override the
-variables directly in your CSS.
+  Colors, radii, shadows, typography, and motion come from `--c15t-*` custom
+  properties. Set them on the provider through `theme`, or override the
+  variables directly in your CSS.
 </section>
 
 <section id="token-roles">
-`consentActions` decides how each action role looks: `default` applies to
-every button, `primary` to whichever actions the policy or your props mark
-primary, and `accept`, `reject`, `customize`, and `dismiss` to one role each.
-Per-action keys win over `primary`, which wins over `default`.
+  `consentActions` decides how each action role looks: `default` applies to
+  every button, `primary` to whichever actions the policy or your props mark
+  primary, and `accept`, `reject`, `customize`, and `dismiss` to one role each.
+  Per-action keys win over `primary`, which wins over `default`.
 
-Banner sizing has its own variables. Override them in CSS when a variant
-needs a different footprint:
+  Banner sizing has its own variables. Override them in CSS when a variant
+  needs a different footprint:
 
-| Variable | Default | Applies to |
-| --- | --- | --- |
-| `--consent-banner-max-width` | `440px` | `floating` cards |
-| `--consent-banner-widget-max-width` | `20rem` | `widget` chips |
-| `--consent-banner-wall-max-width` | `30rem` | `wall` cards |
+  | Variable | Default | Applies to |
+  | --- | --- | --- |
+  | `--consent-banner-max-width` | `440px` | `floating` cards |
+  | `--consent-banner-widget-max-width` | `20rem` | `widget` chips |
+  | `--consent-banner-wall-max-width` | `30rem` | `wall` cards |
 
-## Colors by consent model
+  ## Colors by consent model
 
-The primary action can change while the brand color stays the same. Set
-`consentActions.primary` once, then select `primaryButton` per policy as
-shown in [ConsentBanner](../components/consent-banner#per-policy-buttons).
+  The primary action can change while the brand color stays the same. Set
+  `consentActions.primary` once, then select `primaryButton` per policy as
+  shown in [ConsentBanner](../components/consent-banner#per-policy-buttons).
 
-To give opt-in and opt-out banners different colors, scope the tokens to
-the root's attributes. Include hover and foreground colors when overriding
-CSS tokens directly:
+  To give opt-in and opt-out banners different colors, scope the tokens to
+  the root's attributes. Include hover and foreground colors when overriding
+  CSS tokens directly:
 
-```css
-[data-prompt][data-model='opt-in'] {
-	--c15t-primary: #2f6f4e;
-	--c15t-primary-hover: #24563c;
-	--c15t-text-on-primary: #fff;
-}
+  ```css
+  [data-prompt][data-model='opt-in'] {
+  	--c15t-primary: #2f6f4e;
+  	--c15t-primary-hover: #24563c;
+  	--c15t-text-on-primary: #fff;
+  }
 
-[data-prompt][data-model='opt-out'] {
-	--c15t-primary: #6b3fa0;
-	--c15t-primary-hover: #55327f;
-	--c15t-text-on-primary: #fff;
-}
-```
+  [data-prompt][data-model='opt-out'] {
+  	--c15t-primary: #6b3fa0;
+  	--c15t-primary-hover: #55327f;
+  	--c15t-text-on-primary: #fff;
+  }
+  ```
 
-These colors apply to the action marked primary. Button layout and color
-changes do not change the policy or expire a saved choice.
+  These colors apply to the action marked primary. Button layout and color
+  changes do not change the policy or expire a saved choice.
 
-## Slots
+  ## Slots
 
-Each component part is a slot. A slot accepts any attributes the element
-takes, so the contract is the same whether you write class strings or pass an
-object with `className` and `style`. Set slots on the provider under
-`components`, keyed by component and part.
+  Each component part is a slot. A slot accepts any attributes the element
+  takes, so the contract is the same whether you write class strings or pass an
+  object with `className` and `style`. Set slots on the provider under
+  `components`, keyed by component and part.
 </section>
 
 <section id="slot-recipes">
-The root also carries `data-variant`, so you can restyle one shape without
-touching the others. Tailwind, giving a `bar` a brand-colored top edge and
-tighter text:
+  The root also carries `data-variant`, so you can restyle one shape without
+  touching the others. Tailwind, giving a `bar` a brand-colored top edge and
+  tighter text:
 
-```tsx
-<ConsentProvider
-	options={{
-		mode,
-		presentation: { prompt: { variant: 'bar' } },
-		components: {
-			banner: {
-				root: { className: 'group' },
-				card: {
-					className:
-						'group-data-[variant=bar]:border-t-4 group-data-[variant=bar]:border-t-emerald-600',
-				},
-			},
-			description: {
-				banner: { className: 'group-data-[variant=bar]:text-xs' },
-			},
-		},
-	}}
-/>
-```
+  ```tsx
+  <ConsentProvider
+  	options={{
+  		mode,
+  		presentation: { prompt: { variant: 'bar' } },
+  		components: {
+  			banner: {
+  				root: { className: 'group' },
+  				card: {
+  					className:
+  						'group-data-[variant=bar]:border-t-4 group-data-[variant=bar]:border-t-emerald-600',
+  				},
+  			},
+  			description: {
+  				banner: { className: 'group-data-[variant=bar]:text-xs' },
+  			},
+  		},
+  	}}
+  />
+  ```
 
-`data-variant` sits on the root, so child slots use Tailwind's `group`
-prefix to read it.
+  `data-variant` sits on the root, so child slots use Tailwind's `group`
+  prefix to read it.
 
-StyleX, spreading the result of `stylex.props()` into a slot:
+  StyleX, spreading the result of `stylex.props()` into a slot:
 
-```tsx
-import * as stylex from '@stylexjs/stylex';
+  ```tsx
+  import * as stylex from '@stylexjs/stylex';
 
-const styles = stylex.create({
-	card: { borderRadius: 0, boxShadow: 'none' },
-	rightLink: { textUnderlineOffset: 4, color: 'rgb(185 28 28)' },
-});
+  const styles = stylex.create({
+  	card: { borderRadius: 0, boxShadow: 'none' },
+  	rightLink: { textUnderlineOffset: 4, color: 'rgb(185 28 28)' },
+  });
 
-<ConsentProvider
-	options={{
-		mode,
-		components: {
-			banner: {
-				card: stylex.props(styles.card),
-				rightLink: stylex.props(styles.rightLink),
-			},
-		},
-	}}
-/>;
-```
+  <ConsentProvider
+  	options={{
+  		mode,
+  		components: {
+  			banner: {
+  				card: stylex.props(styles.card),
+  				rightLink: stylex.props(styles.rightLink),
+  			},
+  		},
+  	}}
+  />;
+  ```
 
-Set `noStyle` on a component to drop the built-in classes from every part and
-keep only what your slots pass. Set `noStyle` in the provider options to do it
-for every component.
+  Set `noStyle` on a component to drop the built-in classes from every part and
+  keep only what your slots pass. Set `noStyle` in the provider options to do it
+  for every component.
 
-Banner slot keys under `components.banner`:
+  Banner slot keys under `components.banner`:
 
-| Key | Element |
-| --- | --- |
-| `root` | Fixed-position wrapper carrying `data-prompt`, `data-model`, `data-variant`, `data-position`, and `data-blocking` |
-| `cardShell` | Sizes the card and holds the branding tag |
-| `card` | The visible card, carrying `data-state` |
-| `header` | Title and description container |
-| `title` | Heading |
-| `footer` | Action area |
-| `actions` | Group of action groups |
-| `actionGroup` | One group of equally prominent actions |
-| `rights` | Group of right links, rendered before the actions |
-| `rightLink` | One right link, carrying `data-action="right"` and `data-right` |
-| `overlay` | Backdrop shown when the banner blocks the page |
+  | Key | Element |
+  | --- | --- |
+  | `root` | Fixed-position wrapper carrying `data-prompt`, `data-model`, `data-variant`, `data-position`, and `data-blocking` |
+  | `cardShell` | Sizes the card and holds the branding tag |
+  | `card` | The visible card, carrying `data-state` |
+  | `header` | Title and description container |
+  | `title` | Heading |
+  | `footer` | Action area |
+  | `actions` | Group of action groups |
+  | `actionGroup` | One group of equally prominent actions |
+  | `rights` | Group of right links, rendered before the actions |
+  | `rightLink` | One right link, carrying `data-action="right"` and `data-right` |
+  | `overlay` | Backdrop shown when the banner blocks the page |
 
-Action buttons carry `data-action` and `data-variant`, and right links carry
-`data-action="right"`, so a single rule such as `[data-action='dismiss']` or
-`[data-action='right']` styles one role across every surface. Right links are
-underlined text by default, so the only button on a notice is the primary
-action.
+  Action buttons carry `data-action` and `data-variant`, and right links carry
+  `data-action="right"`, so a single rule such as `[data-action='dismiss']` or
+  `[data-action='right']` styles one role across every surface. Right links are
+  underlined text by default, so the only button on a notice is the primary
+  action.
 </section>

--- a/docs/shared/react/styling/overview.mdx
+++ b/docs/shared/react/styling/overview.mdx
@@ -1,0 +1,150 @@
+---
+title: "Styling"
+description: "Shared token, slot and class-name styling guidance for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="tailwind-layers">
+Every rule lives in `@layer components`, so unlayered utilities from Tailwind
+v4 and atomic classes from StyleX override it without specificity tricks.
+Tailwind v3 treats `@layer components` as its own directive, so import the
+Tailwind 3 build from your Tailwind entry instead, between the `components`
+and `utilities` directives:
+</section>
+
+<section id="tokens-intro">
+Colors, radii, shadows, typography, and motion come from `--c15t-*` custom
+properties. Set them on the provider through `theme`, or override the
+variables directly in your CSS.
+</section>
+
+<section id="token-roles">
+`consentActions` decides how each action role looks: `default` applies to
+every button, `primary` to whichever actions the policy or your props mark
+primary, and `accept`, `reject`, `customize`, and `dismiss` to one role each.
+Per-action keys win over `primary`, which wins over `default`.
+
+Banner sizing has its own variables. Override them in CSS when a variant
+needs a different footprint:
+
+| Variable | Default | Applies to |
+| --- | --- | --- |
+| `--consent-banner-max-width` | `440px` | `floating` cards |
+| `--consent-banner-widget-max-width` | `20rem` | `widget` chips |
+| `--consent-banner-wall-max-width` | `30rem` | `wall` cards |
+
+## Colors by consent model
+
+The primary action can change while the brand color stays the same. Set
+`consentActions.primary` once, then select `primaryButton` per policy as
+shown in [ConsentBanner](../components/consent-banner#per-policy-buttons).
+
+To give opt-in and opt-out banners different colors, scope the tokens to
+the root's attributes. Include hover and foreground colors when overriding
+CSS tokens directly:
+
+```css
+[data-prompt][data-model='opt-in'] {
+	--c15t-primary: #2f6f4e;
+	--c15t-primary-hover: #24563c;
+	--c15t-text-on-primary: #fff;
+}
+
+[data-prompt][data-model='opt-out'] {
+	--c15t-primary: #6b3fa0;
+	--c15t-primary-hover: #55327f;
+	--c15t-text-on-primary: #fff;
+}
+```
+
+These colors apply to the action marked primary. Button layout and color
+changes do not change the policy or expire a saved choice.
+
+## Slots
+
+Each component part is a slot. A slot accepts any attributes the element
+takes, so the contract is the same whether you write class strings or pass an
+object with `className` and `style`. Set slots on the provider under
+`components`, keyed by component and part.
+</section>
+
+<section id="slot-recipes">
+The root also carries `data-variant`, so you can restyle one shape without
+touching the others. Tailwind, giving a `bar` a brand-colored top edge and
+tighter text:
+
+```tsx
+<ConsentProvider
+	options={{
+		mode,
+		presentation: { prompt: { variant: 'bar' } },
+		components: {
+			banner: {
+				root: { className: 'group' },
+				card: {
+					className:
+						'group-data-[variant=bar]:border-t-4 group-data-[variant=bar]:border-t-emerald-600',
+				},
+			},
+			description: {
+				banner: { className: 'group-data-[variant=bar]:text-xs' },
+			},
+		},
+	}}
+/>
+```
+
+`data-variant` sits on the root, so child slots use Tailwind's `group`
+prefix to read it.
+
+StyleX, spreading the result of `stylex.props()` into a slot:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+	card: { borderRadius: 0, boxShadow: 'none' },
+	rightLink: { textUnderlineOffset: 4, color: 'rgb(185 28 28)' },
+});
+
+<ConsentProvider
+	options={{
+		mode,
+		components: {
+			banner: {
+				card: stylex.props(styles.card),
+				rightLink: stylex.props(styles.rightLink),
+			},
+		},
+	}}
+/>;
+```
+
+Set `noStyle` on a component to drop the built-in classes from every part and
+keep only what your slots pass. Set `noStyle` in the provider options to do it
+for every component.
+
+Banner slot keys under `components.banner`:
+
+| Key | Element |
+| --- | --- |
+| `root` | Fixed-position wrapper carrying `data-prompt`, `data-model`, `data-variant`, `data-position`, and `data-blocking` |
+| `cardShell` | Sizes the card and holds the branding tag |
+| `card` | The visible card, carrying `data-state` |
+| `header` | Title and description container |
+| `title` | Heading |
+| `footer` | Action area |
+| `actions` | Group of action groups |
+| `actionGroup` | One group of equally prominent actions |
+| `rights` | Group of right links, rendered before the actions |
+| `rightLink` | One right link, carrying `data-action="right"` and `data-right` |
+| `overlay` | Backdrop shown when the banner blocks the page |
+
+Action buttons carry `data-action` and `data-variant`, and right links carry
+`data-action="right"`, so a single rule such as `[data-action='dismiss']` or
+`[data-action='right']` styles one role across every surface. Right links are
+underlined text by default, so the only button on a notice is the primary
+action.
+</section>

--- a/packages/c15t/AGENTS.md
+++ b/packages/c15t/AGENTS.md
@@ -36,23 +36,25 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [Fetching reference](./docs/frameworks/next/api-reference/data-fetching.md): Reference for Next.js consent URLs, manifest resolution, request geography and offline configuration.
 - [App Router](./docs/frameworks/next/app-router.md): Set up App Router with Inth, cached manifests and consent-gated scripts.
 - [Client-side initialization](./docs/frameworks/next/client-side.md): Initialize Next.js consent in the browser with one backend URL, without server prefetch or local API handlers.
-- [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Pre-built consent banner shown when consent is required.
-- [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Floating button and toolbar that reopen the preference center after the first prompt.
+- [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Render the pre-built ConsentBanner inside a Next.js ConsentBoundary and configure its variants, per-policy buttons and compound parts.
+- [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Add the floating ConsentDialogTrigger button or toolbar to a Next.js ConsentBoundary so visitors can reopen the preference center.
 - [ConsentBoundary](./docs/frameworks/next/components/consent-manager-provider.md): Pass server-prefetched consent and shared configuration to the Next.js consent boundary.
-- [DevTools](./docs/frameworks/next/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
+- [DevTools](./docs/frameworks/next/components/dev-tools.md): Load the c15t DevTools panel only in Next.js development builds to inspect consent state, scripts, policy and events inside ConsentBoundary.
 - [Consent categories](./docs/frameworks/next/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/next/concepts/policy-presets.md): Understand how policy rules affect Next.js prompts, permissions and persistent privacy controls.
+- [Content Security Policy](./docs/frameworks/next/content-security-policy.md): Pass a per-request CSP nonce to ConsentBoundary in Next.js and allow the consent backend in connect-src.
 - [Data fetching](./docs/frameworks/next/data-fetching.md): Choose cached manifests for a Next.js server, backend initialization for a simpler setup, or offline mode for local development.
-- [Headless](./docs/frameworks/next/headless.md): Build your own consent UI on top of the c15t hooks.
-- [Hooks](./docs/frameworks/next/hooks/use-consent-manager/overview.md): Choose focused consent hooks for feature gates, explicit choices and preference actions.
-- [IAB TCF](./docs/frameworks/next/iab/overview.md): Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+- [Forward geography headers](./docs/frameworks/next/geography-headers.md): Use c15tProxy in Next.js proxy.ts or middleware.ts so Server Components and Route Handlers receive the visitor's country and region.
+- [Headless](./docs/frameworks/next/headless.md): Build a custom consent banner in Next.js with the c15t/next/headless hooks inside your existing ConsentBoundary.
+- [Hooks](./docs/frameworks/next/hooks/use-consent-manager/overview.md): Gate features and save consent choices in Next.js Client Components with the focused hooks exported from c15t/next.
+- [IAB TCF](./docs/frameworks/next/iab/overview.md): Mount the IAB TCF banner and dialog inside a Next.js ConsentBoundary and configure the CMP ID, policy and vendor data.
 - [Optimization](./docs/frameworks/next/optimization.md): Reuse cached policy data and optionally reduce browser connection overhead without changing consent behavior.
 - [Pages Router](./docs/frameworks/next/pages-router.md): Set up Pages Router with Inth, cached manifests and consent-gated scripts.
-- [Quickstart](./docs/frameworks/next/quickstart.md): Add c15t to Next.js with Inth. Choose your router or static export below.
+- [Quickstart](./docs/frameworks/next/quickstart.md): Add c15t consent management to Next.js with Inth, with setup guides for the App Router, the Pages Router and static export.
 - [Load scripts with consent](./docs/frameworks/next/script-loader.md): Register vendor scripts in your existing Next.js consent boundary and handle loading and revocation.
 - [Server rendering and hydration](./docs/frameworks/next/server-side.md): Resolve consent on the server, choose what waits for the result, and preserve the same state through hydration.
 - [Static export](./docs/frameworks/next/static-export.md): Add c15t to output export without request helpers or a local API server.
-- [Styling](./docs/frameworks/next/styling/overview.md): Theme c15t components with tokens, slots, and class names.
+- [Styling](./docs/frameworks/next/styling/overview.md): Import the Next.js stylesheet and theme c15t components with tokens, slots, and class names through ConsentBoundary options.
 - [Troubleshoot Next.js consent](./docs/frameworks/next/troubleshooting.md): Diagnose failed Next.js prefetch, verify manifest requests, and fix consent rendering or persistence problems.
 - [Quickstart](./docs/frameworks/nuxt/quickstart.md): Configure the Nuxt module for server rendering, browser initialization or static hosting.
 - [ConsentBanner](./docs/frameworks/react/components/consent-banner.md): Pre-built consent banner shown when consent is required.
@@ -61,12 +63,12 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [DevTools](./docs/frameworks/react/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
 - [Consent categories](./docs/frameworks/react/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/react/concepts/policy-presets.md): Understand how policy rules affect React prompts, permissions and persistent privacy controls.
-- [Headless](./docs/frameworks/react/headless.md): Build your own consent UI on top of the c15t hooks.
-- [Hooks](./docs/frameworks/react/hooks/use-consent-manager/overview.md): Choose focused consent hooks for feature gates, explicit choices and preference actions.
-- [IAB TCF](./docs/frameworks/react/iab/overview.md): Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+- [Headless](./docs/frameworks/react/headless.md): Build a custom consent banner in React with the c15t/react/headless hooks inside your ConsentProvider.
+- [Hooks](./docs/frameworks/react/hooks/use-consent-manager/overview.md): Gate features and save consent choices in React components with the focused hooks exported from c15t/react.
+- [IAB TCF](./docs/frameworks/react/iab/overview.md): Mount the IAB TCF banner and dialog inside a React ConsentProvider and configure the CMP ID, policy and vendor data.
 - [Quickstart](./docs/frameworks/react/quickstart.md): Connect a React application to Inth and add consent UI, persistence and a preferences link.
 - [Load scripts with consent](./docs/frameworks/react/script-loader.md): Register vendor scripts once and let effective permissions control loading.
-- [Styling](./docs/frameworks/react/styling/overview.md): Theme c15t components with tokens, slots, and class names.
+- [Styling](./docs/frameworks/react/styling/overview.md): Import the React stylesheet and theme c15t components with tokens, slots, and class names on ConsentProvider.
 - [Troubleshoot React consent](./docs/frameworks/react/troubleshooting.md): Diagnose policy resolution, early scripts, storage and rendering problems.
 - [Quickstart](./docs/frameworks/svelte/quickstart.md): Mount c15t components and a persistent preferences link in a Svelte 5 application.
 - [Quickstart](./docs/frameworks/sveltekit/quickstart.md): Resolve consent in a SvelteKit server load and hydrate the provider, or initialize in the browser on static hosting.

--- a/packages/nextjs/AGENTS.md
+++ b/packages/nextjs/AGENTS.md
@@ -27,23 +27,25 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [Fetching reference](./docs/frameworks/next/api-reference/data-fetching.md): Reference for Next.js consent URLs, manifest resolution, request geography and offline configuration.
 - [App Router](./docs/frameworks/next/app-router.md): Set up App Router with Inth, cached manifests and consent-gated scripts.
 - [Client-side initialization](./docs/frameworks/next/client-side.md): Initialize Next.js consent in the browser with one backend URL, without server prefetch or local API handlers.
-- [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Pre-built consent banner shown when consent is required.
-- [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Floating button and toolbar that reopen the preference center after the first prompt.
+- [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Render the pre-built ConsentBanner inside a Next.js ConsentBoundary and configure its variants, per-policy buttons and compound parts.
+- [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Add the floating ConsentDialogTrigger button or toolbar to a Next.js ConsentBoundary so visitors can reopen the preference center.
 - [ConsentBoundary](./docs/frameworks/next/components/consent-manager-provider.md): Pass server-prefetched consent and shared configuration to the Next.js consent boundary.
-- [DevTools](./docs/frameworks/next/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
+- [DevTools](./docs/frameworks/next/components/dev-tools.md): Load the c15t DevTools panel only in Next.js development builds to inspect consent state, scripts, policy and events inside ConsentBoundary.
 - [Consent categories](./docs/frameworks/next/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/next/concepts/policy-presets.md): Understand how policy rules affect Next.js prompts, permissions and persistent privacy controls.
+- [Content Security Policy](./docs/frameworks/next/content-security-policy.md): Pass a per-request CSP nonce to ConsentBoundary in Next.js and allow the consent backend in connect-src.
 - [Data fetching](./docs/frameworks/next/data-fetching.md): Choose cached manifests for a Next.js server, backend initialization for a simpler setup, or offline mode for local development.
-- [Headless](./docs/frameworks/next/headless.md): Build your own consent UI on top of the c15t hooks.
-- [Hooks](./docs/frameworks/next/hooks/use-consent-manager/overview.md): Choose focused consent hooks for feature gates, explicit choices and preference actions.
-- [IAB TCF](./docs/frameworks/next/iab/overview.md): Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+- [Forward geography headers](./docs/frameworks/next/geography-headers.md): Use c15tProxy in Next.js proxy.ts or middleware.ts so Server Components and Route Handlers receive the visitor's country and region.
+- [Headless](./docs/frameworks/next/headless.md): Build a custom consent banner in Next.js with the c15t/next/headless hooks inside your existing ConsentBoundary.
+- [Hooks](./docs/frameworks/next/hooks/use-consent-manager/overview.md): Gate features and save consent choices in Next.js Client Components with the focused hooks exported from c15t/next.
+- [IAB TCF](./docs/frameworks/next/iab/overview.md): Mount the IAB TCF banner and dialog inside a Next.js ConsentBoundary and configure the CMP ID, policy and vendor data.
 - [Optimization](./docs/frameworks/next/optimization.md): Reuse cached policy data and optionally reduce browser connection overhead without changing consent behavior.
 - [Pages Router](./docs/frameworks/next/pages-router.md): Set up Pages Router with Inth, cached manifests and consent-gated scripts.
-- [Quickstart](./docs/frameworks/next/quickstart.md): Add c15t to Next.js with Inth. Choose your router or static export below.
+- [Quickstart](./docs/frameworks/next/quickstart.md): Add c15t consent management to Next.js with Inth, with setup guides for the App Router, the Pages Router and static export.
 - [Load scripts with consent](./docs/frameworks/next/script-loader.md): Register vendor scripts in your existing Next.js consent boundary and handle loading and revocation.
 - [Server rendering and hydration](./docs/frameworks/next/server-side.md): Resolve consent on the server, choose what waits for the result, and preserve the same state through hydration.
 - [Static export](./docs/frameworks/next/static-export.md): Add c15t to output export without request helpers or a local API server.
-- [Styling](./docs/frameworks/next/styling/overview.md): Theme c15t components with tokens, slots, and class names.
+- [Styling](./docs/frameworks/next/styling/overview.md): Import the Next.js stylesheet and theme c15t components with tokens, slots, and class names through ConsentBoundary options.
 - [Troubleshoot Next.js consent](./docs/frameworks/next/troubleshooting.md): Diagnose failed Next.js prefetch, verify manifest requests, and fix consent rendering or persistence problems.
 
 ## Guides

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -27,12 +27,12 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [DevTools](./docs/frameworks/react/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
 - [Consent categories](./docs/frameworks/react/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/react/concepts/policy-presets.md): Understand how policy rules affect React prompts, permissions and persistent privacy controls.
-- [Headless](./docs/frameworks/react/headless.md): Build your own consent UI on top of the c15t hooks.
-- [Hooks](./docs/frameworks/react/hooks/use-consent-manager/overview.md): Choose focused consent hooks for feature gates, explicit choices and preference actions.
-- [IAB TCF](./docs/frameworks/react/iab/overview.md): Configure the IAB provider, policy and vendor data before rendering the TCF interface.
+- [Headless](./docs/frameworks/react/headless.md): Build a custom consent banner in React with the c15t/react/headless hooks inside your ConsentProvider.
+- [Hooks](./docs/frameworks/react/hooks/use-consent-manager/overview.md): Gate features and save consent choices in React components with the focused hooks exported from c15t/react.
+- [IAB TCF](./docs/frameworks/react/iab/overview.md): Mount the IAB TCF banner and dialog inside a React ConsentProvider and configure the CMP ID, policy and vendor data.
 - [Quickstart](./docs/frameworks/react/quickstart.md): Connect a React application to Inth and add consent UI, persistence and a preferences link.
 - [Load scripts with consent](./docs/frameworks/react/script-loader.md): Register vendor scripts once and let effective permissions control loading.
-- [Styling](./docs/frameworks/react/styling/overview.md): Theme c15t components with tokens, slots, and class names.
+- [Styling](./docs/frameworks/react/styling/overview.md): Import the React stylesheet and theme c15t components with tokens, slots, and class names on ConsentProvider.
 - [Troubleshoot React consent](./docs/frameworks/react/troubleshooting.md): Diagnose policy resolution, early scripts, storage and rendering problems.
 
 ## Guides


### PR DESCRIPTION
Stacked on #1094 (4/4).

## Summary
- Next.js pages for headless, hooks overview, IAB overview, styling overview, ConsentBanner and ConsentDialogTrigger were near-verbatim clones of the React pages (0.64–0.97 similarity). Shared prose and tables move to `docs/shared/react/**` fragments (same `<section id>` + `<import src="...#id">` pattern as `dev-tools.mdx`); each framework page keeps a framework-specific opener and code with its own import path.
- Every Next.js page now has a unique meta description (previously 8 identical to React).
- Regenerates the tracked package `AGENTS.md` indexes for the whole stack.

`bun run test:scripts` (docs validation incl. link checks) passes. Docs only, no changeset.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated shared guidance for React and Next.js consent components, headless APIs, hooks, IAB TCF integration, and styling.
  * Updated framework documentation with clearer setup and usage instructions for consent boundaries/providers, client components, stylesheet placement, development tools, and geography or CSP configuration.
  * Expanded reference material for component properties, consent actions, hook selection, styling tokens, slots, and IAB verification.
  * Refreshed documentation indexes with updated descriptions and links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->