### PR TITLE
docs: add ConsentDialog, ConsentWidget, ConsentDialogLink and Frame component pages

### DIFF
--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -107,7 +107,11 @@ export default defineDocsConfig({
 							pages: [
 								'components/consent-manager-provider',
 								'components/consent-banner',
+								'components/consent-dialog',
+								'components/consent-widget',
+								'components/consent-dialog-link',
 								'components/consent-dialog-trigger',
+								'components/frame',
 								'components/dev-tools',
 							],
 							title: 'Components',
@@ -166,7 +170,11 @@ export default defineDocsConfig({
 							pages: [
 								'components/consent-manager-provider',
 								'components/consent-banner',
+								'components/consent-dialog',
+								'components/consent-widget',
+								'components/consent-dialog-link',
 								'components/consent-dialog-trigger',
+								'components/frame',
 								'components/dev-tools',
 							],
 							title: 'Components',

--- a/docs/frameworks/next/components/consent-dialog-link.mdx
+++ b/docs/frameworks/next/components/consent-dialog-link.mdx
@@ -1,0 +1,58 @@
+---
+title: ConsentDialogLink
+description: Open the preference center from a Next.js footer with ConsentDialogLink, a Client Component that renders an unstyled button inside ConsentBoundary.
+group: frameworks
+---
+
+## Reopen the preference center from your footer
+
+`ConsentDialogLink` is an unstyled button that opens the consent dialog.
+Put it where your site already keeps its legal links, so preferences stay
+reachable after the banner closes. It is a Client Component and must render
+inside the `ConsentBoundary` from your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) setup, which also mounts
+the `ConsentDialog` it opens.
+
+```tsx title="components/site-footer.tsx"
+'use client';
+
+import Link from 'next/link';
+import { ConsentDialogLink } from 'c15t/next';
+
+export function SiteFooter() {
+  return (
+    <footer>
+      <nav aria-label="Legal">
+        <Link href="/privacy">Privacy policy</Link>
+        <Link href="/terms">Terms</Link>
+        <ConsentDialogLink className="footer-link">Privacy settings</ConsentDialogLink>
+      </nav>
+    </footer>
+  );
+}
+```
+
+Render `SiteFooter` from the root layout as a child of the `Consent`
+wrapper, in place of the inline footer the router guides show. The layout
+stays a Server Component; only this file needs `'use client'`. The link
+renders a `button`, so the CSS for `.footer-link` should reset button chrome
+if your footer styles target anchors only.
+
+To reuse an existing link component, pass `asChild`:
+
+```tsx
+<ConsentDialogLink asChild>
+  <a href="#cookie-preferences">Manage cookies</a>
+</ConsentDialogLink>
+```
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#props" />
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#behavior" />
+
+`ConsentDialogTrigger` has its own page: [ConsentDialogTrigger](./consent-dialog-trigger).
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#verify" />

--- a/docs/frameworks/next/components/consent-dialog.mdx
+++ b/docs/frameworks/next/components/consent-dialog.mdx
@@ -1,0 +1,94 @@
+---
+title: ConsentDialog
+description: Mount ConsentDialog as a Client Component inside a Next.js ConsentBoundary to open the preference center from the banner, links and triggers.
+group: frameworks
+---
+
+## Open the preference center
+
+`ConsentDialog` is the modal preference center. It is a Client Component, so
+it lives in the `components/consent.tsx` wrapper from the
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) setup, inside the
+`ConsentBoundary` that already provides the consent runtime. Mount it once,
+next to the banner; it opens whenever something makes `dialog` the active
+surface: the banner's Customize button, a `ConsentDialogLink` in your footer,
+a `ConsentDialogTrigger`, or your own code.
+
+```tsx title="components/consent.tsx"
+'use client';
+
+import type { ReactNode } from 'react';
+import {
+  ConsentBanner,
+  ConsentBoundary,
+  ConsentDialog,
+  ConsentDialogLink,
+} from 'c15t/next';
+import type { ConsentBoundaryProps } from 'c15t/next';
+import { consentConfig } from '../c15t.config';
+
+export function Consent({
+  children,
+  config,
+}: {
+  children: ReactNode;
+  config: ConsentBoundaryProps['config'];
+}) {
+  return (
+    <ConsentBoundary config={config} consent={consentConfig}>
+      {children}
+      <ConsentBanner />
+      <ConsentDialog hideBranding legalLinks={['privacyPolicy']} />
+      <footer>
+        <ConsentDialogLink>Privacy settings</ConsentDialogLink>
+      </footer>
+    </ConsentBoundary>
+  );
+}
+```
+
+The root layout renders `Consent` with the `config` from
+`prefetchInitialConsent`, as in the router guides. The dialog itself renders
+nothing on the server: it mounts through a portal after hydration, so the
+server HTML and the streamed shell are unaffected by it, and the banner in
+the first HTML is what a new visitor sees.
+
+To open it from another Client Component inside the boundary, set the active
+surface:
+
+```tsx title="components/privacy-menu-item.tsx"
+'use client';
+
+import { useSetActiveUI } from 'c15t/next';
+
+export function PrivacyMenuItem() {
+  const setActiveUI = useSetActiveUI();
+  return (
+    <button type="button" onClick={() => setActiveUI('dialog')}>
+      Cookie preferences
+    </button>
+  );
+}
+```
+
+`ConsentDialogLink` does the same with the policy's rights exposed for
+styling; see [ConsentDialogLink](./consent-dialog-link). For a floating
+button, see [ConsentDialogTrigger](./consent-dialog-trigger). Under an IAB
+policy, mount `IABConsentDialog` from the [IAB guide](../iab/overview)
+instead; this dialog stays closed for the `iab` model.
+
+<import src="../../../shared/react/components/consent-dialog.mdx#props" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#behavior" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#composition" />
+
+The compound parts import from `c15t/next` as properties of `ConsentDialog`,
+and `ConsentWidget` from the same module. Server Components cannot render
+them: keep the composition in a file with `'use client'`. See
+[Styling](../styling/overview) for slots and tokens.
+
+<import src="../../../shared/react/components/consent-dialog.mdx#verify" />

--- a/docs/frameworks/next/components/consent-dialog.mdx
+++ b/docs/frameworks/next/components/consent-dialog.mdx
@@ -51,10 +51,11 @@ export function Consent({
 The root layout renders `Consent` with the `config` from
 `prefetchInitialConsent`, as in the router guides. The dialog itself renders
 nothing on the server: it mounts through a portal after hydration, so the
-server HTML and the streamed shell are unaffected by it. On routes that await
-`prefetchInitialConsent`, the server-rendered banner is what a new visitor
-sees first; on Pages Router pages without `getServerSideProps`, the banner
-appears after the browser resolves policy.
+server HTML and the streamed shell are unaffected by it. If the visitor owes
+a choice or notice, routes that await `prefetchInitialConsent` can render the
+banner on the server. Pages Router pages without `getServerSideProps` show it
+after browser policy resolution. No banner appears when the policy requires
+no prompt or an existing record already satisfies it.
 
 To open it from another Client Component inside the boundary, set the active
 surface:

--- a/docs/frameworks/next/components/consent-dialog.mdx
+++ b/docs/frameworks/next/components/consent-dialog.mdx
@@ -39,7 +39,7 @@ export function Consent({
     <ConsentBoundary config={config} consent={consentConfig}>
       {children}
       <ConsentBanner />
-      <ConsentDialog hideBranding legalLinks={['privacyPolicy']} />
+      <ConsentDialog hideBranding />
       <footer>
         <ConsentDialogLink>Privacy settings</ConsentDialogLink>
       </footer>
@@ -51,8 +51,10 @@ export function Consent({
 The root layout renders `Consent` with the `config` from
 `prefetchInitialConsent`, as in the router guides. The dialog itself renders
 nothing on the server: it mounts through a portal after hydration, so the
-server HTML and the streamed shell are unaffected by it, and the banner in
-the first HTML is what a new visitor sees.
+server HTML and the streamed shell are unaffected by it. On routes that await
+`prefetchInitialConsent`, the server-rendered banner is what a new visitor
+sees first; on Pages Router pages without `getServerSideProps`, the banner
+appears after the browser resolves policy.
 
 To open it from another Client Component inside the boundary, set the active
 surface:

--- a/docs/frameworks/next/components/consent-widget.mdx
+++ b/docs/frameworks/next/components/consent-widget.mdx
@@ -45,10 +45,12 @@ export function CookiePreferences() {
 ```
 
 The page stays a Server Component; only the widget file needs
-`'use client'`. Because the boundary receives the visitor's prepared state
-from `prefetchInitialConsent`, the widget is part of the server HTML with
-the visitor's recorded choices applied, unlike `ConsentDialog`, which mounts
-after hydration. The widget uses the boundary's policy, translations and
+`'use client'`. On routes where the boundary receives the visitor's prepared
+state from an awaited `prefetchInitialConsent` (the App Router layout, or a
+Pages Router page with `getServerSideProps`), the widget is part of the server
+HTML with the visitor's recorded choices applied, unlike `ConsentDialog`,
+which mounts after hydration. On a static or otherwise non-prefetched route the
+widget renders after the browser resolves policy. The widget uses the boundary's policy, translations and
 transport; it does not need a second provider, and it does not open or close
 the banner or dialog by itself.
 

--- a/docs/frameworks/next/components/consent-widget.mdx
+++ b/docs/frameworks/next/components/consent-widget.mdx
@@ -58,8 +58,8 @@ provider, and it does not open or close the banner or dialog by itself.
 
 <import src="../../../shared/react/components/consent-widget.mdx#behavior" />
 
-`useConsentDraft` and `ConsentDraftProvider` import from `c15t/next` and are
-Client Component hooks.
+The `useConsentDraft` hook and `ConsentDraftProvider` component import from
+`c15t/next`. Use them in Client Components.
 
 <import src="../../../shared/react/components/consent-widget.mdx#accessibility" />
 

--- a/docs/frameworks/next/components/consent-widget.mdx
+++ b/docs/frameworks/next/components/consent-widget.mdx
@@ -1,0 +1,70 @@
+---
+title: ConsentWidget
+description: Render ConsentWidget on a Next.js privacy page inside ConsentBoundary as an inline preference center whose switches are part of the server HTML.
+group: frameworks
+---
+
+## Embed the preference center inline
+
+`ConsentWidget` renders the preference center in the page flow instead of in
+a modal: the category switches and the Reject all, Accept all and Save
+actions, without a title, backdrop or portal. Use it on a privacy or
+settings route where the visitor expects the controls to be part of the
+content. It is a Client Component; render it from any route under the
+layout that mounts the `ConsentBoundary` from your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) setup. Keep
+`ConsentDialog` mounted in that boundary as well so the banner's Customize
+button and preference links still have a dialog to open.
+
+```tsx title="app/privacy/page.tsx"
+import { CookiePreferences } from '../../components/cookie-preferences';
+
+export default function PrivacyPage() {
+  return (
+    <main>
+      <h1>Privacy</h1>
+      <p>Choose which optional categories this site may use.</p>
+      <section aria-labelledby="cookie-preferences">
+        <h2 id="cookie-preferences">Cookie preferences</h2>
+        <CookiePreferences />
+      </section>
+    </main>
+  );
+}
+```
+
+```tsx title="components/cookie-preferences.tsx"
+'use client';
+
+import { ConsentWidget } from 'c15t/next';
+
+export function CookiePreferences() {
+  return <ConsentWidget />;
+}
+```
+
+The page stays a Server Component; only the widget file needs
+`'use client'`. Because the boundary receives the visitor's prepared state
+from `prefetchInitialConsent`, the widget is part of the server HTML with
+the visitor's recorded choices applied, unlike `ConsentDialog`, which mounts
+after hydration. The widget uses the boundary's policy, translations and
+transport; it does not need a second provider, and it does not open or close
+the banner or dialog by itself.
+
+<import src="../../../shared/react/components/consent-widget.mdx#props" />
+
+<import src="../../../shared/react/components/consent-widget.mdx#behavior" />
+
+`useConsentDraft` and `ConsentDraftProvider` import from `c15t/next` and are
+Client Component hooks.
+
+<import src="../../../shared/react/components/consent-widget.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-widget.mdx#composition" />
+
+The compound parts import from `c15t/next` as properties of `ConsentWidget`.
+Server Components cannot render them: keep the composition in a file with
+`'use client'`. See [Styling](../styling/overview) for slots and tokens.
+
+<import src="../../../shared/react/components/consent-widget.mdx#verify" />

--- a/docs/frameworks/next/components/consent-widget.mdx
+++ b/docs/frameworks/next/components/consent-widget.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConsentWidget
-description: Render ConsentWidget on a Next.js privacy page inside ConsentBoundary as an inline preference center whose switches are part of the server HTML.
+description: Render ConsentWidget on a Next.js privacy page inside ConsentBoundary as an inline preference center, server-rendered when the route prefetches consent.
 group: frameworks
 ---
 
@@ -50,9 +50,9 @@ state from an awaited `prefetchInitialConsent` (the App Router layout, or a
 Pages Router page with `getServerSideProps`), the widget is part of the server
 HTML with the visitor's recorded choices applied, unlike `ConsentDialog`,
 which mounts after hydration. On a static or otherwise non-prefetched route the
-widget renders after the browser resolves policy. The widget uses the boundary's policy, translations and
-transport; it does not need a second provider, and it does not open or close
-the banner or dialog by itself.
+widget renders after the browser resolves policy. The widget uses the
+boundary's policy, translations and transport; it does not need a second
+provider, and it does not open or close the banner or dialog by itself.
 
 <import src="../../../shared/react/components/consent-widget.mdx#props" />
 

--- a/docs/frameworks/next/components/frame.mdx
+++ b/docs/frameworks/next/components/frame.mdx
@@ -43,7 +43,10 @@ does not shift when the placeholder is replaced.
 
 With the awaited `prefetchInitialConsent` from the App Router guide, the
 server decides between placeholder and embed from the resolved rule and the
-request cookie, with no swap after hydration. Under an opt-in rule a new
+request cookie, and hydration keeps that choice as long as the browser's
+privacy signals agree with the request: a `navigator.globalPrivacyControl`
+that the request did not carry as `Sec-GPC` is re-detected on hydration and
+can withdraw a category. Under an opt-in rule a new
 visitor gets the placeholder and a returning visitor who allowed `marketing`
 gets the iframe; under an opt-out rule a new visitor already has effective
 permission, so the iframe renders until they opt out.

--- a/docs/frameworks/next/components/frame.mdx
+++ b/docs/frameworks/next/components/frame.mdx
@@ -43,8 +43,11 @@ does not shift when the placeholder is replaced.
 
 With the awaited `prefetchInitialConsent` from the App Router guide, the
 server decides between placeholder and embed from the resolved rule and the
-request cookie, and hydration keeps that choice as long as the browser's
-privacy signals agree with the request: a `navigator.globalPrivacyControl`
+request cookie. Pages Router works the same way when `getServerSideProps`
+awaits `prefetchInitialConsent` from `c15t/next/pages` and passes the result
+through `config` to `ConsentBoundary`, as in the
+[Pages Router guide](../pages-router). Hydration keeps that choice as long as
+the browser's privacy signals agree with the request: a `navigator.globalPrivacyControl`
 that the request did not carry as `Sec-GPC` is re-detected on hydration and
 can withdraw a category. Under an opt-in rule a new
 visitor gets the placeholder and a returning visitor who allowed `marketing`

--- a/docs/frameworks/next/components/frame.mdx
+++ b/docs/frameworks/next/components/frame.mdx
@@ -1,0 +1,61 @@
+---
+title: Frame
+description: Consent-gate an iframe in Next.js with Frame inside ConsentBoundary, so the first HTML holds the placeholder or the embed and hydrates without a flash.
+group: frameworks
+---
+
+## Gate an embed behind consent
+
+`Frame` mounts its children only while the effective permission for one
+consent category is granted, and shows a placeholder otherwise. Wrap any
+iframe or third-party widget that would set cookies or contact a vendor on
+load. It is a Client Component; render it from any route under the layout
+that mounts the `ConsentBoundary` from your
+[App Router](/docs/frameworks/next/app-router) or
+[Pages Router](/docs/frameworks/next/pages-router) setup, which also mounts
+the `ConsentDialog` the placeholder button opens.
+
+```tsx title="components/product-video.tsx"
+'use client';
+
+import { Frame } from 'c15t/next';
+
+export function ProductVideo() {
+  return (
+    <Frame category="marketing" className="video-frame">
+      <iframe
+        src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+        title="Product tour"
+        loading="lazy"
+        allowFullScreen
+        style={{ width: '100%', aspectRatio: '16 / 9', border: 0 }}
+      />
+    </Frame>
+  );
+}
+```
+
+Import `ProductVideo` into any page or Server Component; only this file needs
+`'use client'`. `marketing` must be a category in your policy; the
+placeholder names it using the category title from your translations. Set
+`className` or `style` on `Frame` to reserve the embed's space, so the page
+does not shift when the placeholder is replaced.
+
+With the awaited `prefetchInitialConsent` from the App Router guide, the
+server decides between placeholder and embed from the request cookie, so a
+returning visitor who allowed `marketing` gets the iframe in the first HTML
+and a new visitor gets the placeholder, with no swap after hydration.
+
+<import src="../../../shared/react/components/frame.mdx#props" />
+
+<import src="../../../shared/react/components/frame.mdx#behavior" />
+
+To read the same permission in your own Client Components, use `useConsent`
+from `c15t/next`; the `useIframeBlocker` and `useNetworkBlocker` module
+hooks also import from there.
+
+<import src="../../../shared/react/components/frame.mdx#composition" />
+
+<import src="../../../shared/react/components/frame.mdx#accessibility" />
+
+<import src="../../../shared/react/components/frame.mdx#verify" />

--- a/docs/frameworks/next/components/frame.mdx
+++ b/docs/frameworks/next/components/frame.mdx
@@ -1,6 +1,6 @@
 ---
 title: Frame
-description: Consent-gate an iframe in Next.js with Frame inside ConsentBoundary, so the first HTML holds the placeholder or the embed and hydrates without a flash.
+description: Consent-gate an iframe in Next.js with Frame inside ConsentBoundary; with server prefetch the placeholder or embed is decided in the server HTML.
 group: frameworks
 ---
 
@@ -42,9 +42,11 @@ placeholder names it using the category title from your translations. Set
 does not shift when the placeholder is replaced.
 
 With the awaited `prefetchInitialConsent` from the App Router guide, the
-server decides between placeholder and embed from the request cookie, so a
-returning visitor who allowed `marketing` gets the iframe in the first HTML
-and a new visitor gets the placeholder, with no swap after hydration.
+server decides between placeholder and embed from the resolved rule and the
+request cookie, with no swap after hydration. Under an opt-in rule a new
+visitor gets the placeholder and a returning visitor who allowed `marketing`
+gets the iframe; under an opt-out rule a new visitor already has effective
+permission, so the iframe renders until they opt out.
 
 <import src="../../../shared/react/components/frame.mdx#props" />
 

--- a/docs/frameworks/next/components/frame.mdx
+++ b/docs/frameworks/next/components/frame.mdx
@@ -36,8 +36,12 @@ export function ProductVideo() {
 ```
 
 Import `ProductVideo` into any page or Server Component; only this file needs
-`'use client'`. `marketing` must be a category in your policy; the
-placeholder names it using the category title from your translations. Set
+`'use client'`. `marketing` must be in your policy scope. If you set a
+non-empty `options.consentCategories` list on `ConsentBoundary`, include
+`marketing` there too so the preference center can display and save it.
+`Frame` does not add categories to that list.
+
+The placeholder names the category using its title from your translations. Set
 `className` or `style` on `Frame` to reserve the embed's space, so the page
 does not shift when the placeholder is replaced.
 

--- a/docs/frameworks/react/components/consent-dialog-link.mdx
+++ b/docs/frameworks/react/components/consent-dialog-link.mdx
@@ -1,0 +1,51 @@
+---
+title: ConsentDialogLink
+description: Add a ConsentDialogLink to a React footer so visitors reopen the c15t preference center from your own text link, with asChild and rights data.
+group: frameworks
+---
+
+## Reopen the preference center from your footer
+
+`ConsentDialogLink` is an unstyled button that opens the consent dialog.
+Put it where your site already keeps its legal links, so preferences stay
+reachable after the banner closes. It needs a mounted `ConsentDialog` in the
+same `ConsentProvider`; the [quickstart](../quickstart) mounts both.
+
+```tsx title="src/site-footer.tsx"
+import { ConsentDialogLink } from 'c15t/react';
+
+export function SiteFooter() {
+  return (
+    <footer>
+      <nav aria-label="Legal">
+        <a href="/privacy">Privacy policy</a>
+        <a href="/terms">Terms</a>
+        <ConsentDialogLink className="footer-link">Privacy settings</ConsentDialogLink>
+      </nav>
+    </footer>
+  );
+}
+```
+
+Render `SiteFooter` inside the `Consent` wrapper from your quickstart so the
+link can reach the provider. It renders a `button`, so the CSS for
+`.footer-link` should reset button chrome if your footer styles target
+anchors only.
+
+To reuse an existing link component, pass `asChild`:
+
+```tsx
+<ConsentDialogLink asChild>
+  <a href="#cookie-preferences">Manage cookies</a>
+</ConsentDialogLink>
+```
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#props" />
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#behavior" />
+
+`ConsentDialogTrigger` has its own page: [ConsentDialogTrigger](./consent-dialog-trigger).
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-dialog-link.mdx#verify" />

--- a/docs/frameworks/react/components/consent-dialog.mdx
+++ b/docs/frameworks/react/components/consent-dialog.mdx
@@ -1,0 +1,77 @@
+---
+title: ConsentDialog
+description: Open the c15t preference center as a modal ConsentDialog in a React app, wire its triggers and control blocking, focus and policy gating.
+group: frameworks
+---
+
+## Open the preference center
+
+`ConsentDialog` is the modal preference center. Mount it once inside
+`ConsentProvider`, next to the banner, and it opens whenever something makes
+`dialog` the active surface: the banner's Customize button, a
+`ConsentDialogLink` in your footer, a `ConsentDialogTrigger`, or your own
+code.
+
+```tsx title="src/consent.tsx"
+import type { ReactNode } from 'react';
+import {
+  ConsentBanner,
+  ConsentDialog,
+  ConsentDialogLink,
+  ConsentProvider,
+  hosted,
+} from 'c15t/react';
+import 'c15t/react/styles.css';
+
+const backendURL = import.meta.env.VITE_C15T_BACKEND_URL;
+if (!backendURL) throw new Error('Set VITE_C15T_BACKEND_URL');
+const mode = hosted({ url: backendURL });
+
+export function Consent({ children }: { children: ReactNode }) {
+  return (
+    <ConsentProvider options={{ mode }}>
+      {children}
+      <ConsentBanner />
+      <ConsentDialog hideBranding legalLinks={['privacyPolicy']} />
+      <footer>
+        <ConsentDialogLink>Privacy settings</ConsentDialogLink>
+      </footer>
+    </ConsentProvider>
+  );
+}
+```
+
+To open it from your own component, set the active surface:
+
+```tsx
+import { useSetActiveUI } from 'c15t/react';
+
+export function PrivacyMenuItem() {
+  const setActiveUI = useSetActiveUI();
+  return (
+    <button type="button" onClick={() => setActiveUI('dialog')}>
+      Cookie preferences
+    </button>
+  );
+}
+```
+
+`ConsentDialogLink` does the same with the policy's rights exposed for
+styling; see [ConsentDialogLink](./consent-dialog-link). For a floating
+button, see [ConsentDialogTrigger](./consent-dialog-trigger). Under an IAB
+policy, mount `IABConsentDialog` from the [IAB guide](../iab/overview)
+instead; this dialog stays closed for the `iab` model.
+
+<import src="../../../shared/react/components/consent-dialog.mdx#props" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#behavior" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-dialog.mdx#composition" />
+
+The compound parts import from `c15t/react` as properties of `ConsentDialog`,
+and `ConsentWidget` from the same module. See
+[Styling](../styling/overview) for slots and tokens.
+
+<import src="../../../shared/react/components/consent-dialog.mdx#verify" />

--- a/docs/frameworks/react/components/consent-dialog.mdx
+++ b/docs/frameworks/react/components/consent-dialog.mdx
@@ -32,7 +32,7 @@ export function Consent({ children }: { children: ReactNode }) {
     <ConsentProvider options={{ mode }}>
       {children}
       <ConsentBanner />
-      <ConsentDialog hideBranding legalLinks={['privacyPolicy']} />
+      <ConsentDialog hideBranding />
       <footer>
         <ConsentDialogLink>Privacy settings</ConsentDialogLink>
       </footer>

--- a/docs/frameworks/react/components/consent-widget.mdx
+++ b/docs/frameworks/react/components/consent-widget.mdx
@@ -1,0 +1,51 @@
+---
+title: ConsentWidget
+description: Embed the c15t preference center inline with ConsentWidget on a React privacy page, with draft toggles that record a choice only on Save.
+group: frameworks
+---
+
+## Embed the preference center inline
+
+`ConsentWidget` renders the preference center in the page flow instead of in
+a modal: the category switches and the Reject all, Accept all and Save
+actions, without a title, backdrop or portal. Use it on a privacy or
+settings page where the visitor expects the controls to be part of the
+content. Render it anywhere inside the `ConsentProvider` from your
+[quickstart](../quickstart); keep `ConsentDialog` mounted as well so the
+banner's Customize button and preference links still have a dialog to open.
+
+```tsx title="src/pages/privacy.tsx"
+import { ConsentWidget } from 'c15t/react';
+
+export function PrivacyPage() {
+  return (
+    <main>
+      <h1>Privacy</h1>
+      <p>Choose which optional categories this site may use.</p>
+      <section aria-labelledby="cookie-preferences">
+        <h2 id="cookie-preferences">Cookie preferences</h2>
+        <ConsentWidget />
+      </section>
+    </main>
+  );
+}
+```
+
+The widget uses the provider's policy, translations and transport. It does
+not need a second `ConsentProvider`, and it does not open or close the banner
+or dialog by itself.
+
+<import src="../../../shared/react/components/consent-widget.mdx#props" />
+
+<import src="../../../shared/react/components/consent-widget.mdx#behavior" />
+
+`useConsentDraft` and `ConsentDraftProvider` import from `c15t/react`.
+
+<import src="../../../shared/react/components/consent-widget.mdx#accessibility" />
+
+<import src="../../../shared/react/components/consent-widget.mdx#composition" />
+
+The compound parts import from `c15t/react` as properties of `ConsentWidget`.
+See [Styling](../styling/overview) for slots and tokens.
+
+<import src="../../../shared/react/components/consent-widget.mdx#verify" />

--- a/docs/frameworks/react/components/frame.mdx
+++ b/docs/frameworks/react/components/frame.mdx
@@ -1,0 +1,51 @@
+---
+title: Frame
+description: Gate a YouTube or map iframe behind consent with Frame in React, showing a placeholder that opens the preference center until the category is allowed.
+group: frameworks
+---
+
+## Gate an embed behind consent
+
+`Frame` mounts its children only while the effective permission for one
+consent category is granted, and shows a placeholder otherwise. Wrap any
+iframe or third-party widget that would set cookies or contact a vendor on
+load. Render it anywhere inside the `ConsentProvider` from your
+[quickstart](../quickstart), which also mounts the `ConsentDialog` the
+placeholder button opens.
+
+```tsx title="src/product-video.tsx"
+import { Frame } from 'c15t/react';
+
+export function ProductVideo() {
+  return (
+    <Frame category="marketing" className="video-frame">
+      <iframe
+        src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"
+        title="Product tour"
+        loading="lazy"
+        allowFullScreen
+        style={{ width: '100%', aspectRatio: '16 / 9', border: 0 }}
+      />
+    </Frame>
+  );
+}
+```
+
+`marketing` must be a category in your policy; the placeholder names it
+using the category title from your translations. Set `className` or `style`
+on `Frame` to reserve the embed's space, so the page does not shift when the
+placeholder is replaced.
+
+<import src="../../../shared/react/components/frame.mdx#props" />
+
+<import src="../../../shared/react/components/frame.mdx#behavior" />
+
+To read the same permission in your own components, use `useConsent` from
+`c15t/react`; the `useIframeBlocker` and `useNetworkBlocker` module hooks
+also import from there.
+
+<import src="../../../shared/react/components/frame.mdx#composition" />
+
+<import src="../../../shared/react/components/frame.mdx#accessibility" />
+
+<import src="../../../shared/react/components/frame.mdx#verify" />

--- a/docs/frameworks/react/components/frame.mdx
+++ b/docs/frameworks/react/components/frame.mdx
@@ -31,8 +31,12 @@ export function ProductVideo() {
 }
 ```
 
-`marketing` must be a category in your policy; the placeholder names it
-using the category title from your translations. Set `className` or `style`
+`marketing` must be in your policy scope. If you set a non-empty
+`options.consentCategories` list on `ConsentProvider`, include `marketing`
+there too so the preference center can display and save it. `Frame` does
+not add categories to that list.
+
+The placeholder names the category using its title from your translations. Set `className` or `style`
 on `Frame` to reserve the embed's space, so the page does not shift when the
 placeholder is replaced.
 

--- a/docs/shared/react/components/consent-dialog-link.mdx
+++ b/docs/shared/react/components/consent-dialog-link.mdx
@@ -13,7 +13,7 @@ group: reference
   | --- | --- | --- | --- |
   | `children` | `ReactNode` | required | The visible label, such as "Privacy settings" or "Manage preferences". It is also the accessible name. |
   | `asChild` | `boolean` | `false` | Renders your own element, such as an anchor, instead of a `button`, and attaches the click handler to it. |
-  | `noStyle` | `boolean` | `true` | The link ships unstyled so it inherits your footer's text styles. Pass `false` to render it as a consent button with `variant` and `mode`. |
+  | `noStyle` | `boolean` | `true` | Omits c15t button classes. Native browser styles remain unless your CSS resets them. Pass `false` to render it as a consent button with `variant` and `mode`. |
   | `onClick` | `(event) => void` | none | Runs before the dialog opens. Call `event.preventDefault()` to keep it closed. |
 
   Other `button` attributes such as `className`, `style`, `id` and `aria-*`
@@ -23,8 +23,8 @@ group: reference
 <section id="behavior">
   ## Behavior
 
-  `ConsentDialogLink` renders a `button` with `type="button"` and no built-in
-  styling. Clicking it makes `dialog` the active surface, which opens a
+  `ConsentDialogLink` renders a `button` with `type="button"` and no c15t
+  styling by default. Clicking it makes `dialog` the active surface, which opens a
   mounted `ConsentDialog`. It performs no save and does not change any
   permission.
 
@@ -75,8 +75,8 @@ group: reference
 <section id="verify">
   ## Verify
 
-  Scroll to the footer. The link renders with your footer's text styles and
-  no button chrome. Activate it with a click or with Enter: the preference
+  Scroll to the footer. With the footer button reset applied, the link uses
+  your footer's text styles and has no button chrome. Activate it with a click or with Enter: the preference
   center opens as a centered dialog. Close it with Escape: with the default
   blocking dialog, focus returns to the link. In your browser's element
   inspector the link has

--- a/docs/shared/react/components/consent-dialog-link.mdx
+++ b/docs/shared/react/components/consent-dialog-link.mdx
@@ -1,0 +1,82 @@
+---
+title: "ConsentDialogLink"
+description: "Shared ConsentDialogLink reference for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+  ## Props
+
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `children` | `ReactNode` | required | The visible label, such as "Privacy settings" or "Manage preferences". It is also the accessible name. |
+  | `asChild` | `boolean` | `false` | Renders your own element, such as an anchor, instead of a `button`, and attaches the click handler to it. |
+  | `noStyle` | `boolean` | `true` | The link ships unstyled so it inherits your footer's text styles. Pass `false` to render it as a consent button with `variant` and `mode`. |
+  | `onClick` | `(event) => void` | none | Runs before the dialog opens. Call `event.preventDefault()` to keep it closed. |
+
+  Other `button` attributes such as `className`, `style`, `id` and `aria-*`
+  pass through to the rendered element.
+</section>
+
+<section id="behavior">
+  ## Behavior
+
+  `ConsentDialogLink` renders a `button` with `type="button"` and no built-in
+  styling. Clicking it makes `dialog` the active surface, which opens a
+  mounted `ConsentDialog`. It performs no save and does not change any
+  permission.
+
+  The element carries `data-c15t-rights` listing the rights of the active
+  policy rule, for example `disclosure opt-out preferences` under a US
+  opt-out rule and `disclosure preferences` under an opt-in rule, so a
+  stylesheet or a `::after` label can adapt the wording by region.
+
+  Without a resolved policy rule the link renders nothing and appears as soon
+  as a rule resolves, without a remount. A rule with `model: 'none'` owes no
+  rights, so the link hides under it unless the rule lists
+  `rights: ['preferences']`.
+
+  Mount exactly one `ConsentDialog` inside the same provider. If none is
+  mounted, the click still switches the active surface: nothing opens, and a
+  banner that was showing closes because the surface is no longer `banner`.
+
+  With `asChild`, the child's own `onClick` runs first; if it calls
+  `event.preventDefault()` the dialog stays closed. c15t does not prevent the
+  child's native behavior, so an anchor still follows its `href`. Use a
+  fragment or the current page as the destination, or render a `button`.
+
+  ### ConsentDialogLink or ConsentDialogTrigger
+
+  Both open the same dialog and carry `data-c15t-rights`. Use
+  `ConsentDialogLink` where the control belongs in your own layout: a footer,
+  a privacy page, a settings menu. It has no position, icon or visibility
+  rule of its own. Use `ConsentDialogTrigger` when you want a floating,
+  draggable button that positions itself in a corner and can wait until the
+  prompt is answered.
+</section>
+
+<section id="accessibility">
+  ## Accessibility
+
+  The rendered `button` is keyboard-focusable and activates with Enter and
+  Space; its accessible name is the text you pass as `children`, so give it
+  words that describe the destination rather than "click here". Because the
+  dialog it opens is labelled by its own title and returns focus on close, no
+  additional `aria-haspopup` or `aria-controls` is added. With `asChild`,
+  focusability comes from your element: use a `button` or an anchor with an
+  `href`.
+</section>
+
+<section id="verify">
+  ## Verify
+
+  Scroll to the footer. The link renders with your footer's text styles and
+  no button chrome. Activate it with a click or with Enter: the preference
+  center opens as a centered dialog. Close it with Escape: focus returns to
+  the link. In your browser's element inspector the link has
+  `data-c15t-rights`; change the visitor's region to a US opt-out rule and
+  the value includes `opt-out`. Under a rule with `model: 'none'` and no
+  rights, the link is absent.
+</section>

--- a/docs/shared/react/components/consent-dialog-link.mdx
+++ b/docs/shared/react/components/consent-dialog-link.mdx
@@ -64,8 +64,10 @@ group: reference
   The rendered `button` is keyboard-focusable and activates with Enter and
   Space; its accessible name is the text you pass as `children`, so give it
   words that describe the destination rather than "click here". Because the
-  dialog it opens is labelled by its own title and returns focus on close, no
-  additional `aria-haspopup` or `aria-controls` is added. With `asChild`,
+  dialog it opens is labelled by its own title and, while blocking, returns
+  focus to the link on close, no additional `aria-haspopup` or
+  `aria-controls` is added; a non-blocking dialog manages no focus, so the
+  link does not regain it. With `asChild`,
   focusability comes from your element: use a `button` or an anchor with an
   `href`.
 </section>
@@ -75,8 +77,9 @@ group: reference
 
   Scroll to the footer. The link renders with your footer's text styles and
   no button chrome. Activate it with a click or with Enter: the preference
-  center opens as a centered dialog. Close it with Escape: focus returns to
-  the link. In your browser's element inspector the link has
+  center opens as a centered dialog. Close it with Escape: with the default
+  blocking dialog, focus returns to the link. In your browser's element
+  inspector the link has
   `data-c15t-rights`; change the visitor's region to a US opt-out rule and
   the value includes `opt-out`. Under a rule with `model: 'none'` and no
   rights, the link is absent.

--- a/docs/shared/react/components/consent-dialog-link.mdx
+++ b/docs/shared/react/components/consent-dialog-link.mdx
@@ -34,9 +34,10 @@ group: reference
   stylesheet or a `::after` label can adapt the wording by region.
 
   Without a resolved policy rule the link renders nothing and appears as soon
-  as a rule resolves, without a remount. A rule with `model: 'none'` owes no
-  rights, so the link hides under it unless the rule lists
-  `rights: ['preferences']`.
+  as a rule resolves, without a remount. A rule with `model: 'none'` and an
+  empty `rights` list owes no consent UI, so the link hides under it; a `none`
+  rule that lists any right, such as `['disclosure']`, shows the link and the
+  dialog opens as a settings route.
 
   Mount exactly one `ConsentDialog` inside the same provider. If none is
   mounted, the click still switches the active surface: nothing opens, and a

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -83,11 +83,13 @@ group: reference
   and `aria-describedby="consent-dialog-description"`, plus `aria-modal="true"`
   while it is blocking. Its `dir` attribute follows the active language.
 
-  On open, focus moves to the panel itself rather than to a button, so a
-  screen reader announces the title and description first; Tab then enters
-  the legal links and category switches. While blocking, Tab and Shift+Tab
-  wrap inside the panel. On close, focus returns to the element that opened
-  the dialog. The backdrop is `aria-hidden` and is not focusable.
+  While blocking, focus moves on open to the panel itself rather than to a
+  button, so a screen reader announces the title and description first; Tab
+  then enters the legal links and category switches, Tab and Shift+Tab wrap
+  inside the panel, and on close focus returns to the element that opened the
+  dialog. A non-blocking dialog manages no focus: nothing moves focus into the
+  panel or back to the opener. The backdrop is `aria-hidden` and is not
+  focusable.
 
   Each category switch has the category title as its accessible name. The
   `necessary` switch is disabled and always on. A saved grant that the current

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -56,7 +56,7 @@ group: reference
 
   The preference center is blocking by default: a backdrop, body scroll lock
   and focus trap, all as one value. Set `presentation.preferences.blocking:
-    false` in the provider options to remove all three; the deprecated
+        false` in the provider options to remove all three; the deprecated
   `scrollLock` and `trapFocus` props do the same for one dialog. `variant`
   and `position` are prompt options. Setting them under
   `presentation.preferences` logs an `invalid-variant` diagnostic in

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -1,0 +1,144 @@
+---
+title: "ConsentDialog"
+description: "Shared ConsentDialog reference for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+  ## Props
+
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `open` | `boolean` | follows the active surface | Controls the open state. When set, Escape and the dialog's own Save, Accept all and Reject all buttons no longer close it; change the prop instead. A missing policy or an unlisted model still keeps it closed. |
+  | `showTrigger` | `boolean \| ConsentDialogTriggerProps` | `false` | Renders a floating `ConsentDialogTrigger` next to the dialog. Pass an object to configure that trigger. |
+  | `models` | `Model[]` | `['opt-in', 'opt-out', 'none']` | Policy models the dialog responds to. Under a model that is not listed, such as `iab`, it stays closed. |
+  | `legalLinks` | `(keyof LegalLinks)[] \| null` | all configured links | Which legal links from the provider options render after the description. `null` hides them. |
+  | `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag in the card. |
+  | `uiSource` | `string` | `'dialog'` | Source identifier recorded with saves made from this dialog. |
+  | `scrollLock`, `trapFocus` | `boolean` | from `blocking` | Deprecated. Either one set to `false` makes the dialog non-blocking. Prefer `presentation.preferences.blocking` in the provider options. |
+  | `disableAnimation` | `boolean` | `false` | Skips the enter and exit animation of the backdrop and the card. |
+  | `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+</section>
+
+<section id="behavior">
+  ## Behavior
+
+  The dialog is a modal wrapper around the preference center. Its card has a
+  header with the title `consentManagerDialog.title` and the description
+  `consentManagerDialog.description` followed by the legal links, then the
+  same category accordion and Reject all, Accept all and Save actions that
+  `ConsentWidget` renders, then the branding tag. It mounts through a portal
+  into `document.body` after hydration, so it is never part of the server
+  HTML.
+
+  The dialog is open while the active surface is `dialog`. These set it:
+
+  - The Customize button on a `ConsentBanner`, and the "Manage preferences"
+    or "Do not sell or share my data" button a notice renders.
+  - `ConsentDialogLink` and `ConsentDialogTrigger`.
+  - The button in a `Frame` placeholder.
+  - `useSetActiveUI()('dialog')` in your own component, or `openDialog()`
+    from `useHeadlessConsentUI()` on the headless subpath.
+
+  The component code is split into its own chunk. It downloads when the
+  dialog first opens or when a visitor hovers or focuses a Customize button,
+  and renders nothing until that chunk is ready. Passing `open={true}` or
+  `showTrigger` loads it on mount.
+
+  Escape closes the dialog. Save, Accept all and Reject all close it after
+  the save succeeds; a save that fails keeps it open. Clicking the backdrop
+  does not close it. Closing discards toggles that were not saved: the next
+  open starts from the recorded choice again. After a save from the dialog,
+  every consent surface hides unless the policy still owes a prompt, in which
+  case the banner returns.
+
+  The preference center is blocking by default: a backdrop, body scroll lock
+  and focus trap, all as one value. Set `presentation.preferences.blocking:
+    false` in the provider options to remove all three; the deprecated
+  `scrollLock` and `trapFocus` props do the same for one dialog. `variant`
+  and `position` are prompt options. Setting them under
+  `presentation.preferences` logs an `invalid-variant` diagnostic in
+  development and changes nothing; the dialog is always centered.
+
+  The dialog never opens without a resolved policy rule, even when the
+  active surface is already `dialog`; it appears as soon as a rule resolves,
+  without a remount. A rule with `model: 'none'` owes nothing, so the dialog
+  stays closed unless the rule lists `rights: ['preferences']`. Under that
+  rule the dialog opens as a settings route and Save completes without
+  writing a consent record.
+
+  Copy comes from these translation keys: `consentManagerDialog.title`,
+  `consentManagerDialog.description`, `common.acceptAll`, `common.rejectAll`,
+  `common.save`, and `consentTypes.<category>.title` and `.description` for
+  each row.
+</section>
+
+<section id="accessibility">
+  ## Accessibility
+
+  The panel carries `role="dialog"`, `aria-labelledby="consent-dialog-title"`
+  and `aria-describedby="consent-dialog-description"`, plus `aria-modal="true"`
+  while it is blocking. Its `dir` attribute follows the active language.
+
+  On open, focus moves to the panel itself rather than to a button, so a
+  screen reader announces the title and description first; Tab then enters
+  the legal links and category switches. While blocking, Tab and Shift+Tab
+  wrap inside the panel. On close, focus returns to the element that opened
+  the dialog. The backdrop is `aria-hidden` and is not focusable.
+
+  Each category switch has the category title as its accessible name. The
+  `necessary` switch is disabled and always on. A saved grant that the current
+  policy or a privacy signal overrides gets a note under its row, linked to
+  the switch through `aria-describedby`.
+</section>
+
+<section id="composition">
+  ## Composition
+
+  Every part is available as `ConsentDialog.<Part>`: `Root`, `Overlay`,
+  `Card`, `Header`, `HeaderTitle`, `HeaderDescription`, `Content`, `Footer`
+  and `ConsentCustomizationCard`, the stock card. `Root` provides the portal,
+  open state, focus trap, scroll lock and backdrop, and accepts `open`,
+  `models`, `noStyle`, `disableAnimation`, `scrollLock`, `trapFocus`,
+  `uiSource` and `overlay`. Pass `overlay={false}` to render no backdrop, or a
+  node to replace the built-in one.
+
+  ```tsx
+  <ConsentDialog.Root>
+    <ConsentDialog.Card>
+      <ConsentDialog.Header>
+        <ConsentDialog.HeaderTitle>Your privacy choices</ConsentDialog.HeaderTitle>
+        <ConsentDialog.HeaderDescription legalLinks={['privacyPolicy']} />
+      </ConsentDialog.Header>
+      <ConsentDialog.Content>
+        <ConsentWidget />
+      </ConsentDialog.Content>
+      <ConsentDialog.Footer hideBranding />
+    </ConsentDialog.Card>
+  </ConsentDialog.Root>
+  ```
+
+  Keep `ConsentWidget` inside `Content`: it owns the draft, the switches and
+  the policy actions, and inherits the dialog's `uiSource`. `Footer` renders
+  the branding tag unless you pass children or `hideBranding`.
+
+  The positioner carries `data-slot="dialog-positioner"`, and both it and the
+  panel carry `data-blocking="true"` while blocking. Provider component slots
+  for the stock structure are `dialog.root`, `dialog.container`,
+  `dialog.card`, `dialog.header`, `dialog.title`, `dialog.content`,
+  `dialog.overlay`, `description.dialog`, `manager.footer` and `tag.dialog`.
+</section>
+
+<section id="verify">
+  ## Verify
+
+  Open the dialog from the banner's Customize button or a preferences link.
+  A centered card appears over a dimmed backdrop, the page behind it stops
+  scrolling, and Tab stays inside the card. Press Escape: the card closes and
+  focus returns to the button you used. Open it again, turn a category on and
+  choose Save. The dialog closes, the banner does not return, and
+  `useConsent('<category>')` reports `true` in your components. Reload the
+  page and reopen the dialog: the switch reflects the saved choice.
+</section>

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -55,8 +55,8 @@ group: reference
   case the banner returns.
 
   The preference center is blocking by default: a backdrop, body scroll lock
-  and focus trap, all as one value. Set `presentation.preferences.blocking:
-        false` in the provider options to remove all three; the deprecated
+  and focus trap, all as one value. Set `presentation.preferences.blocking`
+  to `false` in the provider options to remove all three; the deprecated
   `scrollLock` and `trapFocus` props do the same for one dialog. `variant`
   and `position` are prompt options. Setting them under
   `presentation.preferences` logs an `invalid-variant` diagnostic in

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -17,7 +17,7 @@ group: reference
   | `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which of the links configured in the provider `options.legalLinks` render after the description. Omitting the prop renders none. `null` hides them. |
   | `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag in the card. |
   | `uiSource` | `string` | `'dialog'` | Source identifier recorded with saves made from this dialog. |
-  | `scrollLock`, `trapFocus` | `boolean` | from `blocking` | Deprecated. Either one set to `false` makes the dialog non-blocking. Prefer `presentation.preferences.blocking` in the provider options. |
+  | `scrollLock`, `trapFocus` | `boolean` | from `blocking` | Deprecated. Either one set to `false` makes the dialog non-blocking, unless the provider sets `presentation.preferences.blocking` explicitly, which wins. Prefer the provider option. |
   | `disableAnimation` | `boolean` | `false` | Skips the enter and exit animation of the backdrop and the card. |
   | `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
 </section>
@@ -141,7 +141,8 @@ group: reference
   A centered card appears over a dimmed backdrop, the page behind it stops
   scrolling, and Tab stays inside the card. Press Escape: the card closes and
   focus returns to the button you used. Open it again, turn a category on and
-  choose Save. The dialog closes, the banner does not return, and
-  `useConsent('<category>')` reports `true` in your components. Reload the
+  choose Save. The dialog closes and `useConsent('<category>')` reports
+  `true` in your components; under a choice prompt the banner does not return,
+  while a `notice` prompt keeps its banner until it is acknowledged. Reload the
   page and reopen the dialog: the switch reflects the saved choice.
 </section>

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -14,7 +14,7 @@ group: reference
   | `open` | `boolean` | follows the active surface | Controls the open state. When set, Escape and the dialog's own Save, Accept all and Reject all buttons no longer close it; change the prop instead. A missing policy or an unlisted model still keeps it closed. |
   | `showTrigger` | `boolean \| ConsentDialogTriggerProps` | `false` | Renders a floating `ConsentDialogTrigger` next to the dialog. Pass an object to configure that trigger. |
   | `models` | `Model[]` | `['opt-in', 'opt-out', 'none']` | Policy models the dialog responds to. Under a model that is not listed, such as `iab`, it stays closed. |
-  | `legalLinks` | `(keyof LegalLinks)[] \| null` | all configured links | Which legal links from the provider options render after the description. `null` hides them. |
+  | `legalLinks` | `(keyof LegalLinks)[] \| null` | none | Which of the links configured in the provider `options.legalLinks` render after the description. Omitting the prop renders none. `null` hides them. |
   | `hideBranding` | `boolean` | `false` | Hides the "Secured by" tag in the card. |
   | `uiSource` | `string` | `'dialog'` | Source identifier recorded with saves made from this dialog. |
   | `scrollLock`, `trapFocus` | `boolean` | from `blocking` | Deprecated. Either one set to `false` makes the dialog non-blocking. Prefer `presentation.preferences.blocking` in the provider options. |
@@ -64,10 +64,11 @@ group: reference
 
   The dialog never opens without a resolved policy rule, even when the
   active surface is already `dialog`; it appears as soon as a rule resolves,
-  without a remount. A rule with `model: 'none'` owes nothing, so the dialog
-  stays closed unless the rule lists `rights: ['preferences']`. Under that
-  rule the dialog opens as a settings route and Save completes without
-  writing a consent record.
+  without a remount. A rule with `model: 'none'` and no rights owes no consent
+  UI, so the dialog stays closed under it. When such a rule lists any right,
+  for example `rights: ['disclosure']` or `rights: ['preferences']`, the dialog
+  can open as a settings route and Save completes without writing a consent
+  record.
 
   Copy comes from these translation keys: `consentManagerDialog.title`,
   `consentManagerDialog.description`, `common.acceptAll`, `common.rejectAll`,

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -47,10 +47,12 @@ group: reference
   and renders nothing until that chunk is ready. Passing `open={true}` or
   `showTrigger` loads it on mount.
 
-  Escape closes the dialog. Save, Accept all and Reject all close it after
-  the save succeeds; a save that fails keeps it open. Clicking the backdrop
-  does not close it. Closing discards toggles that were not saved: the next
-  open starts from the recorded choice again. After a save from the dialog,
+  Without an `open` prop, Escape closes the dialog. Save, Accept all and
+  Reject all close it after the save succeeds; a save that fails keeps it
+  open. With `open={true}`, these actions leave the dialog visible; the
+  parent must set `open={false}` to close it. Clicking the backdrop does not
+  close it. Closing discards toggles that were not saved: the next open starts
+  from the recorded choice again. After a save from an uncontrolled dialog,
   every consent surface hides unless the policy still owes a prompt, in which
   case the banner returns.
 

--- a/docs/shared/react/components/consent-dialog.mdx
+++ b/docs/shared/react/components/consent-dialog.mdx
@@ -33,7 +33,8 @@ group: reference
   into `document.body` after hydration, so it is never part of the server
   HTML.
 
-  The dialog is open while the active surface is `dialog`. These set it:
+  Without an `open` prop, the dialog follows the active surface and opens while
+  it is `dialog`. These set that surface:
 
   - The Customize button on a `ConsentBanner`, and the "Manage preferences"
     or "Do not sell or share my data" button a notice renders.
@@ -139,6 +140,8 @@ group: reference
 <section id="verify">
   ## Verify
 
+  Use the default blocking, uncontrolled dialog and an optional in-scope
+  category that is not restricted by policy or privacy signals such as GPC.
   Open the dialog from the banner's Customize button or a preferences link.
   A centered card appears over a dimmed backdrop, the page behind it stops
   scrolling, and Tab stays inside the card. Press Escape: the card closes and

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -1,0 +1,129 @@
+---
+title: "ConsentWidget"
+description: "Shared ConsentWidget reference for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+  ## Props
+
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `hideBranding` | `boolean` | `true` | A standalone widget hides the "Secured by" tag. Pass `false` to show it. |
+  | `uiSource` | `string` | `'widget'` | Source identifier recorded with saves made from this widget. Inside `ConsentDialog` it inherits `'dialog'`. |
+  | `disableAnimation` | `boolean` | `false` | Skips animations in the widget's parts. |
+  | `noStyle` | `boolean` | `false` | Removes the built-in styling from every part. |
+</section>
+
+<section id="behavior">
+  ## Behavior
+
+  The widget is the preference center without the modal around it: an
+  accordion with one row per category, each with a switch, followed by the
+  Reject all, Accept all and Save actions. `ConsentDialog` renders this same
+  widget inside its card. Standalone, the widget renders in place, takes part
+  in server rendering, and does not touch the active surface, so it suits a
+  privacy page or an account settings screen.
+
+  The rows are `necessary` plus every category in the active policy's scope.
+  The `necessary` switch is on and disabled. Row titles and descriptions come
+  from `consentTypes.<category>.title` and `.description`; the action labels
+  from `common.rejectAll`, `common.acceptAll` and `common.save`. One row is
+  expanded at a time.
+
+  ### Draft and save
+
+  Switches edit a draft, not the visitor's permissions. Nothing is recorded
+  until Save. The draft seeds each category from the recorded choice; without
+  one it uses `presentation.preferences.defaults` from the provider options,
+  and without that it is on under an opt-out rule and on only for the rule's
+  preselected categories under an opt-in rule. Save records the displayed
+  categories, then reseeds the draft from the new record. Accept all and
+  Reject all record immediately without a separate Save. A save answers the
+  prompt, so a banner that is still open closes. Unsaved toggles are lost
+  when the widget unmounts.
+
+  When the policy changes in a way that affects the choice while the draft has
+  unsaved toggles, the widget shows an alert, "The privacy policy changed.
+  Review the current choices before saving.", with a Review choices button
+  that resets the draft. Save is refused until then. A draft without unsaved
+  toggles reseeds silently.
+
+  A saved grant that the current policy or a privacy signal such as Global
+  Privacy Control overrides shows a note under its row: "Your saved choice is
+  restricted by the current privacy settings." The switch still reflects the
+  saved value; the effective permission is off.
+
+  ### Actions
+
+  The preference center always renders Reject all, Accept all and Save, with
+  Save as the primary action. `presentation.preferences.layout`,
+  `primaryActions`, `direction` and `uiProfile` in the provider options
+  reorder and restyle them; a layout that omits one of the three has it
+  restored. Customize and dismiss actions never render here.
+
+  ### When consent is not owed
+
+  Without a resolved policy rule the widget renders nothing and appears as
+  soon as a rule resolves, without a remount. A rule with `model: 'none'`
+  renders nothing unless it lists `rights: ['preferences']`; under that rule
+  the widget renders and Save completes without writing a consent record.
+  Under an opt-out rule the switches start on and Save records the visitor's
+  choice.
+
+  For a fully custom preference center, `useConsentDraft()` returns the same
+  draft: `values`, `displayedCategories`, `isDirty`, `isStale`, `set`,
+  `update`, `acceptAll`, `rejectAll`, `save` and `reset`.
+</section>
+
+<section id="accessibility">
+  ## Accessibility
+
+  Each row is a disclosure: a button that expands the category description
+  and a switch beside it, so a visitor can read the description without
+  changing the choice. Each switch has the category title as its accessible
+  name. The policy-change alert uses `role="alert"`, and a restriction note is
+  an `output` element linked to its switch through `aria-describedby`. The
+  root's `dir` attribute follows the active language.
+</section>
+
+<section id="composition">
+  ## Composition
+
+  Every part is available as `ConsentWidget.<Part>`. `Root` provides the
+  draft and accepts `noStyle`, `disableAnimation` and `uiSource`. `Accordion`
+  and `AccordionItems` render the stock rows; `AccordionItem`,
+  `AccordionTrigger`, `AccordionTriggerInner`, `AccordionContent`,
+  `AccordionArrow` and `Switch` build your own. `PolicyActions` renders the
+  resolved actions in `Footer` and `FooterSubGroup` and accepts `renderAction`
+  to replace one button; `AcceptAllButton`, `RejectButton`, `SaveButton` and
+  `CustomizeButton` are the individual buttons.
+
+  ```tsx
+  <ConsentWidget.Root>
+    <ConsentWidget.Accordion>
+      <ConsentWidget.AccordionItems />
+    </ConsentWidget.Accordion>
+    <ConsentWidget.PolicyActions />
+  </ConsentWidget.Root>
+  ```
+
+  Provider component slots for the stock structure are `manager.root`,
+  `manager.footer`, `manager.actionGroup`, `accordion.root`,
+  `accordion.triggerRow`, `accordion.title`, `accordion.control`,
+  `accordion-item.root`, `accordion-item.trigger`, `accordion-item.content`
+  and `tag.manager`.
+</section>
+
+<section id="verify">
+  ## Verify
+
+  Visit the page with the widget. One row per policy category appears, with
+  `necessary` on and disabled. Turn a category on: `useConsent('<category>')`
+  elsewhere on the page still reports the old value. Choose Save: it now
+  reports `true`, and a banner that was open closes. Reload the page: the
+  switch keeps the saved value. Under an opt-out rule the switches start on
+  before any save.
+</section>

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -28,7 +28,7 @@ group: reference
   privacy page or an account settings screen.
 
   The rows are `necessary` plus the categories in the active policy's scope,
-  narrowed to the provider `options.consentCategories` when that list is set.
+  narrowed to the provider `options.consentCategories` when that list is non-empty.
   The `necessary` switch is on and disabled. Row titles and descriptions come
   from `consentTypes.<category>.title` and `.description`; the action labels
   from `common.rejectAll`, `common.acceptAll` and `common.save`. One row is
@@ -73,8 +73,6 @@ group: reference
   an empty `rights` list renders nothing; a `none` rule that lists any right,
   such as `['disclosure']`, renders the widget and Save completes without
   writing a consent record.
-  Under an opt-out rule the switches start on and Save records the visitor's
-  choice.
 
   For a fully custom preference center, `useConsentDraft()` returns the same
   draft: `values`, `displayedCategories`, `isDirty`, `isStale`, `set`,
@@ -139,13 +137,13 @@ group: reference
 <section id="verify">
   ## Verify
 
-  Visit the page with the widget. Use an in-scope category whose permission is
-  not restricted by policy or privacy signals such as GPC. One row per policy
+  Visit the page with the widget. Use a displayed optional category whose permission is
+  not restricted by policy or privacy signals such as GPC. One row per displayed
   category appears, with `necessary` on and disabled. Turn that category on:
   `useConsent('<category>')`
   elsewhere on the page still reports the old value. Choose Save: it now
   reports `true`. An open choice banner closes when the save answers its
   prompt; a notice banner stays open until acknowledged. Reload the page: the
-  switch keeps the saved value. Under an opt-out rule the switches start on
-  before any save.
+  switch keeps the saved value. Without a saved choice or configured draft
+  defaults, optional switches start on under an opt-out rule.
 </section>

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -142,7 +142,8 @@ group: reference
   Visit the page with the widget. One row per policy category appears, with
   `necessary` on and disabled. Turn a category on: `useConsent('<category>')`
   elsewhere on the page still reports the old value. Choose Save: it now
-  reports `true`, and a banner that was open closes. Reload the page: the
+  reports `true`. An open choice banner closes when the save answers its
+  prompt; a notice banner stays open until acknowledged. Reload the page: the
   switch keeps the saved value. Under an opt-out rule the switches start on
   before any save.
 </section>

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -67,9 +67,10 @@ group: reference
   ### When consent is not owed
 
   Without a resolved policy rule the widget renders nothing and appears as
-  soon as a rule resolves, without a remount. A rule with `model: 'none'`
-  renders nothing unless it lists `rights: ['preferences']`; under that rule
-  the widget renders and Save completes without writing a consent record.
+  soon as a rule resolves, without a remount. A rule with `model: 'none'` and
+  an empty `rights` list renders nothing; a `none` rule that lists any right,
+  such as `['disclosure']`, renders the widget and Save completes without
+  writing a consent record.
   Under an opt-out rule the switches start on and Save records the visitor's
   choice.
 
@@ -101,9 +102,18 @@ group: reference
   to replace one button; `AcceptAllButton`, `RejectButton`, `SaveButton` and
   `CustomizeButton` are the individual buttons.
 
+  `Accordion` is controlled: pass `value` and `onValueChange`, or no
+  category description ever opens. The stock `ConsentWidget` holds that state
+  for you.
+
   ```tsx
+  const [open, setOpen] = useState<string[]>([]);
+
   <ConsentWidget.Root>
-    <ConsentWidget.Accordion>
+    <ConsentWidget.Accordion
+      value={open}
+      onValueChange={(next) => setOpen(Array.isArray(next) ? next : [next])}
+    >
       <ConsentWidget.AccordionItems />
     </ConsentWidget.Accordion>
     <ConsentWidget.PolicyActions />

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -42,9 +42,10 @@ group: reference
   and without that it is on under an opt-out rule and on only for the rule's
   preselected categories under an opt-in rule. Save records the displayed
   categories, then reseeds the draft from the new record. Accept all and
-  Reject all record immediately without a separate Save. A save answers the
-  prompt, so a banner that is still open closes. Unsaved toggles are lost
-  when the widget unmounts.
+  Reject all record immediately without a separate Save. A save answers a
+  choice prompt, so an open choice banner closes; it does not dismiss a
+  `notice` prompt, which keeps its own acknowledgement record. Unsaved toggles
+  are lost when the widget unmounts.
 
   When the policy changes in a way that affects the choice while the draft has
   unsaved toggles, the widget shows an alert, "The privacy policy changed.
@@ -108,6 +109,8 @@ group: reference
   for you.
 
   ```tsx
+  import { useState } from 'react';
+
   const [open, setOpen] = useState<string[]>([]);
 
   <ConsentWidget.Root>

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -27,7 +27,8 @@ group: reference
   in server rendering, and does not touch the active surface, so it suits a
   privacy page or an account settings screen.
 
-  The rows are `necessary` plus every category in the active policy's scope.
+  The rows are `necessary` plus the categories in the active policy's scope,
+  narrowed to the provider `options.consentCategories` when that list is set.
   The `necessary` switch is on and disabled. Row titles and descriptions come
   from `consentTypes.<category>.title` and `.description`; the action labels
   from `common.rejectAll`, `common.acceptAll` and `common.save`. One row is

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -139,8 +139,10 @@ group: reference
 <section id="verify">
   ## Verify
 
-  Visit the page with the widget. One row per policy category appears, with
-  `necessary` on and disabled. Turn a category on: `useConsent('<category>')`
+  Visit the page with the widget. Use an in-scope category whose permission is
+  not restricted by policy or privacy signals such as GPC. One row per policy
+  category appears, with `necessary` on and disabled. Turn that category on:
+  `useConsent('<category>')`
   elsewhere on the page still reports the old value. Choose Save: it now
   reports `true`. An open choice banner closes when the save answers its
   prompt; a notice banner stays open until acknowledged. Reload the page: the

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -106,7 +106,8 @@ group: reference
 
   `Accordion` is controlled: pass `value` and `onValueChange`, or no
   category description ever opens. The stock `ConsentWidget` holds that state
-  for you.
+  for you. In this component, `ConsentWidget` comes from the same import as
+  the example at the top of the page:
 
   ```tsx
   import { useState } from 'react';

--- a/docs/shared/react/components/consent-widget.mdx
+++ b/docs/shared/react/components/consent-widget.mdx
@@ -111,17 +111,21 @@ group: reference
   ```tsx
   import { useState } from 'react';
 
-  const [open, setOpen] = useState<string[]>([]);
+  export function PreferenceCenter() {
+    const [open, setOpen] = useState<string[]>([]);
 
-  <ConsentWidget.Root>
-    <ConsentWidget.Accordion
-      value={open}
-      onValueChange={(next) => setOpen(Array.isArray(next) ? next : [next])}
-    >
-      <ConsentWidget.AccordionItems />
-    </ConsentWidget.Accordion>
-    <ConsentWidget.PolicyActions />
-  </ConsentWidget.Root>
+    return (
+      <ConsentWidget.Root>
+        <ConsentWidget.Accordion
+          value={open}
+          onValueChange={(next) => setOpen(Array.isArray(next) ? next : [next])}
+        >
+          <ConsentWidget.AccordionItems />
+        </ConsentWidget.Accordion>
+        <ConsentWidget.PolicyActions />
+      </ConsentWidget.Root>
+    );
+  }
   ```
 
   Provider component slots for the stock structure are `manager.root`,

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -31,9 +31,8 @@ group: reference
   so it can be granted under an opt-out rule before the visitor records a
   choice, and a recorded grant can be overridden by a privacy signal.
 
-  The children are absent from the DOM while permission is denied, so an
-  iframe or a third-party widget inside `Frame` sends no requests until the
-  visitor allows the category. When the visitor later revokes it, the
+  While effective permission is denied, the children are absent from the DOM,
+  so an iframe or a third-party widget inside `Frame` sends no requests. When the visitor later revokes it, the
   children unmount and the embed disappears. `Frame` does not depend on the
   network blocker or the iframe blocker modules; use those for markup you
   cannot wrap in a component.
@@ -47,14 +46,15 @@ group: reference
   something to open.
 
   Under a policy with `scopeMode: 'strict'`, a category outside the rule's
-  scope cannot be granted. The placeholder then shows `frame.policyBlocked`,
+  scope cannot be granted. The built-in placeholder then shows `frame.policyBlocked`,
   "This content is unavailable under your region's consent policy.", without
   the button, and a stored grant for that category stays blocked.
 
   When the provider starts from a snapshot prefetched on the server, the
-  server renders either the children or the placeholder
-  and hydration keeps that markup; a visitor whose grant arrives in the request
-  cookie gets the embed in the server HTML. In a browser-only setup the
+  server renders the children or placeholder according to effective permission.
+  A grant in the request cookie allows the embed only when policy and privacy
+  signals permit it. Browser privacy signals detected during hydration can
+  withdraw that permission. In a browser-only setup the
   provider has no permission until it resolves policy on the client, so
   `Frame` shows the placeholder first and swaps in the embed after resolution
   when the category is already granted.
@@ -106,6 +106,8 @@ group: reference
 <section id="verify">
   ## Verify
 
+  Use an optional in-scope category that is available in the preference
+  center and is not restricted by policy or privacy signals such as GPC.
   Load the page with the category denied. The placeholder text names the
   category and the network panel shows no request to the embed's host. With a
   prefetched snapshot, the server HTML contains the placeholder for a denied

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -14,6 +14,8 @@ group: reference
   | `category` | `AllConsentNames` | required | The consent category whose effective permission gates the children, for example `'marketing'` or `'functionality'`. |
   | `children` | `ReactNode` | required | The embed. It is not mounted until the category is allowed, so it makes no requests before permission. |
   | `placeholder` | `ReactNode` | built-in placeholder | Rendered instead of the children while the category is not allowed. Replaces the built-in title and button entirely. |
+  | `noStyle` | `boolean` | `false` | Removes the built-in styling from the wrapper and the built-in placeholder parts. |
+  | `theme` | `Theme` | provider theme | Theme overrides scoped to this frame, with the same shape as the provider `theme` option. |
 
   Other `div` attributes such as `className`, `style` and `ref` apply to the
   wrapper element that stays in the page in both states.

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -107,11 +107,12 @@ group: reference
   ## Verify
 
   Load the page with the category denied. The placeholder text names the
-  category and the network panel shows no request to the embed's host. When
-  the provider is server-rendered from a prefetched snapshot, the server HTML
-  already contains the placeholder; a browser-only setup renders it after
-  policy resolves. Activate the placeholder
-  button: the preference center opens. Turn the category on and Save: the
-  placeholder is replaced by the embed and its requests start. Reject the
+  category and the network panel shows no request to the embed's host. With a
+  prefetched snapshot, the server HTML contains the placeholder for a denied
+  category or the embed for a granted category. Browser-only initialization
+  shows the placeholder before policy resolves, then replaces it with the
+  embed if the category is granted. After policy resolves, activate the
+  placeholder button: the preference center opens. Turn the category on and
+  Save: the placeholder is replaced by the embed and its requests start. Reject the
   category again from the preference center: the embed disappears.
 </section>

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -51,8 +51,8 @@ group: reference
   "This content is unavailable under your region's consent policy.", without
   the button, and a stored grant for that category stays blocked.
 
-  When the provider starts from a server-prefetched snapshot, as in the Next.js
-  awaited layout, the server renders either the children or the placeholder
+  When the provider starts from a snapshot prefetched on the server, the
+  server renders either the children or the placeholder
   and hydration keeps that markup; a visitor whose grant arrives in the request
   cookie gets the embed in the server HTML. In a browser-only setup the
   provider has no permission until it resolves policy on the client, so
@@ -107,8 +107,10 @@ group: reference
   ## Verify
 
   Load the page with the category denied. The placeholder text names the
-  category, the network panel shows no request to the embed's host, and the
-  server HTML already contains the placeholder. Activate the placeholder
+  category and the network panel shows no request to the embed's host. When
+  the provider is server-rendered from a prefetched snapshot, the server HTML
+  already contains the placeholder; a browser-only setup renders it after
+  policy resolves. Activate the placeholder
   button: the preference center opens. Turn the category on and Save: the
   placeholder is replaced by the embed and its requests start. Reject the
   category again from the preference center: the embed disappears.

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -1,0 +1,109 @@
+---
+title: "Frame"
+description: "Shared Frame reference for the React and Next.js adapters."
+group: reference
+---
+
+{/* This file is NOT rendered directly. Sections are imported by framework pages. */}
+
+<section id="props">
+  ## Props
+
+  | Prop | Type | Default | Description |
+  | --- | --- | --- | --- |
+  | `category` | `AllConsentNames` | required | The consent category whose effective permission gates the children, for example `'marketing'` or `'functionality'`. |
+  | `children` | `ReactNode` | required | The embed. It is not mounted until the category is allowed, so it makes no requests before permission. |
+  | `placeholder` | `ReactNode` | built-in placeholder | Rendered instead of the children while the category is not allowed. Replaces the built-in title and button entirely. |
+
+  Other `div` attributes such as `className`, `style` and `ref` apply to the
+  wrapper element that stays in the page in both states.
+</section>
+
+<section id="behavior">
+  ## Behavior
+
+  `Frame` renders a `div` wrapper. Inside it, when the effective permission for
+  `category` is granted, it renders the children; otherwise it renders the
+  placeholder. Permission is the same value `useConsent(category)` returns,
+  so it can be granted under an opt-out rule before the visitor records a
+  choice, and a recorded grant can be overridden by a privacy signal.
+
+  The children are absent from the DOM while permission is denied, so an
+  iframe or a third-party widget inside `Frame` sends no requests until the
+  visitor allows the category. When the visitor later revokes it, the
+  children unmount and the embed disappears. `Frame` does not depend on the
+  network blocker or the iframe blocker modules; use those for markup you
+  cannot wrap in a component.
+
+  The built-in placeholder shows the title `frame.title`, "Accept {category}
+  consent to view this content.", with `{category}` replaced by
+  `consentTypes.<category>.title`, and a button labelled `frame.actionButton`,
+  "Enable {category} consent". The button opens the preference center; it
+  does not grant the category by itself, because the visitor still has to
+  save. Mount a `ConsentDialog` in the same provider so the button has
+  something to open.
+
+  Under a policy with `scopeMode: 'strict'`, a category outside the rule's
+  scope cannot be granted. The placeholder then shows `frame.policyBlocked`,
+  "This content is unavailable under your region's consent policy.", without
+  the button, and a stored grant for that category stays blocked.
+
+  Server rendering uses the same permission snapshot as the browser: the first
+  HTML contains either the children or the placeholder, and hydration keeps
+  that markup without replacing it. A visitor whose grant arrives in the
+  request cookie sees the embed in the first HTML.
+
+  `Frame` is one component on this page; the per-vendor embed guides for
+  [YouTube](/docs/integrations/youtube) and
+  [Google Maps](/docs/integrations/google-maps) show a complete embed
+  configuration with sizing, titles and the same `Frame` usage across
+  frameworks.
+</section>
+
+<section id="composition">
+  ## Composition
+
+  The placeholder parts are available as `Frame.Root`, `Frame.Title` and
+  `Frame.Button` for a custom placeholder that keeps the built-in copy and
+  behavior. `Frame.Title` and `Frame.Button` accept `category` and fill in the
+  translated text; pass children to either to replace it.
+
+  ```tsx
+  <Frame
+    category="marketing"
+    placeholder={
+      <Frame.Root>
+        <Frame.Title category="marketing" />
+        <p>The video is also available on our channel.</p>
+        <Frame.Button category="marketing">Choose cookies</Frame.Button>
+      </Frame.Root>
+    }
+  >
+    <iframe src="https://www.youtube-nocookie.com/embed/..." title="Product tour" />
+  </Frame>
+  ```
+
+  The built-in placeholder carries `data-testid="frame-placeholder"` and its
+  button `data-testid="frame-open-dialog"`.
+</section>
+
+<section id="accessibility">
+  ## Accessibility
+
+  The placeholder is plain text and a `button`, so it is readable and
+  operable without the embed. Give the iframe a descriptive `title`, and keep a
+  transcript, address or link outside the `Frame` for visitors who decline
+  the category. A denied category may be fixed by policy, so opening the
+  preference center does not guarantee that the visitor can grant it.
+</section>
+
+<section id="verify">
+  ## Verify
+
+  Load the page with the category denied. The placeholder text names the
+  category, the network panel shows no request to the embed's host, and the
+  server HTML already contains the placeholder. Activate the placeholder
+  button: the preference center opens. Turn the category on and Save: the
+  placeholder is replaced by the embed and its requests start. Reject the
+  category again from the preference center: the embed disappears.
+</section>

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -13,7 +13,7 @@ group: reference
   | --- | --- | --- | --- |
   | `category` | `AllConsentNames` | required | The consent category whose effective permission gates the children, for example `'marketing'` or `'functionality'`. |
   | `children` | `ReactNode` | required | The embed. It is not mounted until the category is allowed, so it makes no requests before permission. |
-  | `placeholder` | `ReactNode` | built-in placeholder | Rendered instead of the children while the category is not allowed. Replaces the built-in title and button entirely. |
+  | `placeholder` | `ReactNode` | built-in placeholder | Replaces the built-in title and button while the category is not allowed. Falsy values such as `null`, `false`, `0` and an empty string use the built-in placeholder. Pass an empty fragment, `<></>`, to render no placeholder content. |
 
   Other `div` attributes such as `className`, `style` and `ref` apply to the
   wrapper element that stays in the page in both states. `FrameProps` also

--- a/docs/shared/react/components/frame.mdx
+++ b/docs/shared/react/components/frame.mdx
@@ -14,11 +14,12 @@ group: reference
   | `category` | `AllConsentNames` | required | The consent category whose effective permission gates the children, for example `'marketing'` or `'functionality'`. |
   | `children` | `ReactNode` | required | The embed. It is not mounted until the category is allowed, so it makes no requests before permission. |
   | `placeholder` | `ReactNode` | built-in placeholder | Rendered instead of the children while the category is not allowed. Replaces the built-in title and button entirely. |
-  | `noStyle` | `boolean` | `false` | Removes the built-in styling from the wrapper and the built-in placeholder parts. |
-  | `theme` | `Theme` | provider theme | Theme overrides scoped to this frame, with the same shape as the provider `theme` option. |
 
   Other `div` attributes such as `className`, `style` and `ref` apply to the
-  wrapper element that stays in the page in both states.
+  wrapper element that stays in the page in both states. `FrameProps` also
+  declares `noStyle` and `theme`, but the component does not apply them yet;
+  style the wrapper with `className` and theme the placeholder through the
+  provider `theme` option.
 </section>
 
 <section id="behavior">
@@ -50,10 +51,13 @@ group: reference
   "This content is unavailable under your region's consent policy.", without
   the button, and a stored grant for that category stays blocked.
 
-  Server rendering uses the same permission snapshot as the browser: the first
-  HTML contains either the children or the placeholder, and hydration keeps
-  that markup without replacing it. A visitor whose grant arrives in the
-  request cookie sees the embed in the first HTML.
+  When the provider starts from a server-prefetched snapshot, as in the Next.js
+  awaited layout, the server renders either the children or the placeholder
+  and hydration keeps that markup; a visitor whose grant arrives in the request
+  cookie gets the embed in the server HTML. In a browser-only setup the
+  provider has no permission until it resolves policy on the client, so
+  `Frame` shows the placeholder first and swaps in the embed after resolution
+  when the category is already granted.
 
   `Frame` is one component on this page; the per-vendor embed guides for
   [YouTube](/docs/integrations/youtube) and

--- a/packages/c15t/AGENTS.md
+++ b/packages/c15t/AGENTS.md
@@ -37,9 +37,13 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [App Router](./docs/frameworks/next/app-router.md): Set up App Router with Inth, cached manifests and consent-gated scripts.
 - [Client-side initialization](./docs/frameworks/next/client-side.md): Initialize Next.js consent in the browser with one backend URL, without server prefetch or local API handlers.
 - [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Render the pre-built ConsentBanner inside a Next.js ConsentBoundary and configure its variants, per-policy buttons and compound parts.
+- [ConsentDialog](./docs/frameworks/next/components/consent-dialog.md): Mount ConsentDialog as a Client Component inside a Next.js ConsentBoundary to open the preference center from the banner, links and triggers.
+- [ConsentDialogLink](./docs/frameworks/next/components/consent-dialog-link.md): Open the preference center from a Next.js footer with ConsentDialogLink, a Client Component that renders an unstyled button inside ConsentBoundary.
 - [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Add the floating ConsentDialogTrigger button or toolbar to a Next.js ConsentBoundary so visitors can reopen the preference center.
 - [ConsentBoundary](./docs/frameworks/next/components/consent-manager-provider.md): Pass server-prefetched consent and shared configuration to the Next.js consent boundary.
+- [ConsentWidget](./docs/frameworks/next/components/consent-widget.md): Render ConsentWidget on a Next.js privacy page inside ConsentBoundary as an inline preference center, server-rendered when the route prefetches consent.
 - [DevTools](./docs/frameworks/next/components/dev-tools.md): Load the c15t DevTools panel only in Next.js development builds to inspect consent state, scripts, policy and events inside ConsentBoundary.
+- [Frame](./docs/frameworks/next/components/frame.md): Consent-gate an iframe in Next.js with Frame inside ConsentBoundary; with server prefetch the placeholder or embed is decided in the server HTML.
 - [Consent categories](./docs/frameworks/next/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/next/concepts/policy-presets.md): Understand how policy rules affect Next.js prompts, permissions and persistent privacy controls.
 - [Content Security Policy](./docs/frameworks/next/content-security-policy.md): Pass a per-request CSP nonce to ConsentBoundary in Next.js and allow the consent backend in connect-src.
@@ -58,9 +62,13 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [Troubleshoot Next.js consent](./docs/frameworks/next/troubleshooting.md): Diagnose failed Next.js prefetch, verify manifest requests, and fix consent rendering or persistence problems.
 - [Quickstart](./docs/frameworks/nuxt/quickstart.md): Configure the Nuxt module for server rendering, browser initialization or static hosting.
 - [ConsentBanner](./docs/frameworks/react/components/consent-banner.md): Pre-built consent banner shown when consent is required.
+- [ConsentDialog](./docs/frameworks/react/components/consent-dialog.md): Open the c15t preference center as a modal ConsentDialog in a React app, wire its triggers and control blocking, focus and policy gating.
+- [ConsentDialogLink](./docs/frameworks/react/components/consent-dialog-link.md): Add a ConsentDialogLink to a React footer so visitors reopen the c15t preference center from your own text link, with asChild and rights data.
 - [ConsentDialogTrigger](./docs/frameworks/react/components/consent-dialog-trigger.md): Floating button and toolbar that reopen the preference center after the first prompt.
 - [ConsentProvider](./docs/frameworks/react/components/consent-manager-provider.md): Configure the v3 consent runtime and share its state with child components.
+- [ConsentWidget](./docs/frameworks/react/components/consent-widget.md): Embed the c15t preference center inline with ConsentWidget on a React privacy page, with draft toggles that record a choice only on Save.
 - [DevTools](./docs/frameworks/react/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
+- [Frame](./docs/frameworks/react/components/frame.md): Gate a YouTube or map iframe behind consent with Frame in React, showing a placeholder that opens the preference center until the category is allowed.
 - [Consent categories](./docs/frameworks/react/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/react/concepts/policy-presets.md): Understand how policy rules affect React prompts, permissions and persistent privacy controls.
 - [Headless](./docs/frameworks/react/headless.md): Build a custom consent banner in React with the c15t/react/headless hooks inside your ConsentProvider.

--- a/packages/nextjs/AGENTS.md
+++ b/packages/nextjs/AGENTS.md
@@ -28,9 +28,13 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 - [App Router](./docs/frameworks/next/app-router.md): Set up App Router with Inth, cached manifests and consent-gated scripts.
 - [Client-side initialization](./docs/frameworks/next/client-side.md): Initialize Next.js consent in the browser with one backend URL, without server prefetch or local API handlers.
 - [ConsentBanner](./docs/frameworks/next/components/consent-banner.md): Render the pre-built ConsentBanner inside a Next.js ConsentBoundary and configure its variants, per-policy buttons and compound parts.
+- [ConsentDialog](./docs/frameworks/next/components/consent-dialog.md): Mount ConsentDialog as a Client Component inside a Next.js ConsentBoundary to open the preference center from the banner, links and triggers.
+- [ConsentDialogLink](./docs/frameworks/next/components/consent-dialog-link.md): Open the preference center from a Next.js footer with ConsentDialogLink, a Client Component that renders an unstyled button inside ConsentBoundary.
 - [ConsentDialogTrigger](./docs/frameworks/next/components/consent-dialog-trigger.md): Add the floating ConsentDialogTrigger button or toolbar to a Next.js ConsentBoundary so visitors can reopen the preference center.
 - [ConsentBoundary](./docs/frameworks/next/components/consent-manager-provider.md): Pass server-prefetched consent and shared configuration to the Next.js consent boundary.
+- [ConsentWidget](./docs/frameworks/next/components/consent-widget.md): Render ConsentWidget on a Next.js privacy page inside ConsentBoundary as an inline preference center, server-rendered when the route prefetches consent.
 - [DevTools](./docs/frameworks/next/components/dev-tools.md): Load the c15t DevTools panel only in Next.js development builds to inspect consent state, scripts, policy and events inside ConsentBoundary.
+- [Frame](./docs/frameworks/next/components/frame.md): Consent-gate an iframe in Next.js with Frame inside ConsentBoundary; with server prefetch the placeholder or embed is decided in the server HTML.
 - [Consent categories](./docs/frameworks/next/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/next/concepts/policy-presets.md): Understand how policy rules affect Next.js prompts, permissions and persistent privacy controls.
 - [Content Security Policy](./docs/frameworks/next/content-security-policy.md): Pass a per-request CSP nonce to ConsentBoundary in Next.js and allow the consent backend in connect-src.

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -22,9 +22,13 @@ These docs describe v3. Start with Inth hosted setup, identify the framework, ro
 ## Frameworks
 
 - [ConsentBanner](./docs/frameworks/react/components/consent-banner.md): Pre-built consent banner shown when consent is required.
+- [ConsentDialog](./docs/frameworks/react/components/consent-dialog.md): Open the c15t preference center as a modal ConsentDialog in a React app, wire its triggers and control blocking, focus and policy gating.
+- [ConsentDialogLink](./docs/frameworks/react/components/consent-dialog-link.md): Add a ConsentDialogLink to a React footer so visitors reopen the c15t preference center from your own text link, with asChild and rights data.
 - [ConsentDialogTrigger](./docs/frameworks/react/components/consent-dialog-trigger.md): Floating button and toolbar that reopen the preference center after the first prompt.
 - [ConsentProvider](./docs/frameworks/react/components/consent-manager-provider.md): Configure the v3 consent runtime and share its state with child components.
+- [ConsentWidget](./docs/frameworks/react/components/consent-widget.md): Embed the c15t preference center inline with ConsentWidget on a React privacy page, with draft toggles that record a choice only on Save.
 - [DevTools](./docs/frameworks/react/components/dev-tools.md): A development tool for inspecting consent state, geolocation, loaded scripts, and consent events in real time.
+- [Frame](./docs/frameworks/react/components/frame.md): Gate a YouTube or map iframe behind consent with Frame in React, showing a placeholder that opens the preference center until the category is allowed.
 - [Consent categories](./docs/frameworks/react/concepts/consent-categories.md): Assign optional features to categories and understand how policy scope affects permission.
 - [Policy presets](./docs/frameworks/react/concepts/policy-presets.md): Understand how policy rules affect React prompts, permissions and persistent privacy controls.
 - [Headless](./docs/frameworks/react/headless.md): Build a custom consent banner in React with the c15t/react/headless hooks inside your ConsentProvider.

--- a/packages/scripts/docs/frameworks/next/script-loader.md
+++ b/packages/scripts/docs/frameworks/next/script-loader.md
@@ -108,20 +108,26 @@ do not add a second provider. Keep your site's content and footer inside it.
 
 ## Pass prepared consent through your router
 
-App Router passes the prefetch promise from its synchronous layout. This partial
-example replaces the boundary in your existing layout, keeping its `html`,
-`body` and stylesheet:
+App Router awaits the prefetch in the `ResolvedConsent` Server Component from
+the [App Router guide](https://c15t.com/docs/frameworks/next/app-router) and renders the
+wrapper inside it. This partial example is that component; keep the
+`Suspense` boundary, `html`, `body` and stylesheet from your existing layout:
 
 ```tsx
+import type { ReactNode } from 'react';
 import { prefetchInitialConsent } from 'c15t/next/server';
 import { consentConfig } from '../c15t.config';
 import { Consent } from '../components/consent';
 
-// Inside the layout:
-const initialConsent = prefetchInitialConsent({ config: consentConfig });
-
-<Consent config={initialConsent}>{children}</Consent>
+async function ResolvedConsent({ children }: { children: ReactNode }) {
+  const initialConsent = await prefetchInitialConsent({ config: consentConfig });
+  return <Consent config={initialConsent}>{children}</Consent>;
+}
 ```
+
+To stream the page shell before consent resolves instead, pass the unawaited
+promise from a synchronous layout as described in
+[stream the page while consent resolves](https://c15t.com/docs/frameworks/next/app-router#stream-the-page-while-consent-resolves).
 
 Pages Router passes `config={pageProps.initialConsent ?? {}}` to this wrapper
 in `_app.tsx`. Keep `getServerSideProps` and its `c15t/next/pages` helper.


### PR DESCRIPTION
Stacked on #1094 (5/5). Closes #1098.

## Summary
- New component pages for both React and Next.js: `consent-dialog`, `consent-widget`, `consent-dialog-link`, `frame`. Shared prose, props tables, behaviour and accessibility live in `docs/shared/react/components/*.mdx` fragments (same `<section id>` / `<import>` pattern as `dev-tools`); each framework page keeps its own opener and import path (`c15t/react` vs `c15t/next`).
- Props verified against `packages/react/src/components/**` and `aggregate-components.tsx`; the Frame table includes `noStyle` and `theme` from `FrameProps`.
- `docs.config.ts`: the four slugs added to the Components group for both frameworks.

`bun run lint:docs` and `bun run test:scripts` pass. Docs only, no changeset.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added React and Next.js documentation for `ConsentDialog`, `ConsentDialogLink`, `ConsentWidget`, and `Frame`.
  * Documented setup, usage examples, configuration options, accessibility guidance, composition patterns, consent behavior, and verification steps.
  * Added shared component references covering common behavior and APIs.
  * Added the new component pages to the documentation navigation for both frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->