### PR TITLE
fix: export theme helpers from framework entries

### DIFF
--- a/.changeset/famous-times-build.md
+++ b/.changeset/famous-times-build.md
@@ -1,0 +1,9 @@
+---
+'c15t': patch
+'@c15t/react': patch
+'@c15t/nextjs': patch
+'@c15t/tanstack-start': patch
+'@c15t/vue': patch
+---
+
+Export `defineTheme` and the `Theme` type from the React, Next.js, TanStack Start, and Vue entries so themes can use the same imports as their framework integration.

--- a/docs/frameworks/next/styling/overview.mdx
+++ b/docs/frameworks/next/styling/overview.mdx
@@ -37,8 +37,7 @@ children and other options. `ConsentBoundary` also accepts `theme` and
 <import src="../../../shared/react/styling/overview.mdx#tokens-intro" />
 
 ```tsx
-import { ConsentProvider } from 'c15t/next';
-import { defineTheme } from 'c15t/react/types';
+import { ConsentProvider, defineTheme } from 'c15t/next';
 
 const theme = defineTheme({
 	colors: { primary: '#2f6f4e' },

--- a/docs/frameworks/nuxt/quickstart.mdx
+++ b/docs/frameworks/nuxt/quickstart.mdx
@@ -89,6 +89,41 @@ provider is not needed. Keep `ConsentRoot` outside route-specific pages so it
 survives navigation. The mounted hook registers scripts against the module's
 existing kernel after hydration; unmounting the app cleans up the loader.
 
+## Customize the theme
+
+Import `defineTheme` from `c15t/vue` in `nuxt.config.ts`. That entry also
+exports the `Theme` type. The helper returns a typed theme object; map its
+values to the module's `tokens` configuration to apply them to the consent UI.
+
+Merge these tokens into your existing module configuration:
+
+```ts title="nuxt.config.ts"
+import { defineTheme } from 'c15t/vue';
+
+const theme = defineTheme({
+  colors: { primary: '#2f6f4e' },
+  radius: { lg: '4px' },
+});
+
+export default defineNuxtConfig({
+  modules: ['c15t/vue'],
+  runtimeConfig: { public: { posthogKey: '', xPixelId: '' } },
+  c15t: {
+    backendURL: process.env.NUXT_PUBLIC_C15T_BACKEND_URL,
+    manifest: true,
+    showTrigger: true,
+    tokens: {
+      'c15t-primary': theme.colors.primary,
+      'c15t-radius-lg': theme.radius.lg,
+    },
+  },
+});
+```
+
+The consent UI uses a green primary color and a 4px large-radius token. Token
+keys omit the leading `--`. Use `c15t/vue/vue-plugin` for theme imports inside
+Vue components; `c15t/vue` is the Nuxt configuration entry.
+
 ## Configure SPA or static output
 
 For a deployment without a Nuxt server, resolve the manifest in the browser and

--- a/docs/frameworks/react/styling/overview.mdx
+++ b/docs/frameworks/react/styling/overview.mdx
@@ -31,8 +31,7 @@ and other options.
 <import src="../../../shared/react/styling/overview.mdx#tokens-intro" />
 
 ```tsx
