### PR TITLE
test(core): justify the conditional expects in the hosted persistence recovery matrix

### DIFF
--- a/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
+++ b/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
@@ -144,7 +144,9 @@ test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(
 		close(outage);
 		const outageChoice = outage.kernel.getSnapshot().explicitChoice;
 		expect(outageChoice?.categories.measurement?.value).toBe(false);
-		/* oxlint-disable vitest/no-conditional-expect -- Only the variants that saved before the outage have stored records to compare against. */
+		// Only the variants that saved before the outage have stored records to
+		// compare against.
+		/* oxlint-disable vitest/no-conditional-expect */
 		if (recovery !== 'offline-rejection') {
 			expect(outageChoice).toEqual(savedChoice);
 			expect(localStorage.getItem('c15t')).toBe(savedLocal);
@@ -160,7 +162,8 @@ test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(
 			policy = matchedResolution(
 				optOutRule({ categories: ['measurement'], scopeMode: 'strict' })
 			);
-			/* oxlint-disable-next-line vitest/no-conditional-expect -- The changed-policy variant must actually change the choice fingerprint. */
+			// The changed-policy variant must actually change the choice fingerprint.
+			/* oxlint-disable-next-line vitest/no-conditional-expect */
 			expect(policy.fingerprints.choice).not.toBe(
 				originalPolicy.fingerprints.choice
 			);

--- a/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
+++ b/packages/core/src/runtime/__tests__/hosted-persistence.test.ts
@@ -144,11 +144,13 @@ test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(
 		close(outage);
 		const outageChoice = outage.kernel.getSnapshot().explicitChoice;
 		expect(outageChoice?.categories.measurement?.value).toBe(false);
+		/* oxlint-disable vitest/no-conditional-expect -- Only the variants that saved before the outage have stored records to compare against. */
 		if (recovery !== 'offline-rejection') {
 			expect(outageChoice).toEqual(savedChoice);
 			expect(localStorage.getItem('c15t')).toBe(savedLocal);
 			expect(document.cookie).toBe(savedCookie);
 		}
+		/* oxlint-enable vitest/no-conditional-expect */
 
 		unavailable = false;
 		if (recovery === 'none') {
@@ -158,6 +160,7 @@ test.each(['opt-out', 'none', 'changed-policy', 'offline-rejection'] as const)(
 			policy = matchedResolution(
 				optOutRule({ categories: ['measurement'], scopeMode: 'strict' })
 			);
+			/* oxlint-disable-next-line vitest/no-conditional-expect -- The changed-policy variant must actually change the choice fingerprint. */
 			expect(policy.fingerprints.choice).not.toBe(
 				originalPolicy.fingerprints.choice
 			);


### PR DESCRIPTION
## Summary
`bun run lint` fails on `v3` with four `vitest/no-conditional-expect` errors in `packages/core/src/runtime/__tests__/hosted-persistence.test.ts` (lines 148–150, 161), which turns the Lint & Type Check job red on every PR against `v3` (#1094, #1099–#1106, #1103).

The expects are legitimately conditional: the `test.each` matrix includes an `offline-rejection` variant that has no stored records before the outage, and a `changed-policy` variant that must assert its fingerprint precondition. This adds `oxlint-disable` blocks with the reason, the same convention already used in `consent-model.test.ts` and `transport.test.ts`. No test behaviour changes.

## Test plan
- [x] `bun turbo run lint --filter=@c15t/core` — 0 errors
- [x] `bun run lint` — 29/29 tasks pass
- [x] `bun run --cwd packages/core test src/runtime/__tests__/hosted-persistence.test.ts` — 5/5 pass

No changeset: test-only.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test annotations to accommodate conditional expectation patterns during linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->