-import { ConsentProvider } from 'c15t/react';
-import { defineTheme } from 'c15t/react/types';
+import { ConsentProvider, defineTheme } from 'c15t/react';
 
 const theme = defineTheme({
 	colors: { primary: '#2f6f4e' },

--- a/docs/frameworks/tanstack-start/quickstart.mdx
+++ b/docs/frameworks/tanstack-start/quickstart.mdx
@@ -114,6 +114,44 @@ settings. The server prepares the configuration; the boundary uses it for the
 first client render. `initRoute={false}` sends browser initialization to
 `${backendURL}/init`, matching this direct-backend setup.
 
+## Customize the theme
+
+Import `defineTheme` from `c15t/tanstack-start` to define colors and radius
+tokens. The same entry exports the `Theme` type for annotations.
+
+```ts title="src/consent-theme.ts"
+import { defineTheme } from 'c15t/tanstack-start';
+
+export const theme = defineTheme({
+  colors: { primary: '#2f6f4e' },
+  radius: { lg: '4px' },
+});
+```
+
+In `src/routes/__root.tsx`, import the theme and add it to the existing boundary's
+`options`. This partial example keeps the loader, transport and children from
+the root-route setup:
+
+```tsx title="src/routes/__root.tsx"
+import { theme } from '../consent-theme';
+
+<ConsentBoundary
+  config={config}
+  backendURL={backendURL}
+  initRoute={false}
+  scripts={scripts}
+  options={{ theme }}
+>
+  <Outlet />
+  <ConsentBanner />
+  <ConsentDialog />
+  <ConsentDialogLink>Privacy settings</ConsentDialogLink>
+</ConsentBoundary>;
+```
+
+The consent UI uses a green primary color and a 4px large-radius token. Merge
+`theme` with any other boundary options you already use.
+
 ## Add a same-origin proxy when needed
 
 If browser traffic should use `/api/c15t`, mount a real Start server route using

--- a/docs/frameworks/vue/quickstart.mdx
+++ b/docs/frameworks/vue/quickstart.mdx
@@ -98,6 +98,42 @@ components include their styles; do not copy a React stylesheet import to a
 nonexistent Vue export. `showTrigger` also enables the built-in persistent
 trigger. The custom button above shows how to offer a footer entry point.
 
+## Customize the theme
+
+Plain Vue exports `defineTheme` and the `Theme` type from
+`c15t/vue/vue-plugin`. The helper returns a typed theme object; Vue applies
+styles through the plugin's `tokens` configuration. Map the values you want
+to use to their CSS token names.
+
+Update the existing plugin registration in `src/main.ts`, keeping any other
+options you already use:
+
+```ts title="src/main.ts"
+import { createApp } from 'vue';
+import { c15tVue, defineTheme } from 'c15t/vue/vue-plugin';
+import App from './App.vue';
+
+const theme = defineTheme({
+  colors: { primary: '#2f6f4e' },
+  radius: { lg: '4px' },
+});
+
+const backendURL = import.meta.env.VITE_C15T_BACKEND_URL;
+if (!backendURL) throw new Error('Set VITE_C15T_BACKEND_URL');
+
+createApp(App).use(c15tVue, {
+  backendURL,
+  showTrigger: true,
+  tokens: {
+    'c15t-primary': theme.colors.primary,
+    'c15t-radius-lg': theme.radius.lg,
+  },
+}).mount('#app');
+```
+
+When `ConsentRoot` mounts, it applies the green primary color and 4px
+large-radius token. Token keys omit the leading `--`.
+
 ## Read reactive permissions
 
 ```vue title="src/OptionalContent.vue"

--- a/packages/c15t/__tests__/facade-parity.test.ts
+++ b/packages/c15t/__tests__/facade-parity.test.ts
@@ -145,6 +145,17 @@ const assertParity = function assertParity(
 };
 
 describe('umbrella facade parity', () => {
+	it.each(['./react', './next', './tanstack-start', './vue'])(
+		'%s exports defineTheme',
+		(subpath) => {
+			const result = rows.find((row) => row.subpath === subpath)?.esm?.umbrella;
+			expect(result).toMatchObject({
+				keys: expect.arrayContaining(['defineTheme']),
+				ok: true,
+			});
+		}
+	);
+
 	it('ignores nondeterministic CSS traversal order in expected failures', () => {
 		const failure = (file: string): LoadFailure => ({
 			code: 'ERR_UNKNOWN_FILE_EXTENSION',

--- a/packages/react/src/__tests__/theme-exports.type-test.ts
+++ b/packages/react/src/__tests__/theme-exports.type-test.ts
@@ -1,0 +1,18 @@
+import type { Theme } from '../index';
+import { defineTheme } from '../index';
+
+const theme = defineTheme({
+	colors: { primary: '#2f6f4e' },
+	consentActions: {
+		primary: { mode: 'filled', variant: 'primary' },
+	},
+});
+
+theme satisfies Theme;
+theme.consentActions.primary.mode satisfies 'filled';
+
+// @ts-expect-error Color tokens must be strings.
+defineTheme({ colors: { primary: 42 } });
+
+// @ts-expect-error Unsupported consent action variants must be rejected.
+defineTheme({ consentActions: { primary: { variant: 'unknown' } } });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -153,6 +153,7 @@ export type {
 } from './provider';
 export { ConsentProvider } from './provider';
 export type { ReactUIOptions } from './types/consent-manager';
+export { defineTheme, type Theme } from './types/theme';
 
 export {
 	useExplicitChoice,

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -36,11 +36,11 @@
 	],
 	"type": "module",
 	"main": "./dist/module.mjs",
-	"types": "./dist/types.d.mts",
+	"types": "./dist/module.d.mts",
 	"typesVersions": {
 		"*": {
 			".": [
-				"./dist/types.d.mts"
+				"./dist/module.d.mts"
 			],
 			"vite": [
 				"./dist/vite.d.mts"
@@ -55,7 +55,7 @@
 	},
 	"exports": {
 		".": {
-			"types": "./dist/types.d.mts",
+			"types": "./dist/module.d.mts",
 			"import": "./dist/module.mjs",
 			"default": "./dist/module.mjs"
 		},

--- a/packages/vue/src/__tests__/theme-exports.test.ts
+++ b/packages/vue/src/__tests__/theme-exports.test.ts
@@ -1,0 +1,21 @@
+import type { Theme as NuxtTheme } from '@c15t/vue';
+import { defineTheme as defineNuxtTheme } from '@c15t/vue';
+import { expect, test } from 'vitest';
+
+import type { Theme } from '../index';
+import { defineTheme } from '../index';
+
+test('defines a theme through the Vue plugin entry', () => {
+	const theme = {
+		colors: { primary: '#2f6f4e' },
+	} satisfies Theme;
+
+	expect(defineTheme(theme)).toBe(theme);
+});
+
+test('defines a theme through the published Nuxt entry', () => {
+	const theme = {
+		colors: { primary: '#2f6f4e' },
+	} satisfies NuxtTheme;
+	expect(defineNuxtTheme(theme)).toBe(theme);
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from './runtime/utils/symbols';
 
 export type * from '@c15t/schema/config';
+export { defineTheme, type Theme } from '@c15t/ui/theme';
 export * from './runtime/composables';
 export type {
 	ConsentConfig,

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -19,6 +19,11 @@ import {
 	resolveNuxtManifestRoute,
 } from './runtime/manifest';
 
+export { defineTheme, type Theme } from '@c15t/ui/theme';
+
+/** Options accepted by the Nuxt module. */
+export type ModuleOptions = Partial<ConsentConfig>;
+
 // Annotated explicitly: the inferred type names `NuxtModule` through
 // @nuxt/schema's store path, which is not portable across installs (TS2883).
 const module: NuxtModule<ConsentConfig> = defineNuxtModule<ConsentConfig>({


### PR DESCRIPTION
## Overview

Expose `defineTheme` and `Theme` through the framework entries so a Next.js app can import its provider and theme helper together:

```ts
import { ConsentProvider, defineTheme, type Theme } from 'c15t/next';
```

React exports its existing theme helper and type; Next.js and TanStack Start inherit those exports. Vue exposes the shared UI helper through both its Nuxt module and Vue plugin entries. The React and Next.js styling examples now use their framework entry. TanStack Start, Vue, and Nuxt quickstarts document the helper and how to apply its values through each adapter's configuration.

## Related issue

Addresses the theme-import portion of #1108. Adapter dependencies stay unchanged to preserve `pnpm add c15t`.

## Type of change

- [x] Bug fix
- [x] Documentation

## Implementation details

Nuxt's generated `types.d.mts` wrapper converts named exports into type-only exports. Point Vue's declaration entries at `module.d.mts` so TypeScript consumers can call `defineTheme`, and explicitly preserve the existing `ModuleOptions` type.

Includes a patch changeset for the umbrella and affected adapters.

## Testing

- [x] Build the umbrella and its dependencies, 13 successful tasks.
- [x] Umbrella public-import tests, 94 passed, including theme exports from all four framework entries.
- [x] Vue tests, 305 passed, including source-plugin and published-Nuxt imports.
- [x] Umbrella generator tests, 32 passed.
- [x] React type checks, including invalid theme tokens and preserved literal inference.
- [x] Vue type checks, including the published Nuxt theme import.
- [x] Lint and formatting for changed files; eight repository docs-validation tests; regenerate bundled docs and verify the new framework examples.
- [x] Type-check the TanStack Start, Vue, and Nuxt theme/config examples against the built public exports.

An isolated pnpm fixture using the built package tarballs compared `c15t/next` with `@c15t/nextjs` in production Next.js 16.2.10 with React 19.2.7. Both pages render the same provider, banner, dialog, and custom theme. All initial and lazy client chunks were inspected through source maps, with an additional Webpack module report.

| Bundler | Extra uncompressed client JS | Gzip difference |
| --- | ---: | ---: |
| Webpack | 0 bytes | +1 byte |
| Turbopack | 0 bytes | +2 bytes |

Neither client build includes Vue, Nuxt, or TanStack code. This verifies the import-path comparison for this fixture; it is not a reduction in package install size.

Full Local CI was attempted but did not complete. The workflow-security action reported "no auditable inputs," and the bundle workflow could not resolve `HEAD^` in the local runner checkout. The targeted checks and isolated production bundle comparisons above passed.

## Checklist

- [x] Issue linked
- [x] Regression tests added
- [x] Documentation updated
- [x] Tested locally
- [x] Code follows the repository style
- [x] Conventional commit and changeset included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `defineTheme` and the `Theme` type to React, Next.js, TanStack Start, and Vue integration exports.
  - Added Vue module options typing for partial consent configuration.

- **Documentation**
  - Updated React and Next.js styling examples to use framework-specific theme imports.
  - Added theme customization guidance to Nuxt, TanStack Start, and Vue quickstarts.

- **Bug Fixes**
  - Corrected the Vue package’s published type declaration path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->